### PR TITLE
Streaming Enhancements

### DIFF
--- a/gapic-generator-cloud/templates/cloud/client/_class.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_class.erb
@@ -87,19 +87,13 @@ class <%= service.client_class_name %>
     )
   end
 
-  def default_settings client_config, timeout, metadata, lib_name,
-                        lib_version
-    google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-    google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-    google_api_client << "gapic/#{<%= service.gem.version_name_full %>}"
-    google_api_client << "gax/#{Google::Gax::VERSION}"
-    google_api_client << "grpc/#{GRPC::VERSION}"
-    google_api_client.join " "
-
-    headers = { "x-goog-api-client": google_api_client }
-    headers.merge! metadata unless metadata.nil?
-
-    Google::Gax.const_get(:CallSettings).new metadata: headers
+  def x_goog_api_client_header lib_name, lib_version
+    x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+    x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+    x_goog_api_client_header << "gapic/#{<%= service.gem.version_name_full %>}"
+    x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+    x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+    x_goog_api_client_header.join " "
   end
 end
 

--- a/gapic-generator-cloud/templates/cloud/client/_init.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_init.erb
@@ -18,26 +18,17 @@
 # @param scopes [Array<String>]
 #   The OAuth scopes for this service. This parameter is ignored if an
 #   updater_proc is supplied.
-# @param client_config [Hash]
-#   A Hash for call options for each method. See Google::Gax#construct_settings
-#   for the structure of this data. Falls back to the default config if not
-#   specified or the specified config is missing data points.
 # @param timeout [Numeric]
 #   The default timeout, in seconds, for calls made through this client.
 # @param metadata [Hash]
 #   Default metadata to be sent with each request. This can be overridden on a
 #   per call basis.
-# @param exception_transformer [Proc]
-#   An optional proc that intercepts any exceptions raised during an API call to
-#   inject custom error handling.
 #
 def initialize \
     credentials: nil,
     scopes: ALL_SCOPES,
-    client_config: {},
     timeout: DEFAULT_TIMEOUT,
     metadata: nil,
-    exception_transformer: nil,
     lib_name: nil,
     lib_version: ""
   # These require statements are intentionally placed here to initialize
@@ -53,9 +44,7 @@ def initialize \
 <%- end -%>
   @<%= service.stub_name %> = create_stub credentials, scopes
 
-  defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
-
-<%- service.methods.each do |method| -%>
-<%= indent render(partial: "client/method/init", locals: { service: service, method: method }), "  " %>
-<%- end -%>
+  @timeout = timeout
+  @metadata = metadata.to_h
+  @metadata["x-goog-api-client".freeze] ||= x_goog_api_client_header lib_name, lib_version
 end

