### PR TITLE
Add Paths module for a service

### DIFF
--- a/gapic-generator-cloud/lib/google/gapic/generators/cloud_generator.rb
+++ b/gapic-generator-cloud/lib/google/gapic/generators/cloud_generator.rb
@@ -65,6 +65,9 @@ module Google
               files << g("client/credentials.erb",
                          "lib/#{service.credentials_class_file_path}",
                          service: service)
+              files << g("client/paths.erb",
+                         "lib/#{service.paths_file_path}",
+                         service: service) if service.paths?
               files << g("client_test.erb",
                          "test/#{service.client_test_file_path}",
                          service: service)

--- a/gapic-generator-cloud/templates/cloud/client/_class.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_class.erb
@@ -19,7 +19,6 @@ require "<%= service.paths_require %>"
 class <%= service.client_class_name %>
 <%- if service.paths? -%>
   include <%= service.paths_name %>
-  extend <%= service.paths_name %>
 
 <%- end -%>
   # @private

--- a/gapic-generator-cloud/templates/cloud/client/_class.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_class.erb
@@ -11,9 +11,17 @@ require "google/gax"
 require "<%= service.gem.version_require %>"
 require "<%= service.service_proto_require %>"
 require "<%= service.credentials_class_require %>"
+<%- if service.paths? -%>
+require "<%= service.paths_require %>"
+<%- end -%>
 <% end %>
 # Service that implements <%= service.name %> API.
 class <%= service.client_class_name %>
+<%- if service.paths? -%>
+  include <%= service.paths_name %>
+  extend <%= service.paths_name %>
+
+<%- end -%>
   # @private
   attr_reader :<%= service.stub_name %>
 

--- a/gapic-generator-cloud/templates/cloud/client/_paths.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_paths.erb
@@ -1,0 +1,7 @@
+<%- assert_locals service -%>
+module Paths
+<%- service.references.each do |resource| -%>
+<%= indent render(partial: "client/resource", locals: { resource: resource }), 2 %>
+
+<%- end %>
+end

--- a/gapic-generator-cloud/templates/cloud/client/_resource.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_resource.erb
@@ -6,21 +6,20 @@
 #
 # `<%= resource.template %>`
 #
-<%- (resource.positional_args + resource.named_args).each do |name, _regexp, msg| -%>
-# @param <%= name %> [String]
-<%- if msg -%>
-#   <%= msg %>
+<%- resource.arguments.each do |arg| -%>
+# @param <%= arg.name %> [String]
+<%- if arg.msg -%>
+#   <%= arg.msg %>
 <%- end -%>
 <%- end -%>
 #
 # @return [String]
-<%- args = resource.positional_args.map(&:first) -%>
-<%- args += resource.named_args.map(&:first).map { |a| "#{a}:"} -%>
+<%- args = resource.arguments.map { |arg| "#{arg.name}:" } -%>
 def <%= resource.path_helper %> <%= args.join ", " %>
-<%- (resource.positional_args + resource.named_args).each do |name, regexp, msg| -%>
-  raise ArgumentError, "<%= name %> is required" if <%= name %>.nil?
-<%- if regexp -%>
-  raise ArgumentError, "<%= msg %>" unless <%= regexp %>.match <%= name %>
+<%- resource.arguments.each do |arg| -%>
+  raise ArgumentError, "<%= arg.name %> is required" if <%= arg.name %>.nil?
+<%- if arg.regexp -%>
+  raise ArgumentError, "<%= arg.msg %>" unless <%= arg.regexp %>.match <%= arg.name %>
 <%- end -%>
 <%- end -%>
 

--- a/gapic-generator-cloud/templates/cloud/client/_resource.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_resource.erb
@@ -8,8 +8,8 @@
 #
 <%- resource.arguments.each do |arg| -%>
 # @param <%= arg.name %> [String]
-<%- if arg.msg -%>
-#   <%= arg.msg %>
+<%- if arg.desc -%>
+#   <%= arg.desc %>
 <%- end -%>
 <%- end -%>
 #
@@ -19,7 +19,7 @@ def <%= resource.path_helper %> <%= args.join ", " %>
 <%- resource.arguments.each do |arg| -%>
   raise ArgumentError, "<%= arg.name %> is required" if <%= arg.name %>.nil?
 <%- if arg.regexp -%>
