### PR TITLE
Update _client.erb

### DIFF
--- a/lib/google/gapic/generator/util.rb
+++ b/lib/google/gapic/generator/util.rb
@@ -49,6 +49,29 @@ module Google
           "#{NAME_TOKEN}#{name}"
         end
 
+        # Converts just the first character to uppercase.
+        # File activesupport/lib/active_support/inflector/methods.rb, line 156
+        def upcase_first(string)
+          string.length > 0 ? string[0].upcase.concat(string[1..-1]) : ""
+        end
+
+        def rubyize_constant s
+          s.split(".").reject(&:empty?).map { |m| upcase_first m }.join("::")
+        end
+
+        # Makes an underscored, lowercase form from the expression in the string.
+        # File activesupport/lib/active_support/inflector/methods.rb, line 92
+        def underscore(camel_cased_word)
+          return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
+          word = camel_cased_word.to_s.gsub("::".freeze, "/".freeze)
+          # word.gsub!(inflections.acronyms_underscore_regex) { "#{$1 && '_'.freeze }#{$2.downcase}" }
+          word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2'.freeze)
+          word.gsub!(/([a-z\d])([A-Z])/, '\1_\2'.freeze)
+          word.tr!("-".freeze, "_".freeze)
+          word.downcase!
+          word
+        end
+
         # Converts a camelCased string to a snake_cased string.
         def snake_case s
           # Replace all capital letters that are preceded by a lower-case letter.

--- a/templates/_client.erb
+++ b/templates/_client.erb
@@ -1,2 +1,182 @@
+# <%= @service.docs.leading_comments -%>
 class <%= @service.name %>Client
