### PR TITLE
Add failing test for demo prep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ jobs:
           name: install dependencies
           command: |
             bundle install --jobs=4 --retry=3
-            bundle install --jobs=4 --retry=3 --gemfile shared/Gemfile
-            bundle install --jobs=4 --retry=3 --gemfile gapic-generator/Gemfile
-            bundle install --jobs=4 --retry=3 --gemfile gapic-generator-cloud/Gemfile
+            cd shared && bundle install --jobs=4 --retry=3
+            cd ../gapic-generator && bundle install --jobs=4 --retry=3
+            cd ../gapic-generator-cloud && bundle install --jobs=4 --retry=3
             bundle clean
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,18 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+            bundle install --jobs=4 --retry=3
+            bundle install --jobs=4 --retry=3 --gemfile shared/Gemfile
+            bundle install --jobs=4 --retry=3 --gemfile gapic-generator/Gemfile
+            bundle install --jobs=4 --retry=3 --gemfile gapic-generator-cloud/Gemfile
+            bundle clean
       - save_cache:
           paths:
-            - ./vendor/bundle
+            - ~/.bundle
           key: v1-dependencies-generator
+      - run:
+          name: wait for showcase server
+          command: dockerize -wait tcp://localhost:7469 -timeout 1m
       - run:
           name: run tests
           command: bundle exec rake ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     docker:
       - image: circleci/ruby:2.4.1-node-browsers
+      - image: gcr.io/gapic-showcase/gapic-showcase:0.0.12
     working_directory: ~/gapic-generator-ruby
     steps:
       - checkout
@@ -15,9 +16,7 @@ jobs:
           command: git submodule update --init --recursive
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "Gemfile.lock" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v1-dependencies-generator
       - run:
           name: install dependencies
           command: |
@@ -25,9 +24,7 @@ jobs:
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
-
-      # run tests!
+          key: v1-dependencies-generator
       - run:
           name: run tests
           command: bundle exec rake ci

--- a/Rakefile
+++ b/Rakefile
@@ -40,6 +40,13 @@ end
 
 desc "Runs tests for all gems."
 task :test do
+  Dir.chdir "shared" do
+    Bundler.with_clean_env do
+      puts "Running shared tests"
+      sh "bundle exec rake test"
+    end
+  end
+
   gem_dirs.each do |gem|
     Dir.chdir gem do
       Bundler.with_clean_env do
@@ -83,6 +90,13 @@ end
 
 desc "Runs CI for all gems."
 task :ci do
+  Dir.chdir "shared" do
+    Bundler.with_clean_env do
+      puts "Running CI for shared"
+      sh "bundle exec rake ci"
+    end
+  end
+
   gem_dirs.each do |gem|
     Dir.chdir gem do
       Bundler.with_clean_env do

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+source "https://rubygems.org"
+
 gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "google-gax"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -2,5 +2,6 @@
 
 gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
+gem "google-gax"
 gem "rake", "~> 10.0"
 gem "grpc-tools", "~> 1.18"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -3,3 +3,4 @@
 gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "rake", "~> 10.0"
+gem "grpc-tools", "~> 1.18"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
-gem "google-gax"
+gem "google-gax", "~> 1.0"
 gem "rake", "~> 10.0"
 gem "grpc-tools", "~> 1.18"

--- a/shared/Rakefile
+++ b/shared/Rakefile
@@ -73,9 +73,26 @@ end
 namespace :test do
   desc "Run functional tests for showcase protos"
   Rake::TestTask.new :showcase do |t|
+    require "tmpdir"
+
+    client_lib = Dir.mktmpdir
+    protoc_cmd = [
+      "grpc_tools_ruby_protoc",
+      "--proto_path=api-common-protos",
+      "--proto_path=protos/showcase",
+      "--ruby_out=#{client_lib}",
+      "--grpc_out=#{client_lib}",
+      "--ruby_gapic_out=#{client_lib}",
+      "protos/showcase/v1alpha3/echo.proto"
+    ].join " "
+    sh protoc_cmd
+
     t.libs << "test"
+    t.libs << client_lib
     t.test_files = FileList["test/showcase/**/*_test.rb"]
     t.warning = false
+
+    # TODO: delete the temporary dir?
   end
 end
 
@@ -97,6 +114,14 @@ task :console do
   ARGV.clear
   IRB.start
 end
+
+desc "Run the CI build"
+task :ci do
+  puts "\nshared test\n"
+  Rake::Task[:test].invoke
+end
+
+task default: :ci
 
 def generate_input_file name, protos
   require "tmpdir"

--- a/shared/Rakefile
+++ b/shared/Rakefile
@@ -71,25 +71,9 @@ end
 namespace :test do
   desc "Run functional tests for showcase protos"
   Rake::TestTask.new :showcase do |t|