-  raise ArgumentError, "<%= arg.msg %>" unless <%= arg.regexp %>.match <%= arg.name %>
+  raise ArgumentError, <%= arg.msg.inspect %> unless <%= arg.regexp %>.match <%= arg.name %>
 <%- end -%>
 <%- end -%>
 

--- a/gapic-generator-cloud/templates/cloud/client/_resource.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_resource.erb
@@ -1,0 +1,28 @@
+<%- assert_locals resource -%>
+##
+# Create a fully-qualified <%= resource.name %> resource string.
+#
+# The resource will be in the following format:
+#
+# `<%= resource.template %>`
+#
+<%- (resource.positional_args + resource.named_args).each do |name, _regexp, msg| -%>
+# @param <%= name %> [String]
+<%- if msg -%>
+#   <%= msg %>
+<%- end -%>
+<%- end -%>
+#
+# @return [String]
+<%- args = resource.positional_args.map(&:first) -%>
+<%- args += resource.named_args.map(&:first).map { |a| "#{a}:"} -%>
+def <%= resource.path_helper %> <%= args.join ", " %>
+<%- (resource.positional_args + resource.named_args).each do |name, regexp, msg| -%>
+  raise ArgumentError, "<%= name %> is required" if <%= name %>.nil?
+<%- if regexp -%>
+  raise ArgumentError, "<%= msg %>" unless <%= regexp %>.match <%= name %>
+<%- end -%>
+<%- end -%>
+
+  "<%= resource.path_string %>"
+end

--- a/gapic-generator-cloud/templates/cloud/client/paths.erb
+++ b/gapic-generator-cloud/templates/cloud/client/paths.erb
@@ -1,0 +1,6 @@
+<%- assert_locals service -%>
+<%= render partial: "client/paths",
+           layout: "layouts/ruby",
+           locals: { service: service,
+                     namespaces: service.namespaces }
+%>

--- a/gapic-generator-cloud/templates/cloud/helpers/presenters/resource_presenter.rb
+++ b/gapic-generator-cloud/templates/cloud/helpers/presenters/resource_presenter.rb
@@ -25,6 +25,11 @@ class ResourcePresenter
       raise ArgumentError, "only resources with named segments are supported, " \
                            " not #{@template.template}"
     end
+
+    if named_arg_templates?
+      raise ArgumentError, "only resources without named templates are supported, " \
+                           " not #{@template.template}"
+    end
   end
 
   def name
@@ -55,6 +60,10 @@ class ResourcePresenter
 
   def positional_args?
     @template.positional_args.any?
+  end
+
+  def named_arg_templates?
+    @template.named_args.select { |arg| arg[3] }.any?
   end
 
   class Template

--- a/gapic-generator-cloud/templates/cloud/helpers/presenters/resource_presenter.rb
+++ b/gapic-generator-cloud/templates/cloud/helpers/presenters/resource_presenter.rb
@@ -20,6 +20,11 @@ class ResourcePresenter
   def initialize name, template
     @name = name
     @template = Template.new template
+
+    if positional_args?
+      raise ArgumentError, "only resources with named segments are supported, " \
+                           " not #{@template.template}"
+    end
   end
 
   def name
@@ -47,6 +52,10 @@ class ResourcePresenter
   end
 
   private
+
+  def positional_args?
+    @template.positional_args.any?
+  end
 
   class Template
     TMPL = /((?<positional>\*\*?)|{(?<name>[^\/]+?)(?:=(?<template>.+?))?})/

