### PR TITLE
Refactor base generator code formatting

### DIFF
--- a/gapic-generator-cloud/lib/google/gapic/generators/cloud_generator.rb
+++ b/gapic-generator-cloud/lib/google/gapic/generators/cloud_generator.rb
@@ -49,15 +49,15 @@ module Google
           ap.packages.each do |package|
             # Package level files
             files << g("package.erb", "lib/#{package.version_file_path}",
-                       package: package, format: true)
+                       package: package)
 
             package.services.each do |service|
               # Service level files
               files << g("client.erb", "lib/#{service.client_file_path}",
-                         service: service, format: true)
+                         service: service)
               files << g("client_test.erb",
                          "test/#{service.client_test_file_path}",
-                         service: service, format: true)
+                         service: service)
             end
           end
 

--- a/gapic-generator-cloud/lib/google/gapic/generators/cloud_generator.rb
+++ b/gapic-generator-cloud/lib/google/gapic/generators/cloud_generator.rb
@@ -48,28 +48,36 @@ module Google
 
           ap.packages.each do |package|
             # Package level files
-            files << cop(gen("package.erb", "lib/#{package.version_file_path}",
-                             package: package))
+            files << g("package.erb", "lib/#{package.version_file_path}",
+                       package: package, format: true)
 
             package.services.each do |service|
               # Service level files
-              files << cop(gen("client.erb",
-                               "lib/#{service.client_file_path}",
-                               service: service))
-              files << cop(gen("client_test.erb",
-                               "test/#{service.client_test_file_path}",
-                               service: service))
+              files << g("client.erb", "lib/#{service.client_file_path}",
+                         service: service, format: true)
+              files << g("client_test.erb",
+                         "test/#{service.client_test_file_path}",
+                         service: service, format: true)
             end
           end
 
           # Api level files
-          files << gen("gemspec.erb",  "#{ap.gem_name}.gemspec", api: ap)
-          files << gen("gemfile.erb",  "Gemfile",                api: ap)
-          files << gen("rakefile.erb", "Rakefile",               api: ap)
-          files << gen("rubocop.erb",  ".rubocop",               api: ap)
-          files << gen("license.erb",  "LICENSE.md",             api: ap)
+          files << g("gemspec.erb",  "#{ap.gem_name}.gemspec", api: ap)
+          files << g("gemfile.erb",  "Gemfile",                api: ap)
+          files << g("rakefile.erb", "Rakefile",               api: ap)
+          files << g("rubocop.erb",  ".rubocop",               api: ap)
+          files << g("license.erb",  "LICENSE.md",             api: ap)
 
           files
+        end
+
+        private
+
+        ##
+        # Override the default rubocop config file to be used.
+        def format_config
+          # TODO: Allow this file to be overriden in the configuration
+          File.expand_path File.join __dir__, "../../../../.rubocop.yml"
         end
       end
     end

--- a/gapic-generator-cloud/lib/google/gapic/generators/cloud_generator.rb
+++ b/gapic-generator-cloud/lib/google/gapic/generators/cloud_generator.rb
@@ -76,8 +76,8 @@ module Google
         ##
         # Override the default rubocop config file to be used.
         def format_config
-          # TODO: Allow this file to be overriden in the configuration
-          File.expand_path File.join __dir__, "../../../../.rubocop.yml"
+          @api.configuration[:format_config] ||
+            File.expand_path File.join __dir__, "../../../../.rubocop.yml"
         end
       end
     end

--- a/gapic-generator-cloud/templates/cloud/client/_client.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_client.erb
@@ -6,7 +6,7 @@ require "pathname"
 require "googleauth"
 require "google/gax"
 <%- if service.client_lro? -%>
-<%= render partial: "client/lro/requires", locals: { service: service } %>
+<%= render partial: "client/lro/requires", locals: { service: service } -%>
 <%- end -%>
 
 require "<%= service.service_proto_require %>"

--- a/gapic-generator-cloud/templates/cloud/rakefile.erb
+++ b/gapic-generator-cloud/templates/cloud/rakefile.erb
@@ -139,7 +139,7 @@ namespace :ci do
   end
 end
 
-task :default => :test
+task default: :test
 
 def header str, token = "#"
   line_length = str.length + 8

