### PR TITLE
Add client package annotation

### DIFF
--- a/gapic-generator/lib/google/gapic/schema/wrappers.rb
+++ b/gapic-generator/lib/google/gapic/schema/wrappers.rb
@@ -79,6 +79,7 @@ module Google
       class Proto
         extend Forwardable
         attr_reader :descriptor, :address, :docs
+        attr_accessor :parent
 
         # Initializes a Proto object.
         # @param descriptor [Object] the protobuf
@@ -208,6 +209,7 @@ module Google
         def initialize descriptor, address, docs, methods
           super descriptor, address, docs
           @methods = methods || []
+          @methods.each { |m| m.parent = self }
         end
 
         # @return [String] The hostname for this service
@@ -340,6 +342,11 @@ module Google
           @enums = enums || []
           @services = services || []
           @generate = generate
+
+          # Apply parent
+          @messages.each { |m| m.parent = self }
+          @enums.each    { |m| m.parent = self }
+          @services.each { |m| m.parent = self }
         end
 
         # rubocop:enable Metrics/ParameterLists
@@ -414,6 +421,7 @@ module Google
         def initialize descriptor, address, docs, values
           super descriptor, address, docs
           @values = values || []
+          @values.each { |v| v.parent = self }
         end
 
         # @!method name
@@ -495,6 +503,11 @@ module Google
           @extensions = extensions || []
           @nested_messages = nested_messages || []
           @nested_enums = nested_enums || []
+
+          @fields.each          { |f| f.parent = self }
+          @extensions.each      { |x| x.parent = self }
+          @nested_messages.each { |m| m.parent = self }
+          @nested_enums.each    { |e| e.parent = self }
         end
 
         # rubocop:enable Metrics/ParameterLists

--- a/gapic-generator/lib/google/gapic/schema/wrappers.rb
+++ b/gapic-generator/lib/google/gapic/schema/wrappers.rb
@@ -224,6 +224,14 @@ module Google
           String(options[:".google.api.oauth_scopes"]).split "," if options
         end
 
+        # @return [Google::Api::Package] Packaging information.
+        #   See `google/api/client.proto`.
+        def client_package
+          return nil if parent.nil?
+
+          parent.client_package
+        end
+
         # @!method name
         #   @return [String] the unqualified name of the service.
         # @!method options
@@ -355,30 +363,10 @@ module Google
           @generate
         end
 
-        # @return [Google::Api::Metdata] Packaging information.
-        #   See `google/api/metadata.proto`.
-        def metadata
-          options[:".google.api.metadata"] if options
-        end
-
-        # @return [Array<Google::Api::Resource>] A representation of a resource.
-        #   At a file level, this is generally used to define information for a
-        #   resource from another API, or for a resource that does not have an
-        #   associated proto message.
-        def resources
-          return options[:".google.api.resource_definition"] if options
-
-          []
-        end
-
-        # @return [Array<Google::Api::ResourceSet>] A representation of a set of
-        #   resources. At a file level, this is generally used to define
-        #   information for a resource set from another API, or for a resource
-        #   that does not have an associated proto message.
-        def resource_sets
-          return options[:".google.api.resource_set_definition"] if options
-
-          []
+        # @return [Google::Api::Package] Packaging information.
+        #   See `google/api/client.proto`.
+        def client_package
+          options[:".google.api.client_package"] if options
         end
 
         # @!method name

--- a/gapic-generator/lib/google/gapic/schema/wrappers.rb
+++ b/gapic-generator/lib/google/gapic/schema/wrappers.rb
@@ -207,7 +207,7 @@ module Google
         # @param methods [Enumerable<Method>] The methods of this service.
         def initialize descriptor, address, docs, methods
           super descriptor, address, docs
-          @methods = methods || {}
+          @methods = methods || []
         end
 
         # @return [String] The hostname for this service
@@ -336,9 +336,9 @@ module Google
         def initialize descriptor, address, docs, messages, enums, services,
                        generate
           super descriptor, address, docs
-          @messages = messages || {}
-          @enums = enums || {}
-          @services = services || {}
+          @messages = messages || []
+          @enums = enums || []
+          @services = services || []
           @generate = generate
         end
 
@@ -413,7 +413,7 @@ module Google
         # @param values [Enumerable<EnumValue>] The EnumValues of this enum.
         def initialize descriptor, address, docs, values
           super descriptor, address, docs
-          @values = values || {}
+          @values = values || []
         end
 
         # @!method name
@@ -491,10 +491,10 @@ module Google
         def initialize descriptor, address, docs, fields, extensions,
                        nested_messages, nested_enums
           super descriptor, address, docs
-          @fields = fields || {}
-          @extensions = extensions || {}
-          @nested_messages = nested_messages || {}
-          @nested_enums = nested_enums || {}
+          @fields = fields || []
+          @extensions = extensions || []
+          @nested_messages = nested_messages || []
+          @nested_enums = nested_enums || []
         end
 
         # rubocop:enable Metrics/ParameterLists

--- a/gapic-generator/test/google/gapic/annotations/package_test.rb
+++ b/gapic-generator/test/google/gapic/annotations/package_test.rb
@@ -17,5 +17,30 @@
 require "test_helper"
 
 class AnnotationPackageTest < AnnotationTest
-  # TODO: Need to get a way to test the top-level FileOptions annotations
+  def test_garbage
+    garbage = api :garbage
+    service = garbage.services.find { |s| s.name == "GarbageService" }
+    refute_nil service
+    file = service.parent
+    refute_nil file
+
+    refute_nil file.options
+    assert_kind_of Google::Protobuf::FileOptions, file.options
+    refute_nil file.options[:client_package]
+    assert_kind_of Google::Api::Package, file.options[:client_package]
+    assert_equal "Testing Garbage", file.options[:client_package][:title]
+    assert_equal ["Endless", "Trash"], file.options[:client_package][:namespace]
+    assert_equal "Forever", file.options[:client_package][:version]
+
+    assert_kind_of Google::Api::Package, file.client_package
+    assert_equal "Testing Garbage", file.client_package.title
+    assert_equal ["Endless", "Trash"], file.client_package.namespace
+    assert_equal "Forever", file.client_package.version
+
+    # client_package is also exposed on the service
+    assert_kind_of Google::Api::Package, service.client_package
+    assert_equal "Testing Garbage", service.client_package.title
+    assert_equal ["Endless", "Trash"], service.client_package.namespace
+    assert_equal "Forever", service.client_package.version
+  end
 end


### PR DESCRIPTION
Enable the `client_package` annotation by adding a parent reference to the schema objects.