--- a/gapic-generator-cloud/templates/cloud/helpers/presenters/resource_presenter.rb
+++ b/gapic-generator-cloud/templates/cloud/helpers/presenters/resource_presenter.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "active_support/inflector"
+
+class ResourcePresenter
+  def initialize name, template
+    @name = name
+    @template = Template.new template
+  end
+
+  def name
+    @name
+  end
+
+  def template
+    @template.template
+  end
+
+  def path_helper
+    "#{ActiveSupport::Inflector.underscore @name}_path"
+  end
+
+  def positional_args
+    @template.positional_args
+  end
+
+  def named_args
+    @template.named_args
+  end
+
+  def path_string
+    @template.output
+  end
+
+  private
+
+  class Template
+    TMPL = /((?<positional>\*\*?)|{(?<name>[^\/]+?)(?:=(?<template>.+?))?})/
+
+    attr_reader :template, :positional_args, :named_args, :output
+
+    def initialize template
+      @template = template
+      @positional_args = []
+      @named_args = []
+
+      out = []
+      tmpl = template.dup
+      while m = TMPL.match(tmpl)
+        pos_arg_num = @positional_args.count + 1
+        out << m.pre_match
+        if m[:positional] == "*"
+          out << "\#{arg#{pos_arg_num}}"
+          @positional_args << ["arg#{pos_arg_num}", "/([^/]+)/", "arg#{pos_arg_num} cannot contain /"]
+        elsif m[:positional] == "**"
+          out << "\#{arg#{pos_arg_num}}"
+          @positional_args << ["arg#{pos_arg_num}", nil, nil]
+        else
+          out << "\#{#{m[:name]}}"
+          if m[:template]
+            named_tmpl_regexp = m[:template].dup
+            named_tmpl_regexp.gsub! "**", ".+"
+            named_tmpl_regexp.gsub! "*", "[^/]+"
+            named_tmpl_regexp.gsub! "/", "\\/"
+            @named_args << [m[:name], named_tmpl_regexp, "#{m[:name]} must match #{m[:template]}"]
+          else
+            @named_args << [m[:name], "/([^/]+)/", "#{m[:name]} cannot contain /"]
+          end
+        end
+        tmpl = m.post_match
+      end
+      @output = out.join
+    end
+  end
+end

--- a/gapic-generator-cloud/templates/cloud/helpers/presenters/resource_presenter.rb
+++ b/gapic-generator-cloud/templates/cloud/helpers/presenters/resource_presenter.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "ostruct"
 require "active_support/inflector"
 
 class ResourcePresenter
@@ -44,12 +45,10 @@ class ResourcePresenter
     "#{ActiveSupport::Inflector.underscore @name}_path"
   end
 
-  def positional_args
-    @template.positional_args
-  end
-
-  def named_args
-    @template.named_args
+  def arguments
+    @template.named_args.map do |name, regexp, msg, template|
+      OpenStruct.new name: name, regexp: regexp, msg: msg
+    end
   end
 
   def path_string

--- a/gapic-generator/lib/google/gapic/template.rb
+++ b/gapic-generator/lib/google/gapic/template.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/gapic/template/parser"
+
+module Google
+  module Gapic
+    module Template
+      # Parse a URI template.
+      #
+      # @param template [String] The template to be parsed.
+      #
+      # @return [Array<Template::Segment|String>] The segments of the template.
+      def self.parse template
+        Parser.new(template).segments
+      end
+    end
+  end
+end

--- a/gapic-generator/lib/google/gapic/template/parser.rb
+++ b/gapic-generator/lib/google/gapic/template/parser.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/gapic/template/segment"
+
+module Google
+  module Gapic
+    module Template
+      # A URI template parser.
+      #
+      # @!attribute [r] template
+      #   @return [String] The template to be parsed.
+      # @!attribute [r] segments
+      #   @return [Array<Segment|String>] The segments of the parsed template.
+      class Parser
+        # @private
+        # /((?<positional>\*\*?)|{(?<name>[^\/]+?)(?:=(?<template>.+?))?})/
+        TEMPLATE = %r{
+          (
+            (?<positional>\*\*?)
+            |
+            {(?<name>[^\/]+?)(?:=(?<template>.+?))?}
+          )
+        }x.freeze
+
+        attr_reader :template, :segments
+
+        # Create a new URI template parser.
+        #
+        # @param template [String] The template to be parsed.
+        def initialize template
+          @template = template
+          @segments = parse! template
+        end
+
+        protected
+
+        def parse! template
+          # segments contain either Strings or segment objects
+          segments = []
+          segment_pos = 0
+
+          while (match = TEMPLATE.match template)
+            # The String before the match needs to be added to the segments
+            segments << match.pre_match unless match.pre_match.empty?
+
+            segment, segment_pos = segment_and_pos_from_match match, segment_pos
+            segments << segment
+
+            template = match.post_match
+          end
+
+          # Whatever String is unmatched needs to be added to the segments
+          segments << template unless template.empty?
+
+          segments
+        end
+
+        def segment_and_pos_from_match match, pos
+          if match[:positional]
+            [Segment.new(pos, match[:positional]), pos + 1]
+          else
+            [Segment.new(match[:name], match[:template]), pos]
+          end
+        end
+      end
+    end
+  end
+end