--- a/gapic-generator/.rubocop.yml
+++ b/gapic-generator/.rubocop.yml
@@ -17,3 +17,5 @@ Style/MethodCallWithArgsParentheses:
   AllowParenthesesInMultilineCall: true
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
+Style/Alias:
+  EnforcedStyle: prefer_alias_method

--- a/gapic-generator/gem_templates/generator.erb
+++ b/gapic-generator/gem_templates/generator.erb
@@ -35,8 +35,8 @@ module Google
           files = []
 
           api_services(@api).each do |service|
-            files << cop(gen("client.erb", ruby_file_path(service),
-                             api: @api, service: service))
+            files << g("client.erb", ruby_file_path(service),
+                       api: @api, service: service, format: true)
           end
 
           files

--- a/gapic-generator/gem_templates/generator.erb
+++ b/gapic-generator/gem_templates/generator.erb
@@ -36,7 +36,7 @@ module Google
 
           api_services(@api).each do |service|
             files << g("client.erb", ruby_file_path(service),
-                       api: @api, service: service, format: true)
+                       api: @api, service: service)
           end
 
           files

--- a/gapic-generator/lib/google/gapic/generators/base_generator.rb
+++ b/gapic-generator/lib/google/gapic/generators/base_generator.rb
@@ -76,12 +76,12 @@ module Google
           file = Google::Protobuf::Compiler::CodeGeneratorResponse::File.new(
             name: filename, content: content
           )
-          format_file! file if format
+          format_file file if format
           file
         end
         alias_method :g, :generate_file
 
-        def format_file! file
+        def format_file file
           require "tmpdir"
           require "fileutils"
           Dir.mktmpdir do |dir|

--- a/gapic-generator/lib/google/gapic/generators/default_generator.rb
+++ b/gapic-generator/lib/google/gapic/generators/default_generator.rb
@@ -49,35 +49,11 @@ module Google
           files = []
 
           api_services(@api).each do |service|
-            files << cop(gen("client.erb", ruby_file_path(service),
-                             api: @api, service: service))
+            files << g("client.erb", ruby_file_path(service),
+                       api: @api, service: service, format: true)
           end
 
           files
-        end
-
-        private
-
-        def cop file
-          Tempfile.open ["input", ".rb"] do |input|
-            Tempfile.open ["output", ".rb"] do |output|
-              input.write file.content
-
-              # Autocorrect file with rubocop.
-              # TODO(landrito) make this call system agnostic.
-              system "rubocop --auto-correct #{input.path} -o #{output.path}" \
-                " -c #{rubocop_filepath}"
-
-              # Read the corrected file.
-              input.rewind
-              file.content = input.read
-            end
-          end
-          file
-        end
-
-        def rubocop_filepath
-          File.expand_path File.join __dir__, "../../../../.rubocop.yml"
         end
       end
     end

--- a/gapic-generator/lib/google/gapic/generators/default_generator.rb
+++ b/gapic-generator/lib/google/gapic/generators/default_generator.rb
@@ -50,7 +50,7 @@ module Google
 
           api_services(@api).each do |service|
             files << g("client.erb", ruby_file_path(service),
-                       api: @api, service: service, format: true)
+                       api: @api, service: service)
           end
 
           files

--- a/shared/output/cloud/showcase/Rakefile
+++ b/shared/output/cloud/showcase/Rakefile
@@ -63,7 +63,7 @@ end
 
 # Acceptance tests
 desc "Run the google-showcase acceptance tests."
-task :acceptance, :project, :keyfile do |t, args|
+task :acceptance, :project, :keyfile do |_t, args|
   project = args[:project]
   project ||=
     ENV["SHOWCASE_TEST_PROJECT"] ||
@@ -80,7 +80,7 @@ task :acceptance, :project, :keyfile do |t, args|
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or SHOWCASE_TEST_PROJECT=test123 SHOWCASE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    raise "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or SHOWCASE_TEST_PROJECT=test123 SHOWCASE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
 
   ENV["SHOWCASE_CREDENTIALS"] = nil
@@ -151,7 +151,7 @@ namespace :ci do
   end
 end
 