-    require "tmpdir"
-
-    client_lib = Dir.mktmpdir
-    protoc_cmd = [
-      "grpc_tools_ruby_protoc",
-      "--proto_path=api-common-protos",
-      "--proto_path=protos/showcase",
-      "--ruby_out=#{client_lib}",
-      "--grpc_out=#{client_lib}",
-      "--ruby_gapic_out=#{client_lib}",
-      "protos/showcase/v1alpha3/echo.proto"
-    ].join " "
-    sh protoc_cmd
-
-    t.libs << ["test",  client_lib]
+    t.libs << ["test"]
     t.test_files = FileList["test/showcase/**/*_test.rb"]
     t.warning = false
-
-    # TODO: delete the temporary dir?
   end
 end
 

--- a/shared/Rakefile
+++ b/shared/Rakefile
@@ -65,10 +65,8 @@ end
 
 require "rake/testtask"
 desc "Run functional tests for all custom protos"
-Rake::TestTask.new do |t|
-  t.libs << "test"
-  t.test_files = FileList["test/**/*_test.rb"]
-  t.warning = false
+task :test do
+  Rake::Task["test:showcase"].invoke
 end
 namespace :test do
   desc "Run functional tests for showcase protos"
@@ -87,8 +85,7 @@ namespace :test do
     ].join " "
     sh protoc_cmd
 
-    t.libs << "test"
-    t.libs << client_lib
+    t.libs << ["test",  client_lib]
     t.test_files = FileList["test/showcase/**/*_test.rb"]
     t.warning = false
 

--- a/shared/Rakefile
+++ b/shared/Rakefile
@@ -71,7 +71,7 @@ end
 namespace :test do
   desc "Run functional tests for showcase protos"
   Rake::TestTask.new :showcase do |t|
-    t.libs << ["test"]
+    t.libs << "test"
     t.test_files = FileList["test/showcase/**/*_test.rb"]
     t.warning = false
   end

--- a/shared/test/showcase/echo_test.rb
+++ b/shared/test/showcase/echo_test.rb
@@ -15,9 +15,16 @@
 # limitations under the License.
 
 require "test_helper"
+require "google/showcase/v1alpha3/echo"
 
 class EchoTest < ShowcaseTest
   def test_echo
-    raise "not implemented"
+    client = Google::Showcase::V1alpha3::EchoClient.new(
+      credentials: GRPC::Core::Channel.new(
+        "localhost:7469", nil, :this_channel_is_insecure))
+
+    response = client.echo 'hi there!', nil
+
+    assert_equal 'hi there!', response.content
   end
 end

--- a/shared/test/test_helper.rb
+++ b/shared/test/test_helper.rb
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
-
 require "minitest/autorun"
 require "open3"
 

--- a/shared/test/test_helper.rb
+++ b/shared/test/test_helper.rb
@@ -37,14 +37,18 @@ end
 
 class ShowcaseTest < Minitest::Test
   @showcase_id = begin
-    puts "Starting showcase server..."
+    server_id = nil
+    if ENV['CI'].nil?
+      puts "Starting showcase server..."
 
-    server_id, status = Open3.capture2 "docker run --rm -d "\
+      server_id, status = Open3.capture2 "docker run --rm -d "\
         "gcr.io/gapic-showcase/gapic-showcase:0.0.12"
-    raise "failed to start showcase" unless status.exitstatus.zero?
+      raise "failed to start showcase" unless status.exitstatus.zero?
 
-    server_id.chop!
-    puts "Started with container id: #{server_id}"
+      server_id.chop!
+      puts "Started with container id: #{server_id}"
+    end
+
     server_id
   end
 
@@ -57,11 +61,13 @@ class ShowcaseTest < Minitest::Test
   end
 
   Minitest.after_run do
-    puts "Stopping showcase server (id: #{@showcase_id})..."
-
     FileUtils.remove_dir @showcase_library, true
 
-    _, status = Open3.capture2 "docker stop #{@showcase_id}"
-    raise "failed to stop showcase" unless status.exitstatus.zero?
+    unless @showcase_id.nil?
+      puts "Stopping showcase server (id: #{@showcase_id})..."
+
+      _, status = Open3.capture2 "docker stop #{@showcase_id}"
+      raise "failed to stop showcase" unless status.exitstatus.zero?
+    end
   end
 end


### PR DESCRIPTION
I would like to be able to have folks do something along the lines #44 for the demo next week. They should be able to build an API (showcase in particular) using just a simple Gemfile/Rakefile pair that will take care of installing everything beyond Ruby and bundler. We'll also show how to write a simple script to use the generated library (and we'll likely have rake run it after generation so it's a one liner demo) i.e.:

```ruby
require "google/showcase/v1alpha3/echo"

client = Google::Showcase::V1alpha3::EchoClient.new(
  credentials: GRPC::Core::Channel.new(
    "localhost:7469", nil, :this_channel_is_insecure))

response = client.echo 'hi there!', nil

puts response.content
```

However, we need to get this test that I've added to pass in order to do that. I was able to edit the generated files by hand to get this test to pass without too much trouble, so I think we can make this happen in time.

To be clear, I don't want to use this integration test in this PR for the demo directly. We'll create a very simple standalone Ruby project that will be very similar. But, we have to get this test to pass for the demo to actually work.

So, let's try to get this test in quickly and then jump on to the harder part - getting it to pass 😄 .