+  # @private
+  attr_reader :<%= @util.snake_case @service.name %>_stub
+
+  # The default address of the service.
+  SERVICE_ADDRESS = "<%= @util.snake_case @service.name %>.googleapis.com"
+
+  # The default port of the service.
+  DEFAULT_SERVICE_PORT = 443
+
+  # The default set of gRPC interceptors.
+  GRPC_INTERCEPTORS = [].freeze
+
+  DEFAULT_TIMEOUT = 30
+
+  # The scopes needed to make gRPC calls to all of the methods defined in
+  # this service.
+  ALL_SCOPES = [
+    "https://www.googleapis.com/auth/cloud-platform"
+  ].freeze
+
+  # @private
+  class OperationsClient < Google::Longrunning::OperationsClient
+    SERVICE_ADDRESS = SpeechClient::SERVICE_ADDRESS
+    GRPC_INTERCEPTORS = SpeechClient::GRPC_INTERCEPTORS.dup
+  end
+
+  ##
+  # @param credentials [Google::Auth::Credentials, String, Hash,
+  #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+  #   Provides the means for authenticating requests made by the client. This parameter can
+  #   be many types.
+  #   A `Google::Auth::Credentials` uses a the properties of its represented keyfile for
+  #   authenticating requests made by this client.
+  #   A `String` will be treated as the path to the keyfile to be used for the construction of
+  #   credentials for this client.
+  #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+  #   credentials for this client.
+  #   A `GRPC::Core::Channel` will be used to make calls through.
+  #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+  #   should already be composed with a `GRPC::Core::CallCredentials` object.
+  #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+  #   metadata for requests, generally, to give OAuth credentials.
+  # @param scopes [Array<String>]
+  #   The OAuth scopes for this service. This parameter is ignored if
+  #   an updater_proc is supplied.
+  # @param client_config [Hash]
+  #   A Hash for call options for each method. See
+  #   Google::Gax#construct_settings for the structure of
+  #   this data. Falls back to the default config if not specified
+  #   or the specified config is missing data points.
+  # @param timeout [Numeric]
+  #   The default timeout, in seconds, for calls made through this client.
+  # @param metadata [Hash]
+  #   Default metadata to be sent with each request. This can be overridden on a per call basis.
+  # @param exception_transformer [Proc]
+  #   An optional proc that intercepts any exceptions raised during an API call to inject
+  #   custom error handling.
+  #
+  def initialize \
+      credentials: nil,
+      scopes: ALL_SCOPES,
+      client_config: {},
+      timeout: DEFAULT_TIMEOUT,
+      metadata: nil,
+      exception_transformer: nil,
+      lib_name: nil,
+      lib_version: ""
+    # These require statements are intentionally placed here to initialize
+    # the gRPC module only when it's required.
+    # See https://github.com/googleapis/toolkit/issues/446
+    require "google/gax/grpc"
+    require "google/cloud/<%= @util.snake_case @service.name %>/v1/cloud_<%= @util.snake_case @service.name %>_services_pb"
+
+    credentials ||= Google::Cloud::<%= @service.name %>::V1::Credentials.default
+
+    @operations_client = OperationsClient.new(
+      credentials: credentials,
+      scopes: scopes,
+      client_config: client_config,
+      timeout: timeout,
+      lib_name: lib_name,
+      lib_version: lib_version
+    )
+    @<%= @util.snake_case @service.name %>_stub = create_stub credentials, scopes
+
+    defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
+
+<% @service.methods.each do |method| %>
+<% method_name = @util.underscore method.descriptor.name %>
+@<%= method_name %> = Google::Gax.create_api_call(
+@<%= @util.snake_case @service.name %>_stub.method(:<%= method_name %>),
+defaults["<%= method_name %>"],
+exception_transformer: exception_transformer
+)
+<% end %>
+  end
+
+  # Service calls
+
+<% @service.methods.each do |method| %>
+<% method_name = @util.underscore method.descriptor.name %>
+  ##
+<%- method.docs.leading_comments.split("\n").each do |s| %>
+  # <%= s %>
+<%- end %>
+  def <%= method_name %> \
+<%- method.input.descriptor.field.each do |f| %>
+      <%= f.name %>,
+<%- end %>
+      options: nil,
+      &block
+    request = {
+<%- method.input.descriptor.field.each do |f| %>
+      <%= f.name %>: <%= f.name %>,
+<%- end %>
+    }.delete_if { |_, v| v.nil? }
+    request = Google::Gax.to_proto request, <%= @util.rubyize_constant method.descriptor.input_type %>
+    @<%= method_name %>.call(request, options, &block)
+  end
+<% end %>
+
+  protected
+
+  def create_stub credentials, scopes
+    if credentials.is_a?(String) || credentials.is_a?(Hash)
+      updater_proc = Google::Cloud::Speech::V1::Credentials.new(credentials).updater_proc
+    elsif credentials.is_a? GRPC::Core::Channel
+      channel = credentials
+    elsif credentials.is_a? GRPC::Core::ChannelCredentials
+      chan_creds = credentials
+    elsif credentials.is_a? Proc
+      updater_proc = credentials
+    elsif credentials.is_a? Google::Auth::Credentials
+      updater_proc = credentials.updater_proc
+    end
+
+    # Allow overriding the service path/port in subclasses.
+    service_path = self.class::SERVICE_ADDRESS
+    port = self.class::DEFAULT_SERVICE_PORT
+    interceptors = self.class::GRPC_INTERCEPTORS
+    stub_new = Google::Cloud::Speech::V1::Speech::Stub.method :new
+    Google::Gax::Grpc.create_stub(
+      service_path,
+      port,
+      chan_creds: chan_creds,
+      channel: channel,
+      updater_proc: updater_proc,
+      scopes: scopes,
+      interceptors: interceptors,
+      &stub_new
+    )
+  end
+
+  def default_settings client_config, timeout, metadata, lib_name, lib_version
+    package_version = Gem.loaded_specs["google-cloud-speech"].version.version
+
+    google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
+    google_api_client << " #{lib_name}/#{lib_version}" if lib_name
+    google_api_client << " gapic/#{package_version} gax/#{Google::Gax::VERSION}"
+    google_api_client << " grpc/#{GRPC::VERSION}"
+    google_api_client.join
+
+    headers = { "x-goog-api-client": google_api_client }
+    headers.merge! metadata unless metadata.nil?
+    client_config_file = Pathname.new(__dir__).join(
+      "<%= @util.snake_case @service.name %>_client_config.json"
+    )
+    client_config_file.open do |f|
+      Google::Gax.construct_settings(
+        "google.cloud.<%= @util.snake_case @service.name %>.v1.<%= @service.name %>",
+        JSON.parse(f.read),
+        client_config,
+        Google::Gax::Grpc::STATUS_CODE_NAMES,
+        timeout,
+        errors: Google::Gax::Grpc::API_ERRORS,
+        metadata: headers
+      )
+    end
+  end
 end


### PR DESCRIPTION
This addition to `templates/_client.erb` correctly adds the Speech `Recognize` unary method. The docs for the method are incomplete.

This PR is still a work-in-progress, since I need to solve the problem of how to add `require` statements in `clients.erb` that are specified in the child template `_client.erb`. (The solution might be something similar to ActionView's [CaptureHelper](https://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html).)

Partial visual diff of the speech.rb generated with this PR and the [example speech_client.rb](https://github.com/googleapis/gapic-generator-ruby/blob/examples/examples/google-cloud-speech/output/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb):

<img width="1889" alt="screen shot 2018-12-19 at 4 29 32 pm" src="https://user-images.githubusercontent.com/205445/50255103-d6d4b300-03ad-11e9-8cb8-fd12b77a28bc.png">
