### PR TITLE
Add a gem version file and constant

### DIFF
--- a/gapic-generator-cloud/lib/google/gapic/generators/cloud_generator.rb
+++ b/gapic-generator-cloud/lib/google/gapic/generators/cloud_generator.rb
@@ -61,7 +61,8 @@ module Google
             end
           end
 
-          # Api level files
+          # Gem level files
+          files << g("version.erb", "lib/#{ap.gem_version_file_path}", api: ap)
           files << g("gemspec.erb",  "#{ap.gem_name}.gemspec", api: ap)
           files << g("gemfile.erb",  "Gemfile",                api: ap)
           files << g("rakefile.erb", "Rakefile",               api: ap)

--- a/gapic-generator-cloud/templates/cloud/client/_client.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_client.erb
@@ -9,6 +9,7 @@ require "google/gax"
 <%= render partial: "client/lro/requires", locals: { service: service } -%>
 <%- end -%>
 
+require "<%= service.api.gem_version_require %>"
 require "<%= service.service_proto_require %>"
 <% end %>
 class <%= service.credentials_class_name %> < Google::Auth::Credentials
@@ -98,12 +99,9 @@ class <%= service.client_class_name %>
 
   def default_settings client_config, timeout, metadata, lib_name,
                         lib_version
-    package_gem = Gem.loaded_specs["<%= service.api.gem_name %>"]
-    package_version = package_gem ? package_gem.version.version : nil
-
     google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
     google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-    google_api_client << "gapic/#{package_version}" if package_version
+    google_api_client << "gapic/#{<%= service.api.gem_version_name_full %>}"
     google_api_client << "gax/#{Google::Gax::VERSION}"
     google_api_client << "grpc/#{GRPC::VERSION}"
     google_api_client.join " "

--- a/gapic-generator-cloud/templates/cloud/gemspec.erb
+++ b/gapic-generator-cloud/templates/cloud/gemspec.erb
@@ -1,6 +1,7 @@
 <%- assert_locals api -%>
 # -*- ruby -*-
 # encoding: utf-8