-task :default => :test
+task default: :test
 
 def header str, token = "#"
   line_length = str.length + 8

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo.rb
@@ -22,7 +22,6 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
-
 require "google/showcase/v1alpha3/echo_pb"
 
 module Google

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+
 require "google/showcase/v1alpha3/echo_pb"
 
 module Google
@@ -126,12 +127,12 @@ module Google
             credentials ||= Credentials.default
 
             @operations_client = OperationsClient.new(
-              credentials: credentials,
-              scopes: scopes,
+              credentials:   credentials,
+              scopes:        scopes,
               client_config: client_config,
-              timeout: timeout,
-              lib_name: lib_name,
-              lib_version: lib_version
+              timeout:       timeout,
+              lib_name:      lib_name,
+              lib_version:   lib_version
             )
             @echo_stub = create_stub credentials, scopes
 
@@ -198,9 +199,7 @@ module Google
           #   TODO
           #
           def echo request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -239,9 +238,7 @@ module Google
           #   TODO
           #
           def expand request = nil, options: nil, **request_fields
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -274,9 +271,7 @@ module Google
           #   TODO
           #
           def collect requests, options: nil, &block
-            unless requests.is_a? Enumerable
-              raise ArgumentError, "requests must be an Enumerable"
-            end
+            raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
@@ -304,9 +299,7 @@ module Google
           #   TODO
           #
           def chat requests, options: nil
-            unless requests.is_a? Enumerable
-              raise ArgumentError, "requests must be an Enumerable"
-            end
+            raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
@@ -346,9 +339,7 @@ module Google
           #   TODO
           #
           def paged_expand request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -392,9 +383,7 @@ module Google
           #   TODO
           #
           def wait request = nil, options: nil, **request_fields
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -434,10 +423,10 @@ module Google
             Google::Gax::Grpc.create_stub(
               service_path,
               port,
-              chan_creds: chan_creds,
-              channel: channel,
+              chan_creds:   chan_creds,
+              channel:      channel,
               updater_proc: updater_proc,
-              scopes: scopes,
+              scopes:       scopes,
               interceptors: interceptors,
               &stub_new
             )

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity.rb
@@ -22,7 +22,6 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
-
 require "google/showcase/v1alpha3/identity_pb"
 
 module Google

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+
 require "google/showcase/v1alpha3/identity_pb"
 
 module Google
@@ -126,12 +127,12 @@ module Google
             credentials ||= Credentials.default
 
             @operations_client = OperationsClient.new(
-              credentials: credentials,
-              scopes: scopes,
+              credentials:   credentials,
+              scopes:        scopes,
               client_config: client_config,
-              timeout: timeout,
-              lib_name: lib_name,
-              lib_version: lib_version
+              timeout:       timeout,
+              lib_name:      lib_name,
+              lib_version:   lib_version
             )
             @identity_stub = create_stub credentials, scopes
 
@@ -191,9 +192,7 @@ module Google
           #   TODO
           #
           def create_user request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -229,9 +228,7 @@ module Google
           #   TODO
           #
           def get_user request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -270,9 +267,7 @@ module Google
           #   TODO
           #
           def update_user request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -308,9 +303,7 @@ module Google
           #   TODO
           #
           def delete_user request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -351,9 +344,7 @@ module Google
           #   TODO
           #
           def list_users request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -387,10 +378,10 @@ module Google
             Google::Gax::Grpc.create_stub(
               service_path,
               port,
-              chan_creds: chan_creds,
-              channel: channel,
+              chan_creds:   chan_creds,
+              channel:      channel,
               updater_proc: updater_proc,
-              scopes: scopes,
+              scopes:       scopes,
               interceptors: interceptors,
               &stub_new
             )

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging.rb
@@ -22,7 +22,6 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
-
 require "google/showcase/v1alpha3/messaging_pb"
 
 module Google

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+
 require "google/showcase/v1alpha3/messaging_pb"
 
 module Google
@@ -126,12 +127,12 @@ module Google
             credentials ||= Credentials.default
 
             @operations_client = OperationsClient.new(
-              credentials: credentials,
-              scopes: scopes,
+              credentials:   credentials,
+              scopes:        scopes,
               client_config: client_config,
-              timeout: timeout,
-              lib_name: lib_name,
-              lib_version: lib_version
+              timeout:       timeout,
+              lib_name:      lib_name,
+              lib_version:   lib_version
             )
             @messaging_stub = create_stub credentials, scopes
 