--- a/gapic-generator/lib/google/gapic/template/segment.rb
+++ b/gapic-generator/lib/google/gapic/template/segment.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Gapic
+    module Template
+      # A segment in a URI template.
+      #
+      # @!attribute [r] name
+      #   @return [String, Integer] The name of a named segment, or the position
+      #     of a positional segment.
+      # @!attribute [r] pattern
+      #   @return [String, nil] The pattern of the segment, nil if not set.
+      class Segment
+        attr_reader :name, :pattern
+
+        def initialize name, pattern
+          @name    = name
+          @pattern = pattern
+        end
+
+        # Determines if the segment is positional (has a number for a name).
+        #
+        # @return [Boolean]
+        def positional?
+          name.is_a? Integer
+        end
+
+        # Determines if the segment is named (has a string for a name).
+        #
+        # @return [Boolean]
+        def named?
+          !positional?
+        end
+
+        # Determines if the segment has a pattern. Positional segments always
+        # have a pattern. Named segments may have a pattern if provided in the
+        # template.
+        #
+        # @return [Boolean]
+        def pattern?
+          !@pattern.nil?
+        end
+
+        # @private
+        def == other
+          return false unless other.is_a? self.class
+
+          (name == other.name) && (pattern == other.pattern)
+        end
+      end
+    end
+  end
+end

--- a/gapic-generator/test/google/gapic/template/empty_test.rb
+++ b/gapic-generator/test/google/gapic/template/empty_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+
+class EmptyTemplateTest < TemplateTest
+  def test_empty_template
+    assert_template(
+      "hello/world",
+      "hello/world"
+    )
+  end
+end

--- a/gapic-generator/test/google/gapic/template/named_test.rb
+++ b/gapic-generator/test/google/gapic/template/named_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+
+class NamedTemplateTest < TemplateTest
+  def test_simple_template
+    assert_template(
+      "foo/{bar}/baz/{bif}",
+      "foo/",
+      Google::Gapic::Template::Segment.new("bar", nil),
+      "/baz/",
+      Google::Gapic::Template::Segment.new("bif", nil)
+    )
+  end
+
+  def test_pattern_template
+    assert_template(
+      "hello/{name=foo/*/bar/**}/world",
+      "hello/",
+      Google::Gapic::Template::Segment.new("name", "foo/*/bar/**"),
+      "/world"
+    )
+  end
+
+  def test_prefix_path_template
+    assert_template(
+      "{foo}/bar/{baz}/bif/{qux}",
+      Google::Gapic::Template::Segment.new("foo", nil),
+      "/bar/",
+      Google::Gapic::Template::Segment.new("baz", nil),
+      "/bif/",
+      Google::Gapic::Template::Segment.new("qux", nil)
+    )
+  end
+
+  def test_trailing_path_template
+    assert_template(
+      "foo/{bar}/baz/{bif}/qux",
+      "foo/",
+      Google::Gapic::Template::Segment.new("bar", nil),
+      "/baz/",
+      Google::Gapic::Template::Segment.new("bif", nil),
+      "/qux"
+    )
+  end
+
+  def test_more_than_two_names_template
+    # This is a bad template, it can be parsed but not matched
+    assert_template(
+      "hello/{foo}{bar}/world",
+      "hello/",
+      Google::Gapic::Template::Segment.new("foo", nil),
+      Google::Gapic::Template::Segment.new("bar", nil),
+      "/world"
+    )
+  end
+end