--- a/gapic-generator-cloud/templates/cloud/client/lro/_init.erb
+++ b/gapic-generator-cloud/templates/cloud/client/lro/_init.erb
@@ -1,7 +1,6 @@
 @operations_client = OperationsClient.new(
   credentials: credentials,
   scopes: scopes,
-  client_config: client_config,
   timeout: timeout,
   lib_name: lib_name,
   lib_version: lib_version

--- a/gapic-generator-cloud/templates/cloud/client/method/_init.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/_init.erb
@@ -1,6 +1,0 @@
-<%- assert_locals method -%>
-<%= method.ivar %> = Google::Gax.create_api_call(
-  @<%= method.service.stub_name %>.method(:<%= method.name %>),
-  defaults,
-  exception_transformer: exception_transformer
-)

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
@@ -9,15 +9,19 @@
 # @param options [Google::Gax::CallOptions]
 #   Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
-# @return [Enumerable<<%= method.return_type %>>]
-#   An enumerable of {<%= method.return_type %>} instances.
+# @yield [response] Called on each streaming responses, when provided.
+# @yieldparam response [<%= method.return_type %>]
+#
+# @return [Enumerable<<%= method.return_type %>, nil>]
+#   An enumerable of {<%= method.return_type %>} instances when a block is not provided.
+#   When a block is provided `nil` is returned.
 #
 # @raise [Google::Gax::GaxError] if the RPC is aborted.
 #
 # @example
 <%= indent method.code_example, "#   " %>
 #
-def <%= method.name %> requests, options: nil
+def <%= method.name %> requests, options: nil, &block
   unless requests.is_a? Enumerable
     raise ArgumentError, "requests must be an Enumerable"
   end
@@ -26,5 +30,5 @@ def <%= method.name %> requests, options: nil
     Google::Gax.to_proto request, <%= method.request_type %>
   end
 
-  <%= method.ivar %>.call(requests, options)
+  <%= method.ivar %>.call(requests, options, &block)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
@@ -6,7 +6,7 @@
 <%- end -%>
 # @param requests [Google::Gax::StreamInput, Enumerable<<%= method.request_type %> | Hash>]
 #   An enumerable of {<%= method.request_type %>} instances.
-# @param options [Google::Gax::CallOptions]
+# @param options [Google::Gax::ApiCall::Options, Hash]
 #   Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
 # @yield [response] Called on each streaming responses, when provided.
@@ -31,8 +31,18 @@ def <%= method.name %> requests, options: nil, &block
   end
 
   requests = requests.lazy.map do |request|
+    # Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
     Google::Gax.to_proto request, <%= method.request_type %>
   end
 
-  <%= method.ivar %>.call(requests, options, enum_proc: block)
+  # Converts hash and nil to an options object
+  options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+  header_params = {} # { name: request.name }
+  request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+  metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
+  retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+  <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>
+  <%= method.ivar %>.call(requests, options: options, on_stream: block)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
@@ -4,7 +4,7 @@
 <%= indent method.doc_description, "# " %>
 #
 <%- end -%>
-# @param requests [Enumerable<<%= method.request_type %> | Hash>]
+# @param requests [Google::Gax::StreamInput, Enumerable<<%= method.request_type %> | Hash>]
 #   An enumerable of {<%= method.request_type %>} instances.
 # @param options [Google::Gax::CallOptions]
 #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -23,7 +23,11 @@
 #
 def <%= method.name %> requests, options: nil, &block
   unless requests.is_a? Enumerable
-    raise ArgumentError, "requests must be an Enumerable"
+    if requests.respond_to? :to_enum
+      requests = requests.to_enum
+    else
+      raise ArgumentError, "requests must be an Enumerable"
+    end
   end
 
   requests = requests.lazy.map do |request|

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
@@ -40,7 +40,7 @@ def <%= method.name %> requests, options: nil, &block
   header_params = {} # { name: request.name }
   request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
   metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
-  retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
   options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
   <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
@@ -34,5 +34,5 @@ def <%= method.name %> requests, options: nil, &block
     Google::Gax.to_proto request, <%= method.request_type %>
   end
 
-  <%= method.ivar %>.call(requests, options, &block)
+  <%= method.ivar %>.call(requests, options, enum_proc: block)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
@@ -4,7 +4,7 @@
 <%= indent method.doc_description, "# " %>
 #
 <%- end -%>
-# @param requests [Enumerable<<%= method.request_type %> | Hash>]
+# @param requests [Google::Gax::StreamInput, Enumerable<<%= method.request_type %> | Hash>]
 #   An enumerable of {<%= method.request_type %>} instances.
 # @param options [Google::Gax::CallOptions]
 #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -22,7 +22,11 @@
 #
 def <%= method.name %> requests, options: nil, &block
   unless requests.is_a? Enumerable
-    raise ArgumentError, "requests must be an Enumerable"
+    if requests.respond_to? :to_enum
+      requests = requests.to_enum
+    else
+      raise ArgumentError, "requests must be an Enumerable"
+    end
   end
 
   requests = requests.lazy.map do |request|

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
@@ -6,11 +6,11 @@
 <%- end -%>
 # @param requests [Google::Gax::StreamInput, Enumerable<<%= method.request_type %> | Hash>]
 #   An enumerable of {<%= method.request_type %>} instances.
-# @param options [Google::Gax::CallOptions]
+# @param options [Google::Gax::ApiCall::Options, Hash]
 #   Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
-# @yield [result, operation] Access the result along with the RPC operation
-# @yieldparam result [<%= method.return_type %>]
+# @yield [response, operation] Access the result along with the RPC operation
+# @yieldparam response [<%= method.return_type %>]
 # @yieldparam operation [GRPC::ActiveCall::Operation]
 #
 # @return [<%= method.return_type %>]
@@ -30,8 +30,18 @@ def <%= method.name %> requests, options: nil, &block
   end
 
   requests = requests.lazy.map do |request|
+    # Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
     Google::Gax.to_proto request, <%= method.request_type %>
   end
 
-  <%= method.ivar %>.call(requests, options, op_proc: block)
+  # Converts hash and nil to an options object
+  options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+  header_params = {} # { name: request.name }
+  request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+  metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
+  retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+  <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>
+  <%= method.ivar %>.call(requests, options: options, on_operation: block)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
@@ -39,7 +39,7 @@ def <%= method.name %> requests, options: nil, &block
   header_params = {} # { name: request.name }
   request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
   metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
-  retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
   options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
   <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
@@ -33,5 +33,5 @@ def <%= method.name %> requests, options: nil, &block
     Google::Gax.to_proto request, <%= method.request_type %>
   end
 
-  <%= method.ivar %>.call(requests, options, &block)
+  <%= method.ivar %>.call(requests, options, op_proc: block)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_lro.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_lro.erb
@@ -55,7 +55,7 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   header_params = {} # { name: request.name }
   request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
   metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
-  retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
   options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
   on_response = ->(response) { Google::Gax::Operation.new(response, @operations_client, options) }

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_normal.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_normal.erb
@@ -9,7 +9,7 @@
 <%- if method.doc_description -%>
 <%= indent method.doc_description, "#     " %>
 <%- end -%>
-#   @param options [Google::Gax::CallOptions]
+#   @param options [Google::Gax::ApiCall::Options, Hash]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
 <%- arg_list = method.arguments.map { |arg| "#{arg.name}: nil"}.join ", " -%>
@@ -20,7 +20,7 @@
 <%= indent arg.doc_description, "#     " %>
 <%- end -%>
 <%- end -%>
-#   @param options [Google::Gax::CallOptions]
+#   @param options [Google::Gax::ApiCall::Options, Hash]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 <%- if method.arguments.find { |arg| arg.name == "options" } -%>
 #
@@ -29,8 +29,8 @@
 #     named arguments.
 <%- end -%>
 #
-# @yield [result, operation] Access the result along with the RPC operation
-# @yieldparam result [<%= method.return_type %>]
+# @yield [response, operation] Access the result along with the RPC operation
+# @yieldparam response [<%= method.return_type %>]
 # @yieldparam operation [GRPC::ActiveCall::Operation]
 #
 # @return [<%= method.return_type %>]
@@ -47,7 +47,19 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   end
 
   request ||= request_fields
+  # request = Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
   request = Google::Gax.to_proto request, <%= method.request_type %>
 
-  <%= method.ivar %>.call(request, options, op_proc: block)
+  # Converts hash and nil to an options object
+  options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+  # Customize the options with defaults
+  header_params = {} # { name: request.name }
+  request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+  metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
+  retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+  <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>
+  <%= method.ivar %>.call(request, options: options, on_operation: block)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_normal.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_normal.erb
@@ -57,7 +57,7 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   header_params = {} # { name: request.name }
   request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
   metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
-  retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
   options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
   <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_normal.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_normal.erb
@@ -49,5 +49,5 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   request ||= request_fields
   request = Google::Gax.to_proto request, <%= method.request_type %>
 
-  <%= method.ivar %>.call(request, options, &block)
+  <%= method.ivar %>.call(request, options, op_proc: block)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_paged.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_paged.erb
@@ -55,7 +55,7 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   header_params = {} # { name: request.name }
   request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
   metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
-  retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
   options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
   on_response = ->(response) { Google::Gax::PagedEnumerable response }

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_paged.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_paged.erb
@@ -30,10 +30,10 @@
 <%- end -%>
 #
 # @yield [response, operation] Access the result along with the RPC operation
-# @yieldparam response [Google::Gax::Operation]
+# @yieldparam response [Google::Gax::PagedEnumerable<<%= method.return_type %>>]
 # @yieldparam operation [GRPC::ActiveCall::Operation]
 #
-# @return [Google::Gax::Operation]
+# @return [Google::Gax::PagedEnumerable<<%= method.return_type %>>]
 # @raise [Google::Gax::GaxError] if the RPC is aborted.
 # @example
 <%= indent method.code_example, "#   " %>
@@ -58,7 +58,7 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
   options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
-  on_response = ->(response) { Google::Gax::Operation.new(response, @operations_client, options) }
+  on_response = ->(response) { Google::Gax::PagedEnumerable response }
 
   <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>
   <%= method.ivar %>.call(request, options: options, on_operation: block, on_response: on_response)

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
@@ -52,5 +52,5 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   request ||= request_fields
   request = Google::Gax.to_proto request, <%= method.request_type %>
 
-  <%= method.ivar %>.call(request, options, &block)
+  <%= method.ivar %>.call(request, options, enum_proc: block)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
@@ -9,7 +9,7 @@
 <%- if method.doc_description -%>
 <%= indent method.doc_description, "#     " %>
 <%- end -%>
-#   @param options [Google::Gax::CallOptions]
+#   @param options [Google::Gax::ApiCall::Options, Hash]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
 <%- arg_list = method.arguments.map { |arg| "#{arg.name}: nil"}.join ", " -%>
@@ -20,7 +20,7 @@
 <%= indent arg.doc_description, "#     " %>
 <%- end -%>
 <%- end -%>
-#   @param options [Google::Gax::CallOptions]
+#   @param options [Google::Gax::ApiCall::Options, Hash]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 <%- if method.arguments.find { |arg| arg.name == "options" } -%>
 #
@@ -50,7 +50,17 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   end
 
   request ||= request_fields
+  # request = Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
   request = Google::Gax.to_proto request, <%= method.request_type %>
 
-  <%= method.ivar %>.call(request, options, enum_proc: block)
+  # Converts hash and nil to an options object
+  options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+  header_params = {} # { name: request.name }
+  request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+  metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
+  retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+  <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>
+  <%= method.ivar %>.call(request, options: options, on_stream: block)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
@@ -58,7 +58,7 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   header_params = {} # { name: request.name }
   request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
   metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
-  retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
   options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
   <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
@@ -29,15 +29,19 @@
 #     named arguments.
 <%- end -%>
 #
-# @return [Enumerable<<%= method.return_type %>>]
-#   An enumerable of {<%= method.return_type %>} instances.
+# @yield [response] Called on each streaming responses, when provided.
+# @yieldparam response [<%= method.return_type %>]
+#
+# @return [Enumerable<<%= method.return_type %>, nil>]
+#   An enumerable of {<%= method.return_type %>} instances when a block is not provided.
+#   When a block is provided `nil` is returned.
 #
 # @raise [Google::Gax::GaxError] if the RPC is aborted.
 #
 # @example
 <%= indent method.code_example, "#   " %>
 #
-def <%= method.name %> request = nil, options: nil, **request_fields
+def <%= method.name %> request = nil, options: nil, **request_fields, &block
   if request.nil? && request_fields.empty?
     raise ArgumentError, "request must be provided"
   end
@@ -48,5 +52,5 @@ def <%= method.name %> request = nil, options: nil, **request_fields
   request ||= request_fields
   request = Google::Gax.to_proto request, <%= method.request_type %>
 
-  <%= method.ivar %>.call(request, options)
+  <%= method.ivar %>.call(request, options, &block)
 end

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,6 +6,6 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "blowmage/gax-ruby", branch: "experimental-2.0"
+gem "google-gax", github: "blowmage/gax-ruby", branch: "experimental-2.0.1"
 gem "grpc-tools", "~> 1.18"
 gem "rake", "~> 10.0"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,6 +6,6 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", "~> 1.0"
+gem "google-gax", github: "blowmage/gax-ruby", branch: "experimental-2.0"
 gem "grpc-tools", "~> 1.18"
 gem "rake", "~> 10.0"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -159,7 +159,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @echo ||= Google::Gax::ApiCall.new @echo_stub.method :echo
@@ -212,7 +212,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @expand ||= Google::Gax::ApiCall.new @echo_stub.method :expand
@@ -259,7 +259,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @collect ||= Google::Gax::ApiCall.new @echo_stub.method :collect
@@ -307,7 +307,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @chat ||= Google::Gax::ApiCall.new @echo_stub.method :chat
@@ -361,7 +361,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @paged_expand ||= Google::Gax::ApiCall.new @echo_stub.method :paged_expand
@@ -416,7 +416,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             on_response = ->(response) { Google::Gax::Operation.new response, @operations_client, options }

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -190,7 +190,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
 
-            @echo.call(request, options, &block)
+            @echo.call request, options, op_proc: block
           end
 
           ##
@@ -233,7 +233,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ExpandRequest
 
-            @expand.call(request, options, &block)
+            @expand.call request, options, enum_proc: block
           end
 
           ##
@@ -270,7 +270,7 @@ module Google
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
             end
 
-            @collect.call(requests, options, &block)
+            @collect.call requests, options, op_proc: block
           end
 
           ##
@@ -308,7 +308,7 @@ module Google
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
             end
 
-            @chat.call(requests, options, &block)
+            @chat.call requests, options, enum_proc: block
           end
 
           ##
@@ -350,7 +350,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::PagedExpandRequest
 
-            @paged_expand.call(request, options, &block)
+            @paged_expand.call request, options, op_proc: block
           end
 
           ##

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -241,7 +241,7 @@ module Google
           # by the client, this method will return the a concatenation of the strings
           # passed to it. This method showcases client-side streaming rpcs.
           #
-          # @param requests [Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
+          # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -258,7 +258,13 @@ module Google
           #   TODO
           #
           def collect requests, options: nil, &block
-            raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
+            unless requests.is_a? Enumerable
+              if requests.respond_to? :to_enum
+                requests = requests.to_enum
+              else
+                raise ArgumentError, "requests must be an Enumerable"
+              end
+            end
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
@@ -272,7 +278,7 @@ module Google
           # be passed  back on the stream. This method showcases bidirectional
           # streaming rpcs.
           #
-          # @param requests [Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
+          # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -290,7 +296,13 @@ module Google
           #   TODO
           #
           def chat requests, options: nil, &block
-            raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
+            unless requests.is_a? Enumerable
+              if requests.respond_to? :to_enum
+                requests = requests.to_enum
+              else
+                raise ArgumentError, "requests must be an Enumerable"
+              end
+            end
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -212,15 +212,19 @@ module Google
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @return [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
-          #   An enumerable of {Google::Showcase::V1alpha3::EchoResponse} instances.
+          # @yield [response] Called on each streaming responses, when provided.
+          # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
+          #
+          # @return [Enumerable<Google::Showcase::V1alpha3::EchoResponse, nil>]
+          #   An enumerable of {Google::Showcase::V1alpha3::EchoResponse} instances when a block is not provided.
+          #   When a block is provided `nil` is returned.
           #
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           #
           # @example
           #   TODO
           #
-          def expand request = nil, options: nil, **request_fields
+          def expand request = nil, options: nil, **request_fields, &block
             raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
@@ -229,7 +233,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ExpandRequest
 
-            @expand.call request, options
+            @expand.call(request, options, &block)
           end
 
           ##
@@ -273,22 +277,26 @@ module Google
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @return [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
-          #   An enumerable of {Google::Showcase::V1alpha3::EchoResponse} instances.
+          # @yield [response] Called on each streaming responses, when provided.
+          # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
+          #
+          # @return [Enumerable<Google::Showcase::V1alpha3::EchoResponse, nil>]
+          #   An enumerable of {Google::Showcase::V1alpha3::EchoResponse} instances when a block is not provided.
+          #   When a block is provided `nil` is returned.
           #
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           #
           # @example
           #   TODO
           #
-          def chat requests, options: nil
+          def chat requests, options: nil, &block
             raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
             end
 
-            @chat.call requests, options
+            @chat.call(requests, options, &block)
           end
 
           ##

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -82,26 +82,17 @@ module Google
           # @param scopes [Array<String>]
           #   The OAuth scopes for this service. This parameter is ignored if an
           #   updater_proc is supplied.
-          # @param client_config [Hash]
-          #   A Hash for call options for each method. See Google::Gax#construct_settings
-          #   for the structure of this data. Falls back to the default config if not
-          #   specified or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a
           #   per call basis.
-          # @param exception_transformer [Proc]
-          #   An optional proc that intercepts any exceptions raised during an API call to
-          #   inject custom error handling.
           #
           def initialize \
               credentials: nil,
               scopes: ALL_SCOPES,
-              client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
-              exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
             # These require statements are intentionally placed here to initialize
@@ -113,42 +104,17 @@ module Google
             credentials ||= Credentials.default
 
             @operations_client = OperationsClient.new(
-              credentials:   credentials,
-              scopes:        scopes,
-              client_config: client_config,
-              timeout:       timeout,
-              lib_name:      lib_name,
-              lib_version:   lib_version
+              credentials: credentials,
+              scopes:      scopes,
+              timeout:     timeout,
+              lib_name:    lib_name,
+              lib_version: lib_version
             )
             @identity_stub = create_stub credentials, scopes
 
-            defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
-
-            @create_user = Google::Gax.create_api_call(
-              @identity_stub.method(:create_user),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @get_user = Google::Gax.create_api_call(
-              @identity_stub.method(:get_user),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @update_user = Google::Gax.create_api_call(
-              @identity_stub.method(:update_user),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @delete_user = Google::Gax.create_api_call(
-              @identity_stub.method(:delete_user),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @list_users = Google::Gax.create_api_call(
-              @identity_stub.method(:list_users),
-              defaults,
-              exception_transformer: exception_transformer
-            )
+            @timeout = timeout
+            @metadata = metadata.to_h
+            @metadata["x-goog-api-client"] ||= x_goog_api_client_header lib_name, lib_version
           end
 
           # Service calls
@@ -159,17 +125,17 @@ module Google
           # @overload create_user(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
           #     Creates a user.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload create_user(user: nil, options: nil)
           #   @param user [Google::Showcase::V1alpha3::User | Hash]
           #     The user to create.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::User]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::User]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::User]
@@ -184,9 +150,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateUserRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateUserRequest
 
-            @create_user.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @create_user ||= Google::Gax::ApiCall.new @identity_stub.method :create_user
+            @create_user.call request, options: options, on_operation: block
           end
 
           ##
@@ -195,17 +173,17 @@ module Google
           # @overload get_user(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
           #     Retrieves the User with the given uri.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload get_user(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested user.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::User]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::User]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::User]
@@ -220,9 +198,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetUserRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetUserRequest
 
-            @get_user.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @get_user ||= Google::Gax::ApiCall.new @identity_stub.method :get_user
+            @get_user.call request, options: options, on_operation: block
           end
 
           ##
@@ -231,7 +221,7 @@ module Google
           # @overload update_user(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
           #     Updates a user.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload update_user(user: nil, update_mask: nil, options: nil)
@@ -240,11 +230,11 @@ module Google
           #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::User]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::User]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::User]
@@ -259,9 +249,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateUserRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateUserRequest
 
-            @update_user.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @update_user ||= Google::Gax::ApiCall.new @identity_stub.method :update_user
+            @update_user.call request, options: options, on_operation: block
           end
 
           ##
@@ -270,17 +272,17 @@ module Google
           # @overload delete_user(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
           #     Deletes a user, their profile, and all of their authored messages.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_user(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the user to delete.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Protobuf::Empty]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Protobuf::Empty]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Protobuf::Empty]
@@ -295,9 +297,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteUserRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteUserRequest
 
-            @delete_user.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @delete_user ||= Google::Gax::ApiCall.new @identity_stub.method :delete_user
+            @delete_user.call request, options: options, on_operation: block
           end
 
           ##
@@ -306,7 +320,7 @@ module Google
           # @overload list_users(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
           #     Lists all users.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_users(page_size: nil, page_token: nil, options: nil)
@@ -317,11 +331,11 @@ module Google
           #     The value of google.showcase.v1alpha3.ListUsersResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Identity\ListUsers` method.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::ListUsersResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::ListUsersResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::ListUsersResponse]
@@ -336,9 +350,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListUsersRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListUsersRequest
 
-            @list_users.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @list_users ||= Google::Gax::ApiCall.new @identity_stub.method :list_users
+            @list_users.call request, options: options, on_operation: block
           end
 
           protected
@@ -373,19 +399,13 @@ module Google
             )
           end
 
-          def default_settings _client_config, _timeout, metadata, lib_name,
-                               lib_version
-            google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-            google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-            google_api_client << "gapic/#{Google::Showcase::VERSION}"
-            google_api_client << "gax/#{Google::Gax::VERSION}"
-            google_api_client << "grpc/#{GRPC::VERSION}"
-            google_api_client.join " "
-
-            headers = { "x-goog-api-client": google_api_client }
-            headers.merge! metadata unless metadata.nil?
-
-            Google::Gax.const_get(:CallSettings).new metadata: headers
+          def x_goog_api_client_header lib_name, lib_version
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            x_goog_api_client_header.join " "
           end
         end
       end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -160,7 +160,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @create_user ||= Google::Gax::ApiCall.new @identity_stub.method :create_user
@@ -208,7 +208,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @get_user ||= Google::Gax::ApiCall.new @identity_stub.method :get_user
@@ -259,7 +259,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @update_user ||= Google::Gax::ApiCall.new @identity_stub.method :update_user
@@ -307,7 +307,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @delete_user ||= Google::Gax::ApiCall.new @identity_stub.method :delete_user
@@ -360,7 +360,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_users ||= Google::Gax::ApiCall.new @identity_stub.method :list_users

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -186,7 +186,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateUserRequest
 
-            @create_user.call(request, options, &block)
+            @create_user.call request, options, op_proc: block
           end
 
           ##
@@ -222,7 +222,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetUserRequest
 
-            @get_user.call(request, options, &block)
+            @get_user.call request, options, op_proc: block
           end
 
           ##
@@ -261,7 +261,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateUserRequest
 
-            @update_user.call(request, options, &block)
+            @update_user.call request, options, op_proc: block
           end
 
           ##
@@ -297,7 +297,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteUserRequest
 
-            @delete_user.call(request, options, &block)
+            @delete_user.call request, options, op_proc: block
           end
 
           ##
@@ -338,7 +338,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListUsersRequest
 
-            @list_users.call(request, options, &block)
+            @list_users.call request, options, op_proc: block
           end
 
           protected

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -231,7 +231,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateRoomRequest
 
-            @create_room.call(request, options, &block)
+            @create_room.call request, options, op_proc: block
           end
 
           ##
@@ -267,7 +267,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetRoomRequest
 
-            @get_room.call(request, options, &block)
+            @get_room.call request, options, op_proc: block
           end
 
           ##
@@ -306,7 +306,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateRoomRequest
 
-            @update_room.call(request, options, &block)
+            @update_room.call request, options, op_proc: block
           end
 
           ##
@@ -342,7 +342,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteRoomRequest
 
-            @delete_room.call(request, options, &block)
+            @delete_room.call request, options, op_proc: block
           end
 
           ##
@@ -383,7 +383,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListRoomsRequest
 
-            @list_rooms.call(request, options, &block)
+            @list_rooms.call request, options, op_proc: block
           end
 
           ##
@@ -426,7 +426,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
 
-            @create_blurb.call(request, options, &block)
+            @create_blurb.call request, options, op_proc: block
           end
 
           ##
@@ -462,7 +462,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetBlurbRequest
 
-            @get_blurb.call(request, options, &block)
+            @get_blurb.call request, options, op_proc: block
           end
 
           ##
@@ -501,7 +501,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateBlurbRequest
 
-            @update_blurb.call(request, options, &block)
+            @update_blurb.call request, options, op_proc: block
           end
 
           ##
@@ -537,7 +537,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteBlurbRequest
 
-            @delete_blurb.call(request, options, &block)
+            @delete_blurb.call request, options, op_proc: block
           end
 
           ##
@@ -583,7 +583,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListBlurbsRequest
 
-            @list_blurbs.call(request, options, &block)
+            @list_blurbs.call request, options, op_proc: block
           end
 
           ##
@@ -684,7 +684,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::StreamBlurbsRequest
 
-            @stream_blurbs.call(request, options, &block)
+            @stream_blurbs.call request, options, enum_proc: block
           end
 
           ##
@@ -720,7 +720,7 @@ module Google
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
             end
 
-            @send_blurbs.call(requests, options, &block)
+            @send_blurbs.call requests, options, op_proc: block
           end
 
           ##
@@ -759,7 +759,7 @@ module Google
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::ConnectRequest
             end
 
-            @connect.call(requests, options, &block)
+            @connect.call requests, options, enum_proc: block
           end
 
           protected

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -82,26 +82,17 @@ module Google
           # @param scopes [Array<String>]
           #   The OAuth scopes for this service. This parameter is ignored if an
           #   updater_proc is supplied.
-          # @param client_config [Hash]
-          #   A Hash for call options for each method. See Google::Gax#construct_settings
-          #   for the structure of this data. Falls back to the default config if not
-          #   specified or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a
           #   per call basis.
-          # @param exception_transformer [Proc]
-          #   An optional proc that intercepts any exceptions raised during an API call to
-          #   inject custom error handling.
           #
           def initialize \
               credentials: nil,
               scopes: ALL_SCOPES,
-              client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
-              exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
             # These require statements are intentionally placed here to initialize
@@ -113,87 +104,17 @@ module Google
             credentials ||= Credentials.default
 
             @operations_client = OperationsClient.new(
-              credentials:   credentials,
-              scopes:        scopes,
-              client_config: client_config,
-              timeout:       timeout,
-              lib_name:      lib_name,
-              lib_version:   lib_version
+              credentials: credentials,
+              scopes:      scopes,
+              timeout:     timeout,
+              lib_name:    lib_name,
+              lib_version: lib_version
             )
             @messaging_stub = create_stub credentials, scopes
 
-            defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
-
-            @create_room = Google::Gax.create_api_call(
-              @messaging_stub.method(:create_room),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @get_room = Google::Gax.create_api_call(
-              @messaging_stub.method(:get_room),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @update_room = Google::Gax.create_api_call(
-              @messaging_stub.method(:update_room),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @delete_room = Google::Gax.create_api_call(
-              @messaging_stub.method(:delete_room),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @list_rooms = Google::Gax.create_api_call(
-              @messaging_stub.method(:list_rooms),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @create_blurb = Google::Gax.create_api_call(
-              @messaging_stub.method(:create_blurb),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @get_blurb = Google::Gax.create_api_call(
-              @messaging_stub.method(:get_blurb),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @update_blurb = Google::Gax.create_api_call(
-              @messaging_stub.method(:update_blurb),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @delete_blurb = Google::Gax.create_api_call(
-              @messaging_stub.method(:delete_blurb),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @list_blurbs = Google::Gax.create_api_call(
-              @messaging_stub.method(:list_blurbs),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @search_blurbs = Google::Gax.create_api_call(
-              @messaging_stub.method(:search_blurbs),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @stream_blurbs = Google::Gax.create_api_call(
-              @messaging_stub.method(:stream_blurbs),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @send_blurbs = Google::Gax.create_api_call(
-              @messaging_stub.method(:send_blurbs),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @connect = Google::Gax.create_api_call(
-              @messaging_stub.method(:connect),
-              defaults,
-              exception_transformer: exception_transformer
-            )
+            @timeout = timeout
+            @metadata = metadata.to_h
+            @metadata["x-goog-api-client"] ||= x_goog_api_client_header lib_name, lib_version
           end
 
           # Service calls
@@ -204,17 +125,17 @@ module Google
           # @overload create_room(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
           #     Creates a room.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload create_room(room: nil, options: nil)
           #   @param room [Google::Showcase::V1alpha3::Room | Hash]
           #     The room to create.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Room]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Room]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Room]
@@ -229,9 +150,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateRoomRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateRoomRequest
 
-            @create_room.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @create_room ||= Google::Gax::ApiCall.new @messaging_stub.method :create_room
+            @create_room.call request, options: options, on_operation: block
           end
 
           ##
@@ -240,17 +173,17 @@ module Google
           # @overload get_room(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
           #     Retrieves the Room with the given resource name.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload get_room(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested room.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Room]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Room]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Room]
@@ -265,9 +198,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetRoomRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetRoomRequest
 
-            @get_room.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @get_room ||= Google::Gax::ApiCall.new @messaging_stub.method :get_room
+            @get_room.call request, options: options, on_operation: block
           end
 
           ##
@@ -276,7 +221,7 @@ module Google
           # @overload update_room(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
           #     Updates a room.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload update_room(room: nil, update_mask: nil, options: nil)
@@ -285,11 +230,11 @@ module Google
           #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Room]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Room]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Room]
@@ -304,9 +249,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateRoomRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateRoomRequest
 
-            @update_room.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @update_room ||= Google::Gax::ApiCall.new @messaging_stub.method :update_room
+            @update_room.call request, options: options, on_operation: block
           end
 
           ##
@@ -315,17 +272,17 @@ module Google
           # @overload delete_room(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
           #     Deletes a room and all of its blurbs.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_room(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested room.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Protobuf::Empty]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Protobuf::Empty]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Protobuf::Empty]
@@ -340,9 +297,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteRoomRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteRoomRequest
 
-            @delete_room.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @delete_room ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_room
+            @delete_room.call request, options: options, on_operation: block
           end
 
           ##
@@ -351,7 +320,7 @@ module Google
           # @overload list_rooms(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
           #     Lists all chat rooms.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_rooms(page_size: nil, page_token: nil, options: nil)
@@ -362,11 +331,11 @@ module Google
           #     The value of google.showcase.v1alpha3.ListRoomsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\ListRooms` method.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::ListRoomsResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::ListRoomsResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::ListRoomsResponse]
@@ -381,9 +350,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListRoomsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListRoomsRequest
 
-            @list_rooms.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @list_rooms ||= Google::Gax::ApiCall.new @messaging_stub.method :list_rooms
+            @list_rooms.call request, options: options, on_operation: block
           end
 
           ##
@@ -396,7 +377,7 @@ module Google
           #     Creates a blurb. If the parent is a room, the blurb is understood to be a
           #     message in that room. If the parent is a profile, the blurb is understood
           #     to be a post on the profile.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload create_blurb(parent: nil, blurb: nil, options: nil)
@@ -405,11 +386,11 @@ module Google
           #     be tied to.
           #   @param blurb [Google::Showcase::V1alpha3::Blurb | Hash]
           #     The blurb to create.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Blurb]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Blurb]
@@ -424,9 +405,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateBlurbRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
 
-            @create_blurb.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @create_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :create_blurb
+            @create_blurb.call request, options: options, on_operation: block
           end
 
           ##
@@ -435,17 +428,17 @@ module Google
           # @overload get_blurb(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
           #     Retrieves the Blurb with the given resource name.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload get_blurb(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested blurb.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Blurb]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Blurb]
@@ -460,9 +453,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetBlurbRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetBlurbRequest
 
-            @get_blurb.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @get_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :get_blurb
+            @get_blurb.call request, options: options, on_operation: block
           end
 
           ##
@@ -471,7 +476,7 @@ module Google
           # @overload update_blurb(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
           #     Updates a blurb.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload update_blurb(blurb: nil, update_mask: nil, options: nil)
@@ -480,11 +485,11 @@ module Google
           #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Blurb]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Blurb]
@@ -499,9 +504,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateBlurbRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateBlurbRequest
 
-            @update_blurb.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @update_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :update_blurb
+            @update_blurb.call request, options: options, on_operation: block
           end
 
           ##
@@ -510,17 +527,17 @@ module Google
           # @overload delete_blurb(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
           #     Deletes a blurb.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_blurb(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested blurb.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Protobuf::Empty]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Protobuf::Empty]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Protobuf::Empty]
@@ -535,9 +552,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteBlurbRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteBlurbRequest
 
-            @delete_blurb.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @delete_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_blurb
+            @delete_blurb.call request, options: options, on_operation: block
           end
 
           ##
@@ -548,7 +577,7 @@ module Google
           #   @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
           #     Lists blurbs for a specific chat room or user profile depending on the
           #     parent resource name.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_blurbs(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -562,11 +591,11 @@ module Google
           #     The value of google.showcase.v1alpha3.ListBlurbsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\ListBlurbs` method.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::ListBlurbsResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::ListBlurbsResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::ListBlurbsResponse]
@@ -581,9 +610,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListBlurbsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListBlurbsRequest
 
-            @list_blurbs.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @list_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :list_blurbs
+            @list_blurbs.call request, options: options, on_operation: block
           end
 
           ##
@@ -596,7 +637,7 @@ module Google
           #     This method searches through all blurbs across all rooms and profiles
           #     for blurbs containing to words found in the query. Only posts that
           #     contain an exact match of a queried word will be returned.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload search_blurbs(query: nil, parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -615,33 +656,40 @@ module Google
           #     google.showcase.v1alpha3.SearchBlurbsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\SearchBlurbs` method.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [operation] Register a callback to be run when an operation is done.
-          # @yieldparam operation [Google::Gax::Operation]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Gax::Operation]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Gax::Operation]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
           #
-          def search_blurbs request = nil, options: nil, **request_fields
+          def search_blurbs request = nil, options: nil, **request_fields, &block
             raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::SearchBlurbsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::SearchBlurbsRequest
 
-            operation = Google::Gax::Operation.new(
-              @search_blurbs.call(request, options),
-              @operations_client,
-              call_options: options
-            )
-            operation.on_done { |operation| yield operation } if block_given?
-            operation
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            on_response = ->(response) { Google::Gax::Operation.new response, @operations_client, options }
+
+            @search_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :search_blurbs
+            @search_blurbs.call request, options: options, on_operation: block, on_response: on_response
           end
 
           ##
@@ -652,7 +700,7 @@ module Google
           #   @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
           #     This returns a stream that emits the blurbs that are created for a
           #     particular chat room or user profile.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload stream_blurbs(name: nil, expire_time: nil, options: nil)
@@ -660,7 +708,7 @@ module Google
           #     The resource name of a chat room or user profile whose blurbs to stream.
           #   @param expire_time [Google::Protobuf::Timestamp | Hash]
           #     The time at which this stream will close.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response] Called on each streaming responses, when provided.
@@ -682,9 +730,19 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::StreamBlurbsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::StreamBlurbsRequest
 
-            @stream_blurbs.call request, options, enum_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @stream_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :stream_blurbs
+            @stream_blurbs.call request, options: options, on_stream: block
           end
 
           ##
@@ -693,11 +751,11 @@ module Google
           #
           # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::CreateBlurbRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::CreateBlurbRequest} instances.
-          # @param options [Google::Gax::CallOptions]
+          # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::SendBlurbsResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::SendBlurbsResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::SendBlurbsResponse]
@@ -717,10 +775,20 @@ module Google
             end
 
             requests = requests.lazy.map do |request|
+              # Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateBlurbRequest
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
             end
 
-            @send_blurbs.call requests, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @send_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :send_blurbs
+            @send_blurbs.call requests, options: options, on_operation: block
           end
 
           ##
@@ -731,7 +799,7 @@ module Google
           #
           # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::ConnectRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::ConnectRequest} instances.
-          # @param options [Google::Gax::CallOptions]
+          # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response] Called on each streaming responses, when provided.
@@ -756,10 +824,20 @@ module Google
             end
 
             requests = requests.lazy.map do |request|
+              # Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ConnectRequest
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::ConnectRequest
             end
 
-            @connect.call requests, options, enum_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @connect ||= Google::Gax::ApiCall.new @messaging_stub.method :connect
+            @connect.call requests, options: options, on_stream: block
           end
 
           protected
@@ -794,19 +872,13 @@ module Google
             )
           end
 
-          def default_settings _client_config, _timeout, metadata, lib_name,
-                               lib_version
-            google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-            google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-            google_api_client << "gapic/#{Google::Showcase::VERSION}"
-            google_api_client << "gax/#{Google::Gax::VERSION}"
-            google_api_client << "grpc/#{GRPC::VERSION}"
-            google_api_client.join " "
-
-            headers = { "x-goog-api-client": google_api_client }
-            headers.merge! metadata unless metadata.nil?
-
-            Google::Gax.const_get(:CallSettings).new metadata: headers
+          def x_goog_api_client_header lib_name, lib_version
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            x_goog_api_client_header.join " "
           end
         end
       end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -691,7 +691,7 @@ module Google
           # This is a stream to create multiple blurbs. If an invalid blurb is
           # requested to be created, the stream will close with an error.
           #
-          # @param requests [Enumerable<Google::Showcase::V1alpha3::CreateBlurbRequest | Hash>]
+          # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::CreateBlurbRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::CreateBlurbRequest} instances.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -708,7 +708,13 @@ module Google
           #   TODO
           #
           def send_blurbs requests, options: nil, &block
-            raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
+            unless requests.is_a? Enumerable
+              if requests.respond_to? :to_enum
+                requests = requests.to_enum
+              else
+                raise ArgumentError, "requests must be an Enumerable"
+              end
+            end
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
@@ -723,7 +729,7 @@ module Google
           # blurbs. If an invalid blurb is requested to be created, the stream will
           # close with an error.
           #
-          # @param requests [Enumerable<Google::Showcase::V1alpha3::ConnectRequest | Hash>]
+          # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::ConnectRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::ConnectRequest} instances.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -741,7 +747,13 @@ module Google
           #   TODO
           #
           def connect requests, options: nil, &block
-            raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
+            unless requests.is_a? Enumerable
+              if requests.respond_to? :to_enum
+                requests = requests.to_enum
+              else
+                raise ArgumentError, "requests must be an Enumerable"
+              end
+            end
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::ConnectRequest

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -160,7 +160,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @create_room ||= Google::Gax::ApiCall.new @messaging_stub.method :create_room
@@ -208,7 +208,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @get_room ||= Google::Gax::ApiCall.new @messaging_stub.method :get_room
@@ -259,7 +259,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @update_room ||= Google::Gax::ApiCall.new @messaging_stub.method :update_room
@@ -307,7 +307,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @delete_room ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_room
@@ -360,7 +360,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_rooms ||= Google::Gax::ApiCall.new @messaging_stub.method :list_rooms
@@ -415,7 +415,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @create_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :create_blurb
@@ -463,7 +463,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @get_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :get_blurb
@@ -514,7 +514,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @update_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :update_blurb
@@ -562,7 +562,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @delete_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_blurb
@@ -620,7 +620,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :list_blurbs
@@ -683,7 +683,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             on_response = ->(response) { Google::Gax::Operation.new response, @operations_client, options }
@@ -738,7 +738,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @stream_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :stream_blurbs
@@ -784,7 +784,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @send_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :send_blurbs
@@ -833,7 +833,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @connect ||= Google::Gax::ApiCall.new @messaging_stub.method :connect

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -663,15 +663,19 @@ module Google
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @return [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]
-          #   An enumerable of {Google::Showcase::V1alpha3::StreamBlurbsResponse} instances.
+          # @yield [response] Called on each streaming responses, when provided.
+          # @yieldparam response [Google::Showcase::V1alpha3::StreamBlurbsResponse]
+          #
+          # @return [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse, nil>]
+          #   An enumerable of {Google::Showcase::V1alpha3::StreamBlurbsResponse} instances when a block is not provided.
+          #   When a block is provided `nil` is returned.
           #
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           #
           # @example
           #   TODO
           #
-          def stream_blurbs request = nil, options: nil, **request_fields
+          def stream_blurbs request = nil, options: nil, **request_fields, &block
             raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
@@ -680,7 +684,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::StreamBlurbsRequest
 
-            @stream_blurbs.call request, options
+            @stream_blurbs.call(request, options, &block)
           end
 
           ##
@@ -724,22 +728,26 @@ module Google
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @return [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]
-          #   An enumerable of {Google::Showcase::V1alpha3::StreamBlurbsResponse} instances.
+          # @yield [response] Called on each streaming responses, when provided.
+          # @yieldparam response [Google::Showcase::V1alpha3::StreamBlurbsResponse]
+          #
+          # @return [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse, nil>]
+          #   An enumerable of {Google::Showcase::V1alpha3::StreamBlurbsResponse} instances when a block is not provided.
+          #   When a block is provided `nil` is returned.
           #
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           #
           # @example
           #   TODO
           #
-          def connect requests, options: nil
+          def connect requests, options: nil, &block
             raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::ConnectRequest
             end
 
-            @connect.call requests, options
+            @connect.call(requests, options, &block)
           end
 
           protected

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -203,7 +203,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateSessionRequest
 
-            @create_session.call(request, options, &block)
+            @create_session.call request, options, op_proc: block
           end
 
           ##
@@ -239,7 +239,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetSessionRequest
 
-            @get_session.call(request, options, &block)
+            @get_session.call request, options, op_proc: block
           end
 
           ##
@@ -277,7 +277,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListSessionsRequest
 
-            @list_sessions.call(request, options, &block)
+            @list_sessions.call request, options, op_proc: block
           end
 
           ##
@@ -313,7 +313,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteSessionRequest
 
-            @delete_session.call(request, options, &block)
+            @delete_session.call request, options, op_proc: block
           end
 
           ##
@@ -353,7 +353,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ReportSessionRequest
 
-            @report_session.call(request, options, &block)
+            @report_session.call request, options, op_proc: block
           end
 
           ##
@@ -393,7 +393,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListTestsRequest
 
-            @list_tests.call(request, options, &block)
+            @list_tests.call request, options, op_proc: block
           end
 
           ##
@@ -439,7 +439,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteTestRequest
 
-            @delete_test.call(request, options, &block)
+            @delete_test.call request, options, op_proc: block
           end
 
           ##
@@ -485,7 +485,7 @@ module Google
             request ||= request_fields
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::VerifyTestRequest
 
-            @verify_test.call(request, options, &block)
+            @verify_test.call request, options, op_proc: block
           end
 
           protected

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -82,26 +82,17 @@ module Google
           # @param scopes [Array<String>]
           #   The OAuth scopes for this service. This parameter is ignored if an
           #   updater_proc is supplied.
-          # @param client_config [Hash]
-          #   A Hash for call options for each method. See Google::Gax#construct_settings
-          #   for the structure of this data. Falls back to the default config if not
-          #   specified or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a
           #   per call basis.
-          # @param exception_transformer [Proc]
-          #   An optional proc that intercepts any exceptions raised during an API call to
-          #   inject custom error handling.
           #
           def initialize \
               credentials: nil,
               scopes: ALL_SCOPES,
-              client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
-              exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
             # These require statements are intentionally placed here to initialize
@@ -113,57 +104,17 @@ module Google
             credentials ||= Credentials.default
 
             @operations_client = OperationsClient.new(
-              credentials:   credentials,
-              scopes:        scopes,
-              client_config: client_config,
-              timeout:       timeout,
-              lib_name:      lib_name,
-              lib_version:   lib_version
+              credentials: credentials,
+              scopes:      scopes,
+              timeout:     timeout,
+              lib_name:    lib_name,
+              lib_version: lib_version
             )
             @testing_stub = create_stub credentials, scopes
 
-            defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
-
-            @create_session = Google::Gax.create_api_call(
-              @testing_stub.method(:create_session),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @get_session = Google::Gax.create_api_call(
-              @testing_stub.method(:get_session),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @list_sessions = Google::Gax.create_api_call(
-              @testing_stub.method(:list_sessions),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @delete_session = Google::Gax.create_api_call(
-              @testing_stub.method(:delete_session),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @report_session = Google::Gax.create_api_call(
-              @testing_stub.method(:report_session),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @list_tests = Google::Gax.create_api_call(
-              @testing_stub.method(:list_tests),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @delete_test = Google::Gax.create_api_call(
-              @testing_stub.method(:delete_test),
-              defaults,
-              exception_transformer: exception_transformer
-            )
-            @verify_test = Google::Gax.create_api_call(
-              @testing_stub.method(:verify_test),
-              defaults,
-              exception_transformer: exception_transformer
-            )
+            @timeout = timeout
+            @metadata = metadata.to_h
+            @metadata["x-goog-api-client"] ||= x_goog_api_client_header lib_name, lib_version
           end
 
           # Service calls
@@ -174,7 +125,7 @@ module Google
           # @overload create_session(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
           #     Creates a new testing session.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload create_session(session: nil, options: nil)
@@ -182,11 +133,11 @@ module Google
           #     The session to be created.
           #     Sessions are immutable once they are created (although they can
           #     be deleted).
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Session]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Session]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Session]
@@ -201,9 +152,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateSessionRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateSessionRequest
 
-            @create_session.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @create_session ||= Google::Gax::ApiCall.new @testing_stub.method :create_session
+            @create_session.call request, options: options, on_operation: block
           end
 
           ##
@@ -212,17 +175,17 @@ module Google
           # @overload get_session(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
           #     Gets a testing session.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload get_session(name: nil, options: nil)
           #   @param name [String]
           #     The session to be retrieved.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Session]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Session]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Session]
@@ -237,9 +200,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetSessionRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetSessionRequest
 
-            @get_session.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @get_session ||= Google::Gax::ApiCall.new @testing_stub.method :get_session
+            @get_session.call request, options: options, on_operation: block
           end
 
           ##
@@ -248,7 +223,7 @@ module Google
           # @overload list_sessions(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
           #     Lists the current test sessions.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_sessions(page_size: nil, page_token: nil, options: nil)
@@ -256,11 +231,11 @@ module Google
           #     The maximum number of sessions to return per page.
           #   @param page_token [String]
           #     The page token, for retrieving subsequent pages.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::ListSessionsResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::ListSessionsResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::ListSessionsResponse]
@@ -275,9 +250,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListSessionsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListSessionsRequest
 
-            @list_sessions.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @list_sessions ||= Google::Gax::ApiCall.new @testing_stub.method :list_sessions
+            @list_sessions.call request, options: options, on_operation: block
           end
 
           ##
@@ -286,17 +273,17 @@ module Google
           # @overload delete_session(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
           #     Delete a test session.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_session(name: nil, options: nil)
           #   @param name [String]
           #     The session to be deleted.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Protobuf::Empty]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Protobuf::Empty]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Protobuf::Empty]
@@ -311,9 +298,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteSessionRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteSessionRequest
 
-            @delete_session.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @delete_session ||= Google::Gax::ApiCall.new @testing_stub.method :delete_session
+            @delete_session.call request, options: options, on_operation: block
           end
 
           ##
@@ -326,17 +325,17 @@ module Google
           #     Report on the status of a session.
           #     This generates a report detailing which tests have been completed,
           #     and an overall rollup.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload report_session(name: nil, options: nil)
           #   @param name [String]
           #     The session to be reported on.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::ReportSessionResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::ReportSessionResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::ReportSessionResponse]
@@ -351,9 +350,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ReportSessionRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ReportSessionRequest
 
-            @report_session.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @report_session ||= Google::Gax::ApiCall.new @testing_stub.method :report_session
+            @report_session.call request, options: options, on_operation: block
           end
 
           ##
@@ -362,7 +373,7 @@ module Google
           # @overload list_tests(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
           #     List the tests of a sessesion.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_tests(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -372,11 +383,11 @@ module Google
           #     The maximum number of tests to return per page.
           #   @param page_token [String]
           #     The page token, for retrieving subsequent pages.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::ListTestsResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::ListTestsResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::ListTestsResponse]
@@ -391,9 +402,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListTestsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListTestsRequest
 
-            @list_tests.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @list_tests ||= Google::Gax::ApiCall.new @testing_stub.method :list_tests
+            @list_tests.call request, options: options, on_operation: block
           end
 
           ##
@@ -412,17 +435,17 @@ module Google
           #     attempting to do the test will error.
           #
           #     This method will error if attempting to delete a required test.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_test(name: nil, options: nil)
           #   @param name [String]
           #     The test to be deleted.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Protobuf::Empty]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Protobuf::Empty]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Protobuf::Empty]
@@ -437,9 +460,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteTestRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteTestRequest
 
-            @delete_test.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @delete_test ||= Google::Gax::ApiCall.new @testing_stub.method :delete_test
+            @delete_test.call request, options: options, on_operation: block
           end
 
           ##
@@ -454,7 +489,7 @@ module Google
           #
           #     In cases where a test involves registering a final answer at the
           #     end of the test, this method provides the means to do so.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload verify_test(name: nil, answer: nil, answers: nil, options: nil)
@@ -464,11 +499,11 @@ module Google
           #     The answer from the test.
           #   @param answers [String]
           #     The answers from the test if multiple are to be checked
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::VerifyTestResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::VerifyTestResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::VerifyTestResponse]
@@ -483,9 +518,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::VerifyTestRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::VerifyTestRequest
 
-            @verify_test.call request, options, op_proc: block
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @verify_test ||= Google::Gax::ApiCall.new @testing_stub.method :verify_test
+            @verify_test.call request, options: options, on_operation: block
           end
 
           protected
@@ -520,19 +567,13 @@ module Google
             )
           end
 
-          def default_settings _client_config, _timeout, metadata, lib_name,
-                               lib_version
-            google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-            google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-            google_api_client << "gapic/#{Google::Showcase::VERSION}"
-            google_api_client << "gax/#{Google::Gax::VERSION}"
-            google_api_client << "grpc/#{GRPC::VERSION}"
-            google_api_client.join " "
-
-            headers = { "x-goog-api-client": google_api_client }
-            headers.merge! metadata unless metadata.nil?
-
-            Google::Gax.const_get(:CallSettings).new metadata: headers
+          def x_goog_api_client_header lib_name, lib_version
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            x_goog_api_client_header.join " "
           end
         end
       end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -162,7 +162,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @create_session ||= Google::Gax::ApiCall.new @testing_stub.method :create_session
@@ -210,7 +210,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @get_session ||= Google::Gax::ApiCall.new @testing_stub.method :get_session
@@ -260,7 +260,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_sessions ||= Google::Gax::ApiCall.new @testing_stub.method :list_sessions
@@ -308,7 +308,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @delete_session ||= Google::Gax::ApiCall.new @testing_stub.method :delete_session
@@ -360,7 +360,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @report_session ||= Google::Gax::ApiCall.new @testing_stub.method :report_session
@@ -412,7 +412,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_tests ||= Google::Gax::ApiCall.new @testing_stub.method :list_tests
@@ -470,7 +470,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @delete_test ||= Google::Gax::ApiCall.new @testing_stub.method :delete_test
@@ -528,7 +528,7 @@ module Google
             header_params = {} # { name: request.name }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
             metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
             options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @verify_test ||= Google::Gax::ApiCall.new @testing_stub.method :verify_test

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -80,26 +80,17 @@ module Google
             # @param scopes [Array<String>]
             #   The OAuth scopes for this service. This parameter is ignored if an
             #   updater_proc is supplied.
-            # @param client_config [Hash]
-            #   A Hash for call options for each method. See Google::Gax#construct_settings
-            #   for the structure of this data. Falls back to the default config if not
-            #   specified or the specified config is missing data points.
             # @param timeout [Numeric]
             #   The default timeout, in seconds, for calls made through this client.
             # @param metadata [Hash]
             #   Default metadata to be sent with each request. This can be overridden on a
             #   per call basis.
-            # @param exception_transformer [Proc]
-            #   An optional proc that intercepts any exceptions raised during an API call to
-            #   inject custom error handling.
             #
             def initialize \
                 credentials: nil,
                 scopes: ALL_SCOPES,
-                client_config: {},
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
-                exception_transformer: nil,
                 lib_name: nil,
                 lib_version: ""
               # These require statements are intentionally placed here to initialize
@@ -111,32 +102,17 @@ module Google
               credentials ||= Credentials.default
 
               @operations_client = OperationsClient.new(
-                credentials:   credentials,
-                scopes:        scopes,
-                client_config: client_config,
-                timeout:       timeout,
-                lib_name:      lib_name,
-                lib_version:   lib_version
+                credentials: credentials,
+                scopes:      scopes,
+                timeout:     timeout,
+                lib_name:    lib_name,
+                lib_version: lib_version
               )
               @speech_stub = create_stub credentials, scopes
 
-              defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
-
-              @recognize = Google::Gax.create_api_call(
-                @speech_stub.method(:recognize),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @long_running_recognize = Google::Gax.create_api_call(
-                @speech_stub.method(:long_running_recognize),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @streaming_recognize = Google::Gax.create_api_call(
-                @speech_stub.method(:streaming_recognize),
-                defaults,
-                exception_transformer: exception_transformer
-              )
+              @timeout = timeout
+              @metadata = metadata.to_h
+              @metadata["x-goog-api-client"] ||= x_goog_api_client_header lib_name, lib_version
             end
 
             # Service calls
@@ -149,7 +125,7 @@ module Google
             #   @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
             #     Performs synchronous speech recognition: receive results after all audio
             #     has been sent and processed.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload recognize(config: nil, audio: nil, options: nil)
@@ -158,11 +134,11 @@ module Google
             #     process the request.
             #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
             #     *Required* The audio data to be recognized.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Speech::V1::RecognizeResponse]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Speech::V1::RecognizeResponse]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Speech::V1::RecognizeResponse]
@@ -177,9 +153,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::RecognizeRequest
               request = Google::Gax.to_proto request, Google::Cloud::Speech::V1::RecognizeRequest
 
-              @recognize.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @recognize ||= Google::Gax::ApiCall.new @speech_stub.method :recognize
+              @recognize.call request, options: options, on_operation: block
             end
 
             ##
@@ -194,7 +182,7 @@ module Google
             #     google.longrunning.Operations interface. Returns either an
             #     `Operation.error` or an `Operation.response` which contains
             #     a `LongRunningRecognizeResponse` message.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload long_running_recognize(config: nil, audio: nil, options: nil)
@@ -203,33 +191,40 @@ module Google
             #     process the request.
             #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
             #     *Required* The audio data to be recognized.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [operation] Register a callback to be run when an operation is done.
-            # @yieldparam operation [Google::Gax::Operation]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Gax::Operation]
+            # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Gax::Operation]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   TODO
             #
-            def long_running_recognize request = nil, options: nil, **request_fields
+            def long_running_recognize request = nil, options: nil, **request_fields, &block
               raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::LongRunningRecognizeRequest
               request = Google::Gax.to_proto request, Google::Cloud::Speech::V1::LongRunningRecognizeRequest
 
-              operation = Google::Gax::Operation.new(
-                @long_running_recognize.call(request, options),
-                @operations_client,
-                call_options: options
-              )
-              operation.on_done { |operation| yield operation } if block_given?
-              operation
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              on_response = ->(response) { Google::Gax::Operation.new response, @operations_client, options }
+
+              @long_running_recognize ||= Google::Gax::ApiCall.new @speech_stub.method :long_running_recognize
+              @long_running_recognize.call request, options: options, on_operation: block, on_response: on_response
             end
 
             ##
@@ -238,7 +233,7 @@ module Google
             #
             # @param requests [Google::Gax::StreamInput, Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeRequest | Hash>]
             #   An enumerable of {Google::Cloud::Speech::V1::StreamingRecognizeRequest} instances.
-            # @param options [Google::Gax::CallOptions]
+            # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response] Called on each streaming responses, when provided.
@@ -263,10 +258,20 @@ module Google
               end
 
               requests = requests.lazy.map do |request|
+                # Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::StreamingRecognizeRequest
                 Google::Gax.to_proto request, Google::Cloud::Speech::V1::StreamingRecognizeRequest
               end
 
-              @streaming_recognize.call requests, options, enum_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @streaming_recognize ||= Google::Gax::ApiCall.new @speech_stub.method :streaming_recognize
+              @streaming_recognize.call requests, options: options, on_stream: block
             end
 
             protected
@@ -301,19 +306,13 @@ module Google
               )
             end
 
-            def default_settings _client_config, _timeout, metadata, lib_name,
-                                 lib_version
-              google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-              google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-              google_api_client << "gapic/#{Google::Cloud::Speech::VERSION}"
-              google_api_client << "gax/#{Google::Gax::VERSION}"
-              google_api_client << "grpc/#{GRPC::VERSION}"
-              google_api_client.join " "
-
-              headers = { "x-goog-api-client": google_api_client }
-              headers.merge! metadata unless metadata.nil?
-
-              Google::Gax.const_get(:CallSettings).new metadata: headers
+            def x_goog_api_client_header lib_name, lib_version
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              x_goog_api_client_header.join " "
             end
           end
         end

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -236,7 +236,7 @@ module Google
             # Performs bidirectional streaming speech recognition: receive results while
             # sending audio. This method is only available via the gRPC API (not REST).
             #
-            # @param requests [Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeRequest | Hash>]
+            # @param requests [Google::Gax::StreamInput, Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeRequest | Hash>]
             #   An enumerable of {Google::Cloud::Speech::V1::StreamingRecognizeRequest} instances.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -254,7 +254,13 @@ module Google
             #   TODO
             #
             def streaming_recognize requests, options: nil, &block
-              raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
+              unless requests.is_a? Enumerable
+                if requests.respond_to? :to_enum
+                  requests = requests.to_enum
+                else
+                  raise ArgumentError, "requests must be an Enumerable"
+                end
+              end
 
               requests = requests.lazy.map do |request|
                 Google::Gax.to_proto request, Google::Cloud::Speech::V1::StreamingRecognizeRequest

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -179,7 +179,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Speech::V1::RecognizeRequest
 
-              @recognize.call(request, options, &block)
+              @recognize.call request, options, op_proc: block
             end
 
             ##
@@ -266,7 +266,7 @@ module Google
                 Google::Gax.to_proto request, Google::Cloud::Speech::V1::StreamingRecognizeRequest
               end
 
-              @streaming_recognize.call(requests, options, &block)
+              @streaming_recognize.call requests, options, enum_proc: block
             end
 
             protected

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -241,22 +241,26 @@ module Google
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @return [Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeResponse>]
-            #   An enumerable of {Google::Cloud::Speech::V1::StreamingRecognizeResponse} instances.
+            # @yield [response] Called on each streaming responses, when provided.
+            # @yieldparam response [Google::Cloud::Speech::V1::StreamingRecognizeResponse]
+            #
+            # @return [Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeResponse, nil>]
+            #   An enumerable of {Google::Cloud::Speech::V1::StreamingRecognizeResponse} instances when a block is not provided.
+            #   When a block is provided `nil` is returned.
             #
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             #
             # @example
             #   TODO
             #
-            def streaming_recognize requests, options: nil
+            def streaming_recognize requests, options: nil, &block
               raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
 
               requests = requests.lazy.map do |request|
                 Google::Gax.to_proto request, Google::Cloud::Speech::V1::StreamingRecognizeRequest
               end
 
-              @streaming_recognize.call requests, options
+              @streaming_recognize.call(requests, options, &block)
             end
 
             protected

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -163,7 +163,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @recognize ||= Google::Gax::ApiCall.new @speech_stub.method :recognize
@@ -218,7 +218,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               on_response = ->(response) { Google::Gax::Operation.new response, @operations_client, options }
@@ -267,7 +267,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @streaming_recognize ||= Google::Gax::ApiCall.new @speech_stub.method :streaming_recognize

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -158,7 +158,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @batch_annotate_images ||= Google::Gax::ApiCall.new @image_annotator_stub.method :batch_annotate_images
@@ -214,7 +214,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               on_response = ->(response) { Google::Gax::Operation.new response, @operations_client, options }

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -80,26 +80,17 @@ module Google
             # @param scopes [Array<String>]
             #   The OAuth scopes for this service. This parameter is ignored if an
             #   updater_proc is supplied.
-            # @param client_config [Hash]
-            #   A Hash for call options for each method. See Google::Gax#construct_settings
-            #   for the structure of this data. Falls back to the default config if not
-            #   specified or the specified config is missing data points.
             # @param timeout [Numeric]
             #   The default timeout, in seconds, for calls made through this client.
             # @param metadata [Hash]
             #   Default metadata to be sent with each request. This can be overridden on a
             #   per call basis.
-            # @param exception_transformer [Proc]
-            #   An optional proc that intercepts any exceptions raised during an API call to
-            #   inject custom error handling.
             #
             def initialize \
                 credentials: nil,
                 scopes: ALL_SCOPES,
-                client_config: {},
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
-                exception_transformer: nil,
                 lib_name: nil,
                 lib_version: ""
               # These require statements are intentionally placed here to initialize
@@ -111,27 +102,17 @@ module Google
               credentials ||= Credentials.default
 
               @operations_client = OperationsClient.new(
-                credentials:   credentials,
-                scopes:        scopes,
-                client_config: client_config,
-                timeout:       timeout,
-                lib_name:      lib_name,
-                lib_version:   lib_version
+                credentials: credentials,
+                scopes:      scopes,
+                timeout:     timeout,
+                lib_name:    lib_name,
+                lib_version: lib_version
               )
               @image_annotator_stub = create_stub credentials, scopes
 
-              defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
-
-              @batch_annotate_images = Google::Gax.create_api_call(
-                @image_annotator_stub.method(:batch_annotate_images),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @async_batch_annotate_files = Google::Gax.create_api_call(
-                @image_annotator_stub.method(:async_batch_annotate_files),
-                defaults,
-                exception_transformer: exception_transformer
-              )
+              @timeout = timeout
+              @metadata = metadata.to_h
+              @metadata["x-goog-api-client"] ||= x_goog_api_client_header lib_name, lib_version
             end
 
             # Service calls
@@ -142,17 +123,17 @@ module Google
             # @overload batch_annotate_images(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
             #     Run image detection and annotation for a batch of images.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload batch_annotate_images(requests: nil, options: nil)
             #   @param requests [Google::Cloud::Vision::V1::AnnotateImageRequest | Hash]
             #     Individual image annotation requests for this batch.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
@@ -167,9 +148,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
 
-              @batch_annotate_images.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @batch_annotate_images ||= Google::Gax::ApiCall.new @image_annotator_stub.method :batch_annotate_images
+              @batch_annotate_images.call request, options: options, on_operation: block
             end
 
             ##
@@ -188,39 +181,46 @@ module Google
             #     `google.longrunning.Operations` interface.
             #     `Operation.metadata` contains `OperationMetadata` (metadata).
             #     `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload async_batch_annotate_files(requests: nil, options: nil)
             #   @param requests [Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash]
             #     Individual async file annotation requests for this batch.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [operation] Register a callback to be run when an operation is done.
-            # @yieldparam operation [Google::Gax::Operation]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Gax::Operation]
+            # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Gax::Operation]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   TODO
             #
-            def async_batch_annotate_files request = nil, options: nil, **request_fields
+            def async_batch_annotate_files request = nil, options: nil, **request_fields, &block
               raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
 
-              operation = Google::Gax::Operation.new(
-                @async_batch_annotate_files.call(request, options),
-                @operations_client,
-                call_options: options
-              )
-              operation.on_done { |operation| yield operation } if block_given?
-              operation
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              on_response = ->(response) { Google::Gax::Operation.new response, @operations_client, options }
+
+              @async_batch_annotate_files ||= Google::Gax::ApiCall.new @image_annotator_stub.method :async_batch_annotate_files
+              @async_batch_annotate_files.call request, options: options, on_operation: block, on_response: on_response
             end
 
             protected
@@ -255,19 +255,13 @@ module Google
               )
             end
 
-            def default_settings _client_config, _timeout, metadata, lib_name,
-                                 lib_version
-              google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-              google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-              google_api_client << "gapic/#{Google::Cloud::Vision::VERSION}"
-              google_api_client << "gax/#{Google::Gax::VERSION}"
-              google_api_client << "grpc/#{GRPC::VERSION}"
-              google_api_client.join " "
-
-              headers = { "x-goog-api-client": google_api_client }
-              headers.merge! metadata unless metadata.nil?
-
-              Google::Gax.const_get(:CallSettings).new metadata: headers
+            def x_goog_api_client_header lib_name, lib_version
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              x_goog_api_client_header.join " "
             end
           end
         end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -169,7 +169,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
 
-              @batch_annotate_images.call(request, options, &block)
+              @batch_annotate_images.call request, options, op_proc: block
             end
 
             ##

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -177,7 +177,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @create_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :create_product_set
@@ -241,7 +241,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @list_product_sets ||= Google::Gax::ApiCall.new @product_search_stub.method :list_product_sets
@@ -300,7 +300,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @get_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :get_product_set
@@ -367,7 +367,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @update_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :update_product_set
@@ -432,7 +432,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @delete_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_product_set
@@ -504,7 +504,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @create_product ||= Google::Gax::ApiCall.new @product_search_stub.method :create_product
@@ -567,7 +567,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @list_products ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products
@@ -626,7 +626,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @get_product ||= Google::Gax::ApiCall.new @product_search_stub.method :get_product
@@ -709,7 +709,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @update_product ||= Google::Gax::ApiCall.new @product_search_stub.method :update_product
@@ -776,7 +776,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @delete_product ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_product
@@ -871,7 +871,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @create_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :create_reference_image
@@ -943,7 +943,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @delete_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_reference_image
@@ -1013,7 +1013,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @list_reference_images ||= Google::Gax::ApiCall.new @product_search_stub.method :list_reference_images
@@ -1073,7 +1073,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @get_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :get_reference_image
@@ -1143,7 +1143,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @add_product_to_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :add_product_to_product_set
@@ -1207,7 +1207,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @remove_product_from_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :remove_product_from_product_set
@@ -1274,7 +1274,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @list_products_in_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products_in_product_set
@@ -1344,7 +1344,7 @@ module Google
               header_params = {} # { name: request.name }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
               metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
               options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               on_response = ->(response) { Google::Gax::Operation.new response, @operations_client, options }

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -80,26 +80,17 @@ module Google
             # @param scopes [Array<String>]
             #   The OAuth scopes for this service. This parameter is ignored if an
             #   updater_proc is supplied.
-            # @param client_config [Hash]
-            #   A Hash for call options for each method. See Google::Gax#construct_settings
-            #   for the structure of this data. Falls back to the default config if not
-            #   specified or the specified config is missing data points.
             # @param timeout [Numeric]
             #   The default timeout, in seconds, for calls made through this client.
             # @param metadata [Hash]
             #   Default metadata to be sent with each request. This can be overridden on a
             #   per call basis.
-            # @param exception_transformer [Proc]
-            #   An optional proc that intercepts any exceptions raised during an API call to
-            #   inject custom error handling.
             #
             def initialize \
                 credentials: nil,
                 scopes: ALL_SCOPES,
-                client_config: {},
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
-                exception_transformer: nil,
                 lib_name: nil,
                 lib_version: ""
               # These require statements are intentionally placed here to initialize
@@ -111,107 +102,17 @@ module Google
               credentials ||= Credentials.default
 
               @operations_client = OperationsClient.new(
-                credentials:   credentials,
-                scopes:        scopes,
-                client_config: client_config,
-                timeout:       timeout,
-                lib_name:      lib_name,
-                lib_version:   lib_version
+                credentials: credentials,
+                scopes:      scopes,
+                timeout:     timeout,
+                lib_name:    lib_name,
+                lib_version: lib_version
               )
               @product_search_stub = create_stub credentials, scopes
 
-              defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
-
-              @create_product_set = Google::Gax.create_api_call(
-                @product_search_stub.method(:create_product_set),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @list_product_sets = Google::Gax.create_api_call(
-                @product_search_stub.method(:list_product_sets),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @get_product_set = Google::Gax.create_api_call(
-                @product_search_stub.method(:get_product_set),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @update_product_set = Google::Gax.create_api_call(
-                @product_search_stub.method(:update_product_set),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @delete_product_set = Google::Gax.create_api_call(
-                @product_search_stub.method(:delete_product_set),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @create_product = Google::Gax.create_api_call(
-                @product_search_stub.method(:create_product),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @list_products = Google::Gax.create_api_call(
-                @product_search_stub.method(:list_products),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @get_product = Google::Gax.create_api_call(
-                @product_search_stub.method(:get_product),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @update_product = Google::Gax.create_api_call(
-                @product_search_stub.method(:update_product),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @delete_product = Google::Gax.create_api_call(
-                @product_search_stub.method(:delete_product),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @create_reference_image = Google::Gax.create_api_call(
-                @product_search_stub.method(:create_reference_image),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @delete_reference_image = Google::Gax.create_api_call(
-                @product_search_stub.method(:delete_reference_image),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @list_reference_images = Google::Gax.create_api_call(
-                @product_search_stub.method(:list_reference_images),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @get_reference_image = Google::Gax.create_api_call(
-                @product_search_stub.method(:get_reference_image),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @add_product_to_product_set = Google::Gax.create_api_call(
-                @product_search_stub.method(:add_product_to_product_set),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @remove_product_from_product_set = Google::Gax.create_api_call(
-                @product_search_stub.method(:remove_product_from_product_set),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @list_products_in_product_set = Google::Gax.create_api_call(
-                @product_search_stub.method(:list_products_in_product_set),
-                defaults,
-                exception_transformer: exception_transformer
-              )
-              @import_product_sets = Google::Gax.create_api_call(
-                @product_search_stub.method(:import_product_sets),
-                defaults,
-                exception_transformer: exception_transformer
-              )
+              @timeout = timeout
+              @metadata = metadata.to_h
+              @metadata["x-goog-api-client"] ||= x_goog_api_client_header lib_name, lib_version
             end
 
             # Service calls
@@ -232,7 +133,7 @@ module Google
             #
             #     * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
             #       4096 characters.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload create_product_set(parent: nil, product_set: nil, product_set_id: nil, options: nil)
@@ -247,11 +148,11 @@ module Google
             #     attempt to use this value as the resource id. If it is already in use, an
             #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
             #     long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ProductSet]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ProductSet]
@@ -266,9 +167,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateProductSetRequest
 
-              @create_product_set.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @create_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :create_product_set
+              @create_product_set.call request, options: options, on_operation: block
             end
 
             ##
@@ -287,7 +200,7 @@ module Google
             #
             #     * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
             #       than 1.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload list_product_sets(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -299,11 +212,11 @@ module Google
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ListProductSetsResponse]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ListProductSetsResponse]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ListProductSetsResponse]
@@ -318,9 +231,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductSetsRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductSetsRequest
 
-              @list_product_sets.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @list_product_sets ||= Google::Gax::ApiCall.new @product_search_stub.method :list_product_sets
+              @list_product_sets.call request, options: options, on_operation: block
             end
 
             ##
@@ -337,7 +262,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the ProductSet does not exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload get_product_set(name: nil, options: nil)
@@ -346,11 +271,11 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ProductSet]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ProductSet]
@@ -365,9 +290,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetProductSetRequest
 
-              @get_product_set.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @get_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :get_product_set
+              @get_product_set.call request, options: options, on_operation: block
             end
 
             ##
@@ -390,7 +327,7 @@ module Google
             #     * Returns NOT_FOUND if the ProductSet does not exist.
             #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but
             #       missing from the request or longer than 4096 characters.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload update_product_set(product_set: nil, update_mask: nil, options: nil)
@@ -401,11 +338,11 @@ module Google
             #     update.
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask path is `display_name`.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ProductSet]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ProductSet]
@@ -420,9 +357,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::UpdateProductSetRequest
 
-              @update_product_set.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @update_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :update_product_set
+              @update_product_set.call request, options: options, on_operation: block
             end
 
             ##
@@ -445,7 +394,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the ProductSet does not exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload delete_product_set(name: nil, options: nil)
@@ -454,11 +403,11 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Protobuf::Empty]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Protobuf::Empty]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Protobuf::Empty]
@@ -473,9 +422,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteProductSetRequest
 
-              @delete_product_set.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @delete_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_product_set
+              @delete_product_set.call request, options: options, on_operation: block
             end
 
             ##
@@ -498,7 +459,7 @@ module Google
             #       characters.
             #     * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
             #     * Returns INVALID_ARGUMENT if product_category is missing or invalid.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload create_product(parent: nil, product: nil, product_id: nil, options: nil)
@@ -514,11 +475,11 @@ module Google
             #     attempt to use this value as the resource id. If it is already in use, an
             #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
             #     long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::Product]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::Product]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::Product]
@@ -533,9 +494,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateProductRequest
 
-              @create_product.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @create_product ||= Google::Gax::ApiCall.new @product_search_stub.method :create_product
+              @create_product.call request, options: options, on_operation: block
             end
 
             ##
@@ -552,7 +525,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload list_products(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -565,11 +538,11 @@ module Google
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ListProductsResponse]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ListProductsResponse]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ListProductsResponse]
@@ -584,9 +557,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductsRequest
 
-              @list_products.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @list_products ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products
+              @list_products.call request, options: options, on_operation: block
             end
 
             ##
@@ -603,7 +588,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the Product does not exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload get_product(name: nil, options: nil)
@@ -612,11 +597,11 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::Product]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::Product]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::Product]
@@ -631,9 +616,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetProductRequest
 
-              @get_product.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @get_product ||= Google::Gax::ApiCall.new @product_search_stub.method :get_product
+              @get_product.call request, options: options, on_operation: block
             end
 
             ##
@@ -670,7 +667,7 @@ module Google
             #     * Returns INVALID_ARGUMENT if description is present in update_mask but is
             #       longer than 4096 characters.
             #     * Returns INVALID_ARGUMENT if product_category is present in update_mask.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload update_product(product: nil, update_mask: nil, options: nil)
@@ -683,11 +680,11 @@ module Google
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask paths include `product_labels`, `display_name`, and
             #     `description`.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::Product]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::Product]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::Product]
@@ -702,9 +699,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::UpdateProductRequest
 
-              @update_product.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @update_product ||= Google::Gax::ApiCall.new @product_search_stub.method :update_product
+              @update_product.call request, options: options, on_operation: block
             end
 
             ##
@@ -729,7 +738,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the product does not exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload delete_product(name: nil, options: nil)
@@ -738,11 +747,11 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Protobuf::Empty]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Protobuf::Empty]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Protobuf::Empty]
@@ -757,9 +766,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteProductRequest
 
-              @delete_product.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @delete_product ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_product
+              @delete_product.call request, options: options, on_operation: block
             end
 
             ##
@@ -804,7 +825,7 @@ module Google
             #     * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
             #       compatible with the parent product's product_category is detected.
             #     * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload create_reference_image(parent: nil, reference_image: nil, reference_image_id: nil, options: nil)
@@ -821,11 +842,11 @@ module Google
             #     the server will attempt to use this value as the resource id. If it is
             #     already in use, an error is returned with code ALREADY_EXISTS. Must be at
             #     most 128 characters long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ReferenceImage]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ReferenceImage]
@@ -840,9 +861,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateReferenceImageRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateReferenceImageRequest
 
-              @create_reference_image.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @create_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :create_reference_image
+              @create_reference_image.call request, options: options, on_operation: block
             end
 
             ##
@@ -871,7 +904,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the reference image does not exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload delete_reference_image(name: nil, options: nil)
@@ -881,11 +914,11 @@ module Google
             #     Format is:
             #
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Protobuf::Empty]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Protobuf::Empty]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Protobuf::Empty]
@@ -900,9 +933,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteReferenceImageRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteReferenceImageRequest
 
-              @delete_reference_image.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @delete_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_reference_image
+              @delete_reference_image.call request, options: options, on_operation: block
             end
 
             ##
@@ -923,7 +968,7 @@ module Google
             #     * Returns NOT_FOUND if the parent product does not exist.
             #     * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
             #       than 1.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload list_reference_images(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -939,11 +984,11 @@ module Google
             #     of `nextPageToken` returned in a previous reference image list request.
             #
             #     Defaults to the first page if not specified.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ListReferenceImagesResponse]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ListReferenceImagesResponse]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ListReferenceImagesResponse]
@@ -958,9 +1003,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListReferenceImagesRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListReferenceImagesRequest
 
-              @list_reference_images.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @list_reference_images ||= Google::Gax::ApiCall.new @product_search_stub.method :list_reference_images
+              @list_reference_images.call request, options: options, on_operation: block
             end
 
             ##
@@ -977,7 +1034,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the specified image does not exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload get_reference_image(name: nil, options: nil)
@@ -987,11 +1044,11 @@ module Google
             #     Format is:
             #
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ReferenceImage]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ReferenceImage]
@@ -1006,9 +1063,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetReferenceImageRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetReferenceImageRequest
 
-              @get_reference_image.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @get_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :get_reference_image
+              @get_reference_image.call request, options: options, on_operation: block
             end
 
             ##
@@ -1031,7 +1100,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload add_product_to_product_set(name: nil, product: nil, options: nil)
@@ -1045,11 +1114,11 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Protobuf::Empty]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Protobuf::Empty]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Protobuf::Empty]
@@ -1064,9 +1133,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AddProductToProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::AddProductToProductSetRequest
 
-              @add_product_to_product_set.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @add_product_to_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :add_product_to_product_set
+              @add_product_to_product_set.call request, options: options, on_operation: block
             end
 
             ##
@@ -1083,7 +1164,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND If the Product is not found under the ProductSet.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload remove_product_from_product_set(name: nil, product: nil, options: nil)
@@ -1097,11 +1178,11 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Protobuf::Empty]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Protobuf::Empty]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Protobuf::Empty]
@@ -1116,9 +1197,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
 
-              @remove_product_from_product_set.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @remove_product_from_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :remove_product_from_product_set
+              @remove_product_from_product_set.call request, options: options, on_operation: block
             end
 
             ##
@@ -1139,7 +1232,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload list_products_in_product_set(name: nil, page_size: nil, page_token: nil, options: nil)
@@ -1152,11 +1245,11 @@ module Google
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ListProductsInProductSetResponse]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ListProductsInProductSetResponse]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ListProductsInProductSetResponse]
@@ -1171,9 +1264,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsInProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductsInProductSetRequest
 
-              @list_products_in_product_set.call request, options, op_proc: block
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @list_products_in_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products_in_product_set
+              @list_products_in_product_set.call request, options: options, on_operation: block
             end
 
             ##
@@ -1202,7 +1307,7 @@ module Google
             #     The input source of this method is a csv file on Google Cloud Storage.
             #     For the format of the csv file please see
             #     [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload import_product_sets(parent: nil, input_config: nil, options: nil)
@@ -1212,33 +1317,40 @@ module Google
             #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
             #   @param input_config [Google::Cloud::Vision::V1::ImportProductSetsInputConfig | Hash]
             #     The input content for the list of requests.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [operation] Register a callback to be run when an operation is done.
-            # @yieldparam operation [Google::Gax::Operation]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Gax::Operation]
+            # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Gax::Operation]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   TODO
             #
-            def import_product_sets request = nil, options: nil, **request_fields
+            def import_product_sets request = nil, options: nil, **request_fields, &block
               raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ImportProductSetsRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ImportProductSetsRequest
 
-              operation = Google::Gax::Operation.new(
-                @import_product_sets.call(request, options),
-                @operations_client,
-                call_options: options
-              )
-              operation.on_done { |operation| yield operation } if block_given?
-              operation
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.merge timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              on_response = ->(response) { Google::Gax::Operation.new response, @operations_client, options }
+
+              @import_product_sets ||= Google::Gax::ApiCall.new @product_search_stub.method :import_product_sets
+              @import_product_sets.call request, options: options, on_operation: block, on_response: on_response
             end
 
             protected
@@ -1273,19 +1385,13 @@ module Google
               )
             end
 
-            def default_settings _client_config, _timeout, metadata, lib_name,
-                                 lib_version
-              google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-              google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-              google_api_client << "gapic/#{Google::Cloud::Vision::VERSION}"
-              google_api_client << "gax/#{Google::Gax::VERSION}"
-              google_api_client << "grpc/#{GRPC::VERSION}"
-              google_api_client.join " "
-
-              headers = { "x-goog-api-client": google_api_client }
-              headers.merge! metadata unless metadata.nil?
-
-              Google::Gax.const_get(:CallSettings).new metadata: headers
+            def x_goog_api_client_header lib_name, lib_version
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              x_goog_api_client_header.join " "
             end
           end
         end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -268,7 +268,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateProductSetRequest
 
-              @create_product_set.call(request, options, &block)
+              @create_product_set.call request, options, op_proc: block
             end
 
             ##
@@ -320,7 +320,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductSetsRequest
 
-              @list_product_sets.call(request, options, &block)
+              @list_product_sets.call request, options, op_proc: block
             end
 
             ##
@@ -367,7 +367,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetProductSetRequest
 
-              @get_product_set.call(request, options, &block)
+              @get_product_set.call request, options, op_proc: block
             end
 
             ##
@@ -422,7 +422,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::UpdateProductSetRequest
 
-              @update_product_set.call(request, options, &block)
+              @update_product_set.call request, options, op_proc: block
             end
 
             ##
@@ -475,7 +475,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteProductSetRequest
 
-              @delete_product_set.call(request, options, &block)
+              @delete_product_set.call request, options, op_proc: block
             end
 
             ##
@@ -535,7 +535,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateProductRequest
 
-              @create_product.call(request, options, &block)
+              @create_product.call request, options, op_proc: block
             end
 
             ##
@@ -586,7 +586,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductsRequest
 
-              @list_products.call(request, options, &block)
+              @list_products.call request, options, op_proc: block
             end
 
             ##
@@ -633,7 +633,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetProductRequest
 
-              @get_product.call(request, options, &block)
+              @get_product.call request, options, op_proc: block
             end
 
             ##
@@ -704,7 +704,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::UpdateProductRequest
 
-              @update_product.call(request, options, &block)
+              @update_product.call request, options, op_proc: block
             end
 
             ##
@@ -759,7 +759,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteProductRequest
 
-              @delete_product.call(request, options, &block)
+              @delete_product.call request, options, op_proc: block
             end
 
             ##
@@ -842,7 +842,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateReferenceImageRequest
 
-              @create_reference_image.call(request, options, &block)
+              @create_reference_image.call request, options, op_proc: block
             end
 
             ##
@@ -902,7 +902,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteReferenceImageRequest
 
-              @delete_reference_image.call(request, options, &block)
+              @delete_reference_image.call request, options, op_proc: block
             end
 
             ##
@@ -960,7 +960,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListReferenceImagesRequest
 
-              @list_reference_images.call(request, options, &block)
+              @list_reference_images.call request, options, op_proc: block
             end
 
             ##
@@ -1008,7 +1008,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetReferenceImageRequest
 
-              @get_reference_image.call(request, options, &block)
+              @get_reference_image.call request, options, op_proc: block
             end
 
             ##
@@ -1066,7 +1066,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::AddProductToProductSetRequest
 
-              @add_product_to_product_set.call(request, options, &block)
+              @add_product_to_product_set.call request, options, op_proc: block
             end
 
             ##
@@ -1118,7 +1118,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
 
-              @remove_product_from_product_set.call(request, options, &block)
+              @remove_product_from_product_set.call request, options, op_proc: block
             end
 
             ##
@@ -1173,7 +1173,7 @@ module Google
               request ||= request_fields
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductsInProductSetRequest
 
-              @list_products_in_product_set.call(request, options, &block)
+              @list_products_in_product_set.call request, options, op_proc: block
             end
 
             ##


### PR DESCRIPTION
This PR is a draft, and here to collect feedback. We have discussed what changes we might want to see in the future versions of GAX, and this PR includes two that I think would be very useful.

The first is use of a `StreamInput` class that would hold a stream open until `#close` is called on it. We currently have this functionality in the GCP gems, but they are part of the private API and not something that is documented for users.

The second is to support change is to support blocks on streaming server and bidi methods, and to have the block process responses as they stream from the server. This would make the majority of streaming responses easier to consume. There are changes that are needed to GAX to support this.

Thoughts?