@@ -236,9 +237,7 @@ module Google
           #   TODO
           #
           def create_room request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -274,9 +273,7 @@ module Google
           #   TODO
           #
           def get_room request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -315,9 +312,7 @@ module Google
           #   TODO
           #
           def update_room request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -353,9 +348,7 @@ module Google
           #   TODO
           #
           def delete_room request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -396,9 +389,7 @@ module Google
           #   TODO
           #
           def list_rooms request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -441,9 +432,7 @@ module Google
           #   TODO
           #
           def create_blurb request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -479,9 +468,7 @@ module Google
           #   TODO
           #
           def get_blurb request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -520,9 +507,7 @@ module Google
           #   TODO
           #
           def update_blurb request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -558,9 +543,7 @@ module Google
           #   TODO
           #
           def delete_blurb request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -606,9 +589,7 @@ module Google
           #   TODO
           #
           def list_blurbs request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -660,9 +641,7 @@ module Google
           #   TODO
           #
           def search_blurbs request = nil, options: nil, **request_fields
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -707,9 +686,7 @@ module Google
           #   TODO
           #
           def stream_blurbs request = nil, options: nil, **request_fields
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -741,9 +718,7 @@ module Google
           #   TODO
           #
           def send_blurbs requests, options: nil, &block
-            unless requests.is_a? Enumerable
-              raise ArgumentError, "requests must be an Enumerable"
-            end
+            raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
@@ -772,9 +747,7 @@ module Google
           #   TODO
           #
           def connect requests, options: nil
-            unless requests.is_a? Enumerable
-              raise ArgumentError, "requests must be an Enumerable"
-            end
+            raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::ConnectRequest
@@ -806,10 +779,10 @@ module Google
             Google::Gax::Grpc.create_stub(
               service_path,
               port,
-              chan_creds: chan_creds,
-              channel: channel,
+              chan_creds:   chan_creds,
+              channel:      channel,
               updater_proc: updater_proc,
-              scopes: scopes,
+              scopes:       scopes,
               interceptors: interceptors,
               &stub_new
             )

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+
 require "google/showcase/v1alpha3/testing_pb"
 
 module Google
@@ -126,12 +127,12 @@ module Google
             credentials ||= Credentials.default
 
             @operations_client = OperationsClient.new(
-              credentials: credentials,
-              scopes: scopes,
+              credentials:   credentials,
+              scopes:        scopes,
               client_config: client_config,
-              timeout: timeout,
-              lib_name: lib_name,
-              lib_version: lib_version
+              timeout:       timeout,
+              lib_name:      lib_name,
+              lib_version:   lib_version
             )
             @testing_stub = create_stub credentials, scopes
 
@@ -208,9 +209,7 @@ module Google
           #   TODO
           #
           def create_session request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -246,9 +245,7 @@ module Google
           #   TODO
           #
           def get_session request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -286,9 +283,7 @@ module Google
           #   TODO
           #
           def list_sessions request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -324,9 +319,7 @@ module Google
           #   TODO
           #
           def delete_session request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -366,9 +359,7 @@ module Google
           #   TODO
           #
           def report_session request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -408,9 +399,7 @@ module Google
           #   TODO
           #
           def list_tests request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -456,9 +445,7 @@ module Google
           #   TODO
           #
           def delete_test request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -504,9 +491,7 @@ module Google
           #   TODO
           #
           def verify_test request = nil, options: nil, **request_fields, &block
-            if request.nil? && request_fields.empty?
-              raise ArgumentError, "request must be provided"
-            end
+            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
@@ -540,10 +525,10 @@ module Google
             Google::Gax::Grpc.create_stub(
               service_path,
               port,
-              chan_creds: chan_creds,
-              channel: channel,
+              chan_creds:   chan_creds,
+              channel:      channel,
               updater_proc: updater_proc,
-              scopes: scopes,
+              scopes:       scopes,
               interceptors: interceptors,
               &stub_new
             )

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing.rb
@@ -22,7 +22,6 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
-
 require "google/showcase/v1alpha3/testing_pb"
 
 module Google

