### PR TITLE
Add Rubocop config and task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+AllCops:
+  TargetRubyVersion: 2.5
+
+Documentation:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  EnforcedStyle: omit_parentheses
+  AllowParenthesesInMultilineCall: true
+Style/MethodDefParentheses:
+  EnforcedStyle: require_no_parentheses

--- a/Rakefile
+++ b/Rakefile
@@ -13,12 +13,24 @@
 # limitations under the License.
 
 require "bundler/gem_tasks"
+require "rubocop/rake_task"
 require "rake/testtask"
 
-Rake::TestTask.new(:test) do |t|
+RuboCop::RakeTask.new # Configuration is in .rubocop.yml
+Rake::TestTask.new :test do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
-task :default => :test
+
+desc "Run the CI build"
+task :ci do
+  puts "\nBUILDING gapic-generator-ruby\n"
+  puts "\ngapic-generator-ruby rubocop\n"
+  Rake::Task[:rubocop].invoke
+  puts "\ngapic-generator-ruby test\n"
+  Rake::Task[:test].invoke
+end
+
+task default: :ci


### PR DESCRIPTION
This PR adds the `rubocop` rake task as well as a `ci` rake task that combines `rubocop` and `test`.

Both `rubocop` and `test` are currently failing.

### rubocop

```sh
18 files inspected, 310 offenses detected
```

### test

```sh
Traceback (most recent call last):
	7: from /Users/quartzmo/.rbenv/versions/2.5.3/gemsets/gapic-generator-ruby/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:4:in `<main>'
	6: from /Users/quartzmo/.rbenv/versions/2.5.3/gemsets/gapic-generator-ruby/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:4:in `select'
	5: from /Users/quartzmo/.rbenv/versions/2.5.3/gemsets/gapic-generator-ruby/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:15:in `block in <main>'
	4: from /Users/quartzmo/.rbenv/versions/2.5.3/gemsets/gapic-generator-ruby/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:15:in `require'
	3: from /Users/quartzmo/code/google/codez/gapic-generator-ruby/test/gapic/generator_test.rb:15:in `<top (required)>'
	2: from /Users/quartzmo/code/google/codez/gapic-generator-ruby/test/gapic/generator_test.rb:15:in `require'
	1: from /Users/quartzmo/code/google/codez/gapic-generator-ruby/test/test_helper.rb:16:in `<top (required)>'
/Users/quartzmo/code/google/codez/gapic-generator-ruby/test/test_helper.rb:16:in `require': cannot load such file -- gapic/generator (LoadError)
```

[refs #9]