--- a/gapic-generator/test/google/gapic/template/positional_test.rb
+++ b/gapic-generator/test/google/gapic/template/positional_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+
+class PositionalTemplateTest < TemplateTest
+  def test_simple_template
+    assert_template(
+      "hello/*/world/**",
+      "hello/",
+      Google::Gapic::Template::Segment.new(0, "*"),
+      "/world/",
+      Google::Gapic::Template::Segment.new(1, "**")
+    )
+  end
+
+  def test_prefix_path_template
+    assert_template(
+      "*/bar/*/bif/*",
+      Google::Gapic::Template::Segment.new(0, "*"),
+      "/bar/",
+      Google::Gapic::Template::Segment.new(1, "*"),
+      "/bif/",
+      Google::Gapic::Template::Segment.new(2, "*")
+    )
+  end
+
+  def test_trailing_path_template
+    assert_template(
+      "foo/*/baz/*/qux",
+      "foo/",
+      Google::Gapic::Template::Segment.new(0, "*"),
+      "/baz/",
+      Google::Gapic::Template::Segment.new(1, "*"),
+      "/qux"
+    )
+  end
+
+  def test_more_than_two_stars_template
+    # This is a bad template, it can be parsed but not matched
+    assert_template(
+      "hello/***/world",
+      "hello/",
+      Google::Gapic::Template::Segment.new(0, "**"),
+      Google::Gapic::Template::Segment.new(1, "*"),
+      "/world"
+    )
+  end
+end

--- a/gapic-generator/test/test_helper.rb
+++ b/gapic-generator/test/test_helper.rb
@@ -17,6 +17,7 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "google/gapic/schema/api"
 require "google/gapic/generator"
+require "google/gapic/template"
 require "action_controller"
 require "action_view"
 
@@ -58,5 +59,19 @@ end
 class GemTest < Minitest::Test
   def expected_content gem, filename
     File.read "expected_output/gems/#{gem}/#{filename}"
+  end
+end
+
+class TemplateTest < Minitest::Test
+  def assert_template template, *exp_segments
+    act_segments = Google::Gapic::Template.parse template
+
+    assert_valid_segments act_segments
+    assert_equal exp_segments, act_segments
+  end
+
+  def assert_valid_segments segments
+    refute segments.any?(nil), "segments won't contain any nil segments"
+    refute segments.any?(""), "segments won't contain any empty segments"
   end
 end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -24,6 +24,7 @@ require "google/longrunning/operations_client"
 require "google/showcase/version"
 require "google/showcase/v1alpha3/identity_pb"
 require "google/showcase/v1alpha3/identity/credentials"
+require "google/showcase/v1alpha3/identity/paths"
 
 module Google
   module Showcase
@@ -31,6 +32,9 @@ module Google
       module Identity
         # Service that implements Identity API.
         class Client
+          include Paths
+          extend Paths
+
           # @private
           attr_reader :identity_stub
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -33,7 +33,6 @@ module Google
         # Service that implements Identity API.
         class Client
           include Paths
-          extend Paths
 
           # @private
           attr_reader :identity_stub

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/paths.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/paths.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Showcase
+    module V1alpha3
+      module Identity
+        module Paths
+          ##
+          # Create a fully-qualified User resource string.
+          #
+          # The resource will be in the following format:
+          #
+          # `users/{user_id}`
+          #
+          # @param user_id [String]
+          #   user_id cannot contain /
+          #
+          # @return [String]
+          def user_path user_id:
+            raise ArgumentError, "user_id is required" if user_id.nil?
+            raise ArgumentError, "user_id cannot contain /" unless /([^/]+)/.match user_id
+
+            "users/#{user_id}"
+          end
+
+        end
+      end
+    end
+  end
+end
+

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/paths.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/paths.rb
@@ -27,19 +27,15 @@ module Google
           # `users/{user_id}`
           #
           # @param user_id [String]
-          #   user_id cannot contain /
           #
           # @return [String]
           def user_path user_id:
             raise ArgumentError, "user_id is required" if user_id.nil?
-            raise ArgumentError, "user_id cannot contain /" unless /([^/]+)/.match user_id
 
             "users/#{user_id}"
           end
-
         end
       end
     end
   end
 end
-

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -33,7 +33,6 @@ module Google
         # Service that implements Messaging API.
         class Client
           include Paths
-          extend Paths
 
           # @private
           attr_reader :messaging_stub

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -24,6 +24,7 @@ require "google/longrunning/operations_client"
 require "google/showcase/version"
 require "google/showcase/v1alpha3/messaging_pb"
 require "google/showcase/v1alpha3/messaging/credentials"
+require "google/showcase/v1alpha3/messaging/paths"
 
 module Google
   module Showcase
@@ -31,6 +32,9 @@ module Google
       module Messaging
         # Service that implements Messaging API.
         class Client