--- a/shared/output/cloud/showcase/test/google/showcase/v1alpha3/echo_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1alpha3/echo_test.rb
@@ -449,8 +449,8 @@ describe Google::Showcase::V1alpha3::Echo do
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/wait_test",
-        done: true,
+        name:     "operations/wait_test",
+        done:     true,
         response: result
       )
 
@@ -493,8 +493,8 @@ describe Google::Showcase::V1alpha3::Echo do
         message: "Operation error for Google::Showcase::V1alpha3::Echo#wait."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/wait_test",
-        done: true,
+        name:  "operations/wait_test",
+        done:  true,
         error: operation_error
       )
 

--- a/shared/output/cloud/showcase/test/google/showcase/v1alpha3/messaging_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1alpha3/messaging_test.rb
@@ -866,8 +866,8 @@ describe Google::Showcase::V1alpha3::Messaging do
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/search_blurbs_test",
-        done: true,
+        name:     "operations/search_blurbs_test",
+        done:     true,
         response: result
       )
 
@@ -910,8 +910,8 @@ describe Google::Showcase::V1alpha3::Messaging do
         message: "Operation error for Google::Showcase::V1alpha3::Messaging#search_blurbs."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/search_blurbs_test",
-        done: true,
+        name:  "operations/search_blurbs_test",
+        done:  true,
         error: operation_error
       )
 

--- a/shared/output/cloud/speech/Rakefile
+++ b/shared/output/cloud/speech/Rakefile
@@ -63,7 +63,7 @@ end
 
 # Acceptance tests
 desc "Run the google-cloud-speech acceptance tests."
-task :acceptance, :project, :keyfile do |t, args|
+task :acceptance, :project, :keyfile do |_t, args|
   project = args[:project]
   project ||=
     ENV["SPEECH_TEST_PROJECT"] ||
@@ -80,7 +80,7 @@ task :acceptance, :project, :keyfile do |t, args|
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or SPEECH_TEST_PROJECT=test123 SPEECH_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    raise "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or SPEECH_TEST_PROJECT=test123 SPEECH_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
 
   ENV["SPEECH_CREDENTIALS"] = nil
@@ -151,7 +151,7 @@ namespace :ci do
   end
 end
 
-task :default => :test
+task default: :test
 
 def header str, token = "#"
   line_length = str.length + 8

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+
 require "google/cloud/speech/v1/cloud_speech_pb"
 
 module Google
@@ -127,12 +128,12 @@ module Google
               credentials ||= Credentials.default
 
               @operations_client = OperationsClient.new(
-                credentials: credentials,
-                scopes: scopes,
+                credentials:   credentials,
+                scopes:        scopes,
                 client_config: client_config,
-                timeout: timeout,
-                lib_name: lib_name,
-                lib_version: lib_version
+                timeout:       timeout,
+                lib_name:      lib_name,
+                lib_version:   lib_version
               )
               @speech_stub = create_stub credentials, scopes
 
@@ -187,9 +188,7 @@ module Google
             #   TODO
             #
             def recognize request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -233,9 +232,7 @@ module Google
             #   TODO
             #
             def long_running_recognize request = nil, options: nil, **request_fields
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -270,9 +267,7 @@ module Google
             #   TODO
             #
             def streaming_recognize requests, options: nil
-              unless requests.is_a? Enumerable
-                raise ArgumentError, "requests must be an Enumerable"
-              end
+              raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
 
               requests = requests.lazy.map do |request|
                 Google::Gax.to_proto request, Google::Cloud::Speech::V1::StreamingRecognizeRequest
@@ -304,10 +299,10 @@ module Google
               Google::Gax::Grpc.create_stub(
                 service_path,
                 port,
-                chan_creds: chan_creds,
-                channel: channel,
+                chan_creds:   chan_creds,
+                channel:      channel,
                 updater_proc: updater_proc,
-                scopes: scopes,
+                scopes:       scopes,
                 interceptors: interceptors,
                 &stub_new
               )

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech.rb
@@ -22,7 +22,6 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
-
 require "google/cloud/speech/v1/cloud_speech_pb"
 
 module Google