+require File.expand_path("../lib/<%= api.gem_version_require %>", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = "<%= api.gem_name %>"

--- a/gapic-generator-cloud/templates/cloud/gemspec.erb
+++ b/gapic-generator-cloud/templates/cloud/gemspec.erb
@@ -5,7 +5,7 @@ require File.expand_path("../lib/<%= api.gem_version_require %>", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = "<%= api.gem_name %>"
-  gem.version       = "0.32.0"
+  gem.version       = <%= api.gem_version_name_full %>
 
   gem.authors       = <%= api.gem_authors.inspect %>
   gem.email         = <%= api.gem_email.inspect %>

--- a/gapic-generator-cloud/templates/cloud/helpers/presenters/api_presenter.rb
+++ b/gapic-generator-cloud/templates/cloud/helpers/presenters/api_presenter.rb
@@ -36,6 +36,10 @@ class ApiPresenter
     end
   end
 
+  def namespaces
+    gem_name.split("-").map(&:classify)
+  end
+
   def gem_name
     @api.configuration[:gem_name] #|| gem_address.join("-")
     # TODO: Infer the gem name from all the package strings
@@ -51,6 +55,23 @@ class ApiPresenter
 
     @api.configuration[:gem_title] ||
       gem_name.split("-").map(&:classify).join(" ")
+  end
+
+  def gem_version
+    @api.configuration[:gem_version] ||
+      "0.0.1"
+  end
+
+  def gem_version_require
+    "#{gem_name.gsub("-", "/")}/version"
+  end
+
+  def gem_version_file_path
+    "#{gem_version_require}.rb"
+  end
+
+  def gem_version_name_full
+    gem_name.split("-").map(&:classify).join("::") + "::VERSION"
   end
 
   def gem_authors

--- a/gapic-generator-cloud/templates/cloud/helpers/presenters/service_presenter.rb
+++ b/gapic-generator-cloud/templates/cloud/helpers/presenters/service_presenter.rb
@@ -32,7 +32,7 @@ class ServicePresenter
   end
 
   def package
-    PackagePresenter.new @service.parent.parent, service.package
+    PackagePresenter.new @service.parent.parent, @service.parent.package
   end
 
   def methods

--- a/gapic-generator-cloud/templates/cloud/package/_version.erb
+++ b/gapic-generator-cloud/templates/cloud/package/_version.erb
@@ -1,0 +1,2 @@
+<%- assert_locals package -%>
+VERSION = "<%= package.gem_version %>"

--- a/gapic-generator-cloud/templates/cloud/package/_version.erb
+++ b/gapic-generator-cloud/templates/cloud/package/_version.erb
@@ -1,2 +1,2 @@
-<%- assert_locals package -%>
-VERSION = "<%= package.gem_version %>"
+<%- assert_locals api -%>
+VERSION = "<%= api.gem_version %>"

--- a/gapic-generator-cloud/templates/cloud/version.erb
+++ b/gapic-generator-cloud/templates/cloud/version.erb
@@ -1,0 +1,6 @@
+<%- assert_locals api -%>
+<%= render partial: "package/version",
+           layout: "layouts/ruby",
+           locals: { package: api,
+                     namespaces: api.namespaces }
+%>

--- a/gapic-generator-cloud/templates/cloud/version.erb
+++ b/gapic-generator-cloud/templates/cloud/version.erb
@@ -1,6 +1,6 @@
 <%- assert_locals api -%>
 <%= render partial: "package/version",
            layout: "layouts/ruby",
-           locals: { package: api,
+           locals: { api: api,
                      namespaces: api.namespaces }
 %>

--- a/shared/output/cloud/showcase/google-showcase.gemspec
+++ b/shared/output/cloud/showcase/google-showcase.gemspec
@@ -1,6 +1,8 @@
 # -*- ruby -*-
 # encoding: utf-8
 
+require File.expand_path("lib/google/showcase/version", __dir__)
+
 Gem::Specification.new do |gem|
   gem.name          = "google-showcase"
   gem.version       = "0.32.0"

--- a/shared/output/cloud/showcase/google-showcase.gemspec
+++ b/shared/output/cloud/showcase/google-showcase.gemspec
@@ -5,7 +5,7 @@ require File.expand_path("lib/google/showcase/version", __dir__)
 
 Gem::Specification.new do |gem|
   gem.name          = "google-showcase"
-  gem.version       = "0.32.0"
+  gem.version       = Google::Showcase::VERSION
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+require "google/showcase/version"
 require "google/showcase/v1alpha3/echo_pb"
 
 module Google
@@ -433,12 +434,9 @@ module Google
 
           def default_settings _client_config, _timeout, metadata, lib_name,
                                lib_version
-            package_gem = Gem.loaded_specs["google-showcase"]
-            package_version = package_gem ? package_gem.version.version : nil
-
             google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
             google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-            google_api_client << "gapic/#{package_version}" if package_version
+            google_api_client << "gapic/#{Google::Showcase::VERSION}"
             google_api_client << "gax/#{Google::Gax::VERSION}"
             google_api_client << "grpc/#{GRPC::VERSION}"
             google_api_client.join " "

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+require "google/showcase/version"
 require "google/showcase/v1alpha3/identity_pb"
 
 module Google
@@ -388,12 +389,9 @@ module Google
 
           def default_settings _client_config, _timeout, metadata, lib_name,
                                lib_version
-            package_gem = Gem.loaded_specs["google-showcase"]
-            package_version = package_gem ? package_gem.version.version : nil
-
             google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
             google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-            google_api_client << "gapic/#{package_version}" if package_version
+            google_api_client << "gapic/#{Google::Showcase::VERSION}"
             google_api_client << "gax/#{Google::Gax::VERSION}"
             google_api_client << "grpc/#{GRPC::VERSION}"
             google_api_client.join " "

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+require "google/showcase/version"
 require "google/showcase/v1alpha3/messaging_pb"
 
 module Google
@@ -789,12 +790,9 @@ module Google
 
           def default_settings _client_config, _timeout, metadata, lib_name,
                                lib_version
-            package_gem = Gem.loaded_specs["google-showcase"]
-            package_version = package_gem ? package_gem.version.version : nil
-
             google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
             google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-            google_api_client << "gapic/#{package_version}" if package_version
+            google_api_client << "gapic/#{Google::Showcase::VERSION}"
             google_api_client << "gax/#{Google::Gax::VERSION}"
             google_api_client << "grpc/#{GRPC::VERSION}"
             google_api_client.join " "

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+require "google/showcase/version"
 require "google/showcase/v1alpha3/testing_pb"
 
 module Google
@@ -535,12 +536,9 @@ module Google
 
           def default_settings _client_config, _timeout, metadata, lib_name,
                                lib_version
-            package_gem = Gem.loaded_specs["google-showcase"]
-            package_version = package_gem ? package_gem.version.version : nil
-
             google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
             google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-            google_api_client << "gapic/#{package_version}" if package_version
+            google_api_client << "gapic/#{Google::Showcase::VERSION}"
             google_api_client << "gax/#{Google::Gax::VERSION}"
             google_api_client << "grpc/#{GRPC::VERSION}"
             google_api_client.join " "

--- a/shared/output/cloud/showcase/lib/google/showcase/version.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/version.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Showcase
+    VERSION = "0.0.1"
+  end
+end

--- a/shared/output/cloud/speech/google-cloud-speech.gemspec
+++ b/shared/output/cloud/speech/google-cloud-speech.gemspec
@@ -1,6 +1,8 @@
 # -*- ruby -*-
 # encoding: utf-8
 
+require File.expand_path("lib/google/cloud/speech/version", __dir__)
+
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-speech"
   gem.version       = "0.32.0"

--- a/shared/output/cloud/speech/google-cloud-speech.gemspec
+++ b/shared/output/cloud/speech/google-cloud-speech.gemspec
@@ -5,7 +5,7 @@ require File.expand_path("lib/google/cloud/speech/version", __dir__)
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-speech"
-  gem.version       = "0.32.0"
+  gem.version       = Google::Cloud::Speech::VERSION
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+require "google/cloud/speech/version"
 require "google/cloud/speech/v1/cloud_speech_pb"
 
 module Google
@@ -309,12 +310,9 @@ module Google
 
             def default_settings _client_config, _timeout, metadata, lib_name,
                                  lib_version
-              package_gem = Gem.loaded_specs["google-cloud-speech"]
-              package_version = package_gem ? package_gem.version.version : nil
-
               google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
               google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-              google_api_client << "gapic/#{package_version}" if package_version
+              google_api_client << "gapic/#{Google::Cloud::Speech::VERSION}"
               google_api_client << "gax/#{Google::Gax::VERSION}"
               google_api_client << "grpc/#{GRPC::VERSION}"
               google_api_client.join " "

--- a/shared/output/cloud/speech/lib/google/cloud/speech/version.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/version.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Cloud
+    module Speech
+      VERSION = "0.0.1"
+    end
+  end
+end

--- a/shared/output/cloud/vision/google-cloud-vision.gemspec
+++ b/shared/output/cloud/vision/google-cloud-vision.gemspec
@@ -5,7 +5,7 @@ require File.expand_path("lib/google/cloud/vision/version", __dir__)
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-vision"
-  gem.version       = "0.32.0"
+  gem.version       = Google::Cloud::Vision::VERSION
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/shared/output/cloud/vision/google-cloud-vision.gemspec
+++ b/shared/output/cloud/vision/google-cloud-vision.gemspec
@@ -1,6 +1,8 @@
 # -*- ruby -*-
 # encoding: utf-8
 
+require File.expand_path("lib/google/cloud/vision/version", __dir__)
+
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-vision"
   gem.version       = "0.32.0"

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+require "google/cloud/vision/version"
 require "google/cloud/vision/v1/image_annotator_pb"
 
 module Google
@@ -273,12 +274,9 @@ module Google
 
             def default_settings _client_config, _timeout, metadata, lib_name,
                                  lib_version
-              package_gem = Gem.loaded_specs["google-cloud-vision"]
-              package_version = package_gem ? package_gem.version.version : nil
-
               google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
               google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-              google_api_client << "gapic/#{package_version}" if package_version
+              google_api_client << "gapic/#{Google::Cloud::Vision::VERSION}"
               google_api_client << "gax/#{Google::Gax::VERSION}"
               google_api_client << "grpc/#{GRPC::VERSION}"
               google_api_client.join " "

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search.rb
@@ -22,6 +22,7 @@ require "google/gax"
 require "google/gax/operation"
 require "google/longrunning/operations_client"
 
+require "google/cloud/vision/version"
 require "google/cloud/vision/v1/product_search_service_pb"
 
 module Google
@@ -1291,12 +1292,9 @@ module Google
 
             def default_settings _client_config, _timeout, metadata, lib_name,
                                  lib_version
-              package_gem = Gem.loaded_specs["google-cloud-vision"]
-              package_version = package_gem ? package_gem.version.version : nil
-
               google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
               google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-              google_api_client << "gapic/#{package_version}" if package_version
+              google_api_client << "gapic/#{Google::Cloud::Vision::VERSION}"
               google_api_client << "gax/#{Google::Gax::VERSION}"
               google_api_client << "grpc/#{GRPC::VERSION}"
               google_api_client.join " "

--- a/shared/output/cloud/vision/lib/google/cloud/vision/version.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/version.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Cloud
+    module Vision
+      VERSION = "0.0.1"
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a version file and a `VERSION` constant that is used in the client's grpc headers instead of looking up the gem version from RubyGems.