+          include Paths
+          extend Paths
+
           # @private
           attr_reader :messaging_stub
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/paths.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/paths.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Showcase
+    module V1alpha3
+      module Messaging
+        module Paths
+          ##
+          # Create a fully-qualified Room resource string.
+          #
+          # The resource will be in the following format:
+          #
+          # `rooms/{room_id}`
+          #
+          # @param room_id [String]
+          #   room_id cannot contain /
+          #
+          # @return [String]
+          def room_path room_id:
+            raise ArgumentError, "room_id is required" if room_id.nil?
+            raise ArgumentError, "room_id cannot contain /" unless /([^/]+)/.match room_id
+
+            "rooms/#{room_id}"
+          end
+
+        end
+      end
+    end
+  end
+end
+

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/paths.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/paths.rb
@@ -27,19 +27,15 @@ module Google
           # `rooms/{room_id}`
           #
           # @param room_id [String]
-          #   room_id cannot contain /
           #
           # @return [String]
           def room_path room_id:
             raise ArgumentError, "room_id is required" if room_id.nil?
-            raise ArgumentError, "room_id cannot contain /" unless /([^/]+)/.match room_id
 
             "rooms/#{room_id}"
           end
-
         end
       end
     end
   end
 end
-

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -33,7 +33,6 @@ module Google
         # Service that implements Testing API.
         class Client
           include Paths
-          extend Paths
 
           # @private
           attr_reader :testing_stub

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -24,6 +24,7 @@ require "google/longrunning/operations_client"
 require "google/showcase/version"
 require "google/showcase/v1alpha3/testing_pb"
 require "google/showcase/v1alpha3/testing/credentials"
+require "google/showcase/v1alpha3/testing/paths"
 
 module Google
   module Showcase
@@ -31,6 +32,9 @@ module Google
       module Testing
         # Service that implements Testing API.
         class Client
+          include Paths
+          extend Paths
+
           # @private
           attr_reader :testing_stub
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/paths.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/paths.rb
@@ -27,12 +27,10 @@ module Google
           # `sessions/{session}`
           #
           # @param session [String]
-          #   session cannot contain /
           #
           # @return [String]
           def session_path session:
             raise ArgumentError, "session is required" if session.nil?
-            raise ArgumentError, "session cannot contain /" unless /([^/]+)/.match session
 
             "sessions/#{session}"
           end
@@ -45,16 +43,13 @@ module Google
           # `sessions/{session}/tests/{test}`
           #
           # @param session [String]
-          #   session cannot contain /
           # @param test [String]
-          #   test cannot contain /
           #
           # @return [String]
           def test_path session:, test:
             raise ArgumentError, "session is required" if session.nil?
             raise ArgumentError, "session cannot contain /" unless /([^/]+)/.match session
             raise ArgumentError, "test is required" if test.nil?
-            raise ArgumentError, "test cannot contain /" unless /([^/]+)/.match test
 
             "sessions/#{session}/tests/#{test}"
           end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/paths.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/paths.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Showcase
+    module V1alpha3
+      module Testing
+        module Paths
+          ##
+          # Create a fully-qualified Session resource string.
+          #
+          # The resource will be in the following format:
+          #
+          # `sessions/{session}`
+          #
+          # @param session [String]
+          #   session cannot contain /
+          #
+          # @return [String]
+          def session_path session:
+            raise ArgumentError, "session is required" if session.nil?
+            raise ArgumentError, "session cannot contain /" unless /([^/]+)/.match session
+
+            "sessions/#{session}"
+          end
+
+          ##
+          # Create a fully-qualified Test resource string.
+          #
+          # The resource will be in the following format:
+          #
+          # `sessions/{session}/tests/{test}`
+          #
+          # @param session [String]
+          #   session cannot contain /
+          # @param test [String]
+          #   test cannot contain /
+          #
+          # @return [String]
+          def test_path session:, test:
+            raise ArgumentError, "session is required" if session.nil?
+            raise ArgumentError, "session cannot contain /" unless /([^/]+)/.match session
+            raise ArgumentError, "test is required" if test.nil?
+            raise ArgumentError, "test cannot contain /" unless /([^/]+)/.match test
+
+            "sessions/#{session}/tests/#{test}"
+          end
+
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This module includes helper methods to create resource strings.
This module is included and extended in the Client class.
This module can be used by users without creating a client object.

[closes #76, #6]