--- a/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
@@ -160,8 +160,8 @@ describe Google::Cloud::Speech::V1::Speech do
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/long_running_recognize_test",
-        done: true,
+        name:     "operations/long_running_recognize_test",
+        done:     true,
         response: result
       )
 
@@ -200,8 +200,8 @@ describe Google::Cloud::Speech::V1::Speech do
         message: "Operation error for Google::Cloud::Speech::V1::Speech#long_running_recognize."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/long_running_recognize_test",
-        done: true,
+        name:  "operations/long_running_recognize_test",
+        done:  true,
         error: operation_error
       )
 

--- a/shared/output/cloud/vision/Rakefile
+++ b/shared/output/cloud/vision/Rakefile
@@ -63,7 +63,7 @@ end
 
 # Acceptance tests
 desc "Run the google-cloud-vision acceptance tests."
-task :acceptance, :project, :keyfile do |t, args|
+task :acceptance, :project, :keyfile do |_t, args|
   project = args[:project]
   project ||=
     ENV["VISION_TEST_PROJECT"] ||
@@ -80,7 +80,7 @@ task :acceptance, :project, :keyfile do |t, args|
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or VISION_TEST_PROJECT=test123 VISION_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    raise "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or VISION_TEST_PROJECT=test123 VISION_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
 
   ENV["VISION_CREDENTIALS"] = nil
@@ -151,7 +151,7 @@ namespace :ci do
   end
 end
 
-task :default => :test
+task default: :test
 
 def header str, token = "#"
   line_length = str.length + 8

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator.rb
@@ -22,7 +22,6 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
-
 require "google/cloud/vision/v1/image_annotator_pb"
 
 module Google

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+
 require "google/cloud/vision/v1/image_annotator_pb"
 
 module Google
@@ -127,12 +128,12 @@ module Google
               credentials ||= Credentials.default
 
               @operations_client = OperationsClient.new(
-                credentials: credentials,
-                scopes: scopes,
+                credentials:   credentials,
+                scopes:        scopes,
                 client_config: client_config,
-                timeout: timeout,
-                lib_name: lib_name,
-                lib_version: lib_version
+                timeout:       timeout,
+                lib_name:      lib_name,
+                lib_version:   lib_version
               )
               @image_annotator_stub = create_stub credentials, scopes
 
@@ -177,9 +178,7 @@ module Google
             #   TODO
             #
             def batch_annotate_images request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -224,9 +223,7 @@ module Google
             #   TODO
             #
             def async_batch_annotate_files request = nil, options: nil, **request_fields
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -266,10 +263,10 @@ module Google
               Google::Gax::Grpc.create_stub(
                 service_path,
                 port,
-                chan_creds: chan_creds,
-                channel: channel,
+                chan_creds:   chan_creds,
+                channel:      channel,
                 updater_proc: updater_proc,
-                scopes: scopes,
+                scopes:       scopes,
                 interceptors: interceptors,
                 &stub_new
               )

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+
 require "google/cloud/vision/v1/product_search_service_pb"
 
 module Google
@@ -127,12 +128,12 @@ module Google
               credentials ||= Credentials.default
 
               @operations_client = OperationsClient.new(
-                credentials: credentials,
-                scopes: scopes,
+                credentials:   credentials,
+                scopes:        scopes,
                 client_config: client_config,
-                timeout: timeout,
-                lib_name: lib_name,
-                lib_version: lib_version
+                timeout:       timeout,
+                lib_name:      lib_name,
+                lib_version:   lib_version
               )
               @product_search_stub = create_stub credentials, scopes
 
