### PR TITLE
Add minitest-autotest dev dependency

### DIFF
--- a/gapic-generator-cloud/gapic-generator-cloud.gemspec
+++ b/gapic-generator-cloud/gapic-generator-cloud.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "minitest-autotest", "~> 1.0"
   spec.add_development_dependency "minitest-focus", "~> 1.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/gapic-generator/gapic-generator.gemspec
+++ b/gapic-generator/gapic-generator.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "grpc-tools", "~> 1.19"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "minitest-autotest", "~> 1.0"
   spec.add_development_dependency "minitest-focus", "~> 1.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
This adds the ability to run `$ bundle exec autotest` from a project and it will re-run only the tests that were failing previously, as well as any tests in files that are saved.