@@ -276,9 +277,7 @@ module Google
             #   TODO
             #
             def create_product_set request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -330,9 +329,7 @@ module Google
             #   TODO
             #
             def list_product_sets request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -379,9 +376,7 @@ module Google
             #   TODO
             #
             def get_product_set request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -436,9 +431,7 @@ module Google
             #   TODO
             #
             def update_product_set request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -491,9 +484,7 @@ module Google
             #   TODO
             #
             def delete_product_set request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -553,9 +544,7 @@ module Google
             #   TODO
             #
             def create_product request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -606,9 +595,7 @@ module Google
             #   TODO
             #
             def list_products request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -655,9 +642,7 @@ module Google
             #   TODO
             #
             def get_product request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -728,9 +713,7 @@ module Google
             #   TODO
             #
             def update_product request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -785,9 +768,7 @@ module Google
             #   TODO
             #
             def delete_product request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -870,9 +851,7 @@ module Google
             #   TODO
             #
             def create_reference_image request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -932,9 +911,7 @@ module Google
             #   TODO
             #
             def delete_reference_image request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -992,9 +969,7 @@ module Google
             #   TODO
             #
             def list_reference_images request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -1042,9 +1017,7 @@ module Google
             #   TODO
             #
             def get_reference_image request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -1102,9 +1075,7 @@ module Google
             #   TODO
             #
             def add_product_to_product_set request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -1156,9 +1127,7 @@ module Google
             #   TODO
             #
             def remove_product_from_product_set request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -1213,9 +1182,7 @@ module Google
             #   TODO
             #
             def list_products_in_product_set request = nil, options: nil, **request_fields, &block
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -1274,9 +1241,7 @@ module Google
             #   TODO
             #
             def import_product_sets request = nil, options: nil, **request_fields
-              if request.nil? && request_fields.empty?
-                raise ArgumentError, "request must be provided"
-              end
+              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
@@ -1316,10 +1281,10 @@ module Google
               Google::Gax::Grpc.create_stub(
                 service_path,
                 port,
-                chan_creds: chan_creds,
-                channel: channel,
+                chan_creds:   chan_creds,
+                channel:      channel,
                 updater_proc: updater_proc,
-                scopes: scopes,
+                scopes:       scopes,
                 interceptors: interceptors,
                 &stub_new
               )

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search.rb
@@ -22,7 +22,6 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
-
 require "google/cloud/vision/v1/product_search_service_pb"
 
 module Google

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -155,8 +155,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator do
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/async_batch_annotate_files_test",
-        done: true,
+        name:     "operations/async_batch_annotate_files_test",
+        done:     true,
         response: result
       )
 
@@ -193,8 +193,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator do
         message: "Operation error for Google::Cloud::Vision::V1::ImageAnnotator#async_batch_annotate_files."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/async_batch_annotate_files_test",
-        done: true,
+        name:  "operations/async_batch_annotate_files_test",
+        done:  true,
         error: operation_error
       )
 

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
@@ -1444,8 +1444,8 @@ describe Google::Cloud::Vision::V1::ProductSearch do
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/import_product_sets_test",
-        done: true,
+        name:     "operations/import_product_sets_test",
+        done:     true,
         response: result
       )
 
@@ -1484,8 +1484,8 @@ describe Google::Cloud::Vision::V1::ProductSearch do
         message: "Operation error for Google::Cloud::Vision::V1::ProductSearch#import_product_sets."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/import_product_sets_test",
-        done: true,
+        name:  "operations/import_product_sets_test",
+        done:  true,
         error: operation_error
       )
 

--- a/shared/output/gapic/gems/my_plugin/lib/google/gapic/generators/my_plugin_generator.rb
+++ b/shared/output/gapic/gems/my_plugin/lib/google/gapic/generators/my_plugin_generator.rb
@@ -48,8 +48,8 @@ module Google
           files = []
 
           api_services(@api).each do |service|
-            files << cop(gen("client.erb", ruby_file_path(service),
-                             api: @api, service: service))
+            files << g("client.erb", ruby_file_path(service),
+                       api: @api, service: service, format: true)
           end
 
           files

--- a/shared/output/gapic/gems/my_plugin/lib/google/gapic/generators/my_plugin_generator.rb
+++ b/shared/output/gapic/gems/my_plugin/lib/google/gapic/generators/my_plugin_generator.rb
@@ -49,7 +49,7 @@ module Google
 
           api_services(@api).each do |service|
             files << g("client.erb", ruby_file_path(service),
-                       api: @api, service: service, format: true)
+                       api: @api, service: service)
           end
 
           files


### PR DESCRIPTION
Move the formatter into the base generator.
Rename the generate_file method, add convenience name as alias.
Add config method that allows plugin generators to override
the location of the configuration file to use to format.
Add formatter code as separate method so it can also be
overridden. (Hi, rubyfmt)
Fix the formatter so it works in the cloud generator.