### PR TITLE
Fix comments

### DIFF
--- a/gapic-generator-cloud/templates/cloud/helpers/presenters/enum_presenter.rb
+++ b/gapic-generator-cloud/templates/cloud/helpers/presenters/enum_presenter.rb
@@ -28,7 +28,12 @@ class EnumPresenter
   def doc_description
     return nil if @enum.docs.leading_comments.empty?
 
-    @enum.docs.leading_comments
+    @enum
+      .docs
+      .leading_comments
+      .each_line
+      .map { |line| (line.start_with? " ") ? line[1..-1] : line }
+      .join
   end
 
   def values

--- a/gapic-generator-cloud/templates/cloud/helpers/presenters/enum_value_presenter.rb
+++ b/gapic-generator-cloud/templates/cloud/helpers/presenters/enum_value_presenter.rb
@@ -26,7 +26,12 @@ class EnumValuePresenter
   def doc_description
     return nil if @value.docs.leading_comments.empty?
 
-    @value.docs.leading_comments
+    @value
+      .docs
+      .leading_comments
+      .each_line
+      .map { |line| (line.start_with? " ") ? line[1..-1] : line }
+      .join
   end
 
   def number

--- a/gapic-generator-cloud/templates/cloud/helpers/presenters/field_presenter.rb
+++ b/gapic-generator-cloud/templates/cloud/helpers/presenters/field_presenter.rb
@@ -54,7 +54,12 @@ class FieldPresenter
   def doc_description
     return nil if @field.docs.leading_comments.empty?
 
-    @field.docs.leading_comments
+    @field
+      .docs
+      .leading_comments
+      .each_line
+      .map { |line| (line.start_with? " ") ? line[1..-1] : line }
+      .join
   end
 
   def default_value

--- a/gapic-generator-cloud/templates/cloud/helpers/presenters/message_presenter.rb
+++ b/gapic-generator-cloud/templates/cloud/helpers/presenters/message_presenter.rb
@@ -34,7 +34,12 @@ class MessagePresenter
   def doc_description
     return nil if @message.docs.leading_comments.empty?
 
-    @message.docs.leading_comments
+    @message
+      .docs
+      .leading_comments
+      .each_line
+      .map { |line| (line.start_with? " ") ? line[1..-1] : line }
+      .join
   end
 
   def default_value

--- a/gapic-generator-cloud/templates/cloud/helpers/presenters/method_presenter.rb
+++ b/gapic-generator-cloud/templates/cloud/helpers/presenters/method_presenter.rb
@@ -54,7 +54,12 @@ class MethodPresenter
   def doc_description
     return nil if @method.docs.leading_comments.empty?
 
-    @method.docs.leading_comments
+    @method
+      .docs
+      .leading_comments
+      .each_line
+      .map { |line| (line.start_with? " ") ? line[1..-1] : line }
+      .join
   end
 
   def arguments

--- a/shared/output/cloud/showcase/lib/doc/google/api/client.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/api/client.rb
@@ -19,57 +19,57 @@ raise "This file is for documentation purposes only."
 module Google
   module Api
     # Information about the API as a whole.
-    #  This is generally used for client library packaging and documentation, and
-    #  only needs to be set when correct values can not be inferred from the proto
-    #  package.
+    # This is generally used for client library packaging and documentation, and
+    # only needs to be set when correct values can not be inferred from the proto
+    # package.
     #
-    #  For example, Pub/Sub sets this to:
+    # For example, Pub/Sub sets this to:
     #
-    #      option (google.api.package) = {
-    #        title: "Pub/Sub"
-    #        namespace: ["Google", "Cloud"]
-    #        version: "v1"
-    #      };
+    #     option (google.api.package) = {
+    #       title: "Pub/Sub"
+    #       namespace: ["Google", "Cloud"]
+    #       version: "v1"
+    #     };
     #
-    #  If this is set, then the `title`, `namespace`, and `version` fields
-    #  should all be set.
+    # If this is set, then the `title`, `namespace`, and `version` fields
+    # should all be set.
     # @!attribute [rw] title
     #   @return [String]
     #     Required. The title of the package (and, by default, the product).
     #
-    #      This should be set to the colloquial name of the API, and is used
-    #      for things such as determining the package name.
+    #     This should be set to the colloquial name of the API, and is used
+    #     for things such as determining the package name.
     #
-    #      Specify this in appropriate title casing, with space as the word
-    #      separator (e.g. "Speech", "BigQuery", "Video Intelligence", "Pub/Sub").
+    #     Specify this in appropriate title casing, with space as the word
+    #     separator (e.g. "Speech", "BigQuery", "Video Intelligence", "Pub/Sub").
     #
-    #      This value may be used as-is in documentation, and code generators should
-    #      normalize it appropriately for idiomatic package, module, etc. names in
-    #      their language.
+    #     This value may be used as-is in documentation, and code generators should
+    #     normalize it appropriately for idiomatic package, module, etc. names in
+    #     their language.
     # @!attribute [rw] namespace
     #   @return [String]
     #     Required. The namespace.
     #
-    #      This should be set to the package namespace, using appropriate title
-    #      casing (the same casing as `title`, above). Client libraries
-    #      should normalize it appropriately for package, module, etc. names in
-    #      their language.
+    #     This should be set to the package namespace, using appropriate title
+    #     casing (the same casing as `title`, above). Client libraries
+    #     should normalize it appropriately for package, module, etc. names in
+    #     their language.
     #
-    #        Example: ["Google", "Cloud"]
+    #       Example: ["Google", "Cloud"]
     #
-    #      This is used to inform the prefix for package manager names, and the code
-    #      layout in cases where the language-specific protobuf options are not set.
+    #     This is used to inform the prefix for package manager names, and the code
+    #     layout in cases where the language-specific protobuf options are not set.
     #
-    #      The "required" note above is "soft". This *should* be set, but an empty
-    #      namespace is technically valid.
+    #     The "required" note above is "soft". This *should* be set, but an empty
+    #     namespace is technically valid.
     # @!attribute [rw] version
     #   @return [String]
     #     Required. The version.
-    #      This should be set to the API version, such as "v1".
+    #     This should be set to the API version, such as "v1".
     # @!attribute [rw] product_title
     #   @return [String]
     #     The title of the product, if different from the package title above.
-    #      This may be used in documentation and package metadata.
+    #     This may be used in documentation and package metadata.
     class Package
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/showcase/lib/doc/google/api/field_behavior.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/api/field_behavior.rb
@@ -19,39 +19,39 @@ raise "This file is for documentation purposes only."
 module Google
   module Api
     # An indicator of the behavior of a given field (for example, that a field
-    #  is required in requests, or given as output but ignored as input).
-    #  This **does not** change the behavior in protocol buffers itself; it only
-    #  denotes the behavior and may affect how API tooling handles the field.
+    # is required in requests, or given as output but ignored as input).
+    # This **does not** change the behavior in protocol buffers itself; it only
+    # denotes the behavior and may affect how API tooling handles the field.
     #
-    #  Note: This enum **may** receive new values in the future.
+    # Note: This enum **may** receive new values in the future.
     module FieldBehavior
       # Conventional default for enums. Do not use this.
       FIELD_BEHAVIOR_UNSPECIFIED = 0
 
       # Specifically denotes a field as optional.
-      #  While all fields in protocol buffers are optional, this may be specified
-      #  for emphasis if appropriate.
+      # While all fields in protocol buffers are optional, this may be specified
+      # for emphasis if appropriate.
       OPTIONAL = 1
 
       # Denotes a field as required.
-      #  This indicates that the field **must** be provided as part of the request,
-      #  and failure to do so will cause an error (usually `INVALID_ARGUMENT`).
+      # This indicates that the field **must** be provided as part of the request,
+      # and failure to do so will cause an error (usually `INVALID_ARGUMENT`).
       REQUIRED = 2
 
       # Denotes a field as output only.
-      #  This indicates that the field is provided in responses, but including the
-      #  field in a request does nothing (the server *must* ignore it and
-      #  *must not* throw an error as a result of the field's presence).
+      # This indicates that the field is provided in responses, but including the
+      # field in a request does nothing (the server *must* ignore it and
+      # *must not* throw an error as a result of the field's presence).
       OUTPUT_ONLY = 3
 
       # Denotes a field as input only.
-      #  This indicates that the field is provided in requests, and the
-      #  corresponding field is not included in output.
+      # This indicates that the field is provided in requests, and the
+      # corresponding field is not included in output.
       INPUT_ONLY = 4
 
       # Denotes a field as immutable.
-      #  This indicates that the field may be set once in a request to create a
-      #  resource, but may not be changed thereafter.
+      # This indicates that the field may be set once in a request to create a
+      # resource, but may not be changed thereafter.
       IMMUTABLE = 5
     end
   end

--- a/shared/output/cloud/showcase/lib/doc/google/api/http.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/api/http.rb
@@ -19,248 +19,248 @@ raise "This file is for documentation purposes only."
 module Google
   module Api
     # Defines the HTTP configuration for an API service. It contains a list of
-    #  [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
-    #  to one or more HTTP REST API methods.
+    # [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
+    # to one or more HTTP REST API methods.
     # @!attribute [rw] rules
     #   @return [Google::Api::HttpRule]
     #     A list of HTTP configuration rules that apply to individual API methods.
     #
-    #      **NOTE:** All service configuration rules follow "last one wins" order.
+    #     **NOTE:** All service configuration rules follow "last one wins" order.
     # @!attribute [rw] fully_decode_reserved_expansion
     #   @return [Boolean]
     #     When set to true, URL path parmeters will be fully URI-decoded except in
-    #      cases of single segment matches in reserved expansion, where "%2F" will be
-    #      left encoded.
+    #     cases of single segment matches in reserved expansion, where "%2F" will be
+    #     left encoded.
     #
-    #      The default behavior is to not decode RFC 6570 reserved characters in multi
-    #      segment matches.
+    #     The default behavior is to not decode RFC 6570 reserved characters in multi
+    #     segment matches.
     class Http
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
     # `HttpRule` defines the mapping of an RPC method to one or more HTTP
-    #  REST API methods. The mapping specifies how different portions of the RPC
-    #  request message are mapped to URL path, URL query parameters, and
-    #  HTTP request body. The mapping is typically specified as an
-    #  `google.api.http` annotation on the RPC method,
-    #  see "google/api/annotations.proto" for details.
+    # REST API methods. The mapping specifies how different portions of the RPC
+    # request message are mapped to URL path, URL query parameters, and
+    # HTTP request body. The mapping is typically specified as an
+    # `google.api.http` annotation on the RPC method,
+    # see "google/api/annotations.proto" for details.
     #
-    #  The mapping consists of a field specifying the path template and
-    #  method kind.  The path template can refer to fields in the request
-    #  message, as in the example below which describes a REST GET
-    #  operation on a resource collection of messages:
-    #
-    #
-    #      service Messaging {
-    #        rpc GetMessage(GetMessageRequest) returns (Message) {
-    #          option (google.api.http).get = "/v1/messages/{message_id}/{sub.subfield}";
-    #        }
-    #      }
-    #      message GetMessageRequest {
-    #        message SubMessage {
-    #          string subfield = 1;
-    #        }
-    #        string message_id = 1; // mapped to the URL
-    #        SubMessage sub = 2;    // `sub.subfield` is url-mapped
-    #      }
-    #      message Message {
-    #        string text = 1; // content of the resource
-    #      }
-    #
-    #  The same http annotation can alternatively be expressed inside the
-    #  `GRPC API Configuration` YAML file.
-    #
-    #      http:
-    #        rules:
-    #          - selector: <proto_package_name>.Messaging.GetMessage
-    #            get: /v1/messages/{message_id}/{sub.subfield}
-    #
-    #  This definition enables an automatic, bidrectional mapping of HTTP
-    #  JSON to RPC. Example:
-    #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `GET /v1/messages/123456/foo`  | `GetMessage(message_id: "123456" sub: SubMessage(subfield: "foo"))`
-    #
-    #  In general, not only fields but also field paths can be referenced
-    #  from a path pattern. Fields mapped to the path pattern cannot be
-    #  repeated and must have a primitive (non-message) type.
-    #
-    #  Any fields in the request message which are not bound by the path
-    #  pattern automatically become (optional) HTTP query
-    #  parameters. Assume the following definition of the request message:
+    # The mapping consists of a field specifying the path template and
+    # method kind.  The path template can refer to fields in the request
+    # message, as in the example below which describes a REST GET
+    # operation on a resource collection of messages:
     #
     #
-    #      service Messaging {
-    #        rpc GetMessage(GetMessageRequest) returns (Message) {
-    #          option (google.api.http).get = "/v1/messages/{message_id}";
-    #        }
-    #      }
-    #      message GetMessageRequest {
-    #        message SubMessage {
-    #          string subfield = 1;
-    #        }
-    #        string message_id = 1; // mapped to the URL
-    #        int64 revision = 2;    // becomes a parameter
-    #        SubMessage sub = 3;    // `sub.subfield` becomes a parameter
-    #      }
+    #     service Messaging {
+    #       rpc GetMessage(GetMessageRequest) returns (Message) {
+    #         option (google.api.http).get = "/v1/messages/{message_id}/{sub.subfield}";
+    #       }
+    #     }
+    #     message GetMessageRequest {
+    #       message SubMessage {
+    #         string subfield = 1;
+    #       }
+    #       string message_id = 1; // mapped to the URL
+    #       SubMessage sub = 2;    // `sub.subfield` is url-mapped
+    #     }
+    #     message Message {
+    #       string text = 1; // content of the resource
+    #     }
+    #
+    # The same http annotation can alternatively be expressed inside the
+    # `GRPC API Configuration` YAML file.
+    #
+    #     http:
+    #       rules:
+    #         - selector: <proto_package_name>.Messaging.GetMessage
+    #           get: /v1/messages/{message_id}/{sub.subfield}
+    #
+    # This definition enables an automatic, bidrectional mapping of HTTP
+    # JSON to RPC. Example:
+    #
+    # HTTP | RPC
+    # -----|-----
+    # `GET /v1/messages/123456/foo`  | `GetMessage(message_id: "123456" sub: SubMessage(subfield: "foo"))`
+    #
+    # In general, not only fields but also field paths can be referenced
+    # from a path pattern. Fields mapped to the path pattern cannot be
+    # repeated and must have a primitive (non-message) type.
+    #
+    # Any fields in the request message which are not bound by the path
+    # pattern automatically become (optional) HTTP query
+    # parameters. Assume the following definition of the request message:
     #
     #
-    #  This enables a HTTP JSON to RPC mapping as below:
-    #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `GET /v1/messages/123456?revision=2&sub.subfield=foo` | `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield: "foo"))`
-    #
-    #  Note that fields which are mapped to HTTP parameters must have a
-    #  primitive type or a repeated primitive type. Message types are not
-    #  allowed. In the case of a repeated type, the parameter can be
-    #  repeated in the URL, as in `...?param=A&param=B`.
-    #
-    #  For HTTP method kinds which allow a request body, the `body` field
-    #  specifies the mapping. Consider a REST update method on the
-    #  message resource collection:
-    #
-    #
-    #      service Messaging {
-    #        rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
-    #          option (google.api.http) = {
-    #            put: "/v1/messages/{message_id}"
-    #            body: "message"
-    #          };
-    #        }
-    #      }
-    #      message UpdateMessageRequest {
-    #        string message_id = 1; // mapped to the URL
-    #        Message message = 2;   // mapped to the body
-    #      }
+    #     service Messaging {
+    #       rpc GetMessage(GetMessageRequest) returns (Message) {
+    #         option (google.api.http).get = "/v1/messages/{message_id}";
+    #       }
+    #     }
+    #     message GetMessageRequest {
+    #       message SubMessage {
+    #         string subfield = 1;
+    #       }
+    #       string message_id = 1; // mapped to the URL
+    #       int64 revision = 2;    // becomes a parameter
+    #       SubMessage sub = 3;    // `sub.subfield` becomes a parameter
+    #     }
     #
     #
-    #  The following HTTP JSON to RPC mapping is enabled, where the
-    #  representation of the JSON in the request body is determined by
-    #  protos JSON encoding:
+    # This enables a HTTP JSON to RPC mapping as below:
     #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `PUT /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
+    # HTTP | RPC
+    # -----|-----
+    # `GET /v1/messages/123456?revision=2&sub.subfield=foo` | `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield: "foo"))`
     #
-    #  The special name `*` can be used in the body mapping to define that
-    #  every field not bound by the path template should be mapped to the
-    #  request body.  This enables the following alternative definition of
-    #  the update method:
+    # Note that fields which are mapped to HTTP parameters must have a
+    # primitive type or a repeated primitive type. Message types are not
+    # allowed. In the case of a repeated type, the parameter can be
+    # repeated in the URL, as in `...?param=A&param=B`.
     #
-    #      service Messaging {
-    #        rpc UpdateMessage(Message) returns (Message) {
-    #          option (google.api.http) = {
-    #            put: "/v1/messages/{message_id}"
-    #            body: "*"
-    #          };
-    #        }
-    #      }
-    #      message Message {
-    #        string message_id = 1;
-    #        string text = 2;
-    #      }
+    # For HTTP method kinds which allow a request body, the `body` field
+    # specifies the mapping. Consider a REST update method on the
+    # message resource collection:
     #
     #
-    #  The following HTTP JSON to RPC mapping is enabled:
-    #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `PUT /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" text: "Hi!")`
-    #
-    #  Note that when using `*` in the body mapping, it is not possible to
-    #  have HTTP parameters, as all fields not bound by the path end in
-    #  the body. This makes this option more rarely used in practice of
-    #  defining REST APIs. The common usage of `*` is in custom methods
-    #  which don't use the URL at all for transferring data.
-    #
-    #  It is possible to define multiple HTTP methods for one RPC by using
-    #  the `additional_bindings` option. Example:
-    #
-    #      service Messaging {
-    #        rpc GetMessage(GetMessageRequest) returns (Message) {
-    #          option (google.api.http) = {
-    #            get: "/v1/messages/{message_id}"
-    #            additional_bindings {
-    #              get: "/v1/users/{user_id}/messages/{message_id}"
-    #            }
-    #          };
-    #        }
-    #      }
-    #      message GetMessageRequest {
-    #        string message_id = 1;
-    #        string user_id = 2;
-    #      }
+    #     service Messaging {
+    #       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+    #         option (google.api.http) = {
+    #           put: "/v1/messages/{message_id}"
+    #           body: "message"
+    #         };
+    #       }
+    #     }
+    #     message UpdateMessageRequest {
+    #       string message_id = 1; // mapped to the URL
+    #       Message message = 2;   // mapped to the body
+    #     }
     #
     #
-    #  This enables the following two alternative HTTP JSON to RPC
-    #  mappings:
+    # The following HTTP JSON to RPC mapping is enabled, where the
+    # representation of the JSON in the request body is determined by
+    # protos JSON encoding:
     #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
-    #  `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id: "123456")`
+    # HTTP | RPC
+    # -----|-----
+    # `PUT /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
     #
-    #  # Rules for HTTP mapping
+    # The special name `*` can be used in the body mapping to define that
+    # every field not bound by the path template should be mapped to the
+    # request body.  This enables the following alternative definition of
+    # the update method:
     #
-    #  The rules for mapping HTTP path, query parameters, and body fields
-    #  to the request message are as follows:
+    #     service Messaging {
+    #       rpc UpdateMessage(Message) returns (Message) {
+    #         option (google.api.http) = {
+    #           put: "/v1/messages/{message_id}"
+    #           body: "*"
+    #         };
+    #       }
+    #     }
+    #     message Message {
+    #       string message_id = 1;
+    #       string text = 2;
+    #     }
     #
-    #  1. The `body` field specifies either `*` or a field path, or is
-    #     omitted. If omitted, it indicates there is no HTTP request body.
-    #  2. Leaf fields (recursive expansion of nested messages in the
-    #     request) can be classified into three types:
-    #      (a) Matched in the URL template.
-    #      (b) Covered by body (if body is `*`, everything except (a) fields;
-    #          else everything under the body field)
-    #      (c) All other fields.
-    #  3. URL query parameters found in the HTTP request are mapped to (c) fields.
-    #  4. Any body sent with an HTTP request can contain only (b) fields.
     #
-    #  The syntax of the path template is as follows:
+    # The following HTTP JSON to RPC mapping is enabled:
     #
-    #      Template = "/" Segments [ Verb ] ;
-    #      Segments = Segment { "/" Segment } ;
-    #      Segment  = "*" | "**" | LITERAL | Variable ;
-    #      Variable = "{" FieldPath [ "=" Segments ] "}" ;
-    #      FieldPath = IDENT { "." IDENT } ;
-    #      Verb     = ":" LITERAL ;
+    # HTTP | RPC
+    # -----|-----
+    # `PUT /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" text: "Hi!")`
     #
-    #  The syntax `*` matches a single path segment. The syntax `**` matches zero
-    #  or more path segments, which must be the last part of the path except the
-    #  `Verb`. The syntax `LITERAL` matches literal text in the path.
+    # Note that when using `*` in the body mapping, it is not possible to
+    # have HTTP parameters, as all fields not bound by the path end in
+    # the body. This makes this option more rarely used in practice of
+    # defining REST APIs. The common usage of `*` is in custom methods
+    # which don't use the URL at all for transferring data.
     #
-    #  The syntax `Variable` matches part of the URL path as specified by its
-    #  template. A variable template must not contain other variables. If a variable
-    #  matches a single path segment, its template may be omitted, e.g. `{var}`
-    #  is equivalent to `{var=*}`.
+    # It is possible to define multiple HTTP methods for one RPC by using
+    # the `additional_bindings` option. Example:
     #
-    #  If a variable contains exactly one path segment, such as `"{var}"` or
-    #  `"{var=*}"`, when such a variable is expanded into a URL path, all characters
-    #  except `[-_.~0-9a-zA-Z]` are percent-encoded. Such variables show up in the
-    #  Discovery Document as `{var}`.
+    #     service Messaging {
+    #       rpc GetMessage(GetMessageRequest) returns (Message) {
+    #         option (google.api.http) = {
+    #           get: "/v1/messages/{message_id}"
+    #           additional_bindings {
+    #             get: "/v1/users/{user_id}/messages/{message_id}"
+    #           }
+    #         };
+    #       }
+    #     }
+    #     message GetMessageRequest {
+    #       string message_id = 1;
+    #       string user_id = 2;
+    #     }
     #
-    #  If a variable contains one or more path segments, such as `"{var=foo/*}"`
-    #  or `"{var=**}"`, when such a variable is expanded into a URL path, all
-    #  characters except `[-_.~/0-9a-zA-Z]` are percent-encoded. Such variables
-    #  show up in the Discovery Document as `{+var}`.
     #
-    #  NOTE: While the single segment variable matches the semantics of
-    #  [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2
-    #  Simple String Expansion, the multi segment variable **does not** match
-    #  RFC 6570 Reserved Expansion. The reason is that the Reserved Expansion
-    #  does not expand special characters like `?` and `#`, which would lead
-    #  to invalid URLs.
+    # This enables the following two alternative HTTP JSON to RPC
+    # mappings:
     #
-    #  NOTE: the field paths in variables and in the `body` must not refer to
-    #  repeated fields or map fields.
+    # HTTP | RPC
+    # -----|-----
+    # `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
+    # `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id: "123456")`
+    #
+    # # Rules for HTTP mapping
+    #
+    # The rules for mapping HTTP path, query parameters, and body fields
+    # to the request message are as follows:
+    #
+    # 1. The `body` field specifies either `*` or a field path, or is
+    #    omitted. If omitted, it indicates there is no HTTP request body.
+    # 2. Leaf fields (recursive expansion of nested messages in the
+    #    request) can be classified into three types:
+    #     (a) Matched in the URL template.
+    #     (b) Covered by body (if body is `*`, everything except (a) fields;
+    #         else everything under the body field)
+    #     (c) All other fields.
+    # 3. URL query parameters found in the HTTP request are mapped to (c) fields.
+    # 4. Any body sent with an HTTP request can contain only (b) fields.
+    #
+    # The syntax of the path template is as follows:
+    #
+    #     Template = "/" Segments [ Verb ] ;
+    #     Segments = Segment { "/" Segment } ;
+    #     Segment  = "*" | "**" | LITERAL | Variable ;
+    #     Variable = "{" FieldPath [ "=" Segments ] "}" ;
+    #     FieldPath = IDENT { "." IDENT } ;
+    #     Verb     = ":" LITERAL ;
+    #
+    # The syntax `*` matches a single path segment. The syntax `**` matches zero
+    # or more path segments, which must be the last part of the path except the
+    # `Verb`. The syntax `LITERAL` matches literal text in the path.
+    #
+    # The syntax `Variable` matches part of the URL path as specified by its
+    # template. A variable template must not contain other variables. If a variable
+    # matches a single path segment, its template may be omitted, e.g. `{var}`
+    # is equivalent to `{var=*}`.
+    #
+    # If a variable contains exactly one path segment, such as `"{var}"` or
+    # `"{var=*}"`, when such a variable is expanded into a URL path, all characters
+    # except `[-_.~0-9a-zA-Z]` are percent-encoded. Such variables show up in the
+    # Discovery Document as `{var}`.
+    #
+    # If a variable contains one or more path segments, such as `"{var=foo/*}"`
+    # or `"{var=**}"`, when such a variable is expanded into a URL path, all
+    # characters except `[-_.~/0-9a-zA-Z]` are percent-encoded. Such variables
+    # show up in the Discovery Document as `{+var}`.
+    #
+    # NOTE: While the single segment variable matches the semantics of
+    # [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2
+    # Simple String Expansion, the multi segment variable **does not** match
+    # RFC 6570 Reserved Expansion. The reason is that the Reserved Expansion
+    # does not expand special characters like `?` and `#`, which would lead
+    # to invalid URLs.
+    #
+    # NOTE: the field paths in variables and in the `body` must not refer to
+    # repeated fields or map fields.
     # @!attribute [rw] selector
     #   @return [String]
     #     Selects methods to which this rule applies.
     #
-    #      Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+    #     Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
     # @!attribute [rw] get
     #   @return [String]
     #     Used for listing and getting information about resources.
@@ -279,25 +279,25 @@ module Google
     # @!attribute [rw] custom
     #   @return [Google::Api::CustomHttpPattern]
     #     The custom pattern is used for specifying an HTTP method that is not
-    #      included in the `pattern` field, such as HEAD, or "*" to leave the
-    #      HTTP method unspecified for this rule. The wild-card rule is useful
-    #      for services that provide content to Web (HTML) clients.
+    #     included in the `pattern` field, such as HEAD, or "*" to leave the
+    #     HTTP method unspecified for this rule. The wild-card rule is useful
+    #     for services that provide content to Web (HTML) clients.
     # @!attribute [rw] body
     #   @return [String]
     #     The name of the request field whose value is mapped to the HTTP body, or
-    #      `*` for mapping all fields not captured by the path pattern to the HTTP
-    #      body. NOTE: the referred field must not be a repeated field and must be
-    #      present at the top-level of request message type.
+    #     `*` for mapping all fields not captured by the path pattern to the HTTP
+    #     body. NOTE: the referred field must not be a repeated field and must be
+    #     present at the top-level of request message type.
     # @!attribute [rw] response_body
     #   @return [String]
     #     Optional. The name of the response field whose value is mapped to the HTTP
-    #      body of response. Other response fields are ignored. When
-    #      not set, the response message will be used as HTTP body of response.
+    #     body of response. Other response fields are ignored. When
+    #     not set, the response message will be used as HTTP body of response.
     # @!attribute [rw] additional_bindings
     #   @return [Google::Api::HttpRule]
     #     Additional HTTP bindings for the selector. Nested bindings must
-    #      not contain an `additional_bindings` field themselves (that is,
-    #      the nesting may only be one level deep).
+    #     not contain an `additional_bindings` field themselves (that is,
+    #     the nesting may only be one level deep).
     class HttpRule
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/showcase/lib/doc/google/api/resource.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/api/resource.rb
@@ -19,67 +19,67 @@ raise "This file is for documentation purposes only."
 module Google
   module Api
     # An annotation designating that this field designates a One Platform
-    #  resource.
+    # resource.
     #
-    #  Example:
+    # Example:
     #
-    #      message Topic {
-    #        string name = 1 [(google.api.resource) = {
-    #          name: "projects/{project}/topics/{topic}"
-    #        }];
-    #      }
+    #     message Topic {
+    #       string name = 1 [(google.api.resource) = {
+    #         name: "projects/{project}/topics/{topic}"
+    #       }];
+    #     }
     # @!attribute [rw] pattern
     #   @return [String]
     #     Required. The resource's name template.
     #
-    #      Examples:
-    #        - "projects/{project}/topics/{topic}"
-    #        - "projects/{project}/knowledgeBases/{knowledge_base}"
+    #     Examples:
+    #       - "projects/{project}/topics/{topic}"
+    #       - "projects/{project}/knowledgeBases/{knowledge_base}"
     # @!attribute [rw] symbol
     #   @return [String]
     #     The name that should be used in code to describe the resource,
-    #      in PascalCase.
+    #     in PascalCase.
     #
-    #      If omitted, this is inferred from the name of the message.
-    #      This is required if the resource is being defined without the context
-    #      of a message (see `resource_definition`, below).
+    #     If omitted, this is inferred from the name of the message.
+    #     This is required if the resource is being defined without the context
+    #     of a message (see `resource_definition`, below).
     #
-    #      Example:
-    #        option (google.api.resource_definition) = {
-    #          pattern: "projects/{project}"
-    #          symbol: "Project"
-    #        };
+    #     Example:
+    #       option (google.api.resource_definition) = {
+    #         pattern: "projects/{project}"
+    #         symbol: "Project"
+    #       };
     class Resource
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
     # An annotation designating that this field designates a set of One Platform
-    #  resources.
+    # resources.
     # @!attribute [rw] symbol
     #   @return [String]
     #     The colloquial name of the resource.
-    #      If omitted, this is the name of the message.
+    #     If omitted, this is the name of the message.
     # @!attribute [rw] resources
     #   @return [Google::Api::Resource]
     #     Component resources that are part of the set.
-    #      Resources declared within a resource set must have `name` set.
+    #     Resources declared within a resource set must have `name` set.
     #
-    #      The final set of resources in the resource set is the union of
-    #      `resources` and `resource_references`.
+    #     The final set of resources in the resource set is the union of
+    #     `resources` and `resource_references`.
     #
-    #      Resources defined here are only scoped within the parent ResourceSet;
-    #      i.e. other messages cannot reference these contained Resources by name.
+    #     Resources defined here are only scoped within the parent ResourceSet;
+    #     i.e. other messages cannot reference these contained Resources by name.
     # @!attribute [rw] resource_references
     #   @return [String]
     #     References to existing resources (messages of resource definitions)
-    #      that are part of the set.
+    #     that are part of the set.
     #
-    #      These may be specified as fully-qualified (e.g. "google.pubsub.v1.Topic")
-    #      or just the resource/proto name if it is defined within the same package.
+    #     These may be specified as fully-qualified (e.g. "google.pubsub.v1.Topic")
+    #     or just the resource/proto name if it is defined within the same package.
     #
-    #      The final set of resources in the resource set is the union of
-    #      `resources` and `resource_references`.
+    #     The final set of resources in the resource set is the union of
+    #     `resources` and `resource_references`.
     class ResourceSet
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/showcase/lib/doc/google/longrunning/operations.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/longrunning/operations.rb
@@ -19,36 +19,36 @@ raise "This file is for documentation purposes only."
 module Google
   module Longrunning
     # This resource represents a long-running operation that is the result of a
-    #  network API call.
+    # network API call.
     # @!attribute [rw] name
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
-    #      originally returns it. If you use the default HTTP mapping, the
-    #      `name` should have the format of `operations/some/unique/name`.
+    #     originally returns it. If you use the default HTTP mapping, the
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
-    #      contains progress information and common metadata such as create time.
-    #      Some services might not provide such metadata.  Any method that returns a
-    #      long-running operation should document the metadata type, if any.
+    #     contains progress information and common metadata such as create time.
+    #     Some services might not provide such metadata.  Any method that returns a
+    #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [Boolean]
     #     If the value is `false`, it means the operation is still in progress.
-    #      If true, the operation is completed, and either `error` or `response` is
-    #      available.
+    #     If true, the operation is completed, and either `error` or `response` is
+    #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
     #     The error result of the operation in case of failure or cancellation.
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #      method returns no data on success, such as `Delete`, the response is
-    #      `google.protobuf.Empty`.  If the original method is standard
-    #      `Get`/`Create`/`Update`, the response should be the resource.  For other
-    #      methods, the response should have the type `XxxResponse`, where `Xxx`
-    #      is the original method name.  For example, if the original method name
-    #      is `TakeSnapshot()`, the inferred response type is
-    #      `TakeSnapshotResponse`.
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
+    #     is the original method name.  For example, if the original method name
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -113,34 +113,34 @@ module Google
 
     # A message representing the message types used by a long-running operation.
     #
-    #  Example:
+    # Example:
     #
-    #    rpc LongRunningRecognize(LongRunningRecognizeRequest)
-    #        returns (google.longrunning.Operation) {
-    #      option (google.longrunning.operation_info) = {
-    #        response_type: "LongRunningRecognizeResponse"
-    #        metadata_type: "LongRunningRecognizeMetadata"
-    #      };
-    #    }
+    #   rpc LongRunningRecognize(LongRunningRecognizeRequest)
+    #       returns (google.longrunning.Operation) {
+    #     option (google.longrunning.operation_info) = {
+    #       response_type: "LongRunningRecognizeResponse"
+    #       metadata_type: "LongRunningRecognizeMetadata"
+    #     };
+    #   }
     # @!attribute [rw] response_type
     #   @return [String]
     #     Required. The message name of the primary return type for this
-    #      long-running operation.
-    #      This type will be used to deserialize the LRO's response.
+    #     long-running operation.
+    #     This type will be used to deserialize the LRO's response.
     #
-    #      If the response is in a different package from the rpc, a fully-qualified
-    #      message name must be used (e.g. `google.protobuf.Struct`).
+    #     If the response is in a different package from the rpc, a fully-qualified
+    #     message name must be used (e.g. `google.protobuf.Struct`).
     #
-    #      Note: Altering this value constitutes a breaking change.
+    #     Note: Altering this value constitutes a breaking change.
     # @!attribute [rw] metadata_type
     #   @return [String]
     #     Required. The message name of the metadata type for this long-running
-    #      operation.
+    #     operation.
     #
-    #      If the response is in a different package from the rpc, a fully-qualified
-    #      message name must be used (e.g. `google.protobuf.Struct`).
+    #     If the response is in a different package from the rpc, a fully-qualified
+    #     message name must be used (e.g. `google.protobuf.Struct`).
     #
-    #      Note: Altering this value constitutes a breaking change.
+    #     Note: Altering this value constitutes a breaking change.
     class OperationInfo
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/showcase/lib/doc/google/protobuf/any.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/protobuf/any.rb
@@ -19,112 +19,112 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # `Any` contains an arbitrary serialized protocol buffer message along with a
-    #  URL that describes the type of the serialized message.
+    # URL that describes the type of the serialized message.
     #
-    #  Protobuf library provides support to pack/unpack Any values in the form
-    #  of utility functions or additional generated methods of the Any type.
+    # Protobuf library provides support to pack/unpack Any values in the form
+    # of utility functions or additional generated methods of the Any type.
     #
-    #  Example 1: Pack and unpack a message in C++.
+    # Example 1: Pack and unpack a message in C++.
     #
-    #      Foo foo = ...;
-    #      Any any;
-    #      any.PackFrom(foo);
-    #      ...
-    #      if (any.UnpackTo(&foo)) {
-    #        ...
-    #      }
-    #
-    #  Example 2: Pack and unpack a message in Java.
-    #
-    #      Foo foo = ...;
-    #      Any any = Any.pack(foo);
-    #      ...
-    #      if (any.is(Foo.class)) {
-    #        foo = any.unpack(Foo.class);
-    #      }
-    #
-    #   Example 3: Pack and unpack a message in Python.
-    #
-    #      foo = Foo(...)
-    #      any = Any()
-    #      any.Pack(foo)
-    #      ...
-    #      if any.Is(Foo.DESCRIPTOR):
-    #        any.Unpack(foo)
-    #        ...
-    #
-    #   Example 4: Pack and unpack a message in Go
-    #
-    #       foo := &pb.Foo{...}
-    #       any, err := ptypes.MarshalAny(foo)
+    #     Foo foo = ...;
+    #     Any any;
+    #     any.PackFrom(foo);
+    #     ...
+    #     if (any.UnpackTo(&foo)) {
     #       ...
-    #       foo := &pb.Foo{}
-    #       if err := ptypes.UnmarshalAny(any, foo); err != nil {
-    #         ...
-    #       }
+    #     }
     #
-    #  The pack methods provided by protobuf library will by default use
-    #  'type.googleapis.com/full.type.name' as the type URL and the unpack
-    #  methods only use the fully qualified type name after the last '/'
-    #  in the type URL, for example "foo.bar.com/x/y.z" will yield type
-    #  name "y.z".
+    # Example 2: Pack and unpack a message in Java.
     #
+    #     Foo foo = ...;
+    #     Any any = Any.pack(foo);
+    #     ...
+    #     if (any.is(Foo.class)) {
+    #       foo = any.unpack(Foo.class);
+    #     }
     #
-    #  JSON
-    #  ====
-    #  The JSON representation of an `Any` value uses the regular
-    #  representation of the deserialized, embedded message, with an
-    #  additional field `@type` which contains the type URL. Example:
+    #  Example 3: Pack and unpack a message in Python.
     #
-    #      package google.profile;
-    #      message Person {
-    #        string first_name = 1;
-    #        string last_name = 2;
+    #     foo = Foo(...)
+    #     any = Any()
+    #     any.Pack(foo)
+    #     ...
+    #     if any.Is(Foo.DESCRIPTOR):
+    #       any.Unpack(foo)
+    #       ...
+    #
+    #  Example 4: Pack and unpack a message in Go
+    #
+    #      foo := &pb.Foo{...}
+    #      any, err := ptypes.MarshalAny(foo)
+    #      ...
+    #      foo := &pb.Foo{}
+    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #        ...
     #      }
     #
-    #      {
-    #        "@type": "type.googleapis.com/google.profile.Person",
-    #        "firstName": <string>,
-    #        "lastName": <string>
-    #      }
+    # The pack methods provided by protobuf library will by default use
+    # 'type.googleapis.com/full.type.name' as the type URL and the unpack
+    # methods only use the fully qualified type name after the last '/'
+    # in the type URL, for example "foo.bar.com/x/y.z" will yield type
+    # name "y.z".
     #
-    #  If the embedded message type is well-known and has a custom JSON
-    #  representation, that representation will be embedded adding a field
-    #  `value` which holds the custom JSON in addition to the `@type`
-    #  field. Example (for message [google.protobuf.Duration][]):
     #
-    #      {
-    #        "@type": "type.googleapis.com/google.protobuf.Duration",
-    #        "value": "1.212s"
-    #      }
+    # JSON
+    # ====
+    # The JSON representation of an `Any` value uses the regular
+    # representation of the deserialized, embedded message, with an
+    # additional field `@type` which contains the type URL. Example:
+    #
+    #     package google.profile;
+    #     message Person {
+    #       string first_name = 1;
+    #       string last_name = 2;
+    #     }
+    #
+    #     {
+    #       "@type": "type.googleapis.com/google.profile.Person",
+    #       "firstName": <string>,
+    #       "lastName": <string>
+    #     }
+    #
+    # If the embedded message type is well-known and has a custom JSON
+    # representation, that representation will be embedded adding a field
+    # `value` which holds the custom JSON in addition to the `@type`
+    # field. Example (for message [google.protobuf.Duration][]):
+    #
+    #     {
+    #       "@type": "type.googleapis.com/google.protobuf.Duration",
+    #       "value": "1.212s"
+    #     }
     # @!attribute [rw] type_url
     #   @return [String]
     #     A URL/resource name that uniquely identifies the type of the serialized
-    #      protocol buffer message. The last segment of the URL's path must represent
-    #      the fully qualified name of the type (as in
-    #      `path/google.protobuf.Duration`). The name should be in a canonical form
-    #      (e.g., leading "." is not accepted).
+    #     protocol buffer message. The last segment of the URL's path must represent
+    #     the fully qualified name of the type (as in
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
+    #     (e.g., leading "." is not accepted).
     #
-    #      In practice, teams usually precompile into the binary all types that they
-    #      expect it to use in the context of Any. However, for URLs which use the
-    #      scheme `http`, `https`, or no scheme, one can optionally set up a type
-    #      server that maps type URLs to message definitions as follows:
+    #     In practice, teams usually precompile into the binary all types that they
+    #     expect it to use in the context of Any. However, for URLs which use the
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
+    #     server that maps type URLs to message definitions as follows:
     #
-    #      * If no scheme is provided, `https` is assumed.
-    #      * An HTTP GET on the URL must yield a [google.protobuf.Type][]
-    #        value in binary format, or produce an error.
-    #      * Applications are allowed to cache lookup results based on the
-    #        URL, or have them precompiled into a binary to avoid any
-    #        lookup. Therefore, binary compatibility needs to be preserved
-    #        on changes to types. (Use versioned type names to manage
-    #        breaking changes.)
+    #     * If no scheme is provided, `https` is assumed.
+    #     * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+    #       value in binary format, or produce an error.
+    #     * Applications are allowed to cache lookup results based on the
+    #       URL, or have them precompiled into a binary to avoid any
+    #       lookup. Therefore, binary compatibility needs to be preserved
+    #       on changes to types. (Use versioned type names to manage
+    #       breaking changes.)
     #
-    #      Note: this functionality is not currently available in the official
-    #      protobuf release, and it is not used for type URLs beginning with
-    #      type.googleapis.com.
+    #     Note: this functionality is not currently available in the official
+    #     protobuf release, and it is not used for type URLs beginning with
+    #     type.googleapis.com.
     #
-    #      Schemes other than `http`, `https` (or the empty scheme) might be
-    #      used with implementation specific semantics.
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
+    #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]
     #     Must be a valid serialized protocol buffer of the above specified type.

--- a/shared/output/cloud/showcase/lib/doc/google/protobuf/descriptor.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/protobuf/descriptor.rb
@@ -19,7 +19,7 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # The protocol compiler can output a FileDescriptorSet containing the .proto
-    #  files it parses.
+    # files it parses.
     # @!attribute [rw] file
     #   @return [Google::Protobuf::FileDescriptorProto]
     class FileDescriptorSet
@@ -41,7 +41,7 @@ module Google
     # @!attribute [rw] weak_dependency
     #   @return [Integer]
     #     Indexes of the weak imported files in the dependency list.
-    #      For Google-internal migration only. Do not use.
+    #     For Google-internal migration only. Do not use.
     # @!attribute [rw] message_type
     #   @return [Google::Protobuf::DescriptorProto]
     #     All top-level definitions in this file.
@@ -56,13 +56,13 @@ module Google
     # @!attribute [rw] source_code_info
     #   @return [Google::Protobuf::SourceCodeInfo]
     #     This field contains optional information about the original source code.
-    #      You may safely remove this entire field without harming runtime
-    #      functionality of the descriptors -- the information is needed only by
-    #      development tools.
+    #     You may safely remove this entire field without harming runtime
+    #     functionality of the descriptors -- the information is needed only by
+    #     development tools.
     # @!attribute [rw] syntax
     #   @return [String]
     #     The syntax of the proto file.
-    #      The supported values are "proto2" and "proto3".
+    #     The supported values are "proto2" and "proto3".
     class FileDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -90,7 +90,7 @@ module Google
     # @!attribute [rw] reserved_name
     #   @return [String]
     #     Reserved field names, which may not be used by fields in the same message.
-    #      A given name may only be reserved once.
+    #     A given name may only be reserved once.
     class DescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -107,8 +107,8 @@ module Google
       end
 
       # Range of reserved tag numbers. Reserved tag numbers may not be used by
-      #  fields or extension ranges in the same message. Reserved ranges may
-      #  not overlap.
+      # fields or extension ranges in the same message. Reserved ranges may
+      # not overlap.
       # @!attribute [rw] start
       #   @return [Integer]
       # @!attribute [rw] end
@@ -137,35 +137,35 @@ module Google
     # @!attribute [rw] type
     #   @return [ENUM(Type)]
     #     If type_name is set, this need not be set.  If both this and type_name
-    #      are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
+    #     are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
     # @!attribute [rw] type_name
     #   @return [String]
     #     For message and enum types, this is the name of the type.  If the name
-    #      starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
-    #      rules are used to find the type (i.e. first the nested types within this
-    #      message are searched, then within the parent, on up to the root
-    #      namespace).
+    #     starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+    #     rules are used to find the type (i.e. first the nested types within this
+    #     message are searched, then within the parent, on up to the root
+    #     namespace).
     # @!attribute [rw] extendee
     #   @return [String]
     #     For extensions, this is the name of the type being extended.  It is
-    #      resolved in the same manner as type_name.
+    #     resolved in the same manner as type_name.
     # @!attribute [rw] default_value
     #   @return [String]
     #     For numeric types, contains the original text representation of the value.
-    #      For booleans, "true" or "false".
-    #      For strings, contains the default text contents (not escaped in any way).
-    #      For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
-    #      TODO(kenton):  Base-64 encode?
+    #     For booleans, "true" or "false".
+    #     For strings, contains the default text contents (not escaped in any way).
+    #     For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
+    #     TODO(kenton):  Base-64 encode?
     # @!attribute [rw] oneof_index
     #   @return [Integer]
     #     If set, gives the index of a oneof in the containing type's oneof_decl
-    #      list.  This field is a member of that oneof.
+    #     list.  This field is a member of that oneof.
     # @!attribute [rw] json_name
     #   @return [String]
     #     JSON name of this field. The value is set by protocol compiler. If the
-    #      user has set a "json_name" option on this field, that option's value
-    #      will be used. Otherwise, it's deduced from the field's name by converting
-    #      it to camelCase.
+    #     user has set a "json_name" option on this field, that option's value
+    #     will be used. Otherwise, it's deduced from the field's name by converting
+    #     it to camelCase.
     # @!attribute [rw] options
     #   @return [Google::Protobuf::FieldOption]
     class FieldDescriptorProto
@@ -174,19 +174,19 @@ module Google
 
       module Type
         # 0 is reserved for errors.
-        #  Order is weird for historical reasons.
+        # Order is weird for historical reasons.
         TYPE_DOUBLE = 1
 
         TYPE_FLOAT = 2
 
         # Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
-        #  negative values are likely.
+        # negative values are likely.
         TYPE_INT64 = 3
 
         TYPE_UINT64 = 4
 
         # Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
-        #  negative values are likely.
+        # negative values are likely.
         TYPE_INT32 = 5
 
         TYPE_FIXED64 = 6
@@ -198,9 +198,9 @@ module Google
         TYPE_STRING = 9
 
         # Tag-delimited aggregate.
-        #  Group type is deprecated and not supported in proto3. However, Proto3
-        #  implementations should still be able to parse the group wire format and
-        #  treat group fields as unknown fields.
+        # Group type is deprecated and not supported in proto3. However, Proto3
+        # implementations should still be able to parse the group wire format and
+        # treat group fields as unknown fields.
         TYPE_GROUP = 10
 
         TYPE_MESSAGE = 11
@@ -251,22 +251,22 @@ module Google
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::EnumDescriptorProto::EnumReservedRange]
     #     Range of reserved numeric values. Reserved numeric values may not be used
-    #      by enum values in the same enum declaration. Reserved ranges may not
-    #      overlap.
+    #     by enum values in the same enum declaration. Reserved ranges may not
+    #     overlap.
     # @!attribute [rw] reserved_name
     #   @return [String]
     #     Reserved enum value names, which may not be reused. A given name may only
-    #      be reserved once.
+    #     be reserved once.
     class EnumDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
 
       # Range of reserved numeric values. Reserved values may not be used by
-      #  entries in the same enum. Reserved ranges may not overlap.
+      # entries in the same enum. Reserved ranges may not overlap.
       #
-      #  Note that this is distinct from DescriptorProto.ReservedRange in that it
-      #  is inclusive such that it can appropriately represent the entire int32
-      #  domain.
+      # Note that this is distinct from DescriptorProto.ReservedRange in that it
+      # is inclusive such that it can appropriately represent the entire int32
+      # domain.
       # @!attribute [rw] start
       #   @return [Integer]
       # @!attribute [rw] end
@@ -307,7 +307,7 @@ module Google
     # @!attribute [rw] input_type
     #   @return [String]
     #     Input and output type names.  These are resolved in the same way as
-    #      FieldDescriptorProto.type_name, but must refer to a message type.
+    #     FieldDescriptorProto.type_name, but must refer to a message type.
     # @!attribute [rw] output_type
     #   @return [String]
     # @!attribute [rw] options
@@ -326,56 +326,56 @@ module Google
     # @!attribute [rw] java_package
     #   @return [String]
     #     Sets the Java package where classes generated from this .proto will be
-    #      placed.  By default, the proto package is used, but this is often
-    #      inappropriate because proto packages do not normally start with backwards
-    #      domain names.
+    #     placed.  By default, the proto package is used, but this is often
+    #     inappropriate because proto packages do not normally start with backwards
+    #     domain names.
     # @!attribute [rw] java_outer_classname
     #   @return [String]
     #     If set, all the classes from the .proto file are wrapped in a single
-    #      outer class with the given name.  This applies to both Proto1
-    #      (equivalent to the old "--one_java_file" option) and Proto2 (where
-    #      a .proto always translates to a single class, but you may want to
-    #      explicitly choose the class name).
+    #     outer class with the given name.  This applies to both Proto1
+    #     (equivalent to the old "--one_java_file" option) and Proto2 (where
+    #     a .proto always translates to a single class, but you may want to
+    #     explicitly choose the class name).
     # @!attribute [rw] java_multiple_files
     #   @return [Boolean]
     #     If set true, then the Java code generator will generate a separate .java
-    #      file for each top-level message, enum, and service defined in the .proto
-    #      file.  Thus, these types will *not* be nested inside the outer class
-    #      named by java_outer_classname.  However, the outer class will still be
-    #      generated to contain the file's getDescriptor() method as well as any
-    #      top-level extensions defined in the file.
+    #     file for each top-level message, enum, and service defined in the .proto
+    #     file.  Thus, these types will *not* be nested inside the outer class
+    #     named by java_outer_classname.  However, the outer class will still be
+    #     generated to contain the file's getDescriptor() method as well as any
+    #     top-level extensions defined in the file.
     # @!attribute [rw] java_generate_equals_and_hash
     #   @return [Boolean]
     #     This option does nothing.
     # @!attribute [rw] java_string_check_utf8
     #   @return [Boolean]
     #     If set true, then the Java2 code generator will generate code that
-    #      throws an exception whenever an attempt is made to assign a non-UTF-8
-    #      byte sequence to a string field.
-    #      Message reflection will do the same.
-    #      However, an extension field still accepts non-UTF-8 byte sequences.
-    #      This option has no effect on when used with the lite runtime.
+    #     throws an exception whenever an attempt is made to assign a non-UTF-8
+    #     byte sequence to a string field.
+    #     Message reflection will do the same.
+    #     However, an extension field still accepts non-UTF-8 byte sequences.
+    #     This option has no effect on when used with the lite runtime.
     # @!attribute [rw] optimize_for
     #   @return [ENUM(OptimizeMode)]
     # @!attribute [rw] go_package
     #   @return [String]
     #     Sets the Go package where structs generated from this .proto will be
-    #      placed. If omitted, the Go package will be derived from the following:
-    #        - The basename of the package import path, if provided.
-    #        - Otherwise, the package statement in the .proto file, if present.
-    #        - Otherwise, the basename of the .proto file, without extension.
+    #     placed. If omitted, the Go package will be derived from the following:
+    #       - The basename of the package import path, if provided.
+    #       - Otherwise, the package statement in the .proto file, if present.
+    #       - Otherwise, the basename of the .proto file, without extension.
     # @!attribute [rw] cc_generic_services
     #   @return [Boolean]
     #     Should generic services be generated in each language?  "Generic" services
-    #      are not specific to any particular RPC system.  They are generated by the
-    #      main code generators in each language (without additional plugins).
-    #      Generic services were the only kind of service generation supported by
-    #      early versions of google.protobuf.
+    #     are not specific to any particular RPC system.  They are generated by the
+    #     main code generators in each language (without additional plugins).
+    #     Generic services were the only kind of service generation supported by
+    #     early versions of google.protobuf.
     #
-    #      Generic services are now considered deprecated in favor of using plugins
-    #      that generate code specific to your particular RPC system.  Therefore,
-    #      these default to false.  Old code which depends on generic services should
-    #      explicitly set them to true.
+    #     Generic services are now considered deprecated in favor of using plugins
+    #     that generate code specific to your particular RPC system.  Therefore,
+    #     these default to false.  Old code which depends on generic services should
+    #     explicitly set them to true.
     # @!attribute [rw] java_generic_services
     #   @return [Boolean]
     # @!attribute [rw] py_generic_services
@@ -385,49 +385,49 @@ module Google
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this file deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for everything in the file, or it will be completely ignored; in the very
-    #      least, this is a formalization for deprecating files.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for everything in the file, or it will be completely ignored; in the very
+    #     least, this is a formalization for deprecating files.
     # @!attribute [rw] cc_enable_arenas
     #   @return [Boolean]
     #     Enables the use of arenas for the proto messages in this file. This applies
-    #      only to generated classes for C++.
+    #     only to generated classes for C++.
     # @!attribute [rw] objc_class_prefix
     #   @return [String]
     #     Sets the objective c class prefix which is prepended to all objective c
-    #      generated classes from this .proto. There is no default.
+    #     generated classes from this .proto. There is no default.
     # @!attribute [rw] csharp_namespace
     #   @return [String]
     #     Namespace for generated classes; defaults to the package.
     # @!attribute [rw] swift_prefix
     #   @return [String]
     #     By default Swift generators will take the proto package and CamelCase it
-    #      replacing '.' with underscore and use that to prefix the types/symbols
-    #      defined. When this options is provided, they will use this value instead
-    #      to prefix the types/symbols defined.
+    #     replacing '.' with underscore and use that to prefix the types/symbols
+    #     defined. When this options is provided, they will use this value instead
+    #     to prefix the types/symbols defined.
     # @!attribute [rw] php_class_prefix
     #   @return [String]
     #     Sets the php class prefix which is prepended to all php generated classes
-    #      from this .proto. Default is empty.
+    #     from this .proto. Default is empty.
     # @!attribute [rw] php_namespace
     #   @return [String]
     #     Use this option to change the namespace of php generated classes. Default
-    #      is empty. When this option is empty, the package name will be used for
-    #      determining the namespace.
+    #     is empty. When this option is empty, the package name will be used for
+    #     determining the namespace.
     # @!attribute [rw] php_metadata_namespace
     #   @return [String]
     #     Use this option to change the namespace of php generated metadata classes.
-    #      Default is empty. When this option is empty, the proto file name will be used
-    #      for determining the namespace.
+    #     Default is empty. When this option is empty, the proto file name will be used
+    #     for determining the namespace.
     # @!attribute [rw] ruby_package
     #   @return [String]
     #     Use this option to change the package of ruby generated classes. Default
-    #      is empty. When this option is not set, the package name will be used for
-    #      determining the ruby package.
+    #     is empty. When this option is not set, the package name will be used for
+    #     determining the ruby package.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here.
-    #      See the documentation for the "Options" section above.
+    #     See the documentation for the "Options" section above.
     class FileOptions
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -446,57 +446,57 @@ module Google
     # @!attribute [rw] message_set_wire_format
     #   @return [Boolean]
     #     Set true to use the old proto1 MessageSet wire format for extensions.
-    #      This is provided for backwards-compatibility with the MessageSet wire
-    #      format.  You should not use this for any other reason:  It's less
-    #      efficient, has fewer features, and is more complicated.
+    #     This is provided for backwards-compatibility with the MessageSet wire
+    #     format.  You should not use this for any other reason:  It's less
+    #     efficient, has fewer features, and is more complicated.
     #
-    #      The message must be defined exactly as follows:
-    #        message Foo {
-    #          option message_set_wire_format = true;
-    #          extensions 4 to max;
-    #        }
-    #      Note that the message cannot have any defined fields; MessageSets only
-    #      have extensions.
+    #     The message must be defined exactly as follows:
+    #       message Foo {
+    #         option message_set_wire_format = true;
+    #         extensions 4 to max;
+    #       }
+    #     Note that the message cannot have any defined fields; MessageSets only
+    #     have extensions.
     #
-    #      All extensions of your type must be singular messages; e.g. they cannot
-    #      be int32s, enums, or repeated messages.
+    #     All extensions of your type must be singular messages; e.g. they cannot
+    #     be int32s, enums, or repeated messages.
     #
-    #      Because this is an option, the above two restrictions are not enforced by
-    #      the protocol compiler.
+    #     Because this is an option, the above two restrictions are not enforced by
+    #     the protocol compiler.
     # @!attribute [rw] no_standard_descriptor_accessor
     #   @return [Boolean]
     #     Disables the generation of the standard "descriptor()" accessor, which can
-    #      conflict with a field of the same name.  This is meant to make migration
-    #      from proto1 easier; new code should avoid fields named "descriptor".
+    #     conflict with a field of the same name.  This is meant to make migration
+    #     from proto1 easier; new code should avoid fields named "descriptor".
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this message deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the message, or it will be completely ignored; in the very least,
-    #      this is a formalization for deprecating messages.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the message, or it will be completely ignored; in the very least,
+    #     this is a formalization for deprecating messages.
     # @!attribute [rw] map_entry
     #   @return [Boolean]
     #     Whether the message is an automatically generated map entry type for the
-    #      maps field.
+    #     maps field.
     #
-    #      For maps fields:
-    #          map<KeyType, ValueType> map_field = 1;
-    #      The parsed descriptor looks like:
-    #          message MapFieldEntry {
-    #              option map_entry = true;
-    #              optional KeyType key = 1;
-    #              optional ValueType value = 2;
-    #          }
-    #          repeated MapFieldEntry map_field = 1;
+    #     For maps fields:
+    #         map<KeyType, ValueType> map_field = 1;
+    #     The parsed descriptor looks like:
+    #         message MapFieldEntry {
+    #             option map_entry = true;
+    #             optional KeyType key = 1;
+    #             optional ValueType value = 2;
+    #         }
+    #         repeated MapFieldEntry map_field = 1;
     #
-    #      Implementations may choose not to generate the map_entry=true message, but
-    #      use a native map in the target language to hold the keys and values.
-    #      The reflection APIs in such implementions still need to work as
-    #      if the field is a repeated message field.
+    #     Implementations may choose not to generate the map_entry=true message, but
+    #     use a native map in the target language to hold the keys and values.
+    #     The reflection APIs in such implementions still need to work as
+    #     if the field is a repeated message field.
     #
-    #      NOTE: Do not set the option in .proto files. Always use the maps syntax
-    #      instead. The option should only be implicitly set by the proto compiler
-    #      parser.
+    #     NOTE: Do not set the option in .proto files. Always use the maps syntax
+    #     instead. The option should only be implicitly set by the proto compiler
+    #     parser.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here. See above.
@@ -508,65 +508,65 @@ module Google
     # @!attribute [rw] ctype
     #   @return [ENUM(CType)]
     #     The ctype option instructs the C++ code generator to use a different
-    #      representation of the field than it normally would.  See the specific
-    #      options below.  This option is not yet implemented in the open source
-    #      release -- sorry, we'll try to include it in a future version!
+    #     representation of the field than it normally would.  See the specific
+    #     options below.  This option is not yet implemented in the open source
+    #     release -- sorry, we'll try to include it in a future version!
     # @!attribute [rw] packed
     #   @return [Boolean]
     #     The packed option can be enabled for repeated primitive fields to enable
-    #      a more efficient representation on the wire. Rather than repeatedly
-    #      writing the tag and type for each element, the entire array is encoded as
-    #      a single length-delimited blob. In proto3, only explicit setting it to
-    #      false will avoid using packed encoding.
+    #     a more efficient representation on the wire. Rather than repeatedly
+    #     writing the tag and type for each element, the entire array is encoded as
+    #     a single length-delimited blob. In proto3, only explicit setting it to
+    #     false will avoid using packed encoding.
     # @!attribute [rw] jstype
     #   @return [ENUM(JSType)]
     #     The jstype option determines the JavaScript type used for values of the
-    #      field.  The option is permitted only for 64 bit integral and fixed types
-    #      (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
-    #      is represented as JavaScript string, which avoids loss of precision that
-    #      can happen when a large value is converted to a floating point JavaScript.
-    #      Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
-    #      use the JavaScript "number" type.  The behavior of the default option
-    #      JS_NORMAL is implementation dependent.
+    #     field.  The option is permitted only for 64 bit integral and fixed types
+    #     (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+    #     is represented as JavaScript string, which avoids loss of precision that
+    #     can happen when a large value is converted to a floating point JavaScript.
+    #     Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+    #     use the JavaScript "number" type.  The behavior of the default option
+    #     JS_NORMAL is implementation dependent.
     #
-    #      This option is an enum to permit additional types to be added, e.g.
-    #      goog.math.Integer.
+    #     This option is an enum to permit additional types to be added, e.g.
+    #     goog.math.Integer.
     # @!attribute [rw] lazy
     #   @return [Boolean]
     #     Should this field be parsed lazily?  Lazy applies only to message-type
-    #      fields.  It means that when the outer message is initially parsed, the
-    #      inner message's contents will not be parsed but instead stored in encoded
-    #      form.  The inner message will actually be parsed when it is first accessed.
+    #     fields.  It means that when the outer message is initially parsed, the
+    #     inner message's contents will not be parsed but instead stored in encoded
+    #     form.  The inner message will actually be parsed when it is first accessed.
     #
-    #      This is only a hint.  Implementations are free to choose whether to use
-    #      eager or lazy parsing regardless of the value of this option.  However,
-    #      setting this option true suggests that the protocol author believes that
-    #      using lazy parsing on this field is worth the additional bookkeeping
-    #      overhead typically needed to implement it.
+    #     This is only a hint.  Implementations are free to choose whether to use
+    #     eager or lazy parsing regardless of the value of this option.  However,
+    #     setting this option true suggests that the protocol author believes that
+    #     using lazy parsing on this field is worth the additional bookkeeping
+    #     overhead typically needed to implement it.
     #
-    #      This option does not affect the public interface of any generated code;
-    #      all method signatures remain the same.  Furthermore, thread-safety of the
-    #      interface is not affected by this option; const methods remain safe to
-    #      call from multiple threads concurrently, while non-const methods continue
-    #      to require exclusive access.
+    #     This option does not affect the public interface of any generated code;
+    #     all method signatures remain the same.  Furthermore, thread-safety of the
+    #     interface is not affected by this option; const methods remain safe to
+    #     call from multiple threads concurrently, while non-const methods continue
+    #     to require exclusive access.
     #
     #
-    #      Note that implementations may choose not to check required fields within
-    #      a lazy sub-message.  That is, calling IsInitialized() on the outer message
-    #      may return true even if the inner message has missing required fields.
-    #      This is necessary because otherwise the inner message would have to be
-    #      parsed in order to perform the check, defeating the purpose of lazy
-    #      parsing.  An implementation which chooses not to check required fields
-    #      must be consistent about it.  That is, for any particular sub-message, the
-    #      implementation must either *always* check its required fields, or *never*
-    #      check its required fields, regardless of whether or not the message has
-    #      been parsed.
+    #     Note that implementations may choose not to check required fields within
+    #     a lazy sub-message.  That is, calling IsInitialized() on the outer message
+    #     may return true even if the inner message has missing required fields.
+    #     This is necessary because otherwise the inner message would have to be
+    #     parsed in order to perform the check, defeating the purpose of lazy
+    #     parsing.  An implementation which chooses not to check required fields
+    #     must be consistent about it.  That is, for any particular sub-message, the
+    #     implementation must either *always* check its required fields, or *never*
+    #     check its required fields, regardless of whether or not the message has
+    #     been parsed.
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this field deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for accessors, or it will be completely ignored; in the very least, this
-    #      is a formalization for deprecating fields.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for accessors, or it will be completely ignored; in the very least, this
+    #     is a formalization for deprecating fields.
     # @!attribute [rw] weak
     #   @return [Boolean]
     #     For Google-internal migration only. Do not use.
@@ -609,13 +609,13 @@ module Google
     # @!attribute [rw] allow_alias
     #   @return [Boolean]
     #     Set this option to true to allow mapping different tag names to the same
-    #      value.
+    #     value.
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this enum deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the enum, or it will be completely ignored; in the very least, this
-    #      is a formalization for deprecating enums.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the enum, or it will be completely ignored; in the very least, this
+    #     is a formalization for deprecating enums.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here. See above.
@@ -627,9 +627,9 @@ module Google
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this enum value deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the enum value, or it will be completely ignored; in the very least,
-    #      this is a formalization for deprecating enum values.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the enum value, or it will be completely ignored; in the very least,
+    #     this is a formalization for deprecating enum values.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here. See above.
@@ -641,9 +641,9 @@ module Google
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this service deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the service, or it will be completely ignored; in the very least,
-    #      this is a formalization for deprecating services.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the service, or it will be completely ignored; in the very least,
+    #     this is a formalization for deprecating services.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here. See above.
@@ -655,9 +655,9 @@ module Google
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this method deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the method, or it will be completely ignored; in the very least,
-    #      this is a formalization for deprecating methods.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the method, or it will be completely ignored; in the very least,
+    #     this is a formalization for deprecating methods.
     # @!attribute [rw] idempotency_level
     #   @return [ENUM(IdempotencyLevel)]
     # @!attribute [rw] uninterpreted_option
@@ -668,8 +668,8 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
 
       # Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
-      #  or neither? HTTP based RPC implementation may choose GET verb for safe
-      #  methods, and PUT verb for idempotent methods instead of the default POST.
+      # or neither? HTTP based RPC implementation may choose GET verb for safe
+      # methods, and PUT verb for idempotent methods instead of the default POST.
       module IdempotencyLevel
         IDEMPOTENCY_UNKNOWN = 0
 
@@ -680,17 +680,17 @@ module Google
     end
 
     # A message representing a option the parser does not recognize. This only
-    #  appears in options protos created by the compiler::Parser class.
-    #  DescriptorPool resolves these when building Descriptor objects. Therefore,
-    #  options protos in descriptor objects (e.g. returned by Descriptor::options(),
-    #  or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
-    #  in them.
+    # appears in options protos created by the compiler::Parser class.
+    # DescriptorPool resolves these when building Descriptor objects. Therefore,
+    # options protos in descriptor objects (e.g. returned by Descriptor::options(),
+    # or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+    # in them.
     # @!attribute [rw] name
     #   @return [Google::Protobuf::UninterpretedOption::NamePart]
     # @!attribute [rw] identifier_value
     #   @return [String]
     #     The value of the uninterpreted option, in whatever type the tokenizer
-    #      identified it as during parsing. Exactly one of these should be set.
+    #     identified it as during parsing. Exactly one of these should be set.
     # @!attribute [rw] positive_int_value
     #   @return [Integer]
     # @!attribute [rw] negative_int_value
@@ -706,10 +706,10 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
 
       # The name of the uninterpreted option.  Each string represents a segment in
-      #  a dot-separated name.  is_extension is true iff a segment represents an
-      #  extension (denoted with parentheses in options specs in .proto files).
-      #  E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
-      #  "foo.(bar.baz).qux".
+      # a dot-separated name.  is_extension is true iff a segment represents an
+      # extension (denoted with parentheses in options specs in .proto files).
+      # E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
+      # "foo.(bar.baz).qux".
       # @!attribute [rw] name_part
       #   @return [String]
       # @!attribute [rw] is_extension
@@ -721,52 +721,52 @@ module Google
     end
 
     # Encapsulates information about the original source file from which a
-    #  FileDescriptorProto was generated.
+    # FileDescriptorProto was generated.
     # @!attribute [rw] location
     #   @return [Google::Protobuf::SourceCodeInfo::Location]
     #     A Location identifies a piece of source code in a .proto file which
-    #      corresponds to a particular definition.  This information is intended
-    #      to be useful to IDEs, code indexers, documentation generators, and similar
-    #      tools.
+    #     corresponds to a particular definition.  This information is intended
+    #     to be useful to IDEs, code indexers, documentation generators, and similar
+    #     tools.
     #
-    #      For example, say we have a file like:
-    #        message Foo {
-    #          optional string foo = 1;
-    #        }
-    #      Let's look at just the field definition:
-    #        optional string foo = 1;
-    #        ^       ^^     ^^  ^  ^^^
-    #        a       bc     de  f  ghi
-    #      We have the following locations:
-    #        span   path               represents
-    #        [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
-    #        [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
-    #        [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
-    #        [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
-    #        [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+    #     For example, say we have a file like:
+    #       message Foo {
+    #         optional string foo = 1;
+    #       }
+    #     Let's look at just the field definition:
+    #       optional string foo = 1;
+    #       ^       ^^     ^^  ^  ^^^
+    #       a       bc     de  f  ghi
+    #     We have the following locations:
+    #       span   path               represents
+    #       [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+    #       [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+    #       [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+    #       [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+    #       [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
     #
-    #      Notes:
-    #      - A location may refer to a repeated field itself (i.e. not to any
-    #        particular index within it).  This is used whenever a set of elements are
-    #        logically enclosed in a single code segment.  For example, an entire
-    #        extend block (possibly containing multiple extension definitions) will
-    #        have an outer location whose path refers to the "extensions" repeated
-    #        field without an index.
-    #      - Multiple locations may have the same path.  This happens when a single
-    #        logical declaration is spread out across multiple places.  The most
-    #        obvious example is the "extend" block again -- there may be multiple
-    #        extend blocks in the same scope, each of which will have the same path.
-    #      - A location's span is not always a subset of its parent's span.  For
-    #        example, the "extendee" of an extension declaration appears at the
-    #        beginning of the "extend" block and is shared by all extensions within
-    #        the block.
-    #      - Just because a location's span is a subset of some other location's span
-    #        does not mean that it is a descendent.  For example, a "group" defines
-    #        both a type and a field in a single declaration.  Thus, the locations
-    #        corresponding to the type and field and their components will overlap.
-    #      - Code which tries to interpret locations should probably be designed to
-    #        ignore those that it doesn't understand, as more types of locations could
-    #        be recorded in the future.
+    #     Notes:
+    #     - A location may refer to a repeated field itself (i.e. not to any
+    #       particular index within it).  This is used whenever a set of elements are
+    #       logically enclosed in a single code segment.  For example, an entire
+    #       extend block (possibly containing multiple extension definitions) will
+    #       have an outer location whose path refers to the "extensions" repeated
+    #       field without an index.
+    #     - Multiple locations may have the same path.  This happens when a single
+    #       logical declaration is spread out across multiple places.  The most
+    #       obvious example is the "extend" block again -- there may be multiple
+    #       extend blocks in the same scope, each of which will have the same path.
+    #     - A location's span is not always a subset of its parent's span.  For
+    #       example, the "extendee" of an extension declaration appears at the
+    #       beginning of the "extend" block and is shared by all extensions within
+    #       the block.
+    #     - Just because a location's span is a subset of some other location's span
+    #       does not mean that it is a descendent.  For example, a "group" defines
+    #       both a type and a field in a single declaration.  Thus, the locations
+    #       corresponding to the type and field and their components will overlap.
+    #     - Code which tries to interpret locations should probably be designed to
+    #       ignore those that it doesn't understand, as more types of locations could
+    #       be recorded in the future.
     class SourceCodeInfo
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -774,84 +774,84 @@ module Google
       # @!attribute [rw] path
       #   @return [Integer]
       #     Identifies which part of the FileDescriptorProto was defined at this
-      #      location.
+      #     location.
       #
-      #      Each element is a field number or an index.  They form a path from
-      #      the root FileDescriptorProto to the place where the definition.  For
-      #      example, this path:
-      #        [ 4, 3, 2, 7, 1 ]
-      #      refers to:
-      #        file.message_type(3)  // 4, 3
-      #            .field(7)         // 2, 7
-      #            .name()           // 1
-      #      This is because FileDescriptorProto.message_type has field number 4:
-      #        repeated DescriptorProto message_type = 4;
-      #      and DescriptorProto.field has field number 2:
-      #        repeated FieldDescriptorProto field = 2;
-      #      and FieldDescriptorProto.name has field number 1:
-      #        optional string name = 1;
+      #     Each element is a field number or an index.  They form a path from
+      #     the root FileDescriptorProto to the place where the definition.  For
+      #     example, this path:
+      #       [ 4, 3, 2, 7, 1 ]
+      #     refers to:
+      #       file.message_type(3)  // 4, 3
+      #           .field(7)         // 2, 7
+      #           .name()           // 1
+      #     This is because FileDescriptorProto.message_type has field number 4:
+      #       repeated DescriptorProto message_type = 4;
+      #     and DescriptorProto.field has field number 2:
+      #       repeated FieldDescriptorProto field = 2;
+      #     and FieldDescriptorProto.name has field number 1:
+      #       optional string name = 1;
       #
-      #      Thus, the above path gives the location of a field name.  If we removed
-      #      the last element:
-      #        [ 4, 3, 2, 7 ]
-      #      this path refers to the whole field declaration (from the beginning
-      #      of the label to the terminating semicolon).
+      #     Thus, the above path gives the location of a field name.  If we removed
+      #     the last element:
+      #       [ 4, 3, 2, 7 ]
+      #     this path refers to the whole field declaration (from the beginning
+      #     of the label to the terminating semicolon).
       # @!attribute [rw] span
       #   @return [Integer]
       #     Always has exactly three or four elements: start line, start column,
-      #      end line (optional, otherwise assumed same as start line), end column.
-      #      These are packed into a single field for efficiency.  Note that line
-      #      and column numbers are zero-based -- typically you will want to add
-      #      1 to each before displaying to a user.
+      #     end line (optional, otherwise assumed same as start line), end column.
+      #     These are packed into a single field for efficiency.  Note that line
+      #     and column numbers are zero-based -- typically you will want to add
+      #     1 to each before displaying to a user.
       # @!attribute [rw] leading_comments
       #   @return [String]
       #     If this SourceCodeInfo represents a complete declaration, these are any
-      #      comments appearing before and after the declaration which appear to be
-      #      attached to the declaration.
+      #     comments appearing before and after the declaration which appear to be
+      #     attached to the declaration.
       #
-      #      A series of line comments appearing on consecutive lines, with no other
-      #      tokens appearing on those lines, will be treated as a single comment.
+      #     A series of line comments appearing on consecutive lines, with no other
+      #     tokens appearing on those lines, will be treated as a single comment.
       #
-      #      leading_detached_comments will keep paragraphs of comments that appear
-      #      before (but not connected to) the current element. Each paragraph,
-      #      separated by empty lines, will be one comment element in the repeated
-      #      field.
+      #     leading_detached_comments will keep paragraphs of comments that appear
+      #     before (but not connected to) the current element. Each paragraph,
+      #     separated by empty lines, will be one comment element in the repeated
+      #     field.
       #
-      #      Only the comment content is provided; comment markers (e.g. //) are
-      #      stripped out.  For block comments, leading whitespace and an asterisk
-      #      will be stripped from the beginning of each line other than the first.
-      #      Newlines are included in the output.
+      #     Only the comment content is provided; comment markers (e.g. //) are
+      #     stripped out.  For block comments, leading whitespace and an asterisk
+      #     will be stripped from the beginning of each line other than the first.
+      #     Newlines are included in the output.
       #
-      #      Examples:
+      #     Examples:
       #
-      #        optional int32 foo = 1;  // Comment attached to foo.
-      #        // Comment attached to bar.
-      #        optional int32 bar = 2;
+      #       optional int32 foo = 1;  // Comment attached to foo.
+      #       // Comment attached to bar.
+      #       optional int32 bar = 2;
       #
-      #        optional string baz = 3;
-      #        // Comment attached to baz.
-      #        // Another line attached to baz.
+      #       optional string baz = 3;
+      #       // Comment attached to baz.
+      #       // Another line attached to baz.
       #
-      #        // Comment attached to qux.
-      #        //
-      #        // Another line attached to qux.
-      #        optional double qux = 4;
+      #       // Comment attached to qux.
+      #       //
+      #       // Another line attached to qux.
+      #       optional double qux = 4;
       #
-      #        // Detached comment for corge. This is not leading or trailing comments
-      #        // to qux or corge because there are blank lines separating it from
-      #        // both.
+      #       // Detached comment for corge. This is not leading or trailing comments
+      #       // to qux or corge because there are blank lines separating it from
+      #       // both.
       #
-      #        // Detached comment for corge paragraph 2.
+      #       // Detached comment for corge paragraph 2.
       #
-      #        optional string corge = 5;
-      #        /* Block comment attached
-      #         * to corge.  Leading asterisks
-      #         * will be removed. */
-      #        /* Block comment attached to
-      #         * grault. */
-      #        optional int32 grault = 6;
+      #       optional string corge = 5;
+      #       /* Block comment attached
+      #        * to corge.  Leading asterisks
+      #        * will be removed. */
+      #       /* Block comment attached to
+      #        * grault. */
+      #       optional int32 grault = 6;
       #
-      #        // ignored detached comments.
+      #       // ignored detached comments.
       # @!attribute [rw] trailing_comments
       #   @return [String]
       # @!attribute [rw] leading_detached_comments
@@ -863,12 +863,12 @@ module Google
     end
 
     # Describes the relationship between generated code and its original source
-    #  file. A GeneratedCodeInfo message is associated with only one generated
-    #  source file, but may contain references to different source .proto files.
+    # file. A GeneratedCodeInfo message is associated with only one generated
+    # source file, but may contain references to different source .proto files.
     # @!attribute [rw] annotation
     #   @return [Google::Protobuf::GeneratedCodeInfo::Annotation]
     #     An Annotation connects some span of text in generated code to an element
-    #      of its generating .proto file.
+    #     of its generating .proto file.
     class GeneratedCodeInfo
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -876,19 +876,19 @@ module Google
       # @!attribute [rw] path
       #   @return [Integer]
       #     Identifies the element in the original source .proto file. This field
-      #      is formatted the same as SourceCodeInfo.Location.path.
+      #     is formatted the same as SourceCodeInfo.Location.path.
       # @!attribute [rw] source_file
       #   @return [String]
       #     Identifies the filesystem path to the original source .proto.
       # @!attribute [rw] begin
       #   @return [Integer]
       #     Identifies the starting offset in bytes in the generated code
-      #      that relates to the identified object.
+      #     that relates to the identified object.
       # @!attribute [rw] end
       #   @return [Integer]
       #     Identifies the ending offset in bytes in the generated code that
-      #      relates to the identified offset. The end offset should be one past
-      #      the last relevant byte (so the length of the text = end - begin).
+      #     relates to the identified offset. The end offset should be one past
+      #     the last relevant byte (so the length of the text = end - begin).
       class Annotation
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/showcase/lib/doc/google/protobuf/duration.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/protobuf/duration.rb
@@ -19,76 +19,76 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # A Duration represents a signed, fixed-length span of time represented
-    #  as a count of seconds and fractions of seconds at nanosecond
-    #  resolution. It is independent of any calendar and concepts like "day"
-    #  or "month". It is related to Timestamp in that the difference between
-    #  two Timestamp values is a Duration and it can be added or subtracted
-    #  from a Timestamp. Range is approximately +-10,000 years.
+    # as a count of seconds and fractions of seconds at nanosecond
+    # resolution. It is independent of any calendar and concepts like "day"
+    # or "month". It is related to Timestamp in that the difference between
+    # two Timestamp values is a Duration and it can be added or subtracted
+    # from a Timestamp. Range is approximately +-10,000 years.
     #
-    #  # Examples
+    # # Examples
     #
-    #  Example 1: Compute Duration from two Timestamps in pseudo code.
+    # Example 1: Compute Duration from two Timestamps in pseudo code.
     #
-    #      Timestamp start = ...;
-    #      Timestamp end = ...;
-    #      Duration duration = ...;
+    #     Timestamp start = ...;
+    #     Timestamp end = ...;
+    #     Duration duration = ...;
     #
-    #      duration.seconds = end.seconds - start.seconds;
-    #      duration.nanos = end.nanos - start.nanos;
+    #     duration.seconds = end.seconds - start.seconds;
+    #     duration.nanos = end.nanos - start.nanos;
     #
-    #      if (duration.seconds < 0 && duration.nanos > 0) {
-    #        duration.seconds += 1;
-    #        duration.nanos -= 1000000000;
-    #      } else if (durations.seconds > 0 && duration.nanos < 0) {
-    #        duration.seconds -= 1;
-    #        duration.nanos += 1000000000;
-    #      }
+    #     if (duration.seconds < 0 && duration.nanos > 0) {
+    #       duration.seconds += 1;
+    #       duration.nanos -= 1000000000;
+    #     } else if (durations.seconds > 0 && duration.nanos < 0) {
+    #       duration.seconds -= 1;
+    #       duration.nanos += 1000000000;
+    #     }
     #
-    #  Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+    # Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
     #
-    #      Timestamp start = ...;
-    #      Duration duration = ...;
-    #      Timestamp end = ...;
+    #     Timestamp start = ...;
+    #     Duration duration = ...;
+    #     Timestamp end = ...;
     #
-    #      end.seconds = start.seconds + duration.seconds;
-    #      end.nanos = start.nanos + duration.nanos;
+    #     end.seconds = start.seconds + duration.seconds;
+    #     end.nanos = start.nanos + duration.nanos;
     #
-    #      if (end.nanos < 0) {
-    #        end.seconds -= 1;
-    #        end.nanos += 1000000000;
-    #      } else if (end.nanos >= 1000000000) {
-    #        end.seconds += 1;
-    #        end.nanos -= 1000000000;
-    #      }
+    #     if (end.nanos < 0) {
+    #       end.seconds -= 1;
+    #       end.nanos += 1000000000;
+    #     } else if (end.nanos >= 1000000000) {
+    #       end.seconds += 1;
+    #       end.nanos -= 1000000000;
+    #     }
     #
-    #  Example 3: Compute Duration from datetime.timedelta in Python.
+    # Example 3: Compute Duration from datetime.timedelta in Python.
     #
-    #      td = datetime.timedelta(days=3, minutes=10)
-    #      duration = Duration()
-    #      duration.FromTimedelta(td)
+    #     td = datetime.timedelta(days=3, minutes=10)
+    #     duration = Duration()
+    #     duration.FromTimedelta(td)
     #
-    #  # JSON Mapping
+    # # JSON Mapping
     #
-    #  In JSON format, the Duration type is encoded as a string rather than an
-    #  object, where the string ends in the suffix "s" (indicating seconds) and
-    #  is preceded by the number of seconds, with nanoseconds expressed as
-    #  fractional seconds. For example, 3 seconds with 0 nanoseconds should be
-    #  encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
-    #  be expressed in JSON format as "3.000000001s", and 3 seconds and 1
-    #  microsecond should be expressed in JSON format as "3.000001s".
+    # In JSON format, the Duration type is encoded as a string rather than an
+    # object, where the string ends in the suffix "s" (indicating seconds) and
+    # is preceded by the number of seconds, with nanoseconds expressed as
+    # fractional seconds. For example, 3 seconds with 0 nanoseconds should be
+    # encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
+    # be expressed in JSON format as "3.000000001s", and 3 seconds and 1
+    # microsecond should be expressed in JSON format as "3.000001s".
     # @!attribute [rw] seconds
     #   @return [Integer]
     #     Signed seconds of the span of time. Must be from -315,576,000,000
-    #      to +315,576,000,000 inclusive. Note: these bounds are computed from:
-    #      60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+    #     to +315,576,000,000 inclusive. Note: these bounds are computed from:
+    #     60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
     # @!attribute [rw] nanos
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
-    #      of time. Durations less than one second are represented with a 0
-    #      `seconds` field and a positive or negative `nanos` field. For durations
-    #      of one second or more, a non-zero value for the `nanos` field must be
-    #      of the same sign as the `seconds` field. Must be from -999,999,999
-    #      to +999,999,999 inclusive.
+    #     of time. Durations less than one second are represented with a 0
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
+    #     to +999,999,999 inclusive.
     class Duration
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/showcase/lib/doc/google/protobuf/empty.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/protobuf/empty.rb
@@ -19,14 +19,14 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # A generic empty message that you can re-use to avoid defining duplicated
-    #  empty messages in your APIs. A typical example is to use it as the request
-    #  or the response type of an API method. For instance:
+    # empty messages in your APIs. A typical example is to use it as the request
+    # or the response type of an API method. For instance:
     #
-    #      service Foo {
-    #        rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-    #      }
+    #     service Foo {
+    #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+    #     }
     #
-    #  The JSON representation for `Empty` is empty JSON object `{}`.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/showcase/lib/doc/google/protobuf/field_mask.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/protobuf/field_mask.rb
@@ -20,211 +20,211 @@ module Google
   module Protobuf
     # `FieldMask` represents a set of symbolic field paths, for example:
     #
-    #      paths: "f.a"
-    #      paths: "f.b.d"
+    #     paths: "f.a"
+    #     paths: "f.b.d"
     #
-    #  Here `f` represents a field in some root message, `a` and `b`
-    #  fields in the message found in `f`, and `d` a field found in the
-    #  message in `f.b`.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
-    #  Field masks are used to specify a subset of fields that should be
-    #  returned by a get operation or modified by an update operation.
-    #  Field masks also have a custom JSON encoding (see below).
+    # Field masks are used to specify a subset of fields that should be
+    # returned by a get operation or modified by an update operation.
+    # Field masks also have a custom JSON encoding (see below).
     #
-    #  # Field Masks in Projections
+    # # Field Masks in Projections
     #
-    #  When used in the context of a projection, a response message or
-    #  sub-message is filtered by the API to only contain those fields as
-    #  specified in the mask. For example, if the mask in the previous
-    #  example is applied to a response message as follows:
+    # When used in the context of a projection, a response message or
+    # sub-message is filtered by the API to only contain those fields as
+    # specified in the mask. For example, if the mask in the previous
+    # example is applied to a response message as follows:
     #
-    #      f {
-    #        a : 22
-    #        b {
-    #          d : 1
-    #          x : 2
-    #        }
-    #        y : 13
-    #      }
-    #      z: 8
+    #     f {
+    #       a : 22
+    #       b {
+    #         d : 1
+    #         x : 2
+    #       }
+    #       y : 13
+    #     }
+    #     z: 8
     #
-    #  The result will not contain specific values for fields x,y and z
-    #  (their value will be set to the default, and omitted in proto text
-    #  output):
+    # The result will not contain specific values for fields x,y and z
+    # (their value will be set to the default, and omitted in proto text
+    # output):
     #
     #
-    #      f {
-    #        a : 22
-    #        b {
-    #          d : 1
-    #        }
-    #      }
+    #     f {
+    #       a : 22
+    #       b {
+    #         d : 1
+    #       }
+    #     }
     #
-    #  A repeated field is not allowed except at the last position of a
-    #  paths string.
+    # A repeated field is not allowed except at the last position of a
+    # paths string.
     #
-    #  If a FieldMask object is not present in a get operation, the
-    #  operation applies to all fields (as if a FieldMask of all fields
-    #  had been specified).
+    # If a FieldMask object is not present in a get operation, the
+    # operation applies to all fields (as if a FieldMask of all fields
+    # had been specified).
     #
-    #  Note that a field mask does not necessarily apply to the
-    #  top-level response message. In case of a REST get operation, the
-    #  field mask applies directly to the response, but in case of a REST
-    #  list operation, the mask instead applies to each individual message
-    #  in the returned resource list. In case of a REST custom method,
-    #  other definitions may be used. Where the mask applies will be
-    #  clearly documented together with its declaration in the API.  In
-    #  any case, the effect on the returned resource/resources is required
-    #  behavior for APIs.
+    # Note that a field mask does not necessarily apply to the
+    # top-level response message. In case of a REST get operation, the
+    # field mask applies directly to the response, but in case of a REST
+    # list operation, the mask instead applies to each individual message
+    # in the returned resource list. In case of a REST custom method,
+    # other definitions may be used. Where the mask applies will be
+    # clearly documented together with its declaration in the API.  In
+    # any case, the effect on the returned resource/resources is required
+    # behavior for APIs.
     #
-    #  # Field Masks in Update Operations
+    # # Field Masks in Update Operations
     #
-    #  A field mask in update operations specifies which fields of the
-    #  targeted resource are going to be updated. The API is required
-    #  to only change the values of the fields as specified in the mask
-    #  and leave the others untouched. If a resource is passed in to
-    #  describe the updated values, the API ignores the values of all
-    #  fields not covered by the mask.
+    # A field mask in update operations specifies which fields of the
+    # targeted resource are going to be updated. The API is required
+    # to only change the values of the fields as specified in the mask
+    # and leave the others untouched. If a resource is passed in to
+    # describe the updated values, the API ignores the values of all
+    # fields not covered by the mask.
     #
-    #  If a repeated field is specified for an update operation, the existing
-    #  repeated values in the target resource will be overwritten by the new values.
-    #  Note that a repeated field is only allowed in the last position of a `paths`
-    #  string.
+    # If a repeated field is specified for an update operation, the existing
+    # repeated values in the target resource will be overwritten by the new values.
+    # Note that a repeated field is only allowed in the last position of a `paths`
+    # string.
     #
-    #  If a sub-message is specified in the last position of the field mask for an
-    #  update operation, then the existing sub-message in the target resource is
-    #  overwritten. Given the target message:
+    # If a sub-message is specified in the last position of the field mask for an
+    # update operation, then the existing sub-message in the target resource is
+    # overwritten. Given the target message:
     #
-    #      f {
-    #        b {
-    #          d : 1
-    #          x : 2
-    #        }
-    #        c : 1
-    #      }
+    #     f {
+    #       b {
+    #         d : 1
+    #         x : 2
+    #       }
+    #       c : 1
+    #     }
     #
-    #  And an update message:
+    # And an update message:
     #
-    #      f {
-    #        b {
-    #          d : 10
-    #        }
-    #      }
+    #     f {
+    #       b {
+    #         d : 10
+    #       }
+    #     }
     #
-    #  then if the field mask is:
+    # then if the field mask is:
     #
-    #   paths: "f.b"
+    #  paths: "f.b"
     #
-    #  then the result will be:
+    # then the result will be:
     #
-    #      f {
-    #        b {
-    #          d : 10
-    #        }
-    #        c : 1
-    #      }
+    #     f {
+    #       b {
+    #         d : 10
+    #       }
+    #       c : 1
+    #     }
     #
-    #  However, if the update mask was:
+    # However, if the update mask was:
     #
-    #   paths: "f.b.d"
+    #  paths: "f.b.d"
     #
-    #  then the result would be:
+    # then the result would be:
     #
-    #      f {
-    #        b {
-    #          d : 10
-    #          x : 2
-    #        }
-    #        c : 1
-    #      }
+    #     f {
+    #       b {
+    #         d : 10
+    #         x : 2
+    #       }
+    #       c : 1
+    #     }
     #
-    #  In order to reset a field's value to the default, the field must
-    #  be in the mask and set to the default value in the provided resource.
-    #  Hence, in order to reset all fields of a resource, provide a default
-    #  instance of the resource and set all fields in the mask, or do
-    #  not provide a mask as described below.
+    # In order to reset a field's value to the default, the field must
+    # be in the mask and set to the default value in the provided resource.
+    # Hence, in order to reset all fields of a resource, provide a default
+    # instance of the resource and set all fields in the mask, or do
+    # not provide a mask as described below.
     #
-    #  If a field mask is not present on update, the operation applies to
-    #  all fields (as if a field mask of all fields has been specified).
-    #  Note that in the presence of schema evolution, this may mean that
-    #  fields the client does not know and has therefore not filled into
-    #  the request will be reset to their default. If this is unwanted
-    #  behavior, a specific service may require a client to always specify
-    #  a field mask, producing an error if not.
+    # If a field mask is not present on update, the operation applies to
+    # all fields (as if a field mask of all fields has been specified).
+    # Note that in the presence of schema evolution, this may mean that
+    # fields the client does not know and has therefore not filled into
+    # the request will be reset to their default. If this is unwanted
+    # behavior, a specific service may require a client to always specify
+    # a field mask, producing an error if not.
     #
-    #  As with get operations, the location of the resource which
-    #  describes the updated values in the request message depends on the
-    #  operation kind. In any case, the effect of the field mask is
-    #  required to be honored by the API.
+    # As with get operations, the location of the resource which
+    # describes the updated values in the request message depends on the
+    # operation kind. In any case, the effect of the field mask is
+    # required to be honored by the API.
     #
-    #  ## Considerations for HTTP REST
+    # ## Considerations for HTTP REST
     #
-    #  The HTTP kind of an update operation which uses a field mask must
-    #  be set to PATCH instead of PUT in order to satisfy HTTP semantics
-    #  (PUT must only be used for full updates).
+    # The HTTP kind of an update operation which uses a field mask must
+    # be set to PATCH instead of PUT in order to satisfy HTTP semantics
+    # (PUT must only be used for full updates).
     #
-    #  # JSON Encoding of Field Masks
+    # # JSON Encoding of Field Masks
     #
-    #  In JSON, a field mask is encoded as a single string where paths are
-    #  separated by a comma. Fields name in each path are converted
-    #  to/from lower-camel naming conventions.
+    # In JSON, a field mask is encoded as a single string where paths are
+    # separated by a comma. Fields name in each path are converted
+    # to/from lower-camel naming conventions.
     #
-    #  As an example, consider the following message declarations:
+    # As an example, consider the following message declarations:
     #
-    #      message Profile {
-    #        User user = 1;
-    #        Photo photo = 2;
-    #      }
-    #      message User {
-    #        string display_name = 1;
-    #        string address = 2;
-    #      }
+    #     message Profile {
+    #       User user = 1;
+    #       Photo photo = 2;
+    #     }
+    #     message User {
+    #       string display_name = 1;
+    #       string address = 2;
+    #     }
     #
-    #  In proto a field mask for `Profile` may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
-    #      mask {
-    #        paths: "user.display_name"
-    #        paths: "photo"
-    #      }
+    #     mask {
+    #       paths: "user.display_name"
+    #       paths: "photo"
+    #     }
     #
-    #  In JSON, the same mask is represented as below:
+    # In JSON, the same mask is represented as below:
     #
-    #      {
-    #        mask: "user.displayName,photo"
-    #      }
+    #     {
+    #       mask: "user.displayName,photo"
+    #     }
     #
-    #  # Field Masks and Oneof Fields
+    # # Field Masks and Oneof Fields
     #
-    #  Field masks treat fields in oneofs just as regular fields. Consider the
-    #  following message:
+    # Field masks treat fields in oneofs just as regular fields. Consider the
+    # following message:
     #
-    #      message SampleMessage {
-    #        oneof test_oneof {
-    #          string name = 4;
-    #          SubMessage sub_message = 9;
-    #        }
-    #      }
+    #     message SampleMessage {
+    #       oneof test_oneof {
+    #         string name = 4;
+    #         SubMessage sub_message = 9;
+    #       }
+    #     }
     #
-    #  The field mask can be:
+    # The field mask can be:
     #
-    #      mask {
-    #        paths: "name"
-    #      }
+    #     mask {
+    #       paths: "name"
+    #     }
     #
-    #  Or:
+    # Or:
     #
-    #      mask {
-    #        paths: "sub_message"
-    #      }
+    #     mask {
+    #       paths: "sub_message"
+    #     }
     #
-    #  Note that oneof type names ("test_oneof" in this case) cannot be used in
-    #  paths.
+    # Note that oneof type names ("test_oneof" in this case) cannot be used in
+    # paths.
     #
-    #  ## Field Mask Verification
+    # ## Field Mask Verification
     #
-    #  The implementation of any API method which has a FieldMask type field in the
-    #  request should verify the included field paths, and return an
-    #  `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
+    # The implementation of any API method which has a FieldMask type field in the
+    # request should verify the included field paths, and return an
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [String]
     #     The set of field mask paths.

--- a/shared/output/cloud/showcase/lib/doc/google/protobuf/timestamp.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/protobuf/timestamp.rb
@@ -19,94 +19,94 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # A Timestamp represents a point in time independent of any time zone
-    #  or calendar, represented as seconds and fractions of seconds at
-    #  nanosecond resolution in UTC Epoch time. It is encoded using the
-    #  Proleptic Gregorian Calendar which extends the Gregorian calendar
-    #  backwards to year one. It is encoded assuming all minutes are 60
-    #  seconds long, i.e. leap seconds are "smeared" so that no leap second
-    #  table is needed for interpretation. Range is from
-    #  0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
-    #  By restricting to that range, we ensure that we can convert to
-    #  and from  RFC 3339 date strings.
-    #  See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
+    # or calendar, represented as seconds and fractions of seconds at
+    # nanosecond resolution in UTC Epoch time. It is encoded using the
+    # Proleptic Gregorian Calendar which extends the Gregorian calendar
+    # backwards to year one. It is encoded assuming all minutes are 60
+    # seconds long, i.e. leap seconds are "smeared" so that no leap second
+    # table is needed for interpretation. Range is from
+    # 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
+    # By restricting to that range, we ensure that we can convert to
+    # and from  RFC 3339 date strings.
+    # See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
     #
-    #  # Examples
+    # # Examples
     #
-    #  Example 1: Compute Timestamp from POSIX `time()`.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
-    #      Timestamp timestamp;
-    #      timestamp.set_seconds(time(NULL));
-    #      timestamp.set_nanos(0);
+    #     Timestamp timestamp;
+    #     timestamp.set_seconds(time(NULL));
+    #     timestamp.set_nanos(0);
     #
-    #  Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
-    #      struct timeval tv;
-    #      gettimeofday(&tv, NULL);
+    #     struct timeval tv;
+    #     gettimeofday(&tv, NULL);
     #
-    #      Timestamp timestamp;
-    #      timestamp.set_seconds(tv.tv_sec);
-    #      timestamp.set_nanos(tv.tv_usec * 1000);
+    #     Timestamp timestamp;
+    #     timestamp.set_seconds(tv.tv_sec);
+    #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    #  Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
-    #      FILETIME ft;
-    #      GetSystemTimeAsFileTime(&ft);
-    #      UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+    #     FILETIME ft;
+    #     GetSystemTimeAsFileTime(&ft);
+    #     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
     #
-    #      // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
-    #      // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
-    #      Timestamp timestamp;
-    #      timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
-    #      timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+    #     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+    #     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+    #     Timestamp timestamp;
+    #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+    #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    #  Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
-    #      long millis = System.currentTimeMillis();
+    #     long millis = System.currentTimeMillis();
     #
-    #      Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
-    #          .setNanos((int) ((millis % 1000) * 1000000)).build();
+    #     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+    #         .setNanos((int) ((millis % 1000) * 1000000)).build();
     #
     #
-    #  Example 5: Compute Timestamp from current time in Python.
+    # Example 5: Compute Timestamp from current time in Python.
     #
-    #      timestamp = Timestamp()
-    #      timestamp.GetCurrentTime()
+    #     timestamp = Timestamp()
+    #     timestamp.GetCurrentTime()
     #
-    #  # JSON Mapping
+    # # JSON Mapping
     #
-    #  In JSON format, the Timestamp type is encoded as a string in the
-    #  [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    #  format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    #  where {year} is always expressed using four digits while {month}, {day},
-    #  {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
-    #  seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
-    #  are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
-    #  is required. A proto3 JSON serializer should always use UTC (as indicated by
-    #  "Z") when printing the Timestamp type and a proto3 JSON parser should be
-    #  able to accept both UTC and other timezones (as indicated by an offset).
+    # In JSON format, the Timestamp type is encoded as a string in the
+    # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+    # where {year} is always expressed using four digits while {month}, {day},
+    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+    # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+    # is required. A proto3 JSON serializer should always use UTC (as indicated by
+    # "Z") when printing the Timestamp type and a proto3 JSON parser should be
+    # able to accept both UTC and other timezones (as indicated by an offset).
     #
-    #  For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
-    #  01:30 UTC on January 15, 2017.
+    # For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+    # 01:30 UTC on January 15, 2017.
     #
-    #  In JavaScript, one can convert a Date object to this format using the
-    #  standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    #  method. In Python, a standard `datetime.datetime` object can be converted
-    #  to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
-    #  with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    #  can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
-    #  http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
-    #  ) to obtain a formatter capable of generating timestamps in this format.
+    # In JavaScript, one can convert a Date object to this format using the
+    # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
+    # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
+    # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
+    # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds
     #   @return [Integer]
     #     Represents seconds of UTC time since Unix epoch
-    #      1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-    #      9999-12-31T23:59:59Z inclusive.
+    #     1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+    #     9999-12-31T23:59:59Z inclusive.
     # @!attribute [rw] nanos
     #   @return [Integer]
     #     Non-negative fractions of a second at nanosecond resolution. Negative
-    #      second values with fractions must still have non-negative nanos values
-    #      that count forward in time. Must be from 0 to 999,999,999
-    #      inclusive.
+    #     second values with fractions must still have non-negative nanos values
+    #     that count forward in time. Must be from 0 to 999,999,999
+    #     inclusive.
     class Timestamp
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/showcase/lib/doc/google/rpc/error_details.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/rpc/error_details.rb
@@ -19,18 +19,18 @@ raise "This file is for documentation purposes only."
 module Google
   module Rpc
     # Describes when the clients can retry a failed request. Clients could ignore
-    #  the recommendation here or retry when this information is missing from error
-    #  responses.
+    # the recommendation here or retry when this information is missing from error
+    # responses.
     #
-    #  It's always recommended that clients should use exponential backoff when
-    #  retrying.
+    # It's always recommended that clients should use exponential backoff when
+    # retrying.
     #
-    #  Clients should wait until `retry_delay` amount of time has passed since
-    #  receiving the error response before retrying.  If retrying requests also
-    #  fail, clients should use an exponential backoff scheme to gradually increase
-    #  the delay between retries based on `retry_delay`, until either a maximum
-    #  number of retires have been reached or a maximum retry delay cap has been
-    #  reached.
+    # Clients should wait until `retry_delay` amount of time has passed since
+    # receiving the error response before retrying.  If retrying requests also
+    # fail, clients should use an exponential backoff scheme to gradually increase
+    # the delay between retries based on `retry_delay`, until either a maximum
+    # number of retires have been reached or a maximum retry delay cap has been
+    # reached.
     # @!attribute [rw] retry_delay
     #   @return [Google::Protobuf::Duration]
     #     Clients should wait at least this long between retrying the same request.
@@ -53,15 +53,15 @@ module Google
 
     # Describes how a quota check failed.
     #
-    #  For example if a daily limit was exceeded for the calling project,
-    #  a service could respond with a QuotaFailure detail containing the project
-    #  id and the description of the quota limit that was exceeded.  If the
-    #  calling project hasn't enabled the service in the developer console, then
-    #  a service could respond with the project id and set `service_disabled`
-    #  to true.
+    # For example if a daily limit was exceeded for the calling project,
+    # a service could respond with a QuotaFailure detail containing the project
+    # id and the description of the quota limit that was exceeded.  If the
+    # calling project hasn't enabled the service in the developer console, then
+    # a service could respond with the project id and set `service_disabled`
+    # to true.
     #
-    #  Also see RetryDetail and Help types for other details about handling a
-    #  quota failure.
+    # Also see RetryDetail and Help types for other details about handling a
+    # quota failure.
     # @!attribute [rw] violations
     #   @return [Google::Rpc::QuotaFailure::Violation]
     #     Describes all quota violations.
@@ -70,21 +70,21 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
 
       # A message type used to describe a single quota violation.  For example, a
-      #  daily quota or a custom quota that was exceeded.
+      # daily quota or a custom quota that was exceeded.
       # @!attribute [rw] subject
       #   @return [String]
       #     The subject on which the quota check failed.
-      #      For example, "clientip:<ip address of client>" or "project:<Google
-      #      developer project id>".
+      #     For example, "clientip:<ip address of client>" or "project:<Google
+      #     developer project id>".
       # @!attribute [rw] description
       #   @return [String]
       #     A description of how the quota check failed. Clients can use this
-      #      description to find more about the quota configuration in the service's
-      #      public documentation, or find the relevant quota limit to adjust through
-      #      developer console.
+      #     description to find more about the quota configuration in the service's
+      #     public documentation, or find the relevant quota limit to adjust through
+      #     developer console.
       #
-      #      For example: "Service disabled" or "Daily Limit for read operations
-      #      exceeded".
+      #     For example: "Service disabled" or "Daily Limit for read operations
+      #     exceeded".
       class Violation
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
@@ -93,9 +93,9 @@ module Google
 
     # Describes what preconditions have failed.
     #
-    #  For example, if an RPC failed because it required the Terms of Service to be
-    #  acknowledged, it could list the terms of service violation in the
-    #  PreconditionFailure message.
+    # For example, if an RPC failed because it required the Terms of Service to be
+    # acknowledged, it could list the terms of service violation in the
+    # PreconditionFailure message.
     # @!attribute [rw] violations
     #   @return [Google::Rpc::PreconditionFailure::Violation]
     #     Describes all precondition violations.
@@ -107,19 +107,19 @@ module Google
       # @!attribute [rw] type
       #   @return [String]
       #     The type of PreconditionFailure. We recommend using a service-specific
-      #      enum type to define the supported precondition violation types. For
-      #      example, "TOS" for "Terms of Service violation".
+      #     enum type to define the supported precondition violation types. For
+      #     example, "TOS" for "Terms of Service violation".
       # @!attribute [rw] subject
       #   @return [String]
       #     The subject, relative to the type, that failed.
-      #      For example, "google.com/cloud" relative to the "TOS" type would
-      #      indicate which terms of service is being referenced.
+      #     For example, "google.com/cloud" relative to the "TOS" type would
+      #     indicate which terms of service is being referenced.
       # @!attribute [rw] description
       #   @return [String]
       #     A description of how the precondition failed. Developers can use this
-      #      description to understand how to fix the failure.
+      #     description to understand how to fix the failure.
       #
-      #      For example: "Terms of service not accepted".
+      #     For example: "Terms of service not accepted".
       class Violation
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
@@ -127,7 +127,7 @@ module Google
     end
 
     # Describes violations in a client request. This error type focuses on the
-    #  syntactic aspects of the request.
+    # syntactic aspects of the request.
     # @!attribute [rw] field_violations
     #   @return [Google::Rpc::BadRequest::FieldViolation]
     #     Describes all violations in a client request.
@@ -139,8 +139,8 @@ module Google
       # @!attribute [rw] field
       #   @return [String]
       #     A path leading to a field in the request body. The value will be a
-      #      sequence of dot-separated identifiers that identify a protocol buffer
-      #      field. E.g., "field_violations.field" would identify this field.
+      #     sequence of dot-separated identifiers that identify a protocol buffer
+      #     field. E.g., "field_violations.field" would identify this field.
       # @!attribute [rw] description
       #   @return [String]
       #     A description of why the request element is bad.
@@ -151,15 +151,15 @@ module Google
     end
 
     # Contains metadata about the request that clients can attach when filing a bug
-    #  or providing other forms of feedback.
+    # or providing other forms of feedback.
     # @!attribute [rw] request_id
     #   @return [String]
     #     An opaque string that should only be interpreted by the service generating
-    #      it. For example, it can be used to identify requests in the service's logs.
+    #     it. For example, it can be used to identify requests in the service's logs.
     # @!attribute [rw] serving_data
     #   @return [String]
     #     Any data that was used to serve this request. For example, an encrypted
-    #      stack trace that can be sent back to the service provider for debugging.
+    #     stack trace that can be sent back to the service provider for debugging.
     class RequestInfo
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -169,23 +169,23 @@ module Google
     # @!attribute [rw] resource_type
     #   @return [String]
     #     A name for the type of resource being accessed, e.g. "sql table",
-    #      "cloud storage bucket", "file", "Google calendar"; or the type URL
-    #      of the resource: e.g. "type.googleapis.com/google.pubsub.v1.Topic".
+    #     "cloud storage bucket", "file", "Google calendar"; or the type URL
+    #     of the resource: e.g. "type.googleapis.com/google.pubsub.v1.Topic".
     # @!attribute [rw] resource_name
     #   @return [String]
     #     The name of the resource being accessed.  For example, a shared calendar
-    #      name: "example.com_4fghdhgsrgh@group.calendar.google.com", if the current
-    #      error is [google.rpc.Code.PERMISSION_DENIED][google.rpc.Code.PERMISSION_DENIED].
+    #     name: "example.com_4fghdhgsrgh@group.calendar.google.com", if the current
+    #     error is [google.rpc.Code.PERMISSION_DENIED][google.rpc.Code.PERMISSION_DENIED].
     # @!attribute [rw] owner
     #   @return [String]
     #     The owner of the resource (optional).
-    #      For example, "user:<owner email>" or "project:<Google developer project
-    #      id>".
+    #     For example, "user:<owner email>" or "project:<Google developer project
+    #     id>".
     # @!attribute [rw] description
     #   @return [String]
     #     Describes what error is encountered when accessing this resource.
-    #      For example, updating a cloud project may require the `writer` permission
-    #      on the developer console project.
+    #     For example, updating a cloud project may require the `writer` permission
+    #     on the developer console project.
     class ResourceInfo
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -193,9 +193,9 @@ module Google
 
     # Provides links to documentation or for performing an out of band action.
     #
-    #  For example, if a quota check failed with an error indicating the calling
-    #  project hasn't enabled the accessed service, this can contain a URL pointing
-    #  directly to the right place in the developer console to flip the bit.
+    # For example, if a quota check failed with an error indicating the calling
+    # project hasn't enabled the accessed service, this can contain a URL pointing
+    # directly to the right place in the developer console to flip the bit.
     # @!attribute [rw] links
     #   @return [Google::Rpc::Help::Link]
     #     URL(s) pointing to additional information on handling the current error.
@@ -217,12 +217,12 @@ module Google
     end
 
     # Provides a localized error message that is safe to return to the user
-    #  which can be attached to an RPC error.
+    # which can be attached to an RPC error.
     # @!attribute [rw] locale
     #   @return [String]
     #     The locale used following the specification defined at
-    #      http://www.rfc-editor.org/rfc/bcp/bcp47.txt.
-    #      Examples are: "en-US", "fr-CH", "es-MX"
+    #     http://www.rfc-editor.org/rfc/bcp/bcp47.txt.
+    #     Examples are: "en-US", "fr-CH", "es-MX"
     # @!attribute [rw] message
     #   @return [String]
     #     The localized error message in the above locale.

--- a/shared/output/cloud/showcase/lib/doc/google/rpc/status.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/rpc/status.rb
@@ -19,69 +19,69 @@ raise "This file is for documentation purposes only."
 module Google
   module Rpc
     # The `Status` type defines a logical error model that is suitable for different
-    #  programming environments, including REST APIs and RPC APIs. It is used by
-    #  [gRPC](https://github.com/grpc). The error model is designed to be:
+    # programming environments, including REST APIs and RPC APIs. It is used by
+    # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
-    #  - Simple to use and understand for most users
-    #  - Flexible enough to meet unexpected needs
+    # - Simple to use and understand for most users
+    # - Flexible enough to meet unexpected needs
     #
-    #  # Overview
+    # # Overview
     #
-    #  The `Status` message contains three pieces of data: error code, error message,
-    #  and error details. The error code should be an enum value of
-    #  [google.rpc.Code][google.rpc.Code], but it may accept additional error codes if needed.  The
-    #  error message should be a developer-facing English message that helps
-    #  developers *understand* and *resolve* the error. If a localized user-facing
-    #  error message is needed, put the localized message in the error details or
-    #  localize it in the client. The optional error details may contain arbitrary
-    #  information about the error. There is a predefined set of error detail types
-    #  in the package `google.rpc` that can be used for common error conditions.
+    # The `Status` message contains three pieces of data: error code, error message,
+    # and error details. The error code should be an enum value of
+    # [google.rpc.Code][google.rpc.Code], but it may accept additional error codes if needed.  The
+    # error message should be a developer-facing English message that helps
+    # developers *understand* and *resolve* the error. If a localized user-facing
+    # error message is needed, put the localized message in the error details or
+    # localize it in the client. The optional error details may contain arbitrary
+    # information about the error. There is a predefined set of error detail types
+    # in the package `google.rpc` that can be used for common error conditions.
     #
-    #  # Language mapping
+    # # Language mapping
     #
-    #  The `Status` message is the logical representation of the error model, but it
-    #  is not necessarily the actual wire format. When the `Status` message is
-    #  exposed in different client libraries and different wire protocols, it can be
-    #  mapped differently. For example, it will likely be mapped to some exceptions
-    #  in Java, but more likely mapped to some error codes in C.
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
+    # exposed in different client libraries and different wire protocols, it can be
+    # mapped differently. For example, it will likely be mapped to some exceptions
+    # in Java, but more likely mapped to some error codes in C.
     #
-    #  # Other uses
+    # # Other uses
     #
-    #  The error model and the `Status` message can be used in a variety of
-    #  environments, either with or without APIs, to provide a
-    #  consistent developer experience across different environments.
+    # The error model and the `Status` message can be used in a variety of
+    # environments, either with or without APIs, to provide a
+    # consistent developer experience across different environments.
     #
-    #  Example uses of this error model include:
+    # Example uses of this error model include:
     #
-    #  - Partial errors. If a service needs to return partial errors to the client,
-    #      it may embed the `Status` in the normal response to indicate the partial
-    #      errors.
+    # - Partial errors. If a service needs to return partial errors to the client,
+    #     it may embed the `Status` in the normal response to indicate the partial
+    #     errors.
     #
-    #  - Workflow errors. A typical workflow has multiple steps. Each step may
-    #      have a `Status` message for error reporting.
+    # - Workflow errors. A typical workflow has multiple steps. Each step may
+    #     have a `Status` message for error reporting.
     #
-    #  - Batch operations. If a client uses batch request and batch response, the
-    #      `Status` message should be used directly inside batch response, one for
-    #      each error sub-response.
+    # - Batch operations. If a client uses batch request and batch response, the
+    #     `Status` message should be used directly inside batch response, one for
+    #     each error sub-response.
     #
-    #  - Asynchronous operations. If an API call embeds asynchronous operation
-    #      results in its response, the status of those operations should be
-    #      represented directly using the `Status` message.
+    # - Asynchronous operations. If an API call embeds asynchronous operation
+    #     results in its response, the status of those operations should be
+    #     represented directly using the `Status` message.
     #
-    #  - Logging. If some API errors are stored in logs, the message `Status` could
-    #      be used directly after any stripping needed for security/privacy reasons.
+    # - Logging. If some API errors are stored in logs, the message `Status` could
+    #     be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]
     #     The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
     # @!attribute [rw] message
     #   @return [String]
     #     A developer-facing error message, which should be in English. Any
-    #      user-facing error message should be localized and sent in the
-    #      [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+    #     user-facing error message should be localized and sent in the
+    #     [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
     # @!attribute [rw] details
     #   @return [Google::Protobuf::Any]
     #     A list of messages that carry the error details.  There is a common set of
-    #      message types for APIs to use.
+    #     message types for APIs to use.
     class Status
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/showcase/lib/doc/google/showcase/v1alpha3/echo.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/showcase/v1alpha3/echo.rb
@@ -20,7 +20,7 @@ module Google
   module Showcase
     module V1alpha3
       # The request message used for the Echo, Collect and Chat methods. If content
-      #  is set in this message then the request will succeed. If a status is
+      # is set in this message then the request will succeed. If a status is
       # @!attribute [rw] content
       #   @return [String]
       #     The content to be echoed by the server.
@@ -90,7 +90,7 @@ module Google
       # @!attribute [rw] error
       #   @return [Google::Rpc::Status]
       #     The error that will be returned by the server. If this code is specified
-      #      to be the OK rpc code, an empty response will be returned.
+      #     to be the OK rpc code, an empty response will be returned.
       # @!attribute [rw] success
       #   @return [Google::Showcase::V1alpha3::WaitResponse]
       #     The response to be returned on operation completion.

--- a/shared/output/cloud/showcase/lib/doc/google/showcase/v1alpha3/identity.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/showcase/v1alpha3/identity.rb
@@ -41,7 +41,7 @@ module Google
       end
 
       # The request message for the google.showcase.v1alpha3.Identity\CreateUser
-      #  method.
+      # method.
       # @!attribute [rw] user
       #   @return [Google::Showcase::V1alpha3::User]
       #     The user to create.
@@ -51,7 +51,7 @@ module Google
       end
 
       # The request message for the google.showcase.v1alpha3.Identity\GetUser
-      #  method.
+      # method.
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of the requested user.
@@ -61,21 +61,21 @@ module Google
       end
 
       # The request message for the google.showcase.v1alpha3.Identity\UpdateUser
-      #  method.
+      # method.
       # @!attribute [rw] user
       #   @return [Google::Showcase::V1alpha3::User]
       #     The user to update.
       # @!attribute [rw] update_mask
       #   @return [Google::Protobuf::FieldMask]
       #     The field mask to determine wich fields are to be updated. If empty, the
-      #      server will assume all fields are to be updated.
+      #     server will assume all fields are to be updated.
       class UpdateUserRequest
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
       end
 
       # The request message for the google.showcase.v1alpha3.Identity\DeleteUser
-      #  method.
+      # method.
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of the user to delete.
@@ -85,32 +85,32 @@ module Google
       end
 
       # The request message for the google.showcase.v1alpha3.Identity\ListUsers
-      #  method.
+      # method.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     The maximum number of users to return. Server may return fewer users
-      #      than requested. If unspecified, server will pick an appropriate default.
+      #     than requested. If unspecified, server will pick an appropriate default.
       # @!attribute [rw] page_token
       #   @return [String]
       #     The value of google.showcase.v1alpha3.ListUsersResponse.next_page_token
-      #      returned from the previous call to
-      #      `google.showcase.v1alpha3.Identity\ListUsers` method.
+      #     returned from the previous call to
+      #     `google.showcase.v1alpha3.Identity\ListUsers` method.
       class ListUsersRequest
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
       end
 
       # The response message for the google.showcase.v1alpha3.Identity\ListUsers
-      #  method.
+      # method.
       # @!attribute [rw] users
       #   @return [Google::Showcase::V1alpha3::User]
       #     The list of users.
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     A token to retrieve next page of results.
-      #      Pass this value in ListUsersRequest.page_token field in the subsequent
-      #      call to `google.showcase.v1alpha3.Message\ListUsers` method to retrieve the
-      #      next page of results.
+      #     Pass this value in ListUsersRequest.page_token field in the subsequent
+      #     call to `google.showcase.v1alpha3.Message\ListUsers` method to retrieve the
+      #     next page of results.
       class ListUsersResponse
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/showcase/lib/doc/google/showcase/v1alpha3/messaging.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/showcase/v1alpha3/messaging.rb
@@ -41,7 +41,7 @@ module Google
       end
 
       # The request message for the google.showcase.v1alpha3.Messaging\CreateRoom
-      #  method.
+      # method.
       # @!attribute [rw] room
       #   @return [Google::Showcase::V1alpha3::Room]
       #     The room to create.
@@ -51,7 +51,7 @@ module Google
       end
 
       # The request message for the google.showcase.v1alpha3.Messaging\GetRoom
-      #  method.
+      # method.
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of the requested room.
@@ -61,21 +61,21 @@ module Google
       end
 
       # The request message for the google.showcase.v1alpha3.Messaging\UpdateRoom
-      #  method.
+      # method.
       # @!attribute [rw] room
       #   @return [Google::Showcase::V1alpha3::Room]
       #     The room to update.
       # @!attribute [rw] update_mask
       #   @return [Google::Protobuf::FieldMask]
       #     The field mask to determine wich fields are to be updated. If empty, the
-      #      server will assume all fields are to be updated.
+      #     server will assume all fields are to be updated.
       class UpdateRoomRequest
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
       end
 
       # The request message for the google.showcase.v1alpha3.Messaging\DeleteRoom
-      #  method.
+      # method.
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of the requested room.
@@ -85,39 +85,39 @@ module Google
       end
 
       # The request message for the google.showcase.v1alpha3.Messaging\ListRooms
-      #  method.
+      # method.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     The maximum number of rooms return. Server may return fewer rooms
-      #      than requested. If unspecified, server will pick an appropriate default.
+      #     than requested. If unspecified, server will pick an appropriate default.
       # @!attribute [rw] page_token
       #   @return [String]
       #     The value of google.showcase.v1alpha3.ListRoomsResponse.next_page_token
-      #      returned from the previous call to
-      #      `google.showcase.v1alpha3.Messaging\ListRooms` method.
+      #     returned from the previous call to
+      #     `google.showcase.v1alpha3.Messaging\ListRooms` method.
       class ListRoomsRequest
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
       end
 
       # The response message for the google.showcase.v1alpha3.Messaging\ListRooms
-      #  method.
+      # method.
       # @!attribute [rw] rooms
       #   @return [Google::Showcase::V1alpha3::Room]
       #     The list of rooms.
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     A token to retrieve next page of results.
-      #      Pass this value in ListRoomsRequest.page_token field in the subsequent
-      #      call to `google.showcase.v1alpha3.Messaging\ListRooms` method to retrieve the
-      #      next page of results.
+      #     Pass this value in ListRoomsRequest.page_token field in the subsequent
+      #     call to `google.showcase.v1alpha3.Messaging\ListRooms` method to retrieve the
+      #     next page of results.
       class ListRoomsResponse
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
       end
 
       # This protocol buffer message represents a blurb sent to a chat room or
-      #  posted on a user profile.
+      # posted on a user profile.
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of the chat room.
@@ -142,11 +142,11 @@ module Google
       end
 
       # The request message for the google.showcase.v1alpha3.Messaging\CreateBlurb
-      #  method.
+      # method.
       # @!attribute [rw] parent
       #   @return [String]
       #     The resource name of the chat room or user profile that this blurb will
-      #      be tied to.
+      #     be tied to.
       # @!attribute [rw] blurb
       #   @return [Google::Showcase::V1alpha3::Blurb]
       #     The blurb to create.
@@ -156,7 +156,7 @@ module Google
       end
 
       # The request message for the google.showcase.v1alpha3.Messaging\GetBlurb
-      #  method.
+      # method.
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of the requested blurb.
@@ -166,21 +166,21 @@ module Google
       end
 
       # The request message for the google.showcase.v1alpha3.Messaging\UpdateBlurb
-      #  method.
+      # method.
       # @!attribute [rw] blurb
       #   @return [Google::Showcase::V1alpha3::Blurb]
       #     The blurb to update.
       # @!attribute [rw] update_mask
       #   @return [Google::Protobuf::FieldMask]
       #     The field mask to determine wich fields are to be updated. If empty, the
-      #      server will assume all fields are to be updated.
+      #     server will assume all fields are to be updated.
       class UpdateBlurbRequest
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
       end
 
       # The request message for the google.showcase.v1alpha3.Messaging\DeleteBlurb
-      #  method.
+      # method.
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of the requested blurb.
@@ -190,69 +190,69 @@ module Google
       end
 
       # The request message for the google.showcase.v1alpha3.Messaging\ListBlurbs
-      #  method.
+      # method.
       # @!attribute [rw] parent
       #   @return [String]
       #     The resource name of the requested room or profile whos blurbs to list.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     The maximum number of blurbs to return. Server may return fewer
-      #      blurbs than requested. If unspecified, server will pick an appropriate
-      #      default.
+      #     blurbs than requested. If unspecified, server will pick an appropriate
+      #     default.
       # @!attribute [rw] page_token
       #   @return [String]
       #     The value of google.showcase.v1alpha3.ListBlurbsResponse.next_page_token
-      #      returned from the previous call to
-      #      `google.showcase.v1alpha3.Messaging\ListBlurbs` method.
+      #     returned from the previous call to
+      #     `google.showcase.v1alpha3.Messaging\ListBlurbs` method.
       class ListBlurbsRequest
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
       end
 
       # The response message for the google.showcase.v1alpha3.Messaging\ListBlurbs
-      #  method.
+      # method.
       # @!attribute [rw] blurbs
       #   @return [Google::Showcase::V1alpha3::Blurb]
       #     The list of blurbs.
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     A token to retrieve next page of results.
-      #      Pass this value in ListBlurbsRequest.page_token field in the subsequent
-      #      call to `google.showcase.v1alpha3.Blurb\ListBlurbs` method to retrieve
-      #      the next page of results.
+      #     Pass this value in ListBlurbsRequest.page_token field in the subsequent
+      #     call to `google.showcase.v1alpha3.Blurb\ListBlurbs` method to retrieve
+      #     the next page of results.
       class ListBlurbsResponse
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
       end
 
       # The request message for the google.showcase.v1alpha3.Messaging\SearchBlurbs
-      #  method.
+      # method.
       # @!attribute [rw] query
       #   @return [String]
       #     The query used to search for blurbs containing to words of this string.
-      #      Only posts that contain an exact match of a queried word will be returned.
+      #     Only posts that contain an exact match of a queried word will be returned.
       # @!attribute [rw] parent
       #   @return [String]
       #     The rooms or profiles to search. If unset, `SearchBlurbs` will search all
-      #      rooms and all profiles.
+      #     rooms and all profiles.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     The maximum number of blurbs return. Server may return fewer
-      #      blurbs than requested. If unspecified, server will pick an appropriate
-      #      default.
+      #     blurbs than requested. If unspecified, server will pick an appropriate
+      #     default.
       # @!attribute [rw] page_token
       #   @return [String]
       #     The value of
-      #      google.showcase.v1alpha3.SearchBlurbsResponse.next_page_token
-      #      returned from the previous call to
-      #      `google.showcase.v1alpha3.Messaging\SearchBlurbs` method.
+      #     google.showcase.v1alpha3.SearchBlurbsResponse.next_page_token
+      #     returned from the previous call to
+      #     `google.showcase.v1alpha3.Messaging\SearchBlurbs` method.
       class SearchBlurbsRequest
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
       end
 
       # The operation metadata message for the
-      #  google.showcase.v1alpha3.Messaging\SearchBlurbs method.
+      # google.showcase.v1alpha3.Messaging\SearchBlurbs method.
       # @!attribute [rw] retry_info
       #   @return [Google::Rpc::RetryInfo]
       #     This signals to the client when to next poll for response.
@@ -262,23 +262,23 @@ module Google
       end
 
       # The operation response message for the
-      #  google.showcase.v1alpha3.Messaging\SearchBlurbs method.
+      # google.showcase.v1alpha3.Messaging\SearchBlurbs method.
       # @!attribute [rw] blurbs
       #   @return [Google::Showcase::V1alpha3::Blurb]
       #     Blurbs that matched the search query.
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     A token to retrieve next page of results.
-      #      Pass this value in SearchBlurbsRequest.page_token field in the subsequent
-      #      call to `google.showcase.v1alpha3.Blurb\SearchBlurbs` method to
-      #      retrieve the next page of results.
+      #     Pass this value in SearchBlurbsRequest.page_token field in the subsequent
+      #     call to `google.showcase.v1alpha3.Blurb\SearchBlurbs` method to
+      #     retrieve the next page of results.
       class SearchBlurbsResponse
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
       end
 
       # The request message for the google.showcase.v1alpha3.Messaging\StreamBlurbs
-      #  method.
+      # method.
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of a chat room or user profile whose blurbs to stream.
@@ -291,7 +291,7 @@ module Google
       end
 
       # The response message for the google.showcase.v1alpha3.Messaging\StreamBlurbs
-      #  method.
+      # method.
       # @!attribute [rw] blurb
       #   @return [Google::Showcase::V1alpha3::Blurb]
       #     The blurb that was either created, updated, or deleted.
@@ -318,7 +318,7 @@ module Google
       end
 
       # The response message for the google.showcase.v1alpha3.Messaging\SendBlurbs
-      #  method.
+      # method.
       # @!attribute [rw] names
       #   @return [String]
       #     The names of successful blurb creations.
@@ -328,11 +328,11 @@ module Google
       end
 
       # The request message for the google.showcase.v1alpha3.Messaging\Connect
-      #  method.
+      # method.
       # @!attribute [rw] config
       #   @return [Google::Showcase::V1alpha3::ConnectRequest::ConnectConfig]
       #     Provides information that specifies how to process subsequent requests.
-      #      The first `ConnectRequest` message must contain a `config`  message.
+      #     The first `ConnectRequest` message must contain a `config`  message.
       # @!attribute [rw] blurb
       #   @return [Google::Showcase::V1alpha3::Blurb]
       #     The blurb to be created.

--- a/shared/output/cloud/showcase/lib/doc/google/showcase/v1alpha3/testing.rb
+++ b/shared/output/cloud/showcase/lib/doc/google/showcase/v1alpha3/testing.rb
@@ -20,14 +20,14 @@ module Google
   module Showcase
     module V1alpha3
       # A session is a suite of tests, generally being made in the context
-      #  of testing code generation.
+      # of testing code generation.
       #
-      #  A session defines tests it may expect, based on which version of the
-      #  code generation spec is in use.
+      # A session defines tests it may expect, based on which version of the
+      # code generation spec is in use.
       # @!attribute [rw] name
       #   @return [String]
       #     The name of the session. The ID must conform to ^[a-z]+$
-      #      If this is not provided, Showcase chooses one at random.
+      #     If this is not provided, Showcase chooses one at random.
       # @!attribute [rw] version
       #   @return [ENUM(Version)]
       #     Required. The version this session is using.
@@ -38,7 +38,7 @@ module Google
         # The specification versions understood by Showcase.
         module Version
           # Unspecified version. If passed on creation, the session will default
-          #  to using the latest stable release.
+          # to using the latest stable release.
           VERSION_UNSPECIFIED = 0
 
           # The latest v1. Currently, this is v1.0.
@@ -53,8 +53,8 @@ module Google
       # @!attribute [rw] session
       #   @return [Google::Showcase::V1alpha3::Session]
       #     The session to be created.
-      #      Sessions are immutable once they are created (although they can
-      #      be deleted).
+      #     Sessions are immutable once they are created (although they can
+      #     be deleted).
       class CreateSessionRequest
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
@@ -88,7 +88,7 @@ module Google
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     The next page token, if any.
-      #      An empty value here means the last page has been reached.
+      #     An empty value here means the last page has been reached.
       class ListSessionsResponse
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
@@ -141,8 +141,8 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The name of the test.
-      #      The tests/* portion of the names are hard-coded, and do not change
-      #      from session to session.
+      #     The tests/* portion of the names are hard-coded, and do not change
+      #     from session to session.
       # @!attribute [rw] expectation_level
       #   @return [ENUM(ExpectationLevel)]
       #     The expectation level for this test.
@@ -152,17 +152,17 @@ module Google
       # @!attribute [rw] blueprints
       #   @return [Google::Showcase::V1alpha3::Test::Blueprint]
       #     The blueprints that will satisfy this test. There may be multiple blueprints
-      #      that can signal to the server that this test case is being exercised. Although
-      #      multiple blueprints are specified, only a single blueprint needs to be run to
-      #      signal that the test case was exercised.
+      #     that can signal to the server that this test case is being exercised. Although
+      #     multiple blueprints are specified, only a single blueprint needs to be run to
+      #     signal that the test case was exercised.
       class Test
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
 
         # A blueprint is an explicit definition of methods and requests that are needed
-        #  to be made to test this specific test case. Ideally this would be represented
-        #  by something more robust like CEL, but as of writing this, I am unsure if CEL
-        #  is ready.
+        # to be made to test this specific test case. Ideally this would be represented
+        # by something more robust like CEL, but as of writing this, I am unsure if CEL
+        # is ready.
         # @!attribute [rw] name
         #   @return [String]
         #     The name of this blueprint.
@@ -201,21 +201,21 @@ module Google
 
           # This test is recommended.
           #
-          #  If a generator explicitly ignores a recommended test (see `DeleteTest`),
-          #  then the report may still pass, but with a warning.
+          # If a generator explicitly ignores a recommended test (see `DeleteTest`),
+          # then the report may still pass, but with a warning.
           #
-          #  If a generator skips a recommended test and does not explicitly
-          #  express that intention, the report will fail.
+          # If a generator skips a recommended test and does not explicitly
+          # express that intention, the report will fail.
           RECOMMENDED = 2
 
           # This test is optional.
           #
-          #  If a generator explicitly ignores an optional test (see `DeleteTest`),
-          #  then the report may still pass, and no warning will be issued.
+          # If a generator explicitly ignores an optional test (see `DeleteTest`),
+          # then the report may still pass, and no warning will be issued.
           #
-          #  If a generator skips an optional test and does not explicitly
-          #  express that intention, the report may still pass, but with a
-          #  warning.
+          # If a generator skips an optional test and does not explicitly
+          # express that intention, the report may still pass, but with a
+          # warning.
           OPTIONAL = 3
         end
       end
@@ -245,7 +245,7 @@ module Google
           PENDING = 2
 
           # The test was instrumented, but Showcase got an unexpected
-          #  value when the generator tried to confirm success.
+          # value when the generator tried to confirm success.
           INCORRECT_CONFIRMATION = 3
         end
 
@@ -283,7 +283,7 @@ module Google
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     The next page token, if any.
-      #      An empty value here means the last page has been reached.
+      #     An empty value here means the last page has been reached.
       class ListTestsResponse
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
@@ -293,8 +293,8 @@ module Google
       # @!attribute [rw] test
       #   @return [String]
       #     The name of the test.
-      #      The tests/* portion of the names are hard-coded, and do not change
-      #      from session to session.
+      #     The tests/* portion of the names are hard-coded, and do not change
+      #     from session to session.
       # @!attribute [rw] issue
       #   @return [Google::Showcase::V1alpha3::Issue]
       #     An issue found with the test run. If empty, this test run was successful.

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -195,12 +195,12 @@ module Google
 
           ##
           # This method split the given content into words and will pass each word back
-          #  through the stream. This method showcases server-side streaming rpcs.
+          # through the stream. This method showcases server-side streaming rpcs.
           #
           # @overload expand(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ExpandRequest | Hash]
           #     This method split the given content into words and will pass each word back
-          #      through the stream. This method showcases server-side streaming rpcs.
+          #     through the stream. This method showcases server-side streaming rpcs.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -234,8 +234,8 @@ module Google
 
           ##
           # This method will collect the words given to it. When the stream is closed
-          #  by the client, this method will return the a concatenation of the strings
-          #  passed to it. This method showcases client-side streaming rpcs.
+          # by the client, this method will return the a concatenation of the strings
+          # passed to it. This method showcases client-side streaming rpcs.
           #
           # @param requests [Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
@@ -265,8 +265,8 @@ module Google
 
           ##
           # This method, upon receiving a request on the stream, the same content will
-          #  be passed  back on the stream. This method showcases bidirectional
-          #  streaming rpcs.
+          # be passed  back on the stream. This method showcases bidirectional
+          # streaming rpcs.
           #
           # @param requests [Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
@@ -293,12 +293,12 @@ module Google
 
           ##
           # This is similar to the Expand method but instead of returning a stream of
-          #  expanded words, this method returns a paged list of expanded words.
+          # expanded words, this method returns a paged list of expanded words.
           #
           # @overload paged_expand(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::PagedExpandRequest | Hash]
           #     This is similar to the Expand method but instead of returning a stream of
-          #      expanded words, this method returns a paged list of expanded words.
+          #     expanded words, this method returns a paged list of expanded words.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -335,12 +335,12 @@ module Google
 
           ##
           # This method will wait the requested amount of and then return.
-          #  This method showcases how a client handles a request timing out.
+          # This method showcases how a client handles a request timing out.
           #
           # @overload wait(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::WaitRequest | Hash]
           #     This method will wait the requested amount of and then return.
-          #      This method showcases how a client handles a request timing out.
+          #     This method showcases how a client handles a request timing out.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -351,7 +351,7 @@ module Google
           #     The duration of this operation.
           #   @param error [Google::Rpc::Status | Hash]
           #     The error that will be returned by the server. If this code is specified
-          #      to be the OK rpc code, an empty response will be returned.
+          #     to be the OK rpc code, an empty response will be returned.
           #   @param success [Google::Showcase::V1alpha3::WaitResponse | Hash]
           #     The response to be returned on operation completion.
           #   @param options [Google::Gax::CallOptions]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -239,7 +239,7 @@ module Google
           #     The user to update.
           #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
-          #      server will assume all fields are to be updated.
+          #     server will assume all fields are to be updated.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -312,11 +312,11 @@ module Google
           # @overload list_users(page_size: nil, page_token: nil, options: nil)
           #   @param page_size [Integer]
           #     The maximum number of users to return. Server may return fewer users
-          #      than requested. If unspecified, server will pick an appropriate default.
+          #     than requested. If unspecified, server will pick an appropriate default.
           #   @param page_token [String]
           #     The value of google.showcase.v1alpha3.ListUsersResponse.next_page_token
-          #      returned from the previous call to
-          #      `google.showcase.v1alpha3.Identity\ListUsers` method.
+          #     returned from the previous call to
+          #     `google.showcase.v1alpha3.Identity\ListUsers` method.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -284,7 +284,7 @@ module Google
           #     The room to update.
           #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
-          #      server will assume all fields are to be updated.
+          #     server will assume all fields are to be updated.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -357,11 +357,11 @@ module Google
           # @overload list_rooms(page_size: nil, page_token: nil, options: nil)
           #   @param page_size [Integer]
           #     The maximum number of rooms return. Server may return fewer rooms
-          #      than requested. If unspecified, server will pick an appropriate default.
+          #     than requested. If unspecified, server will pick an appropriate default.
           #   @param page_token [String]
           #     The value of google.showcase.v1alpha3.ListRoomsResponse.next_page_token
-          #      returned from the previous call to
-          #      `google.showcase.v1alpha3.Messaging\ListRooms` method.
+          #     returned from the previous call to
+          #     `google.showcase.v1alpha3.Messaging\ListRooms` method.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -388,21 +388,21 @@ module Google
 
           ##
           # Creates a blurb. If the parent is a room, the blurb is understood to be a
-          #  message in that room. If the parent is a profile, the blurb is understood
-          #  to be a post on the profile.
+          # message in that room. If the parent is a profile, the blurb is understood
+          # to be a post on the profile.
           #
           # @overload create_blurb(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::CreateBlurbRequest | Hash]
           #     Creates a blurb. If the parent is a room, the blurb is understood to be a
-          #      message in that room. If the parent is a profile, the blurb is understood
-          #      to be a post on the profile.
+          #     message in that room. If the parent is a profile, the blurb is understood
+          #     to be a post on the profile.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload create_blurb(parent: nil, blurb: nil, options: nil)
           #   @param parent [String]
           #     The resource name of the chat room or user profile that this blurb will
-          #      be tied to.
+          #     be tied to.
           #   @param blurb [Google::Showcase::V1alpha3::Blurb | Hash]
           #     The blurb to create.
           #   @param options [Google::Gax::CallOptions]
@@ -479,7 +479,7 @@ module Google
           #     The blurb to update.
           #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
-          #      server will assume all fields are to be updated.
+          #     server will assume all fields are to be updated.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -542,12 +542,12 @@ module Google
 
           ##
           # Lists blurbs for a specific chat room or user profile depending on the
-          #  parent resource name.
+          # parent resource name.
           #
           # @overload list_blurbs(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
           #     Lists blurbs for a specific chat room or user profile depending on the
-          #      parent resource name.
+          #     parent resource name.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -556,12 +556,12 @@ module Google
           #     The resource name of the requested room or profile whos blurbs to list.
           #   @param page_size [Integer]
           #     The maximum number of blurbs to return. Server may return fewer
-          #      blurbs than requested. If unspecified, server will pick an appropriate
-          #      default.
+          #     blurbs than requested. If unspecified, server will pick an appropriate
+          #     default.
           #   @param page_token [String]
           #     The value of google.showcase.v1alpha3.ListBlurbsResponse.next_page_token
-          #      returned from the previous call to
-          #      `google.showcase.v1alpha3.Messaging\ListBlurbs` method.
+          #     returned from the previous call to
+          #     `google.showcase.v1alpha3.Messaging\ListBlurbs` method.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -588,33 +588,33 @@ module Google
 
           ##
           # This method searches through all blurbs across all rooms and profiles
-          #  for blurbs containing to words found in the query. Only posts that
-          #  contain an exact match of a queried word will be returned.
+          # for blurbs containing to words found in the query. Only posts that
+          # contain an exact match of a queried word will be returned.
           #
           # @overload search_blurbs(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::SearchBlurbsRequest | Hash]
           #     This method searches through all blurbs across all rooms and profiles
-          #      for blurbs containing to words found in the query. Only posts that
-          #      contain an exact match of a queried word will be returned.
+          #     for blurbs containing to words found in the query. Only posts that
+          #     contain an exact match of a queried word will be returned.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload search_blurbs(query: nil, parent: nil, page_size: nil, page_token: nil, options: nil)
           #   @param query [String]
           #     The query used to search for blurbs containing to words of this string.
-          #      Only posts that contain an exact match of a queried word will be returned.
+          #     Only posts that contain an exact match of a queried word will be returned.
           #   @param parent [String]
           #     The rooms or profiles to search. If unset, `SearchBlurbs` will search all
-          #      rooms and all profiles.
+          #     rooms and all profiles.
           #   @param page_size [Integer]
           #     The maximum number of blurbs return. Server may return fewer
-          #      blurbs than requested. If unspecified, server will pick an appropriate
-          #      default.
+          #     blurbs than requested. If unspecified, server will pick an appropriate
+          #     default.
           #   @param page_token [String]
           #     The value of
-          #      google.showcase.v1alpha3.SearchBlurbsResponse.next_page_token
-          #      returned from the previous call to
-          #      `google.showcase.v1alpha3.Messaging\SearchBlurbs` method.
+          #     google.showcase.v1alpha3.SearchBlurbsResponse.next_page_token
+          #     returned from the previous call to
+          #     `google.showcase.v1alpha3.Messaging\SearchBlurbs` method.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -646,12 +646,12 @@ module Google
 
           ##
           # This returns a stream that emits the blurbs that are created for a
-          #  particular chat room or user profile.
+          # particular chat room or user profile.
           #
           # @overload stream_blurbs(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
           #     This returns a stream that emits the blurbs that are created for a
-          #      particular chat room or user profile.
+          #     particular chat room or user profile.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -685,7 +685,7 @@ module Google
 
           ##
           # This is a stream to create multiple blurbs. If an invalid blurb is
-          #  requested to be created, the stream will close with an error.
+          # requested to be created, the stream will close with an error.
           #
           # @param requests [Enumerable<Google::Showcase::V1alpha3::CreateBlurbRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::CreateBlurbRequest} instances.
@@ -715,9 +715,9 @@ module Google
 
           ##
           # This method starts a bidirectional stream that receives all blurbs that
-          #  are being created after the stream has started and sends requests to create
-          #  blurbs. If an invalid blurb is requested to be created, the stream will
-          #  close with an error.
+          # are being created after the stream has started and sends requests to create
+          # blurbs. If an invalid blurb is requested to be created, the stream will
+          # close with an error.
           #
           # @param requests [Enumerable<Google::Showcase::V1alpha3::ConnectRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::ConnectRequest} instances.

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -180,8 +180,8 @@ module Google
           # @overload create_session(session: nil, options: nil)
           #   @param session [Google::Showcase::V1alpha3::Session | Hash]
           #     The session to be created.
-          #      Sessions are immutable once they are created (although they can
-          #      be deleted).
+          #     Sessions are immutable once they are created (although they can
+          #     be deleted).
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -318,14 +318,14 @@ module Google
 
           ##
           # Report on the status of a session.
-          #  This generates a report detailing which tests have been completed,
-          #  and an overall rollup.
+          # This generates a report detailing which tests have been completed,
+          # and an overall rollup.
           #
           # @overload report_session(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ReportSessionRequest | Hash]
           #     Report on the status of a session.
-          #      This generates a report detailing which tests have been completed,
-          #      and an overall rollup.
+          #     This generates a report detailing which tests have been completed,
+          #     and an overall rollup.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -399,19 +399,19 @@ module Google
           ##
           # Explicitly decline to implement a test.
           #
-          #  This removes the test from subsequent `ListTests` calls, and
-          #  attempting to do the test will error.
+          # This removes the test from subsequent `ListTests` calls, and
+          # attempting to do the test will error.
           #
-          #  This method will error if attempting to delete a required test.
+          # This method will error if attempting to delete a required test.
           #
           # @overload delete_test(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::DeleteTestRequest | Hash]
           #     Explicitly decline to implement a test.
           #
-          #      This removes the test from subsequent `ListTests` calls, and
-          #      attempting to do the test will error.
+          #     This removes the test from subsequent `ListTests` calls, and
+          #     attempting to do the test will error.
           #
-          #      This method will error if attempting to delete a required test.
+          #     This method will error if attempting to delete a required test.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
@@ -445,15 +445,15 @@ module Google
           ##
           # Register a response to a test.
           #
-          #  In cases where a test involves registering a final answer at the
-          #  end of the test, this method provides the means to do so.
+          # In cases where a test involves registering a final answer at the
+          # end of the test, this method provides the means to do so.
           #
           # @overload verify_test(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::VerifyTestRequest | Hash]
           #     Register a response to a test.
           #
-          #      In cases where a test involves registering a final answer at the
-          #      end of the test, this method provides the means to do so.
+          #     In cases where a test involves registering a final answer at the
+          #     end of the test, this method provides the means to do so.
           #   @param options [Google::Gax::CallOptions]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #

--- a/shared/output/cloud/speech/lib/doc/google/api/http.rb
+++ b/shared/output/cloud/speech/lib/doc/google/api/http.rb
@@ -19,248 +19,248 @@ raise "This file is for documentation purposes only."
 module Google
   module Api
     # Defines the HTTP configuration for an API service. It contains a list of
-    #  [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
-    #  to one or more HTTP REST API methods.
+    # [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
+    # to one or more HTTP REST API methods.
     # @!attribute [rw] rules
     #   @return [Google::Api::HttpRule]
     #     A list of HTTP configuration rules that apply to individual API methods.
     #
-    #      **NOTE:** All service configuration rules follow "last one wins" order.
+    #     **NOTE:** All service configuration rules follow "last one wins" order.
     # @!attribute [rw] fully_decode_reserved_expansion
     #   @return [Boolean]
     #     When set to true, URL path parmeters will be fully URI-decoded except in
-    #      cases of single segment matches in reserved expansion, where "%2F" will be
-    #      left encoded.
+    #     cases of single segment matches in reserved expansion, where "%2F" will be
+    #     left encoded.
     #
-    #      The default behavior is to not decode RFC 6570 reserved characters in multi
-    #      segment matches.
+    #     The default behavior is to not decode RFC 6570 reserved characters in multi
+    #     segment matches.
     class Http
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
     # `HttpRule` defines the mapping of an RPC method to one or more HTTP
-    #  REST API methods. The mapping specifies how different portions of the RPC
-    #  request message are mapped to URL path, URL query parameters, and
-    #  HTTP request body. The mapping is typically specified as an
-    #  `google.api.http` annotation on the RPC method,
-    #  see "google/api/annotations.proto" for details.
+    # REST API methods. The mapping specifies how different portions of the RPC
+    # request message are mapped to URL path, URL query parameters, and
+    # HTTP request body. The mapping is typically specified as an
+    # `google.api.http` annotation on the RPC method,
+    # see "google/api/annotations.proto" for details.
     #
-    #  The mapping consists of a field specifying the path template and
-    #  method kind.  The path template can refer to fields in the request
-    #  message, as in the example below which describes a REST GET
-    #  operation on a resource collection of messages:
-    #
-    #
-    #      service Messaging {
-    #        rpc GetMessage(GetMessageRequest) returns (Message) {
-    #          option (google.api.http).get = "/v1/messages/{message_id}/{sub.subfield}";
-    #        }
-    #      }
-    #      message GetMessageRequest {
-    #        message SubMessage {
-    #          string subfield = 1;
-    #        }
-    #        string message_id = 1; // mapped to the URL
-    #        SubMessage sub = 2;    // `sub.subfield` is url-mapped
-    #      }
-    #      message Message {
-    #        string text = 1; // content of the resource
-    #      }
-    #
-    #  The same http annotation can alternatively be expressed inside the
-    #  `GRPC API Configuration` YAML file.
-    #
-    #      http:
-    #        rules:
-    #          - selector: <proto_package_name>.Messaging.GetMessage
-    #            get: /v1/messages/{message_id}/{sub.subfield}
-    #
-    #  This definition enables an automatic, bidrectional mapping of HTTP
-    #  JSON to RPC. Example:
-    #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `GET /v1/messages/123456/foo`  | `GetMessage(message_id: "123456" sub: SubMessage(subfield: "foo"))`
-    #
-    #  In general, not only fields but also field paths can be referenced
-    #  from a path pattern. Fields mapped to the path pattern cannot be
-    #  repeated and must have a primitive (non-message) type.
-    #
-    #  Any fields in the request message which are not bound by the path
-    #  pattern automatically become (optional) HTTP query
-    #  parameters. Assume the following definition of the request message:
+    # The mapping consists of a field specifying the path template and
+    # method kind.  The path template can refer to fields in the request
+    # message, as in the example below which describes a REST GET
+    # operation on a resource collection of messages:
     #
     #
-    #      service Messaging {
-    #        rpc GetMessage(GetMessageRequest) returns (Message) {
-    #          option (google.api.http).get = "/v1/messages/{message_id}";
-    #        }
-    #      }
-    #      message GetMessageRequest {
-    #        message SubMessage {
-    #          string subfield = 1;
-    #        }
-    #        string message_id = 1; // mapped to the URL
-    #        int64 revision = 2;    // becomes a parameter
-    #        SubMessage sub = 3;    // `sub.subfield` becomes a parameter
-    #      }
+    #     service Messaging {
+    #       rpc GetMessage(GetMessageRequest) returns (Message) {
+    #         option (google.api.http).get = "/v1/messages/{message_id}/{sub.subfield}";
+    #       }
+    #     }
+    #     message GetMessageRequest {
+    #       message SubMessage {
+    #         string subfield = 1;
+    #       }
+    #       string message_id = 1; // mapped to the URL
+    #       SubMessage sub = 2;    // `sub.subfield` is url-mapped
+    #     }
+    #     message Message {
+    #       string text = 1; // content of the resource
+    #     }
+    #
+    # The same http annotation can alternatively be expressed inside the
+    # `GRPC API Configuration` YAML file.
+    #
+    #     http:
+    #       rules:
+    #         - selector: <proto_package_name>.Messaging.GetMessage
+    #           get: /v1/messages/{message_id}/{sub.subfield}
+    #
+    # This definition enables an automatic, bidrectional mapping of HTTP
+    # JSON to RPC. Example:
+    #
+    # HTTP | RPC
+    # -----|-----
+    # `GET /v1/messages/123456/foo`  | `GetMessage(message_id: "123456" sub: SubMessage(subfield: "foo"))`
+    #
+    # In general, not only fields but also field paths can be referenced
+    # from a path pattern. Fields mapped to the path pattern cannot be
+    # repeated and must have a primitive (non-message) type.
+    #
+    # Any fields in the request message which are not bound by the path
+    # pattern automatically become (optional) HTTP query
+    # parameters. Assume the following definition of the request message:
     #
     #
-    #  This enables a HTTP JSON to RPC mapping as below:
-    #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `GET /v1/messages/123456?revision=2&sub.subfield=foo` | `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield: "foo"))`
-    #
-    #  Note that fields which are mapped to HTTP parameters must have a
-    #  primitive type or a repeated primitive type. Message types are not
-    #  allowed. In the case of a repeated type, the parameter can be
-    #  repeated in the URL, as in `...?param=A&param=B`.
-    #
-    #  For HTTP method kinds which allow a request body, the `body` field
-    #  specifies the mapping. Consider a REST update method on the
-    #  message resource collection:
-    #
-    #
-    #      service Messaging {
-    #        rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
-    #          option (google.api.http) = {
-    #            put: "/v1/messages/{message_id}"
-    #            body: "message"
-    #          };
-    #        }
-    #      }
-    #      message UpdateMessageRequest {
-    #        string message_id = 1; // mapped to the URL
-    #        Message message = 2;   // mapped to the body
-    #      }
+    #     service Messaging {
+    #       rpc GetMessage(GetMessageRequest) returns (Message) {
+    #         option (google.api.http).get = "/v1/messages/{message_id}";
+    #       }
+    #     }
+    #     message GetMessageRequest {
+    #       message SubMessage {
+    #         string subfield = 1;
+    #       }
+    #       string message_id = 1; // mapped to the URL
+    #       int64 revision = 2;    // becomes a parameter
+    #       SubMessage sub = 3;    // `sub.subfield` becomes a parameter
+    #     }
     #
     #
-    #  The following HTTP JSON to RPC mapping is enabled, where the
-    #  representation of the JSON in the request body is determined by
-    #  protos JSON encoding:
+    # This enables a HTTP JSON to RPC mapping as below:
     #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `PUT /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
+    # HTTP | RPC
+    # -----|-----
+    # `GET /v1/messages/123456?revision=2&sub.subfield=foo` | `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield: "foo"))`
     #
-    #  The special name `*` can be used in the body mapping to define that
-    #  every field not bound by the path template should be mapped to the
-    #  request body.  This enables the following alternative definition of
-    #  the update method:
+    # Note that fields which are mapped to HTTP parameters must have a
+    # primitive type or a repeated primitive type. Message types are not
+    # allowed. In the case of a repeated type, the parameter can be
+    # repeated in the URL, as in `...?param=A&param=B`.
     #
-    #      service Messaging {
-    #        rpc UpdateMessage(Message) returns (Message) {
-    #          option (google.api.http) = {
-    #            put: "/v1/messages/{message_id}"
-    #            body: "*"
-    #          };
-    #        }
-    #      }
-    #      message Message {
-    #        string message_id = 1;
-    #        string text = 2;
-    #      }
+    # For HTTP method kinds which allow a request body, the `body` field
+    # specifies the mapping. Consider a REST update method on the
+    # message resource collection:
     #
     #
-    #  The following HTTP JSON to RPC mapping is enabled:
-    #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `PUT /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" text: "Hi!")`
-    #
-    #  Note that when using `*` in the body mapping, it is not possible to
-    #  have HTTP parameters, as all fields not bound by the path end in
-    #  the body. This makes this option more rarely used in practice of
-    #  defining REST APIs. The common usage of `*` is in custom methods
-    #  which don't use the URL at all for transferring data.
-    #
-    #  It is possible to define multiple HTTP methods for one RPC by using
-    #  the `additional_bindings` option. Example:
-    #
-    #      service Messaging {
-    #        rpc GetMessage(GetMessageRequest) returns (Message) {
-    #          option (google.api.http) = {
-    #            get: "/v1/messages/{message_id}"
-    #            additional_bindings {
-    #              get: "/v1/users/{user_id}/messages/{message_id}"
-    #            }
-    #          };
-    #        }
-    #      }
-    #      message GetMessageRequest {
-    #        string message_id = 1;
-    #        string user_id = 2;
-    #      }
+    #     service Messaging {
+    #       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+    #         option (google.api.http) = {
+    #           put: "/v1/messages/{message_id}"
+    #           body: "message"
+    #         };
+    #       }
+    #     }
+    #     message UpdateMessageRequest {
+    #       string message_id = 1; // mapped to the URL
+    #       Message message = 2;   // mapped to the body
+    #     }
     #
     #
-    #  This enables the following two alternative HTTP JSON to RPC
-    #  mappings:
+    # The following HTTP JSON to RPC mapping is enabled, where the
+    # representation of the JSON in the request body is determined by
+    # protos JSON encoding:
     #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
-    #  `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id: "123456")`
+    # HTTP | RPC
+    # -----|-----
+    # `PUT /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
     #
-    #  # Rules for HTTP mapping
+    # The special name `*` can be used in the body mapping to define that
+    # every field not bound by the path template should be mapped to the
+    # request body.  This enables the following alternative definition of
+    # the update method:
     #
-    #  The rules for mapping HTTP path, query parameters, and body fields
-    #  to the request message are as follows:
+    #     service Messaging {
+    #       rpc UpdateMessage(Message) returns (Message) {
+    #         option (google.api.http) = {
+    #           put: "/v1/messages/{message_id}"
+    #           body: "*"
+    #         };
+    #       }
+    #     }
+    #     message Message {
+    #       string message_id = 1;
+    #       string text = 2;
+    #     }
     #
-    #  1. The `body` field specifies either `*` or a field path, or is
-    #     omitted. If omitted, it indicates there is no HTTP request body.
-    #  2. Leaf fields (recursive expansion of nested messages in the
-    #     request) can be classified into three types:
-    #      (a) Matched in the URL template.
-    #      (b) Covered by body (if body is `*`, everything except (a) fields;
-    #          else everything under the body field)
-    #      (c) All other fields.
-    #  3. URL query parameters found in the HTTP request are mapped to (c) fields.
-    #  4. Any body sent with an HTTP request can contain only (b) fields.
     #
-    #  The syntax of the path template is as follows:
+    # The following HTTP JSON to RPC mapping is enabled:
     #
-    #      Template = "/" Segments [ Verb ] ;
-    #      Segments = Segment { "/" Segment } ;
-    #      Segment  = "*" | "**" | LITERAL | Variable ;
-    #      Variable = "{" FieldPath [ "=" Segments ] "}" ;
-    #      FieldPath = IDENT { "." IDENT } ;
-    #      Verb     = ":" LITERAL ;
+    # HTTP | RPC
+    # -----|-----
+    # `PUT /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" text: "Hi!")`
     #
-    #  The syntax `*` matches a single path segment. The syntax `**` matches zero
-    #  or more path segments, which must be the last part of the path except the
-    #  `Verb`. The syntax `LITERAL` matches literal text in the path.
+    # Note that when using `*` in the body mapping, it is not possible to
+    # have HTTP parameters, as all fields not bound by the path end in
+    # the body. This makes this option more rarely used in practice of
+    # defining REST APIs. The common usage of `*` is in custom methods
+    # which don't use the URL at all for transferring data.
     #
-    #  The syntax `Variable` matches part of the URL path as specified by its
-    #  template. A variable template must not contain other variables. If a variable
-    #  matches a single path segment, its template may be omitted, e.g. `{var}`
-    #  is equivalent to `{var=*}`.
+    # It is possible to define multiple HTTP methods for one RPC by using
+    # the `additional_bindings` option. Example:
     #
-    #  If a variable contains exactly one path segment, such as `"{var}"` or
-    #  `"{var=*}"`, when such a variable is expanded into a URL path, all characters
-    #  except `[-_.~0-9a-zA-Z]` are percent-encoded. Such variables show up in the
-    #  Discovery Document as `{var}`.
+    #     service Messaging {
+    #       rpc GetMessage(GetMessageRequest) returns (Message) {
+    #         option (google.api.http) = {
+    #           get: "/v1/messages/{message_id}"
+    #           additional_bindings {
+    #             get: "/v1/users/{user_id}/messages/{message_id}"
+    #           }
+    #         };
+    #       }
+    #     }
+    #     message GetMessageRequest {
+    #       string message_id = 1;
+    #       string user_id = 2;
+    #     }
     #
-    #  If a variable contains one or more path segments, such as `"{var=foo/*}"`
-    #  or `"{var=**}"`, when such a variable is expanded into a URL path, all
-    #  characters except `[-_.~/0-9a-zA-Z]` are percent-encoded. Such variables
-    #  show up in the Discovery Document as `{+var}`.
     #
-    #  NOTE: While the single segment variable matches the semantics of
-    #  [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2
-    #  Simple String Expansion, the multi segment variable **does not** match
-    #  RFC 6570 Reserved Expansion. The reason is that the Reserved Expansion
-    #  does not expand special characters like `?` and `#`, which would lead
-    #  to invalid URLs.
+    # This enables the following two alternative HTTP JSON to RPC
+    # mappings:
     #
-    #  NOTE: the field paths in variables and in the `body` must not refer to
-    #  repeated fields or map fields.
+    # HTTP | RPC
+    # -----|-----
+    # `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
+    # `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id: "123456")`
+    #
+    # # Rules for HTTP mapping
+    #
+    # The rules for mapping HTTP path, query parameters, and body fields
+    # to the request message are as follows:
+    #
+    # 1. The `body` field specifies either `*` or a field path, or is
+    #    omitted. If omitted, it indicates there is no HTTP request body.
+    # 2. Leaf fields (recursive expansion of nested messages in the
+    #    request) can be classified into three types:
+    #     (a) Matched in the URL template.
+    #     (b) Covered by body (if body is `*`, everything except (a) fields;
+    #         else everything under the body field)
+    #     (c) All other fields.
+    # 3. URL query parameters found in the HTTP request are mapped to (c) fields.
+    # 4. Any body sent with an HTTP request can contain only (b) fields.
+    #
+    # The syntax of the path template is as follows:
+    #
+    #     Template = "/" Segments [ Verb ] ;
+    #     Segments = Segment { "/" Segment } ;
+    #     Segment  = "*" | "**" | LITERAL | Variable ;
+    #     Variable = "{" FieldPath [ "=" Segments ] "}" ;
+    #     FieldPath = IDENT { "." IDENT } ;
+    #     Verb     = ":" LITERAL ;
+    #
+    # The syntax `*` matches a single path segment. The syntax `**` matches zero
+    # or more path segments, which must be the last part of the path except the
+    # `Verb`. The syntax `LITERAL` matches literal text in the path.
+    #
+    # The syntax `Variable` matches part of the URL path as specified by its
+    # template. A variable template must not contain other variables. If a variable
+    # matches a single path segment, its template may be omitted, e.g. `{var}`
+    # is equivalent to `{var=*}`.
+    #
+    # If a variable contains exactly one path segment, such as `"{var}"` or
+    # `"{var=*}"`, when such a variable is expanded into a URL path, all characters
+    # except `[-_.~0-9a-zA-Z]` are percent-encoded. Such variables show up in the
+    # Discovery Document as `{var}`.
+    #
+    # If a variable contains one or more path segments, such as `"{var=foo/*}"`
+    # or `"{var=**}"`, when such a variable is expanded into a URL path, all
+    # characters except `[-_.~/0-9a-zA-Z]` are percent-encoded. Such variables
+    # show up in the Discovery Document as `{+var}`.
+    #
+    # NOTE: While the single segment variable matches the semantics of
+    # [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2
+    # Simple String Expansion, the multi segment variable **does not** match
+    # RFC 6570 Reserved Expansion. The reason is that the Reserved Expansion
+    # does not expand special characters like `?` and `#`, which would lead
+    # to invalid URLs.
+    #
+    # NOTE: the field paths in variables and in the `body` must not refer to
+    # repeated fields or map fields.
     # @!attribute [rw] selector
     #   @return [String]
     #     Selects methods to which this rule applies.
     #
-    #      Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+    #     Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
     # @!attribute [rw] get
     #   @return [String]
     #     Used for listing and getting information about resources.
@@ -279,25 +279,25 @@ module Google
     # @!attribute [rw] custom
     #   @return [Google::Api::CustomHttpPattern]
     #     The custom pattern is used for specifying an HTTP method that is not
-    #      included in the `pattern` field, such as HEAD, or "*" to leave the
-    #      HTTP method unspecified for this rule. The wild-card rule is useful
-    #      for services that provide content to Web (HTML) clients.
+    #     included in the `pattern` field, such as HEAD, or "*" to leave the
+    #     HTTP method unspecified for this rule. The wild-card rule is useful
+    #     for services that provide content to Web (HTML) clients.
     # @!attribute [rw] body
     #   @return [String]
     #     The name of the request field whose value is mapped to the HTTP body, or
-    #      `*` for mapping all fields not captured by the path pattern to the HTTP
-    #      body. NOTE: the referred field must not be a repeated field and must be
-    #      present at the top-level of request message type.
+    #     `*` for mapping all fields not captured by the path pattern to the HTTP
+    #     body. NOTE: the referred field must not be a repeated field and must be
+    #     present at the top-level of request message type.
     # @!attribute [rw] response_body
     #   @return [String]
     #     Optional. The name of the response field whose value is mapped to the HTTP
-    #      body of response. Other response fields are ignored. When
-    #      not set, the response message will be used as HTTP body of response.
+    #     body of response. Other response fields are ignored. When
+    #     not set, the response message will be used as HTTP body of response.
     # @!attribute [rw] additional_bindings
     #   @return [Google::Api::HttpRule]
     #     Additional HTTP bindings for the selector. Nested bindings must
-    #      not contain an `additional_bindings` field themselves (that is,
-    #      the nesting may only be one level deep).
+    #     not contain an `additional_bindings` field themselves (that is,
+    #     the nesting may only be one level deep).
     class HttpRule
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/speech/lib/doc/google/cloud/speech/v1/cloud_speech.rb
+++ b/shared/output/cloud/speech/lib/doc/google/cloud/speech/v1/cloud_speech.rb
@@ -24,7 +24,7 @@ module Google
         # @!attribute [rw] config
         #   @return [Google::Cloud::Speech::V1::RecognitionConfig]
         #     *Required* Provides information to the recognizer that specifies how to
-        #      process the request.
+        #     process the request.
         # @!attribute [rw] audio
         #   @return [Google::Cloud::Speech::V1::RecognitionAudio]
         #     *Required* The audio data to be recognized.
@@ -34,11 +34,11 @@ module Google
         end
 
         # The top-level message sent by the client for the `LongRunningRecognize`
-        #  method.
+        # method.
         # @!attribute [rw] config
         #   @return [Google::Cloud::Speech::V1::RecognitionConfig]
         #     *Required* Provides information to the recognizer that specifies how to
-        #      process the request.
+        #     process the request.
         # @!attribute [rw] audio
         #   @return [Google::Cloud::Speech::V1::RecognitionAudio]
         #     *Required* The audio data to be recognized.
@@ -48,214 +48,214 @@ module Google
         end
 
         # The top-level message sent by the client for the `StreamingRecognize` method.
-        #  Multiple `StreamingRecognizeRequest` messages are sent. The first message
-        #  must contain a `streaming_config` message and must not contain `audio` data.
-        #  All subsequent messages must contain `audio` data and must not contain a
-        #  `streaming_config` message.
+        # Multiple `StreamingRecognizeRequest` messages are sent. The first message
+        # must contain a `streaming_config` message and must not contain `audio` data.
+        # All subsequent messages must contain `audio` data and must not contain a
+        # `streaming_config` message.
         # @!attribute [rw] streaming_config
         #   @return [Google::Cloud::Speech::V1::StreamingRecognitionConfig]
         #     Provides information to the recognizer that specifies how to process the
-        #      request. The first `StreamingRecognizeRequest` message must contain a
-        #      `streaming_config`  message.
+        #     request. The first `StreamingRecognizeRequest` message must contain a
+        #     `streaming_config`  message.
         # @!attribute [rw] audio_content
         #   @return [String]
         #     The audio data to be recognized. Sequential chunks of audio data are sent
-        #      in sequential `StreamingRecognizeRequest` messages. The first
-        #      `StreamingRecognizeRequest` message must not contain `audio_content` data
-        #      and all subsequent `StreamingRecognizeRequest` messages must contain
-        #      `audio_content` data. The audio bytes must be encoded as specified in
-        #      `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
-        #      pure binary representation (not base64). See
-        #      [content limits](/speech-to-text/quotas#content).
+        #     in sequential `StreamingRecognizeRequest` messages. The first
+        #     `StreamingRecognizeRequest` message must not contain `audio_content` data
+        #     and all subsequent `StreamingRecognizeRequest` messages must contain
+        #     `audio_content` data. The audio bytes must be encoded as specified in
+        #     `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
+        #     pure binary representation (not base64). See
+        #     [content limits](/speech-to-text/quotas#content).
         class StreamingRecognizeRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
         # Provides information to the recognizer that specifies how to process the
-        #  request.
+        # request.
         # @!attribute [rw] config
         #   @return [Google::Cloud::Speech::V1::RecognitionConfig]
         #     *Required* Provides information to the recognizer that specifies how to
-        #      process the request.
+        #     process the request.
         # @!attribute [rw] single_utterance
         #   @return [Boolean]
         #     *Optional* If `false` or omitted, the recognizer will perform continuous
-        #      recognition (continuing to wait for and process audio even if the user
-        #      pauses speaking) until the client closes the input stream (gRPC API) or
-        #      until the maximum time limit has been reached. May return multiple
-        #      `StreamingRecognitionResult`s with the `is_final` flag set to `true`.
+        #     recognition (continuing to wait for and process audio even if the user
+        #     pauses speaking) until the client closes the input stream (gRPC API) or
+        #     until the maximum time limit has been reached. May return multiple
+        #     `StreamingRecognitionResult`s with the `is_final` flag set to `true`.
         #
-        #      If `true`, the recognizer will detect a single spoken utterance. When it
-        #      detects that the user has paused or stopped speaking, it will return an
-        #      `END_OF_SINGLE_UTTERANCE` event and cease recognition. It will return no
-        #      more than one `StreamingRecognitionResult` with the `is_final` flag set to
-        #      `true`.
+        #     If `true`, the recognizer will detect a single spoken utterance. When it
+        #     detects that the user has paused or stopped speaking, it will return an
+        #     `END_OF_SINGLE_UTTERANCE` event and cease recognition. It will return no
+        #     more than one `StreamingRecognitionResult` with the `is_final` flag set to
+        #     `true`.
         # @!attribute [rw] interim_results
         #   @return [Boolean]
         #     *Optional* If `true`, interim results (tentative hypotheses) may be
-        #      returned as they become available (these interim results are indicated with
-        #      the `is_final=false` flag).
-        #      If `false` or omitted, only `is_final=true` result(s) are returned.
+        #     returned as they become available (these interim results are indicated with
+        #     the `is_final=false` flag).
+        #     If `false` or omitted, only `is_final=true` result(s) are returned.
         class StreamingRecognitionConfig
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
         # Provides information to the recognizer that specifies how to process the
-        #  request.
+        # request.
         # @!attribute [rw] encoding
         #   @return [ENUM(AudioEncoding)]
         #     Encoding of audio data sent in all `RecognitionAudio` messages.
-        #      This field is optional for `FLAC` and `WAV` audio files and required
-        #      for all other audio formats. For details, see
-        #      [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
+        #     This field is optional for `FLAC` and `WAV` audio files and required
+        #     for all other audio formats. For details, see
+        #     [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
         # @!attribute [rw] sample_rate_hertz
         #   @return [Integer]
         #     Sample rate in Hertz of the audio data sent in all
-        #      `RecognitionAudio` messages. Valid values are: 8000-48000.
-        #      16000 is optimal. For best results, set the sampling rate of the audio
-        #      source to 16000 Hz. If that's not possible, use the native sample rate of
-        #      the audio source (instead of re-sampling).
-        #      This field is optional for `FLAC` and `WAV` audio files and required
-        #      for all other audio formats. For details, see
-        #      [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
+        #     `RecognitionAudio` messages. Valid values are: 8000-48000.
+        #     16000 is optimal. For best results, set the sampling rate of the audio
+        #     source to 16000 Hz. If that's not possible, use the native sample rate of
+        #     the audio source (instead of re-sampling).
+        #     This field is optional for `FLAC` and `WAV` audio files and required
+        #     for all other audio formats. For details, see
+        #     [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
         # @!attribute [rw] audio_channel_count
         #   @return [Integer]
         #     *Optional* The number of channels in the input audio data.
-        #      ONLY set this for MULTI-CHANNEL recognition.
-        #      Valid values for LINEAR16 and FLAC are `1`-`8`.
-        #      Valid values for OGG_OPUS are '1'-'254'.
-        #      Valid value for MULAW, AMR, AMR_WB and SPEEX_WITH_HEADER_BYTE is only `1`.
-        #      If `0` or omitted, defaults to one channel (mono).
-        #      Note: We only recognize the first channel by default.
-        #      To perform independent recognition on each channel set
-        #      `enable_separate_recognition_per_channel` to 'true'.
+        #     ONLY set this for MULTI-CHANNEL recognition.
+        #     Valid values for LINEAR16 and FLAC are `1`-`8`.
+        #     Valid values for OGG_OPUS are '1'-'254'.
+        #     Valid value for MULAW, AMR, AMR_WB and SPEEX_WITH_HEADER_BYTE is only `1`.
+        #     If `0` or omitted, defaults to one channel (mono).
+        #     Note: We only recognize the first channel by default.
+        #     To perform independent recognition on each channel set
+        #     `enable_separate_recognition_per_channel` to 'true'.
         # @!attribute [rw] enable_separate_recognition_per_channel
         #   @return [Boolean]
         #     This needs to be set to `true` explicitly and `audio_channel_count` > 1
-        #      to get each channel recognized separately. The recognition result will
-        #      contain a `channel_tag` field to state which channel that result belongs
-        #      to. If this is not true, we will only recognize the first channel. The
-        #      request is billed cumulatively for all channels recognized:
-        #      `audio_channel_count` multiplied by the length of the audio.
+        #     to get each channel recognized separately. The recognition result will
+        #     contain a `channel_tag` field to state which channel that result belongs
+        #     to. If this is not true, we will only recognize the first channel. The
+        #     request is billed cumulatively for all channels recognized:
+        #     `audio_channel_count` multiplied by the length of the audio.
         # @!attribute [rw] language_code
         #   @return [String]
         #     *Required* The language of the supplied audio as a
-        #      [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
-        #      Example: "en-US".
-        #      See [Language Support](/speech-to-text/docs/languages)
-        #      for a list of the currently supported language codes.
+        #     [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
+        #     Example: "en-US".
+        #     See [Language Support](/speech-to-text/docs/languages)
+        #     for a list of the currently supported language codes.
         # @!attribute [rw] max_alternatives
         #   @return [Integer]
         #     *Optional* Maximum number of recognition hypotheses to be returned.
-        #      Specifically, the maximum number of `SpeechRecognitionAlternative` messages
-        #      within each `SpeechRecognitionResult`.
-        #      The server may return fewer than `max_alternatives`.
-        #      Valid values are `0`-`30`. A value of `0` or `1` will return a maximum of
-        #      one. If omitted, will return a maximum of one.
+        #     Specifically, the maximum number of `SpeechRecognitionAlternative` messages
+        #     within each `SpeechRecognitionResult`.
+        #     The server may return fewer than `max_alternatives`.
+        #     Valid values are `0`-`30`. A value of `0` or `1` will return a maximum of
+        #     one. If omitted, will return a maximum of one.
         # @!attribute [rw] profanity_filter
         #   @return [Boolean]
         #     *Optional* If set to `true`, the server will attempt to filter out
-        #      profanities, replacing all but the initial character in each filtered word
-        #      with asterisks, e.g. "f***". If set to `false` or omitted, profanities
-        #      won't be filtered out.
+        #     profanities, replacing all but the initial character in each filtered word
+        #     with asterisks, e.g. "f***". If set to `false` or omitted, profanities
+        #     won't be filtered out.
         # @!attribute [rw] speech_contexts
         #   @return [Google::Cloud::Speech::V1::SpeechContext]
         #     *Optional* array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
-        #      A means to provide context to assist the speech recognition. For more
-        #      information, see [Phrase Hints](/speech-to-text/docs/basics#phrase-hints).
+        #     A means to provide context to assist the speech recognition. For more
+        #     information, see [Phrase Hints](/speech-to-text/docs/basics#phrase-hints).
         # @!attribute [rw] enable_word_time_offsets
         #   @return [Boolean]
         #     *Optional* If `true`, the top result includes a list of words and
-        #      the start and end time offsets (timestamps) for those words. If
-        #      `false`, no word-level time offset information is returned. The default is
-        #      `false`.
+        #     the start and end time offsets (timestamps) for those words. If
+        #     `false`, no word-level time offset information is returned. The default is
+        #     `false`.
         # @!attribute [rw] enable_automatic_punctuation
         #   @return [Boolean]
         #     *Optional* If 'true', adds punctuation to recognition result hypotheses.
-        #      This feature is only available in select languages. Setting this for
-        #      requests in other languages has no effect at all.
-        #      The default 'false' value does not add punctuation to result hypotheses.
-        #      Note: This is currently offered as an experimental service, complimentary
-        #      to all users. In the future this may be exclusively available as a
-        #      premium feature.
+        #     This feature is only available in select languages. Setting this for
+        #     requests in other languages has no effect at all.
+        #     The default 'false' value does not add punctuation to result hypotheses.
+        #     Note: This is currently offered as an experimental service, complimentary
+        #     to all users. In the future this may be exclusively available as a
+        #     premium feature.
         # @!attribute [rw] model
         #   @return [String]
         #     *Optional* Which model to select for the given request. Select the model
-        #      best suited to your domain to get best results. If a model is not
-        #      explicitly specified, then we auto-select a model based on the parameters
-        #      in the RecognitionConfig.
-        #      <table>
-        #        <tr>
-        #          <td><b>Model</b></td>
-        #          <td><b>Description</b></td>
-        #        </tr>
-        #        <tr>
-        #          <td><code>command_and_search</code></td>
-        #          <td>Best for short queries such as voice commands or voice search.</td>
-        #        </tr>
-        #        <tr>
-        #          <td><code>phone_call</code></td>
-        #          <td>Best for audio that originated from a phone call (typically
-        #          recorded at an 8khz sampling rate).</td>
-        #        </tr>
-        #        <tr>
-        #          <td><code>video</code></td>
-        #          <td>Best for audio that originated from from video or includes multiple
-        #              speakers. Ideally the audio is recorded at a 16khz or greater
-        #              sampling rate. This is a premium model that costs more than the
-        #              standard rate.</td>
-        #        </tr>
-        #        <tr>
-        #          <td><code>default</code></td>
-        #          <td>Best for audio that is not one of the specific audio models.
-        #              For example, long-form audio. Ideally the audio is high-fidelity,
-        #              recorded at a 16khz or greater sampling rate.</td>
-        #        </tr>
-        #      </table>
+        #     best suited to your domain to get best results. If a model is not
+        #     explicitly specified, then we auto-select a model based on the parameters
+        #     in the RecognitionConfig.
+        #     <table>
+        #       <tr>
+        #         <td><b>Model</b></td>
+        #         <td><b>Description</b></td>
+        #       </tr>
+        #       <tr>
+        #         <td><code>command_and_search</code></td>
+        #         <td>Best for short queries such as voice commands or voice search.</td>
+        #       </tr>
+        #       <tr>
+        #         <td><code>phone_call</code></td>
+        #         <td>Best for audio that originated from a phone call (typically
+        #         recorded at an 8khz sampling rate).</td>
+        #       </tr>
+        #       <tr>
+        #         <td><code>video</code></td>
+        #         <td>Best for audio that originated from from video or includes multiple
+        #             speakers. Ideally the audio is recorded at a 16khz or greater
+        #             sampling rate. This is a premium model that costs more than the
+        #             standard rate.</td>
+        #       </tr>
+        #       <tr>
+        #         <td><code>default</code></td>
+        #         <td>Best for audio that is not one of the specific audio models.
+        #             For example, long-form audio. Ideally the audio is high-fidelity,
+        #             recorded at a 16khz or greater sampling rate.</td>
+        #       </tr>
+        #     </table>
         # @!attribute [rw] use_enhanced
         #   @return [Boolean]
         #     *Optional* Set to true to use an enhanced model for speech recognition.
-        #      If `use_enhanced` is set to true and the `model` field is not set, then
-        #      an appropriate enhanced model is chosen if:
-        #      1. project is eligible for requesting enhanced models
-        #      2. an enhanced model exists for the audio
+        #     If `use_enhanced` is set to true and the `model` field is not set, then
+        #     an appropriate enhanced model is chosen if:
+        #     1. project is eligible for requesting enhanced models
+        #     2. an enhanced model exists for the audio
         #
-        #      If `use_enhanced` is true and an enhanced version of the specified model
-        #      does not exist, then the speech is recognized using the standard version
-        #      of the specified model.
+        #     If `use_enhanced` is true and an enhanced version of the specified model
+        #     does not exist, then the speech is recognized using the standard version
+        #     of the specified model.
         #
-        #      Enhanced speech models require that you opt-in to data logging using
-        #      instructions in the
-        #      [documentation](/speech-to-text/docs/enable-data-logging). If you set
-        #      `use_enhanced` to true and you have not enabled audio logging, then you
-        #      will receive an error.
+        #     Enhanced speech models require that you opt-in to data logging using
+        #     instructions in the
+        #     [documentation](/speech-to-text/docs/enable-data-logging). If you set
+        #     `use_enhanced` to true and you have not enabled audio logging, then you
+        #     will receive an error.
         class RecognitionConfig
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
 
           # The encoding of the audio data sent in the request.
           #
-          #  All encodings support only 1 channel (mono) audio.
+          # All encodings support only 1 channel (mono) audio.
           #
-          #  For best results, the audio source should be captured and transmitted using
-          #  a lossless encoding (`FLAC` or `LINEAR16`). The accuracy of the speech
-          #  recognition can be reduced if lossy codecs are used to capture or transmit
-          #  audio, particularly if background noise is present. Lossy codecs include
-          #  `MULAW`, `AMR`, `AMR_WB`, `OGG_OPUS`, and `SPEEX_WITH_HEADER_BYTE`.
+          # For best results, the audio source should be captured and transmitted using
+          # a lossless encoding (`FLAC` or `LINEAR16`). The accuracy of the speech
+          # recognition can be reduced if lossy codecs are used to capture or transmit
+          # audio, particularly if background noise is present. Lossy codecs include
+          # `MULAW`, `AMR`, `AMR_WB`, `OGG_OPUS`, and `SPEEX_WITH_HEADER_BYTE`.
           #
-          #  The `FLAC` and `WAV` audio file formats include a header that describes the
-          #  included audio content. You can request recognition for `WAV` files that
-          #  contain either `LINEAR16` or `MULAW` encoded audio.
-          #  If you send `FLAC` or `WAV` audio file format in
-          #  your request, you do not need to specify an `AudioEncoding`; the audio
-          #  encoding format is determined from the file header. If you specify
-          #  an `AudioEncoding` when you send  send `FLAC` or `WAV` audio, the
-          #  encoding configuration must match the encoding described in the audio
-          #  header; otherwise the request returns an
-          #  [google.rpc.Code.INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT] error
-          #  code.
+          # The `FLAC` and `WAV` audio file formats include a header that describes the
+          # included audio content. You can request recognition for `WAV` files that
+          # contain either `LINEAR16` or `MULAW` encoded audio.
+          # If you send `FLAC` or `WAV` audio file format in
+          # your request, you do not need to specify an `AudioEncoding`; the audio
+          # encoding format is determined from the file header. If you specify
+          # an `AudioEncoding` when you send  send `FLAC` or `WAV` audio, the
+          # encoding configuration must match the encoding described in the audio
+          # header; otherwise the request returns an
+          # [google.rpc.Code.INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT] error
+          # code.
           module AudioEncoding
             # Not specified.
             ENCODING_UNSPECIFIED = 0
@@ -264,11 +264,11 @@ module Google
             LINEAR16 = 1
 
             # `FLAC` (Free Lossless Audio
-            #  Codec) is the recommended encoding because it is
-            #  lossless--therefore recognition is not compromised--and
-            #  requires only about half the bandwidth of `LINEAR16`. `FLAC` stream
-            #  encoding supports 16-bit and 24-bit samples, however, not all fields in
-            #  `STREAMINFO` are supported.
+            # Codec) is the recommended encoding because it is
+            # lossless--therefore recognition is not compromised--and
+            # requires only about half the bandwidth of `LINEAR16`. `FLAC` stream
+            # encoding supports 16-bit and 24-bit samples, however, not all fields in
+            # `STREAMINFO` are supported.
             FLAC = 2
 
             # 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
@@ -281,99 +281,99 @@ module Google
             AMR_WB = 5
 
             # Opus encoded audio frames in Ogg container
-            #  ([OggOpus](https://wiki.xiph.org/OggOpus)).
-            #  `sample_rate_hertz` must be one of 8000, 12000, 16000, 24000, or 48000.
+            # ([OggOpus](https://wiki.xiph.org/OggOpus)).
+            # `sample_rate_hertz` must be one of 8000, 12000, 16000, 24000, or 48000.
             OGG_OPUS = 6
 
             # Although the use of lossy encodings is not recommended, if a very low
-            #  bitrate encoding is required, `OGG_OPUS` is highly preferred over
-            #  Speex encoding. The [Speex](https://speex.org/)  encoding supported by
-            #  Cloud Speech API has a header byte in each block, as in MIME type
-            #  `audio/x-speex-with-header-byte`.
-            #  It is a variant of the RTP Speex encoding defined in
-            #  [RFC 5574](https://tools.ietf.org/html/rfc5574).
-            #  The stream is a sequence of blocks, one block per RTP packet. Each block
-            #  starts with a byte containing the length of the block, in bytes, followed
-            #  by one or more frames of Speex data, padded to an integral number of
-            #  bytes (octets) as specified in RFC 5574. In other words, each RTP header
-            #  is replaced with a single byte containing the block length. Only Speex
-            #  wideband is supported. `sample_rate_hertz` must be 16000.
+            # bitrate encoding is required, `OGG_OPUS` is highly preferred over
+            # Speex encoding. The [Speex](https://speex.org/)  encoding supported by
+            # Cloud Speech API has a header byte in each block, as in MIME type
+            # `audio/x-speex-with-header-byte`.
+            # It is a variant of the RTP Speex encoding defined in
+            # [RFC 5574](https://tools.ietf.org/html/rfc5574).
+            # The stream is a sequence of blocks, one block per RTP packet. Each block
+            # starts with a byte containing the length of the block, in bytes, followed
+            # by one or more frames of Speex data, padded to an integral number of
+            # bytes (octets) as specified in RFC 5574. In other words, each RTP header
+            # is replaced with a single byte containing the block length. Only Speex
+            # wideband is supported. `sample_rate_hertz` must be 16000.
             SPEEX_WITH_HEADER_BYTE = 7
           end
         end
 
         # Provides "hints" to the speech recognizer to favor specific words and phrases
-        #  in the results.
+        # in the results.
         # @!attribute [rw] phrases
         #   @return [String]
         #     *Optional* A list of strings containing words and phrases "hints" so that
-        #      the speech recognition is more likely to recognize them. This can be used
-        #      to improve the accuracy for specific words and phrases, for example, if
-        #      specific commands are typically spoken by the user. This can also be used
-        #      to add additional words to the vocabulary of the recognizer. See
-        #      [usage limits](/speech-to-text/quotas#content).
+        #     the speech recognition is more likely to recognize them. This can be used
+        #     to improve the accuracy for specific words and phrases, for example, if
+        #     specific commands are typically spoken by the user. This can also be used
+        #     to add additional words to the vocabulary of the recognizer. See
+        #     [usage limits](/speech-to-text/quotas#content).
         class SpeechContext
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
         # Contains audio data in the encoding specified in the `RecognitionConfig`.
-        #  Either `content` or `uri` must be supplied. Supplying both or neither
-        #  returns [google.rpc.Code.INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT].
-        #  See [content limits](/speech-to-text/quotas#content).
+        # Either `content` or `uri` must be supplied. Supplying both or neither
+        # returns [google.rpc.Code.INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT].
+        # See [content limits](/speech-to-text/quotas#content).
         # @!attribute [rw] content
         #   @return [String]
         #     The audio data bytes encoded as specified in
-        #      `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
-        #      pure binary representation, whereas JSON representations use base64.
+        #     `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
+        #     pure binary representation, whereas JSON representations use base64.
         # @!attribute [rw] uri
         #   @return [String]
         #     URI that points to a file that contains audio data bytes as specified in
-        #      `RecognitionConfig`. The file must not be compressed (for example, gzip).
-        #      Currently, only Google Cloud Storage URIs are
-        #      supported, which must be specified in the following format:
-        #      `gs://bucket_name/object_name` (other URI formats return
-        #      [google.rpc.Code.INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT]).
-        #      For more information, see [Request
-        #      URIs](https://cloud.google.com/storage/docs/reference-uris).
+        #     `RecognitionConfig`. The file must not be compressed (for example, gzip).
+        #     Currently, only Google Cloud Storage URIs are
+        #     supported, which must be specified in the following format:
+        #     `gs://bucket_name/object_name` (other URI formats return
+        #     [google.rpc.Code.INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT]).
+        #     For more information, see [Request
+        #     URIs](https://cloud.google.com/storage/docs/reference-uris).
         class RecognitionAudio
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
         # The only message returned to the client by the `Recognize` method. It
-        #  contains the result as zero or more sequential `SpeechRecognitionResult`
-        #  messages.
+        # contains the result as zero or more sequential `SpeechRecognitionResult`
+        # messages.
         # @!attribute [rw] results
         #   @return [Google::Cloud::Speech::V1::SpeechRecognitionResult]
         #     Output only. Sequential list of transcription results corresponding to
-        #      sequential portions of audio.
+        #     sequential portions of audio.
         class RecognizeResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
         # The only message returned to the client by the `LongRunningRecognize` method.
-        #  It contains the result as zero or more sequential `SpeechRecognitionResult`
-        #  messages. It is included in the `result.response` field of the `Operation`
-        #  returned by the `GetOperation` call of the `google::longrunning::Operations`
-        #  service.
+        # It contains the result as zero or more sequential `SpeechRecognitionResult`
+        # messages. It is included in the `result.response` field of the `Operation`
+        # returned by the `GetOperation` call of the `google::longrunning::Operations`
+        # service.
         # @!attribute [rw] results
         #   @return [Google::Cloud::Speech::V1::SpeechRecognitionResult]
         #     Output only. Sequential list of transcription results corresponding to
-        #      sequential portions of audio.
+        #     sequential portions of audio.
         class LongRunningRecognizeResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
         # Describes the progress of a long-running `LongRunningRecognize` call. It is
-        #  included in the `metadata` field of the `Operation` returned by the
-        #  `GetOperation` call of the `google::longrunning::Operations` service.
+        # included in the `metadata` field of the `Operation` returned by the
+        # `GetOperation` call of the `google::longrunning::Operations` service.
         # @!attribute [rw] progress_percent
         #   @return [Integer]
         #     Approximate percentage of audio processed thus far. Guaranteed to be 100
-        #      when the audio is fully processed and the results are available.
+        #     when the audio is fully processed and the results are available.
         # @!attribute [rw] start_time
         #   @return [Google::Protobuf::Timestamp]
         #     Time when the request was received.
@@ -386,64 +386,64 @@ module Google
         end
 
         # `StreamingRecognizeResponse` is the only message returned to the client by
-        #  `StreamingRecognize`. A series of zero or more `StreamingRecognizeResponse`
-        #  messages are streamed back to the client. If there is no recognizable
-        #  audio, and `single_utterance` is set to false, then no messages are streamed
-        #  back to the client.
+        # `StreamingRecognize`. A series of zero or more `StreamingRecognizeResponse`
+        # messages are streamed back to the client. If there is no recognizable
+        # audio, and `single_utterance` is set to false, then no messages are streamed
+        # back to the client.
         #
-        #  Here's an example of a series of ten `StreamingRecognizeResponse`s that might
-        #  be returned while processing audio:
+        # Here's an example of a series of ten `StreamingRecognizeResponse`s that might
+        # be returned while processing audio:
         #
-        #  1. results { alternatives { transcript: "tube" } stability: 0.01 }
+        # 1. results { alternatives { transcript: "tube" } stability: 0.01 }
         #
-        #  2. results { alternatives { transcript: "to be a" } stability: 0.01 }
+        # 2. results { alternatives { transcript: "to be a" } stability: 0.01 }
         #
-        #  3. results { alternatives { transcript: "to be" } stability: 0.9 }
-        #     results { alternatives { transcript: " or not to be" } stability: 0.01 }
+        # 3. results { alternatives { transcript: "to be" } stability: 0.9 }
+        #    results { alternatives { transcript: " or not to be" } stability: 0.01 }
         #
-        #  4. results { alternatives { transcript: "to be or not to be"
-        #                              confidence: 0.92 }
-        #               alternatives { transcript: "to bee or not to bee" }
-        #               is_final: true }
+        # 4. results { alternatives { transcript: "to be or not to be"
+        #                             confidence: 0.92 }
+        #              alternatives { transcript: "to bee or not to bee" }
+        #              is_final: true }
         #
-        #  5. results { alternatives { transcript: " that's" } stability: 0.01 }
+        # 5. results { alternatives { transcript: " that's" } stability: 0.01 }
         #
-        #  6. results { alternatives { transcript: " that is" } stability: 0.9 }
-        #     results { alternatives { transcript: " the question" } stability: 0.01 }
+        # 6. results { alternatives { transcript: " that is" } stability: 0.9 }
+        #    results { alternatives { transcript: " the question" } stability: 0.01 }
         #
-        #  7. results { alternatives { transcript: " that is the question"
-        #                              confidence: 0.98 }
-        #               alternatives { transcript: " that was the question" }
-        #               is_final: true }
+        # 7. results { alternatives { transcript: " that is the question"
+        #                             confidence: 0.98 }
+        #              alternatives { transcript: " that was the question" }
+        #              is_final: true }
         #
-        #  Notes:
+        # Notes:
         #
-        #  - Only two of the above responses #4 and #7 contain final results; they are
-        #    indicated by `is_final: true`. Concatenating these together generates the
-        #    full transcript: "to be or not to be that is the question".
+        # - Only two of the above responses #4 and #7 contain final results; they are
+        #   indicated by `is_final: true`. Concatenating these together generates the
+        #   full transcript: "to be or not to be that is the question".
         #
-        #  - The others contain interim `results`. #3 and #6 contain two interim
-        #    `results`: the first portion has a high stability and is less likely to
-        #    change; the second portion has a low stability and is very likely to
-        #    change. A UI designer might choose to show only high stability `results`.
+        # - The others contain interim `results`. #3 and #6 contain two interim
+        #   `results`: the first portion has a high stability and is less likely to
+        #   change; the second portion has a low stability and is very likely to
+        #   change. A UI designer might choose to show only high stability `results`.
         #
-        #  - The specific `stability` and `confidence` values shown above are only for
-        #    illustrative purposes. Actual values may vary.
+        # - The specific `stability` and `confidence` values shown above are only for
+        #   illustrative purposes. Actual values may vary.
         #
-        #  - In each response, only one of these fields will be set:
-        #      `error`,
-        #      `speech_event_type`, or
-        #      one or more (repeated) `results`.
+        # - In each response, only one of these fields will be set:
+        #     `error`,
+        #     `speech_event_type`, or
+        #     one or more (repeated) `results`.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]
         #     Output only. If set, returns a [google.rpc.Status][google.rpc.Status]
-        #      message that specifies the error for the operation.
+        #     message that specifies the error for the operation.
         # @!attribute [rw] results
         #   @return [Google::Cloud::Speech::V1::StreamingRecognitionResult]
         #     Output only. This repeated list contains zero or more results that
-        #      correspond to consecutive portions of the audio currently being processed.
-        #      It contains zero or one `is_final=true` result (the newly settled portion),
-        #      followed by zero or more `is_final=false` results (the interim results).
+        #     correspond to consecutive portions of the audio currently being processed.
+        #     It contains zero or one `is_final=true` result (the newly settled portion),
+        #     followed by zero or more `is_final=false` results (the interim results).
         # @!attribute [rw] speech_event_type
         #   @return [ENUM(SpeechEventType)]
         #     Output only. Indicates the type of speech event.
@@ -457,43 +457,43 @@ module Google
             SPEECH_EVENT_UNSPECIFIED = 0
 
             # This event indicates that the server has detected the end of the user's
-            #  speech utterance and expects no additional speech. Therefore, the server
-            #  will not process additional audio (although it may subsequently return
-            #  additional results). The client should stop sending additional audio
-            #  data, half-close the gRPC connection, and wait for any additional results
-            #  until the server closes the gRPC connection. This event is only sent if
-            #  `single_utterance` was set to `true`, and is not used otherwise.
+            # speech utterance and expects no additional speech. Therefore, the server
+            # will not process additional audio (although it may subsequently return
+            # additional results). The client should stop sending additional audio
+            # data, half-close the gRPC connection, and wait for any additional results
+            # until the server closes the gRPC connection. This event is only sent if
+            # `single_utterance` was set to `true`, and is not used otherwise.
             END_OF_SINGLE_UTTERANCE = 1
           end
         end
 
         # A streaming speech recognition result corresponding to a portion of the audio
-        #  that is currently being processed.
+        # that is currently being processed.
         # @!attribute [rw] alternatives
         #   @return [Google::Cloud::Speech::V1::SpeechRecognitionAlternative]
         #     Output only. May contain one or more recognition hypotheses (up to the
-        #      maximum specified in `max_alternatives`).
-        #      These alternatives are ordered in terms of accuracy, with the top (first)
-        #      alternative being the most probable, as ranked by the recognizer.
+        #     maximum specified in `max_alternatives`).
+        #     These alternatives are ordered in terms of accuracy, with the top (first)
+        #     alternative being the most probable, as ranked by the recognizer.
         # @!attribute [rw] is_final
         #   @return [Boolean]
         #     Output only. If `false`, this `StreamingRecognitionResult` represents an
-        #      interim result that may change. If `true`, this is the final time the
-        #      speech service will return this particular `StreamingRecognitionResult`,
-        #      the recognizer will not return any further hypotheses for this portion of
-        #      the transcript and corresponding audio.
+        #     interim result that may change. If `true`, this is the final time the
+        #     speech service will return this particular `StreamingRecognitionResult`,
+        #     the recognizer will not return any further hypotheses for this portion of
+        #     the transcript and corresponding audio.
         # @!attribute [rw] stability
         #   @return [Float]
         #     Output only. An estimate of the likelihood that the recognizer will not
-        #      change its guess about this interim result. Values range from 0.0
-        #      (completely unstable) to 1.0 (completely stable).
-        #      This field is only provided for interim results (`is_final=false`).
-        #      The default of 0.0 is a sentinel value indicating `stability` was not set.
+        #     change its guess about this interim result. Values range from 0.0
+        #     (completely unstable) to 1.0 (completely stable).
+        #     This field is only provided for interim results (`is_final=false`).
+        #     The default of 0.0 is a sentinel value indicating `stability` was not set.
         # @!attribute [rw] channel_tag
         #   @return [Integer]
         #     For multi-channel audio, this is the channel number corresponding to the
-        #      recognized result for the audio from that channel.
-        #      For audio_channel_count = N, its output values can range from '1' to 'N'.
+        #     recognized result for the audio from that channel.
+        #     For audio_channel_count = N, its output values can range from '1' to 'N'.
         class StreamingRecognitionResult
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -503,14 +503,14 @@ module Google
         # @!attribute [rw] alternatives
         #   @return [Google::Cloud::Speech::V1::SpeechRecognitionAlternative]
         #     Output only. May contain one or more recognition hypotheses (up to the
-        #      maximum specified in `max_alternatives`).
-        #      These alternatives are ordered in terms of accuracy, with the top (first)
-        #      alternative being the most probable, as ranked by the recognizer.
+        #     maximum specified in `max_alternatives`).
+        #     These alternatives are ordered in terms of accuracy, with the top (first)
+        #     alternative being the most probable, as ranked by the recognizer.
         # @!attribute [rw] channel_tag
         #   @return [Integer]
         #     For multi-channel audio, this is the channel number corresponding to the
-        #      recognized result for the audio from that channel.
-        #      For audio_channel_count = N, its output values can range from '1' to 'N'.
+        #     recognized result for the audio from that channel.
+        #     For audio_channel_count = N, its output values can range from '1' to 'N'.
         class SpeechRecognitionResult
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -523,17 +523,17 @@ module Google
         # @!attribute [rw] confidence
         #   @return [Float]
         #     Output only. The confidence estimate between 0.0 and 1.0. A higher number
-        #      indicates an estimated greater likelihood that the recognized words are
-        #      correct. This field is set only for the top alternative of a non-streaming
-        #      result or, of a streaming result where `is_final=true`.
-        #      This field is not guaranteed to be accurate and users should not rely on it
-        #      to be always provided.
-        #      The default of 0.0 is a sentinel value indicating `confidence` was not set.
+        #     indicates an estimated greater likelihood that the recognized words are
+        #     correct. This field is set only for the top alternative of a non-streaming
+        #     result or, of a streaming result where `is_final=true`.
+        #     This field is not guaranteed to be accurate and users should not rely on it
+        #     to be always provided.
+        #     The default of 0.0 is a sentinel value indicating `confidence` was not set.
         # @!attribute [rw] words
         #   @return [Google::Cloud::Speech::V1::WordInfo]
         #     Output only. A list of word-specific information for each recognized word.
-        #      Note: When `enable_speaker_diarization` is true, you will see all the words
-        #      from the beginning of the audio.
+        #     Note: When `enable_speaker_diarization` is true, you will see all the words
+        #     from the beginning of the audio.
         class SpeechRecognitionAlternative
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -543,19 +543,19 @@ module Google
         # @!attribute [rw] start_time
         #   @return [Google::Protobuf::Duration]
         #     Output only. Time offset relative to the beginning of the audio,
-        #      and corresponding to the start of the spoken word.
-        #      This field is only set if `enable_word_time_offsets=true` and only
-        #      in the top hypothesis.
-        #      This is an experimental feature and the accuracy of the time offset can
-        #      vary.
+        #     and corresponding to the start of the spoken word.
+        #     This field is only set if `enable_word_time_offsets=true` and only
+        #     in the top hypothesis.
+        #     This is an experimental feature and the accuracy of the time offset can
+        #     vary.
         # @!attribute [rw] end_time
         #   @return [Google::Protobuf::Duration]
         #     Output only. Time offset relative to the beginning of the audio,
-        #      and corresponding to the end of the spoken word.
-        #      This field is only set if `enable_word_time_offsets=true` and only
-        #      in the top hypothesis.
-        #      This is an experimental feature and the accuracy of the time offset can
-        #      vary.
+        #     and corresponding to the end of the spoken word.
+        #     This field is only set if `enable_word_time_offsets=true` and only
+        #     in the top hypothesis.
+        #     This is an experimental feature and the accuracy of the time offset can
+        #     vary.
         # @!attribute [rw] word
         #   @return [String]
         #     Output only. The word corresponding to this set of information.

--- a/shared/output/cloud/speech/lib/doc/google/longrunning/operations.rb
+++ b/shared/output/cloud/speech/lib/doc/google/longrunning/operations.rb
@@ -19,36 +19,36 @@ raise "This file is for documentation purposes only."
 module Google
   module Longrunning
     # This resource represents a long-running operation that is the result of a
-    #  network API call.
+    # network API call.
     # @!attribute [rw] name
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
-    #      originally returns it. If you use the default HTTP mapping, the
-    #      `name` should have the format of `operations/some/unique/name`.
+    #     originally returns it. If you use the default HTTP mapping, the
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
-    #      contains progress information and common metadata such as create time.
-    #      Some services might not provide such metadata.  Any method that returns a
-    #      long-running operation should document the metadata type, if any.
+    #     contains progress information and common metadata such as create time.
+    #     Some services might not provide such metadata.  Any method that returns a
+    #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [Boolean]
     #     If the value is `false`, it means the operation is still in progress.
-    #      If true, the operation is completed, and either `error` or `response` is
-    #      available.
+    #     If true, the operation is completed, and either `error` or `response` is
+    #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
     #     The error result of the operation in case of failure or cancellation.
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #      method returns no data on success, such as `Delete`, the response is
-    #      `google.protobuf.Empty`.  If the original method is standard
-    #      `Get`/`Create`/`Update`, the response should be the resource.  For other
-    #      methods, the response should have the type `XxxResponse`, where `Xxx`
-    #      is the original method name.  For example, if the original method name
-    #      is `TakeSnapshot()`, the inferred response type is
-    #      `TakeSnapshotResponse`.
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
+    #     is the original method name.  For example, if the original method name
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -113,34 +113,34 @@ module Google
 
     # A message representing the message types used by a long-running operation.
     #
-    #  Example:
+    # Example:
     #
-    #    rpc LongRunningRecognize(LongRunningRecognizeRequest)
-    #        returns (google.longrunning.Operation) {
-    #      option (google.longrunning.operation_info) = {
-    #        response_type: "LongRunningRecognizeResponse"
-    #        metadata_type: "LongRunningRecognizeMetadata"
-    #      };
-    #    }
+    #   rpc LongRunningRecognize(LongRunningRecognizeRequest)
+    #       returns (google.longrunning.Operation) {
+    #     option (google.longrunning.operation_info) = {
+    #       response_type: "LongRunningRecognizeResponse"
+    #       metadata_type: "LongRunningRecognizeMetadata"
+    #     };
+    #   }
     # @!attribute [rw] response_type
     #   @return [String]
     #     Required. The message name of the primary return type for this
-    #      long-running operation.
-    #      This type will be used to deserialize the LRO's response.
+    #     long-running operation.
+    #     This type will be used to deserialize the LRO's response.
     #
-    #      If the response is in a different package from the rpc, a fully-qualified
-    #      message name must be used (e.g. `google.protobuf.Struct`).
+    #     If the response is in a different package from the rpc, a fully-qualified
+    #     message name must be used (e.g. `google.protobuf.Struct`).
     #
-    #      Note: Altering this value constitutes a breaking change.
+    #     Note: Altering this value constitutes a breaking change.
     # @!attribute [rw] metadata_type
     #   @return [String]
     #     Required. The message name of the metadata type for this long-running
-    #      operation.
+    #     operation.
     #
-    #      If the response is in a different package from the rpc, a fully-qualified
-    #      message name must be used (e.g. `google.protobuf.Struct`).
+    #     If the response is in a different package from the rpc, a fully-qualified
+    #     message name must be used (e.g. `google.protobuf.Struct`).
     #
-    #      Note: Altering this value constitutes a breaking change.
+    #     Note: Altering this value constitutes a breaking change.
     class OperationInfo
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/speech/lib/doc/google/protobuf/any.rb
+++ b/shared/output/cloud/speech/lib/doc/google/protobuf/any.rb
@@ -19,112 +19,112 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # `Any` contains an arbitrary serialized protocol buffer message along with a
-    #  URL that describes the type of the serialized message.
+    # URL that describes the type of the serialized message.
     #
-    #  Protobuf library provides support to pack/unpack Any values in the form
-    #  of utility functions or additional generated methods of the Any type.
+    # Protobuf library provides support to pack/unpack Any values in the form
+    # of utility functions or additional generated methods of the Any type.
     #
-    #  Example 1: Pack and unpack a message in C++.
+    # Example 1: Pack and unpack a message in C++.
     #
-    #      Foo foo = ...;
-    #      Any any;
-    #      any.PackFrom(foo);
-    #      ...
-    #      if (any.UnpackTo(&foo)) {
-    #        ...
-    #      }
-    #
-    #  Example 2: Pack and unpack a message in Java.
-    #
-    #      Foo foo = ...;
-    #      Any any = Any.pack(foo);
-    #      ...
-    #      if (any.is(Foo.class)) {
-    #        foo = any.unpack(Foo.class);
-    #      }
-    #
-    #   Example 3: Pack and unpack a message in Python.
-    #
-    #      foo = Foo(...)
-    #      any = Any()
-    #      any.Pack(foo)
-    #      ...
-    #      if any.Is(Foo.DESCRIPTOR):
-    #        any.Unpack(foo)
-    #        ...
-    #
-    #   Example 4: Pack and unpack a message in Go
-    #
-    #       foo := &pb.Foo{...}
-    #       any, err := ptypes.MarshalAny(foo)
+    #     Foo foo = ...;
+    #     Any any;
+    #     any.PackFrom(foo);
+    #     ...
+    #     if (any.UnpackTo(&foo)) {
     #       ...
-    #       foo := &pb.Foo{}
-    #       if err := ptypes.UnmarshalAny(any, foo); err != nil {
-    #         ...
-    #       }
+    #     }
     #
-    #  The pack methods provided by protobuf library will by default use
-    #  'type.googleapis.com/full.type.name' as the type URL and the unpack
-    #  methods only use the fully qualified type name after the last '/'
-    #  in the type URL, for example "foo.bar.com/x/y.z" will yield type
-    #  name "y.z".
+    # Example 2: Pack and unpack a message in Java.
     #
+    #     Foo foo = ...;
+    #     Any any = Any.pack(foo);
+    #     ...
+    #     if (any.is(Foo.class)) {
+    #       foo = any.unpack(Foo.class);
+    #     }
     #
-    #  JSON
-    #  ====
-    #  The JSON representation of an `Any` value uses the regular
-    #  representation of the deserialized, embedded message, with an
-    #  additional field `@type` which contains the type URL. Example:
+    #  Example 3: Pack and unpack a message in Python.
     #
-    #      package google.profile;
-    #      message Person {
-    #        string first_name = 1;
-    #        string last_name = 2;
+    #     foo = Foo(...)
+    #     any = Any()
+    #     any.Pack(foo)
+    #     ...
+    #     if any.Is(Foo.DESCRIPTOR):
+    #       any.Unpack(foo)
+    #       ...
+    #
+    #  Example 4: Pack and unpack a message in Go
+    #
+    #      foo := &pb.Foo{...}
+    #      any, err := ptypes.MarshalAny(foo)
+    #      ...
+    #      foo := &pb.Foo{}
+    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #        ...
     #      }
     #
-    #      {
-    #        "@type": "type.googleapis.com/google.profile.Person",
-    #        "firstName": <string>,
-    #        "lastName": <string>
-    #      }
+    # The pack methods provided by protobuf library will by default use
+    # 'type.googleapis.com/full.type.name' as the type URL and the unpack
+    # methods only use the fully qualified type name after the last '/'
+    # in the type URL, for example "foo.bar.com/x/y.z" will yield type
+    # name "y.z".
     #
-    #  If the embedded message type is well-known and has a custom JSON
-    #  representation, that representation will be embedded adding a field
-    #  `value` which holds the custom JSON in addition to the `@type`
-    #  field. Example (for message [google.protobuf.Duration][]):
     #
-    #      {
-    #        "@type": "type.googleapis.com/google.protobuf.Duration",
-    #        "value": "1.212s"
-    #      }
+    # JSON
+    # ====
+    # The JSON representation of an `Any` value uses the regular
+    # representation of the deserialized, embedded message, with an
+    # additional field `@type` which contains the type URL. Example:
+    #
+    #     package google.profile;
+    #     message Person {
+    #       string first_name = 1;
+    #       string last_name = 2;
+    #     }
+    #
+    #     {
+    #       "@type": "type.googleapis.com/google.profile.Person",
+    #       "firstName": <string>,
+    #       "lastName": <string>
+    #     }
+    #
+    # If the embedded message type is well-known and has a custom JSON
+    # representation, that representation will be embedded adding a field
+    # `value` which holds the custom JSON in addition to the `@type`
+    # field. Example (for message [google.protobuf.Duration][]):
+    #
+    #     {
+    #       "@type": "type.googleapis.com/google.protobuf.Duration",
+    #       "value": "1.212s"
+    #     }
     # @!attribute [rw] type_url
     #   @return [String]
     #     A URL/resource name that uniquely identifies the type of the serialized
-    #      protocol buffer message. The last segment of the URL's path must represent
-    #      the fully qualified name of the type (as in
-    #      `path/google.protobuf.Duration`). The name should be in a canonical form
-    #      (e.g., leading "." is not accepted).
+    #     protocol buffer message. The last segment of the URL's path must represent
+    #     the fully qualified name of the type (as in
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
+    #     (e.g., leading "." is not accepted).
     #
-    #      In practice, teams usually precompile into the binary all types that they
-    #      expect it to use in the context of Any. However, for URLs which use the
-    #      scheme `http`, `https`, or no scheme, one can optionally set up a type
-    #      server that maps type URLs to message definitions as follows:
+    #     In practice, teams usually precompile into the binary all types that they
+    #     expect it to use in the context of Any. However, for URLs which use the
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
+    #     server that maps type URLs to message definitions as follows:
     #
-    #      * If no scheme is provided, `https` is assumed.
-    #      * An HTTP GET on the URL must yield a [google.protobuf.Type][]
-    #        value in binary format, or produce an error.
-    #      * Applications are allowed to cache lookup results based on the
-    #        URL, or have them precompiled into a binary to avoid any
-    #        lookup. Therefore, binary compatibility needs to be preserved
-    #        on changes to types. (Use versioned type names to manage
-    #        breaking changes.)
+    #     * If no scheme is provided, `https` is assumed.
+    #     * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+    #       value in binary format, or produce an error.
+    #     * Applications are allowed to cache lookup results based on the
+    #       URL, or have them precompiled into a binary to avoid any
+    #       lookup. Therefore, binary compatibility needs to be preserved
+    #       on changes to types. (Use versioned type names to manage
+    #       breaking changes.)
     #
-    #      Note: this functionality is not currently available in the official
-    #      protobuf release, and it is not used for type URLs beginning with
-    #      type.googleapis.com.
+    #     Note: this functionality is not currently available in the official
+    #     protobuf release, and it is not used for type URLs beginning with
+    #     type.googleapis.com.
     #
-    #      Schemes other than `http`, `https` (or the empty scheme) might be
-    #      used with implementation specific semantics.
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
+    #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]
     #     Must be a valid serialized protocol buffer of the above specified type.

--- a/shared/output/cloud/speech/lib/doc/google/protobuf/descriptor.rb
+++ b/shared/output/cloud/speech/lib/doc/google/protobuf/descriptor.rb
@@ -19,7 +19,7 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # The protocol compiler can output a FileDescriptorSet containing the .proto
-    #  files it parses.
+    # files it parses.
     # @!attribute [rw] file
     #   @return [Google::Protobuf::FileDescriptorProto]
     class FileDescriptorSet
@@ -41,7 +41,7 @@ module Google
     # @!attribute [rw] weak_dependency
     #   @return [Integer]
     #     Indexes of the weak imported files in the dependency list.
-    #      For Google-internal migration only. Do not use.
+    #     For Google-internal migration only. Do not use.
     # @!attribute [rw] message_type
     #   @return [Google::Protobuf::DescriptorProto]
     #     All top-level definitions in this file.
@@ -56,13 +56,13 @@ module Google
     # @!attribute [rw] source_code_info
     #   @return [Google::Protobuf::SourceCodeInfo]
     #     This field contains optional information about the original source code.
-    #      You may safely remove this entire field without harming runtime
-    #      functionality of the descriptors -- the information is needed only by
-    #      development tools.
+    #     You may safely remove this entire field without harming runtime
+    #     functionality of the descriptors -- the information is needed only by
+    #     development tools.
     # @!attribute [rw] syntax
     #   @return [String]
     #     The syntax of the proto file.
-    #      The supported values are "proto2" and "proto3".
+    #     The supported values are "proto2" and "proto3".
     class FileDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -90,7 +90,7 @@ module Google
     # @!attribute [rw] reserved_name
     #   @return [String]
     #     Reserved field names, which may not be used by fields in the same message.
-    #      A given name may only be reserved once.
+    #     A given name may only be reserved once.
     class DescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -107,8 +107,8 @@ module Google
       end
 
       # Range of reserved tag numbers. Reserved tag numbers may not be used by
-      #  fields or extension ranges in the same message. Reserved ranges may
-      #  not overlap.
+      # fields or extension ranges in the same message. Reserved ranges may
+      # not overlap.
       # @!attribute [rw] start
       #   @return [Integer]
       # @!attribute [rw] end
@@ -137,35 +137,35 @@ module Google
     # @!attribute [rw] type
     #   @return [ENUM(Type)]
     #     If type_name is set, this need not be set.  If both this and type_name
-    #      are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
+    #     are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
     # @!attribute [rw] type_name
     #   @return [String]
     #     For message and enum types, this is the name of the type.  If the name
-    #      starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
-    #      rules are used to find the type (i.e. first the nested types within this
-    #      message are searched, then within the parent, on up to the root
-    #      namespace).
+    #     starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+    #     rules are used to find the type (i.e. first the nested types within this
+    #     message are searched, then within the parent, on up to the root
+    #     namespace).
     # @!attribute [rw] extendee
     #   @return [String]
     #     For extensions, this is the name of the type being extended.  It is
-    #      resolved in the same manner as type_name.
+    #     resolved in the same manner as type_name.
     # @!attribute [rw] default_value
     #   @return [String]
     #     For numeric types, contains the original text representation of the value.
-    #      For booleans, "true" or "false".
-    #      For strings, contains the default text contents (not escaped in any way).
-    #      For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
-    #      TODO(kenton):  Base-64 encode?
+    #     For booleans, "true" or "false".
+    #     For strings, contains the default text contents (not escaped in any way).
+    #     For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
+    #     TODO(kenton):  Base-64 encode?
     # @!attribute [rw] oneof_index
     #   @return [Integer]
     #     If set, gives the index of a oneof in the containing type's oneof_decl
-    #      list.  This field is a member of that oneof.
+    #     list.  This field is a member of that oneof.
     # @!attribute [rw] json_name
     #   @return [String]
     #     JSON name of this field. The value is set by protocol compiler. If the
-    #      user has set a "json_name" option on this field, that option's value
-    #      will be used. Otherwise, it's deduced from the field's name by converting
-    #      it to camelCase.
+    #     user has set a "json_name" option on this field, that option's value
+    #     will be used. Otherwise, it's deduced from the field's name by converting
+    #     it to camelCase.
     # @!attribute [rw] options
     #   @return [Google::Protobuf::FieldOption]
     class FieldDescriptorProto
@@ -174,19 +174,19 @@ module Google
 
       module Type
         # 0 is reserved for errors.
-        #  Order is weird for historical reasons.
+        # Order is weird for historical reasons.
         TYPE_DOUBLE = 1
 
         TYPE_FLOAT = 2
 
         # Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
-        #  negative values are likely.
+        # negative values are likely.
         TYPE_INT64 = 3
 
         TYPE_UINT64 = 4
 
         # Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
-        #  negative values are likely.
+        # negative values are likely.
         TYPE_INT32 = 5
 
         TYPE_FIXED64 = 6
@@ -198,9 +198,9 @@ module Google
         TYPE_STRING = 9
 
         # Tag-delimited aggregate.
-        #  Group type is deprecated and not supported in proto3. However, Proto3
-        #  implementations should still be able to parse the group wire format and
-        #  treat group fields as unknown fields.
+        # Group type is deprecated and not supported in proto3. However, Proto3
+        # implementations should still be able to parse the group wire format and
+        # treat group fields as unknown fields.
         TYPE_GROUP = 10
 
         TYPE_MESSAGE = 11
@@ -251,22 +251,22 @@ module Google
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::EnumDescriptorProto::EnumReservedRange]
     #     Range of reserved numeric values. Reserved numeric values may not be used
-    #      by enum values in the same enum declaration. Reserved ranges may not
-    #      overlap.
+    #     by enum values in the same enum declaration. Reserved ranges may not
+    #     overlap.
     # @!attribute [rw] reserved_name
     #   @return [String]
     #     Reserved enum value names, which may not be reused. A given name may only
-    #      be reserved once.
+    #     be reserved once.
     class EnumDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
 
       # Range of reserved numeric values. Reserved values may not be used by
-      #  entries in the same enum. Reserved ranges may not overlap.
+      # entries in the same enum. Reserved ranges may not overlap.
       #
-      #  Note that this is distinct from DescriptorProto.ReservedRange in that it
-      #  is inclusive such that it can appropriately represent the entire int32
-      #  domain.
+      # Note that this is distinct from DescriptorProto.ReservedRange in that it
+      # is inclusive such that it can appropriately represent the entire int32
+      # domain.
       # @!attribute [rw] start
       #   @return [Integer]
       # @!attribute [rw] end
@@ -307,7 +307,7 @@ module Google
     # @!attribute [rw] input_type
     #   @return [String]
     #     Input and output type names.  These are resolved in the same way as
-    #      FieldDescriptorProto.type_name, but must refer to a message type.
+    #     FieldDescriptorProto.type_name, but must refer to a message type.
     # @!attribute [rw] output_type
     #   @return [String]
     # @!attribute [rw] options
@@ -326,56 +326,56 @@ module Google
     # @!attribute [rw] java_package
     #   @return [String]
     #     Sets the Java package where classes generated from this .proto will be
-    #      placed.  By default, the proto package is used, but this is often
-    #      inappropriate because proto packages do not normally start with backwards
-    #      domain names.
+    #     placed.  By default, the proto package is used, but this is often
+    #     inappropriate because proto packages do not normally start with backwards
+    #     domain names.
     # @!attribute [rw] java_outer_classname
     #   @return [String]
     #     If set, all the classes from the .proto file are wrapped in a single
-    #      outer class with the given name.  This applies to both Proto1
-    #      (equivalent to the old "--one_java_file" option) and Proto2 (where
-    #      a .proto always translates to a single class, but you may want to
-    #      explicitly choose the class name).
+    #     outer class with the given name.  This applies to both Proto1
+    #     (equivalent to the old "--one_java_file" option) and Proto2 (where
+    #     a .proto always translates to a single class, but you may want to
+    #     explicitly choose the class name).
     # @!attribute [rw] java_multiple_files
     #   @return [Boolean]
     #     If set true, then the Java code generator will generate a separate .java
-    #      file for each top-level message, enum, and service defined in the .proto
-    #      file.  Thus, these types will *not* be nested inside the outer class
-    #      named by java_outer_classname.  However, the outer class will still be
-    #      generated to contain the file's getDescriptor() method as well as any
-    #      top-level extensions defined in the file.
+    #     file for each top-level message, enum, and service defined in the .proto
+    #     file.  Thus, these types will *not* be nested inside the outer class
+    #     named by java_outer_classname.  However, the outer class will still be
+    #     generated to contain the file's getDescriptor() method as well as any
+    #     top-level extensions defined in the file.
     # @!attribute [rw] java_generate_equals_and_hash
     #   @return [Boolean]
     #     This option does nothing.
     # @!attribute [rw] java_string_check_utf8
     #   @return [Boolean]
     #     If set true, then the Java2 code generator will generate code that
-    #      throws an exception whenever an attempt is made to assign a non-UTF-8
-    #      byte sequence to a string field.
-    #      Message reflection will do the same.
-    #      However, an extension field still accepts non-UTF-8 byte sequences.
-    #      This option has no effect on when used with the lite runtime.
+    #     throws an exception whenever an attempt is made to assign a non-UTF-8
+    #     byte sequence to a string field.
+    #     Message reflection will do the same.
+    #     However, an extension field still accepts non-UTF-8 byte sequences.
+    #     This option has no effect on when used with the lite runtime.
     # @!attribute [rw] optimize_for
     #   @return [ENUM(OptimizeMode)]
     # @!attribute [rw] go_package
     #   @return [String]
     #     Sets the Go package where structs generated from this .proto will be
-    #      placed. If omitted, the Go package will be derived from the following:
-    #        - The basename of the package import path, if provided.
-    #        - Otherwise, the package statement in the .proto file, if present.
-    #        - Otherwise, the basename of the .proto file, without extension.
+    #     placed. If omitted, the Go package will be derived from the following:
+    #       - The basename of the package import path, if provided.
+    #       - Otherwise, the package statement in the .proto file, if present.
+    #       - Otherwise, the basename of the .proto file, without extension.
     # @!attribute [rw] cc_generic_services
     #   @return [Boolean]
     #     Should generic services be generated in each language?  "Generic" services
-    #      are not specific to any particular RPC system.  They are generated by the
-    #      main code generators in each language (without additional plugins).
-    #      Generic services were the only kind of service generation supported by
-    #      early versions of google.protobuf.
+    #     are not specific to any particular RPC system.  They are generated by the
+    #     main code generators in each language (without additional plugins).
+    #     Generic services were the only kind of service generation supported by
+    #     early versions of google.protobuf.
     #
-    #      Generic services are now considered deprecated in favor of using plugins
-    #      that generate code specific to your particular RPC system.  Therefore,
-    #      these default to false.  Old code which depends on generic services should
-    #      explicitly set them to true.
+    #     Generic services are now considered deprecated in favor of using plugins
+    #     that generate code specific to your particular RPC system.  Therefore,
+    #     these default to false.  Old code which depends on generic services should
+    #     explicitly set them to true.
     # @!attribute [rw] java_generic_services
     #   @return [Boolean]
     # @!attribute [rw] py_generic_services
@@ -385,49 +385,49 @@ module Google
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this file deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for everything in the file, or it will be completely ignored; in the very
-    #      least, this is a formalization for deprecating files.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for everything in the file, or it will be completely ignored; in the very
+    #     least, this is a formalization for deprecating files.
     # @!attribute [rw] cc_enable_arenas
     #   @return [Boolean]
     #     Enables the use of arenas for the proto messages in this file. This applies
-    #      only to generated classes for C++.
+    #     only to generated classes for C++.
     # @!attribute [rw] objc_class_prefix
     #   @return [String]
     #     Sets the objective c class prefix which is prepended to all objective c
-    #      generated classes from this .proto. There is no default.
+    #     generated classes from this .proto. There is no default.
     # @!attribute [rw] csharp_namespace
     #   @return [String]
     #     Namespace for generated classes; defaults to the package.
     # @!attribute [rw] swift_prefix
     #   @return [String]
     #     By default Swift generators will take the proto package and CamelCase it
-    #      replacing '.' with underscore and use that to prefix the types/symbols
-    #      defined. When this options is provided, they will use this value instead
-    #      to prefix the types/symbols defined.
+    #     replacing '.' with underscore and use that to prefix the types/symbols
+    #     defined. When this options is provided, they will use this value instead
+    #     to prefix the types/symbols defined.
     # @!attribute [rw] php_class_prefix
     #   @return [String]
     #     Sets the php class prefix which is prepended to all php generated classes
-    #      from this .proto. Default is empty.
+    #     from this .proto. Default is empty.
     # @!attribute [rw] php_namespace
     #   @return [String]
     #     Use this option to change the namespace of php generated classes. Default
-    #      is empty. When this option is empty, the package name will be used for
-    #      determining the namespace.
+    #     is empty. When this option is empty, the package name will be used for
+    #     determining the namespace.
     # @!attribute [rw] php_metadata_namespace
     #   @return [String]
     #     Use this option to change the namespace of php generated metadata classes.
-    #      Default is empty. When this option is empty, the proto file name will be used
-    #      for determining the namespace.
+    #     Default is empty. When this option is empty, the proto file name will be used
+    #     for determining the namespace.
     # @!attribute [rw] ruby_package
     #   @return [String]
     #     Use this option to change the package of ruby generated classes. Default
-    #      is empty. When this option is not set, the package name will be used for
-    #      determining the ruby package.
+    #     is empty. When this option is not set, the package name will be used for
+    #     determining the ruby package.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here.
-    #      See the documentation for the "Options" section above.
+    #     See the documentation for the "Options" section above.
     class FileOptions
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -446,57 +446,57 @@ module Google
     # @!attribute [rw] message_set_wire_format
     #   @return [Boolean]
     #     Set true to use the old proto1 MessageSet wire format for extensions.
-    #      This is provided for backwards-compatibility with the MessageSet wire
-    #      format.  You should not use this for any other reason:  It's less
-    #      efficient, has fewer features, and is more complicated.
+    #     This is provided for backwards-compatibility with the MessageSet wire
+    #     format.  You should not use this for any other reason:  It's less
+    #     efficient, has fewer features, and is more complicated.
     #
-    #      The message must be defined exactly as follows:
-    #        message Foo {
-    #          option message_set_wire_format = true;
-    #          extensions 4 to max;
-    #        }
-    #      Note that the message cannot have any defined fields; MessageSets only
-    #      have extensions.
+    #     The message must be defined exactly as follows:
+    #       message Foo {
+    #         option message_set_wire_format = true;
+    #         extensions 4 to max;
+    #       }
+    #     Note that the message cannot have any defined fields; MessageSets only
+    #     have extensions.
     #
-    #      All extensions of your type must be singular messages; e.g. they cannot
-    #      be int32s, enums, or repeated messages.
+    #     All extensions of your type must be singular messages; e.g. they cannot
+    #     be int32s, enums, or repeated messages.
     #
-    #      Because this is an option, the above two restrictions are not enforced by
-    #      the protocol compiler.
+    #     Because this is an option, the above two restrictions are not enforced by
+    #     the protocol compiler.
     # @!attribute [rw] no_standard_descriptor_accessor
     #   @return [Boolean]
     #     Disables the generation of the standard "descriptor()" accessor, which can
-    #      conflict with a field of the same name.  This is meant to make migration
-    #      from proto1 easier; new code should avoid fields named "descriptor".
+    #     conflict with a field of the same name.  This is meant to make migration
+    #     from proto1 easier; new code should avoid fields named "descriptor".
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this message deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the message, or it will be completely ignored; in the very least,
-    #      this is a formalization for deprecating messages.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the message, or it will be completely ignored; in the very least,
+    #     this is a formalization for deprecating messages.
     # @!attribute [rw] map_entry
     #   @return [Boolean]
     #     Whether the message is an automatically generated map entry type for the
-    #      maps field.
+    #     maps field.
     #
-    #      For maps fields:
-    #          map<KeyType, ValueType> map_field = 1;
-    #      The parsed descriptor looks like:
-    #          message MapFieldEntry {
-    #              option map_entry = true;
-    #              optional KeyType key = 1;
-    #              optional ValueType value = 2;
-    #          }
-    #          repeated MapFieldEntry map_field = 1;
+    #     For maps fields:
+    #         map<KeyType, ValueType> map_field = 1;
+    #     The parsed descriptor looks like:
+    #         message MapFieldEntry {
+    #             option map_entry = true;
+    #             optional KeyType key = 1;
+    #             optional ValueType value = 2;
+    #         }
+    #         repeated MapFieldEntry map_field = 1;
     #
-    #      Implementations may choose not to generate the map_entry=true message, but
-    #      use a native map in the target language to hold the keys and values.
-    #      The reflection APIs in such implementions still need to work as
-    #      if the field is a repeated message field.
+    #     Implementations may choose not to generate the map_entry=true message, but
+    #     use a native map in the target language to hold the keys and values.
+    #     The reflection APIs in such implementions still need to work as
+    #     if the field is a repeated message field.
     #
-    #      NOTE: Do not set the option in .proto files. Always use the maps syntax
-    #      instead. The option should only be implicitly set by the proto compiler
-    #      parser.
+    #     NOTE: Do not set the option in .proto files. Always use the maps syntax
+    #     instead. The option should only be implicitly set by the proto compiler
+    #     parser.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here. See above.
@@ -508,65 +508,65 @@ module Google
     # @!attribute [rw] ctype
     #   @return [ENUM(CType)]
     #     The ctype option instructs the C++ code generator to use a different
-    #      representation of the field than it normally would.  See the specific
-    #      options below.  This option is not yet implemented in the open source
-    #      release -- sorry, we'll try to include it in a future version!
+    #     representation of the field than it normally would.  See the specific
+    #     options below.  This option is not yet implemented in the open source
+    #     release -- sorry, we'll try to include it in a future version!
     # @!attribute [rw] packed
     #   @return [Boolean]
     #     The packed option can be enabled for repeated primitive fields to enable
-    #      a more efficient representation on the wire. Rather than repeatedly
-    #      writing the tag and type for each element, the entire array is encoded as
-    #      a single length-delimited blob. In proto3, only explicit setting it to
-    #      false will avoid using packed encoding.
+    #     a more efficient representation on the wire. Rather than repeatedly
+    #     writing the tag and type for each element, the entire array is encoded as
+    #     a single length-delimited blob. In proto3, only explicit setting it to
+    #     false will avoid using packed encoding.
     # @!attribute [rw] jstype
     #   @return [ENUM(JSType)]
     #     The jstype option determines the JavaScript type used for values of the
-    #      field.  The option is permitted only for 64 bit integral and fixed types
-    #      (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
-    #      is represented as JavaScript string, which avoids loss of precision that
-    #      can happen when a large value is converted to a floating point JavaScript.
-    #      Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
-    #      use the JavaScript "number" type.  The behavior of the default option
-    #      JS_NORMAL is implementation dependent.
+    #     field.  The option is permitted only for 64 bit integral and fixed types
+    #     (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+    #     is represented as JavaScript string, which avoids loss of precision that
+    #     can happen when a large value is converted to a floating point JavaScript.
+    #     Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+    #     use the JavaScript "number" type.  The behavior of the default option
+    #     JS_NORMAL is implementation dependent.
     #
-    #      This option is an enum to permit additional types to be added, e.g.
-    #      goog.math.Integer.
+    #     This option is an enum to permit additional types to be added, e.g.
+    #     goog.math.Integer.
     # @!attribute [rw] lazy
     #   @return [Boolean]
     #     Should this field be parsed lazily?  Lazy applies only to message-type
-    #      fields.  It means that when the outer message is initially parsed, the
-    #      inner message's contents will not be parsed but instead stored in encoded
-    #      form.  The inner message will actually be parsed when it is first accessed.
+    #     fields.  It means that when the outer message is initially parsed, the
+    #     inner message's contents will not be parsed but instead stored in encoded
+    #     form.  The inner message will actually be parsed when it is first accessed.
     #
-    #      This is only a hint.  Implementations are free to choose whether to use
-    #      eager or lazy parsing regardless of the value of this option.  However,
-    #      setting this option true suggests that the protocol author believes that
-    #      using lazy parsing on this field is worth the additional bookkeeping
-    #      overhead typically needed to implement it.
+    #     This is only a hint.  Implementations are free to choose whether to use
+    #     eager or lazy parsing regardless of the value of this option.  However,
+    #     setting this option true suggests that the protocol author believes that
+    #     using lazy parsing on this field is worth the additional bookkeeping
+    #     overhead typically needed to implement it.
     #
-    #      This option does not affect the public interface of any generated code;
-    #      all method signatures remain the same.  Furthermore, thread-safety of the
-    #      interface is not affected by this option; const methods remain safe to
-    #      call from multiple threads concurrently, while non-const methods continue
-    #      to require exclusive access.
+    #     This option does not affect the public interface of any generated code;
+    #     all method signatures remain the same.  Furthermore, thread-safety of the
+    #     interface is not affected by this option; const methods remain safe to
+    #     call from multiple threads concurrently, while non-const methods continue
+    #     to require exclusive access.
     #
     #
-    #      Note that implementations may choose not to check required fields within
-    #      a lazy sub-message.  That is, calling IsInitialized() on the outer message
-    #      may return true even if the inner message has missing required fields.
-    #      This is necessary because otherwise the inner message would have to be
-    #      parsed in order to perform the check, defeating the purpose of lazy
-    #      parsing.  An implementation which chooses not to check required fields
-    #      must be consistent about it.  That is, for any particular sub-message, the
-    #      implementation must either *always* check its required fields, or *never*
-    #      check its required fields, regardless of whether or not the message has
-    #      been parsed.
+    #     Note that implementations may choose not to check required fields within
+    #     a lazy sub-message.  That is, calling IsInitialized() on the outer message
+    #     may return true even if the inner message has missing required fields.
+    #     This is necessary because otherwise the inner message would have to be
+    #     parsed in order to perform the check, defeating the purpose of lazy
+    #     parsing.  An implementation which chooses not to check required fields
+    #     must be consistent about it.  That is, for any particular sub-message, the
+    #     implementation must either *always* check its required fields, or *never*
+    #     check its required fields, regardless of whether or not the message has
+    #     been parsed.
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this field deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for accessors, or it will be completely ignored; in the very least, this
-    #      is a formalization for deprecating fields.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for accessors, or it will be completely ignored; in the very least, this
+    #     is a formalization for deprecating fields.
     # @!attribute [rw] weak
     #   @return [Boolean]
     #     For Google-internal migration only. Do not use.
@@ -609,13 +609,13 @@ module Google
     # @!attribute [rw] allow_alias
     #   @return [Boolean]
     #     Set this option to true to allow mapping different tag names to the same
-    #      value.
+    #     value.
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this enum deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the enum, or it will be completely ignored; in the very least, this
-    #      is a formalization for deprecating enums.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the enum, or it will be completely ignored; in the very least, this
+    #     is a formalization for deprecating enums.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here. See above.
@@ -627,9 +627,9 @@ module Google
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this enum value deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the enum value, or it will be completely ignored; in the very least,
-    #      this is a formalization for deprecating enum values.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the enum value, or it will be completely ignored; in the very least,
+    #     this is a formalization for deprecating enum values.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here. See above.
@@ -641,9 +641,9 @@ module Google
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this service deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the service, or it will be completely ignored; in the very least,
-    #      this is a formalization for deprecating services.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the service, or it will be completely ignored; in the very least,
+    #     this is a formalization for deprecating services.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here. See above.
@@ -655,9 +655,9 @@ module Google
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this method deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the method, or it will be completely ignored; in the very least,
-    #      this is a formalization for deprecating methods.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the method, or it will be completely ignored; in the very least,
+    #     this is a formalization for deprecating methods.
     # @!attribute [rw] idempotency_level
     #   @return [ENUM(IdempotencyLevel)]
     # @!attribute [rw] uninterpreted_option
@@ -668,8 +668,8 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
 
       # Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
-      #  or neither? HTTP based RPC implementation may choose GET verb for safe
-      #  methods, and PUT verb for idempotent methods instead of the default POST.
+      # or neither? HTTP based RPC implementation may choose GET verb for safe
+      # methods, and PUT verb for idempotent methods instead of the default POST.
       module IdempotencyLevel
         IDEMPOTENCY_UNKNOWN = 0
 
@@ -680,17 +680,17 @@ module Google
     end
 
     # A message representing a option the parser does not recognize. This only
-    #  appears in options protos created by the compiler::Parser class.
-    #  DescriptorPool resolves these when building Descriptor objects. Therefore,
-    #  options protos in descriptor objects (e.g. returned by Descriptor::options(),
-    #  or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
-    #  in them.
+    # appears in options protos created by the compiler::Parser class.
+    # DescriptorPool resolves these when building Descriptor objects. Therefore,
+    # options protos in descriptor objects (e.g. returned by Descriptor::options(),
+    # or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+    # in them.
     # @!attribute [rw] name
     #   @return [Google::Protobuf::UninterpretedOption::NamePart]
     # @!attribute [rw] identifier_value
     #   @return [String]
     #     The value of the uninterpreted option, in whatever type the tokenizer
-    #      identified it as during parsing. Exactly one of these should be set.
+    #     identified it as during parsing. Exactly one of these should be set.
     # @!attribute [rw] positive_int_value
     #   @return [Integer]
     # @!attribute [rw] negative_int_value
@@ -706,10 +706,10 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
 
       # The name of the uninterpreted option.  Each string represents a segment in
-      #  a dot-separated name.  is_extension is true iff a segment represents an
-      #  extension (denoted with parentheses in options specs in .proto files).
-      #  E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
-      #  "foo.(bar.baz).qux".
+      # a dot-separated name.  is_extension is true iff a segment represents an
+      # extension (denoted with parentheses in options specs in .proto files).
+      # E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
+      # "foo.(bar.baz).qux".
       # @!attribute [rw] name_part
       #   @return [String]
       # @!attribute [rw] is_extension
@@ -721,52 +721,52 @@ module Google
     end
 
     # Encapsulates information about the original source file from which a
-    #  FileDescriptorProto was generated.
+    # FileDescriptorProto was generated.
     # @!attribute [rw] location
     #   @return [Google::Protobuf::SourceCodeInfo::Location]
     #     A Location identifies a piece of source code in a .proto file which
-    #      corresponds to a particular definition.  This information is intended
-    #      to be useful to IDEs, code indexers, documentation generators, and similar
-    #      tools.
+    #     corresponds to a particular definition.  This information is intended
+    #     to be useful to IDEs, code indexers, documentation generators, and similar
+    #     tools.
     #
-    #      For example, say we have a file like:
-    #        message Foo {
-    #          optional string foo = 1;
-    #        }
-    #      Let's look at just the field definition:
-    #        optional string foo = 1;
-    #        ^       ^^     ^^  ^  ^^^
-    #        a       bc     de  f  ghi
-    #      We have the following locations:
-    #        span   path               represents
-    #        [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
-    #        [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
-    #        [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
-    #        [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
-    #        [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+    #     For example, say we have a file like:
+    #       message Foo {
+    #         optional string foo = 1;
+    #       }
+    #     Let's look at just the field definition:
+    #       optional string foo = 1;
+    #       ^       ^^     ^^  ^  ^^^
+    #       a       bc     de  f  ghi
+    #     We have the following locations:
+    #       span   path               represents
+    #       [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+    #       [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+    #       [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+    #       [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+    #       [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
     #
-    #      Notes:
-    #      - A location may refer to a repeated field itself (i.e. not to any
-    #        particular index within it).  This is used whenever a set of elements are
-    #        logically enclosed in a single code segment.  For example, an entire
-    #        extend block (possibly containing multiple extension definitions) will
-    #        have an outer location whose path refers to the "extensions" repeated
-    #        field without an index.
-    #      - Multiple locations may have the same path.  This happens when a single
-    #        logical declaration is spread out across multiple places.  The most
-    #        obvious example is the "extend" block again -- there may be multiple
-    #        extend blocks in the same scope, each of which will have the same path.
-    #      - A location's span is not always a subset of its parent's span.  For
-    #        example, the "extendee" of an extension declaration appears at the
-    #        beginning of the "extend" block and is shared by all extensions within
-    #        the block.
-    #      - Just because a location's span is a subset of some other location's span
-    #        does not mean that it is a descendent.  For example, a "group" defines
-    #        both a type and a field in a single declaration.  Thus, the locations
-    #        corresponding to the type and field and their components will overlap.
-    #      - Code which tries to interpret locations should probably be designed to
-    #        ignore those that it doesn't understand, as more types of locations could
-    #        be recorded in the future.
+    #     Notes:
+    #     - A location may refer to a repeated field itself (i.e. not to any
+    #       particular index within it).  This is used whenever a set of elements are
+    #       logically enclosed in a single code segment.  For example, an entire
+    #       extend block (possibly containing multiple extension definitions) will
+    #       have an outer location whose path refers to the "extensions" repeated
+    #       field without an index.
+    #     - Multiple locations may have the same path.  This happens when a single
+    #       logical declaration is spread out across multiple places.  The most
+    #       obvious example is the "extend" block again -- there may be multiple
+    #       extend blocks in the same scope, each of which will have the same path.
+    #     - A location's span is not always a subset of its parent's span.  For
+    #       example, the "extendee" of an extension declaration appears at the
+    #       beginning of the "extend" block and is shared by all extensions within
+    #       the block.
+    #     - Just because a location's span is a subset of some other location's span
+    #       does not mean that it is a descendent.  For example, a "group" defines
+    #       both a type and a field in a single declaration.  Thus, the locations
+    #       corresponding to the type and field and their components will overlap.
+    #     - Code which tries to interpret locations should probably be designed to
+    #       ignore those that it doesn't understand, as more types of locations could
+    #       be recorded in the future.
     class SourceCodeInfo
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -774,84 +774,84 @@ module Google
       # @!attribute [rw] path
       #   @return [Integer]
       #     Identifies which part of the FileDescriptorProto was defined at this
-      #      location.
+      #     location.
       #
-      #      Each element is a field number or an index.  They form a path from
-      #      the root FileDescriptorProto to the place where the definition.  For
-      #      example, this path:
-      #        [ 4, 3, 2, 7, 1 ]
-      #      refers to:
-      #        file.message_type(3)  // 4, 3
-      #            .field(7)         // 2, 7
-      #            .name()           // 1
-      #      This is because FileDescriptorProto.message_type has field number 4:
-      #        repeated DescriptorProto message_type = 4;
-      #      and DescriptorProto.field has field number 2:
-      #        repeated FieldDescriptorProto field = 2;
-      #      and FieldDescriptorProto.name has field number 1:
-      #        optional string name = 1;
+      #     Each element is a field number or an index.  They form a path from
+      #     the root FileDescriptorProto to the place where the definition.  For
+      #     example, this path:
+      #       [ 4, 3, 2, 7, 1 ]
+      #     refers to:
+      #       file.message_type(3)  // 4, 3
+      #           .field(7)         // 2, 7
+      #           .name()           // 1
+      #     This is because FileDescriptorProto.message_type has field number 4:
+      #       repeated DescriptorProto message_type = 4;
+      #     and DescriptorProto.field has field number 2:
+      #       repeated FieldDescriptorProto field = 2;
+      #     and FieldDescriptorProto.name has field number 1:
+      #       optional string name = 1;
       #
-      #      Thus, the above path gives the location of a field name.  If we removed
-      #      the last element:
-      #        [ 4, 3, 2, 7 ]
-      #      this path refers to the whole field declaration (from the beginning
-      #      of the label to the terminating semicolon).
+      #     Thus, the above path gives the location of a field name.  If we removed
+      #     the last element:
+      #       [ 4, 3, 2, 7 ]
+      #     this path refers to the whole field declaration (from the beginning
+      #     of the label to the terminating semicolon).
       # @!attribute [rw] span
       #   @return [Integer]
       #     Always has exactly three or four elements: start line, start column,
-      #      end line (optional, otherwise assumed same as start line), end column.
-      #      These are packed into a single field for efficiency.  Note that line
-      #      and column numbers are zero-based -- typically you will want to add
-      #      1 to each before displaying to a user.
+      #     end line (optional, otherwise assumed same as start line), end column.
+      #     These are packed into a single field for efficiency.  Note that line
+      #     and column numbers are zero-based -- typically you will want to add
+      #     1 to each before displaying to a user.
       # @!attribute [rw] leading_comments
       #   @return [String]
       #     If this SourceCodeInfo represents a complete declaration, these are any
-      #      comments appearing before and after the declaration which appear to be
-      #      attached to the declaration.
+      #     comments appearing before and after the declaration which appear to be
+      #     attached to the declaration.
       #
-      #      A series of line comments appearing on consecutive lines, with no other
-      #      tokens appearing on those lines, will be treated as a single comment.
+      #     A series of line comments appearing on consecutive lines, with no other
+      #     tokens appearing on those lines, will be treated as a single comment.
       #
-      #      leading_detached_comments will keep paragraphs of comments that appear
-      #      before (but not connected to) the current element. Each paragraph,
-      #      separated by empty lines, will be one comment element in the repeated
-      #      field.
+      #     leading_detached_comments will keep paragraphs of comments that appear
+      #     before (but not connected to) the current element. Each paragraph,
+      #     separated by empty lines, will be one comment element in the repeated
+      #     field.
       #
-      #      Only the comment content is provided; comment markers (e.g. //) are
-      #      stripped out.  For block comments, leading whitespace and an asterisk
-      #      will be stripped from the beginning of each line other than the first.
-      #      Newlines are included in the output.
+      #     Only the comment content is provided; comment markers (e.g. //) are
+      #     stripped out.  For block comments, leading whitespace and an asterisk
+      #     will be stripped from the beginning of each line other than the first.
+      #     Newlines are included in the output.
       #
-      #      Examples:
+      #     Examples:
       #
-      #        optional int32 foo = 1;  // Comment attached to foo.
-      #        // Comment attached to bar.
-      #        optional int32 bar = 2;
+      #       optional int32 foo = 1;  // Comment attached to foo.
+      #       // Comment attached to bar.
+      #       optional int32 bar = 2;
       #
-      #        optional string baz = 3;
-      #        // Comment attached to baz.
-      #        // Another line attached to baz.
+      #       optional string baz = 3;
+      #       // Comment attached to baz.
+      #       // Another line attached to baz.
       #
-      #        // Comment attached to qux.
-      #        //
-      #        // Another line attached to qux.
-      #        optional double qux = 4;
+      #       // Comment attached to qux.
+      #       //
+      #       // Another line attached to qux.
+      #       optional double qux = 4;
       #
-      #        // Detached comment for corge. This is not leading or trailing comments
-      #        // to qux or corge because there are blank lines separating it from
-      #        // both.
+      #       // Detached comment for corge. This is not leading or trailing comments
+      #       // to qux or corge because there are blank lines separating it from
+      #       // both.
       #
-      #        // Detached comment for corge paragraph 2.
+      #       // Detached comment for corge paragraph 2.
       #
-      #        optional string corge = 5;
-      #        /* Block comment attached
-      #         * to corge.  Leading asterisks
-      #         * will be removed. */
-      #        /* Block comment attached to
-      #         * grault. */
-      #        optional int32 grault = 6;
+      #       optional string corge = 5;
+      #       /* Block comment attached
+      #        * to corge.  Leading asterisks
+      #        * will be removed. */
+      #       /* Block comment attached to
+      #        * grault. */
+      #       optional int32 grault = 6;
       #
-      #        // ignored detached comments.
+      #       // ignored detached comments.
       # @!attribute [rw] trailing_comments
       #   @return [String]
       # @!attribute [rw] leading_detached_comments
@@ -863,12 +863,12 @@ module Google
     end
 
     # Describes the relationship between generated code and its original source
-    #  file. A GeneratedCodeInfo message is associated with only one generated
-    #  source file, but may contain references to different source .proto files.
+    # file. A GeneratedCodeInfo message is associated with only one generated
+    # source file, but may contain references to different source .proto files.
     # @!attribute [rw] annotation
     #   @return [Google::Protobuf::GeneratedCodeInfo::Annotation]
     #     An Annotation connects some span of text in generated code to an element
-    #      of its generating .proto file.
+    #     of its generating .proto file.
     class GeneratedCodeInfo
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -876,19 +876,19 @@ module Google
       # @!attribute [rw] path
       #   @return [Integer]
       #     Identifies the element in the original source .proto file. This field
-      #      is formatted the same as SourceCodeInfo.Location.path.
+      #     is formatted the same as SourceCodeInfo.Location.path.
       # @!attribute [rw] source_file
       #   @return [String]
       #     Identifies the filesystem path to the original source .proto.
       # @!attribute [rw] begin
       #   @return [Integer]
       #     Identifies the starting offset in bytes in the generated code
-      #      that relates to the identified object.
+      #     that relates to the identified object.
       # @!attribute [rw] end
       #   @return [Integer]
       #     Identifies the ending offset in bytes in the generated code that
-      #      relates to the identified offset. The end offset should be one past
-      #      the last relevant byte (so the length of the text = end - begin).
+      #     relates to the identified offset. The end offset should be one past
+      #     the last relevant byte (so the length of the text = end - begin).
       class Annotation
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/speech/lib/doc/google/protobuf/duration.rb
+++ b/shared/output/cloud/speech/lib/doc/google/protobuf/duration.rb
@@ -19,76 +19,76 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # A Duration represents a signed, fixed-length span of time represented
-    #  as a count of seconds and fractions of seconds at nanosecond
-    #  resolution. It is independent of any calendar and concepts like "day"
-    #  or "month". It is related to Timestamp in that the difference between
-    #  two Timestamp values is a Duration and it can be added or subtracted
-    #  from a Timestamp. Range is approximately +-10,000 years.
+    # as a count of seconds and fractions of seconds at nanosecond
+    # resolution. It is independent of any calendar and concepts like "day"
+    # or "month". It is related to Timestamp in that the difference between
+    # two Timestamp values is a Duration and it can be added or subtracted
+    # from a Timestamp. Range is approximately +-10,000 years.
     #
-    #  # Examples
+    # # Examples
     #
-    #  Example 1: Compute Duration from two Timestamps in pseudo code.
+    # Example 1: Compute Duration from two Timestamps in pseudo code.
     #
-    #      Timestamp start = ...;
-    #      Timestamp end = ...;
-    #      Duration duration = ...;
+    #     Timestamp start = ...;
+    #     Timestamp end = ...;
+    #     Duration duration = ...;
     #
-    #      duration.seconds = end.seconds - start.seconds;
-    #      duration.nanos = end.nanos - start.nanos;
+    #     duration.seconds = end.seconds - start.seconds;
+    #     duration.nanos = end.nanos - start.nanos;
     #
-    #      if (duration.seconds < 0 && duration.nanos > 0) {
-    #        duration.seconds += 1;
-    #        duration.nanos -= 1000000000;
-    #      } else if (durations.seconds > 0 && duration.nanos < 0) {
-    #        duration.seconds -= 1;
-    #        duration.nanos += 1000000000;
-    #      }
+    #     if (duration.seconds < 0 && duration.nanos > 0) {
+    #       duration.seconds += 1;
+    #       duration.nanos -= 1000000000;
+    #     } else if (durations.seconds > 0 && duration.nanos < 0) {
+    #       duration.seconds -= 1;
+    #       duration.nanos += 1000000000;
+    #     }
     #
-    #  Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+    # Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
     #
-    #      Timestamp start = ...;
-    #      Duration duration = ...;
-    #      Timestamp end = ...;
+    #     Timestamp start = ...;
+    #     Duration duration = ...;
+    #     Timestamp end = ...;
     #
-    #      end.seconds = start.seconds + duration.seconds;
-    #      end.nanos = start.nanos + duration.nanos;
+    #     end.seconds = start.seconds + duration.seconds;
+    #     end.nanos = start.nanos + duration.nanos;
     #
-    #      if (end.nanos < 0) {
-    #        end.seconds -= 1;
-    #        end.nanos += 1000000000;
-    #      } else if (end.nanos >= 1000000000) {
-    #        end.seconds += 1;
-    #        end.nanos -= 1000000000;
-    #      }
+    #     if (end.nanos < 0) {
+    #       end.seconds -= 1;
+    #       end.nanos += 1000000000;
+    #     } else if (end.nanos >= 1000000000) {
+    #       end.seconds += 1;
+    #       end.nanos -= 1000000000;
+    #     }
     #
-    #  Example 3: Compute Duration from datetime.timedelta in Python.
+    # Example 3: Compute Duration from datetime.timedelta in Python.
     #
-    #      td = datetime.timedelta(days=3, minutes=10)
-    #      duration = Duration()
-    #      duration.FromTimedelta(td)
+    #     td = datetime.timedelta(days=3, minutes=10)
+    #     duration = Duration()
+    #     duration.FromTimedelta(td)
     #
-    #  # JSON Mapping
+    # # JSON Mapping
     #
-    #  In JSON format, the Duration type is encoded as a string rather than an
-    #  object, where the string ends in the suffix "s" (indicating seconds) and
-    #  is preceded by the number of seconds, with nanoseconds expressed as
-    #  fractional seconds. For example, 3 seconds with 0 nanoseconds should be
-    #  encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
-    #  be expressed in JSON format as "3.000000001s", and 3 seconds and 1
-    #  microsecond should be expressed in JSON format as "3.000001s".
+    # In JSON format, the Duration type is encoded as a string rather than an
+    # object, where the string ends in the suffix "s" (indicating seconds) and
+    # is preceded by the number of seconds, with nanoseconds expressed as
+    # fractional seconds. For example, 3 seconds with 0 nanoseconds should be
+    # encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
+    # be expressed in JSON format as "3.000000001s", and 3 seconds and 1
+    # microsecond should be expressed in JSON format as "3.000001s".
     # @!attribute [rw] seconds
     #   @return [Integer]
     #     Signed seconds of the span of time. Must be from -315,576,000,000
-    #      to +315,576,000,000 inclusive. Note: these bounds are computed from:
-    #      60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+    #     to +315,576,000,000 inclusive. Note: these bounds are computed from:
+    #     60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
     # @!attribute [rw] nanos
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
-    #      of time. Durations less than one second are represented with a 0
-    #      `seconds` field and a positive or negative `nanos` field. For durations
-    #      of one second or more, a non-zero value for the `nanos` field must be
-    #      of the same sign as the `seconds` field. Must be from -999,999,999
-    #      to +999,999,999 inclusive.
+    #     of time. Durations less than one second are represented with a 0
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
+    #     to +999,999,999 inclusive.
     class Duration
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/speech/lib/doc/google/protobuf/empty.rb
+++ b/shared/output/cloud/speech/lib/doc/google/protobuf/empty.rb
@@ -19,14 +19,14 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # A generic empty message that you can re-use to avoid defining duplicated
-    #  empty messages in your APIs. A typical example is to use it as the request
-    #  or the response type of an API method. For instance:
+    # empty messages in your APIs. A typical example is to use it as the request
+    # or the response type of an API method. For instance:
     #
-    #      service Foo {
-    #        rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-    #      }
+    #     service Foo {
+    #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+    #     }
     #
-    #  The JSON representation for `Empty` is empty JSON object `{}`.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/speech/lib/doc/google/protobuf/timestamp.rb
+++ b/shared/output/cloud/speech/lib/doc/google/protobuf/timestamp.rb
@@ -19,94 +19,94 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # A Timestamp represents a point in time independent of any time zone
-    #  or calendar, represented as seconds and fractions of seconds at
-    #  nanosecond resolution in UTC Epoch time. It is encoded using the
-    #  Proleptic Gregorian Calendar which extends the Gregorian calendar
-    #  backwards to year one. It is encoded assuming all minutes are 60
-    #  seconds long, i.e. leap seconds are "smeared" so that no leap second
-    #  table is needed for interpretation. Range is from
-    #  0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
-    #  By restricting to that range, we ensure that we can convert to
-    #  and from  RFC 3339 date strings.
-    #  See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
+    # or calendar, represented as seconds and fractions of seconds at
+    # nanosecond resolution in UTC Epoch time. It is encoded using the
+    # Proleptic Gregorian Calendar which extends the Gregorian calendar
+    # backwards to year one. It is encoded assuming all minutes are 60
+    # seconds long, i.e. leap seconds are "smeared" so that no leap second
+    # table is needed for interpretation. Range is from
+    # 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
+    # By restricting to that range, we ensure that we can convert to
+    # and from  RFC 3339 date strings.
+    # See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
     #
-    #  # Examples
+    # # Examples
     #
-    #  Example 1: Compute Timestamp from POSIX `time()`.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
-    #      Timestamp timestamp;
-    #      timestamp.set_seconds(time(NULL));
-    #      timestamp.set_nanos(0);
+    #     Timestamp timestamp;
+    #     timestamp.set_seconds(time(NULL));
+    #     timestamp.set_nanos(0);
     #
-    #  Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
-    #      struct timeval tv;
-    #      gettimeofday(&tv, NULL);
+    #     struct timeval tv;
+    #     gettimeofday(&tv, NULL);
     #
-    #      Timestamp timestamp;
-    #      timestamp.set_seconds(tv.tv_sec);
-    #      timestamp.set_nanos(tv.tv_usec * 1000);
+    #     Timestamp timestamp;
+    #     timestamp.set_seconds(tv.tv_sec);
+    #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    #  Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
-    #      FILETIME ft;
-    #      GetSystemTimeAsFileTime(&ft);
-    #      UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+    #     FILETIME ft;
+    #     GetSystemTimeAsFileTime(&ft);
+    #     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
     #
-    #      // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
-    #      // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
-    #      Timestamp timestamp;
-    #      timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
-    #      timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+    #     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+    #     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+    #     Timestamp timestamp;
+    #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+    #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    #  Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
-    #      long millis = System.currentTimeMillis();
+    #     long millis = System.currentTimeMillis();
     #
-    #      Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
-    #          .setNanos((int) ((millis % 1000) * 1000000)).build();
+    #     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+    #         .setNanos((int) ((millis % 1000) * 1000000)).build();
     #
     #
-    #  Example 5: Compute Timestamp from current time in Python.
+    # Example 5: Compute Timestamp from current time in Python.
     #
-    #      timestamp = Timestamp()
-    #      timestamp.GetCurrentTime()
+    #     timestamp = Timestamp()
+    #     timestamp.GetCurrentTime()
     #
-    #  # JSON Mapping
+    # # JSON Mapping
     #
-    #  In JSON format, the Timestamp type is encoded as a string in the
-    #  [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    #  format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    #  where {year} is always expressed using four digits while {month}, {day},
-    #  {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
-    #  seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
-    #  are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
-    #  is required. A proto3 JSON serializer should always use UTC (as indicated by
-    #  "Z") when printing the Timestamp type and a proto3 JSON parser should be
-    #  able to accept both UTC and other timezones (as indicated by an offset).
+    # In JSON format, the Timestamp type is encoded as a string in the
+    # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+    # where {year} is always expressed using four digits while {month}, {day},
+    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+    # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+    # is required. A proto3 JSON serializer should always use UTC (as indicated by
+    # "Z") when printing the Timestamp type and a proto3 JSON parser should be
+    # able to accept both UTC and other timezones (as indicated by an offset).
     #
-    #  For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
-    #  01:30 UTC on January 15, 2017.
+    # For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+    # 01:30 UTC on January 15, 2017.
     #
-    #  In JavaScript, one can convert a Date object to this format using the
-    #  standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    #  method. In Python, a standard `datetime.datetime` object can be converted
-    #  to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
-    #  with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    #  can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
-    #  http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
-    #  ) to obtain a formatter capable of generating timestamps in this format.
+    # In JavaScript, one can convert a Date object to this format using the
+    # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
+    # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
+    # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
+    # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds
     #   @return [Integer]
     #     Represents seconds of UTC time since Unix epoch
-    #      1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-    #      9999-12-31T23:59:59Z inclusive.
+    #     1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+    #     9999-12-31T23:59:59Z inclusive.
     # @!attribute [rw] nanos
     #   @return [Integer]
     #     Non-negative fractions of a second at nanosecond resolution. Negative
-    #      second values with fractions must still have non-negative nanos values
-    #      that count forward in time. Must be from 0 to 999,999,999
-    #      inclusive.
+    #     second values with fractions must still have non-negative nanos values
+    #     that count forward in time. Must be from 0 to 999,999,999
+    #     inclusive.
     class Timestamp
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/speech/lib/doc/google/rpc/status.rb
+++ b/shared/output/cloud/speech/lib/doc/google/rpc/status.rb
@@ -19,69 +19,69 @@ raise "This file is for documentation purposes only."
 module Google
   module Rpc
     # The `Status` type defines a logical error model that is suitable for different
-    #  programming environments, including REST APIs and RPC APIs. It is used by
-    #  [gRPC](https://github.com/grpc). The error model is designed to be:
+    # programming environments, including REST APIs and RPC APIs. It is used by
+    # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
-    #  - Simple to use and understand for most users
-    #  - Flexible enough to meet unexpected needs
+    # - Simple to use and understand for most users
+    # - Flexible enough to meet unexpected needs
     #
-    #  # Overview
+    # # Overview
     #
-    #  The `Status` message contains three pieces of data: error code, error message,
-    #  and error details. The error code should be an enum value of
-    #  [google.rpc.Code][google.rpc.Code], but it may accept additional error codes if needed.  The
-    #  error message should be a developer-facing English message that helps
-    #  developers *understand* and *resolve* the error. If a localized user-facing
-    #  error message is needed, put the localized message in the error details or
-    #  localize it in the client. The optional error details may contain arbitrary
-    #  information about the error. There is a predefined set of error detail types
-    #  in the package `google.rpc` that can be used for common error conditions.
+    # The `Status` message contains three pieces of data: error code, error message,
+    # and error details. The error code should be an enum value of
+    # [google.rpc.Code][google.rpc.Code], but it may accept additional error codes if needed.  The
+    # error message should be a developer-facing English message that helps
+    # developers *understand* and *resolve* the error. If a localized user-facing
+    # error message is needed, put the localized message in the error details or
+    # localize it in the client. The optional error details may contain arbitrary
+    # information about the error. There is a predefined set of error detail types
+    # in the package `google.rpc` that can be used for common error conditions.
     #
-    #  # Language mapping
+    # # Language mapping
     #
-    #  The `Status` message is the logical representation of the error model, but it
-    #  is not necessarily the actual wire format. When the `Status` message is
-    #  exposed in different client libraries and different wire protocols, it can be
-    #  mapped differently. For example, it will likely be mapped to some exceptions
-    #  in Java, but more likely mapped to some error codes in C.
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
+    # exposed in different client libraries and different wire protocols, it can be
+    # mapped differently. For example, it will likely be mapped to some exceptions
+    # in Java, but more likely mapped to some error codes in C.
     #
-    #  # Other uses
+    # # Other uses
     #
-    #  The error model and the `Status` message can be used in a variety of
-    #  environments, either with or without APIs, to provide a
-    #  consistent developer experience across different environments.
+    # The error model and the `Status` message can be used in a variety of
+    # environments, either with or without APIs, to provide a
+    # consistent developer experience across different environments.
     #
-    #  Example uses of this error model include:
+    # Example uses of this error model include:
     #
-    #  - Partial errors. If a service needs to return partial errors to the client,
-    #      it may embed the `Status` in the normal response to indicate the partial
-    #      errors.
+    # - Partial errors. If a service needs to return partial errors to the client,
+    #     it may embed the `Status` in the normal response to indicate the partial
+    #     errors.
     #
-    #  - Workflow errors. A typical workflow has multiple steps. Each step may
-    #      have a `Status` message for error reporting.
+    # - Workflow errors. A typical workflow has multiple steps. Each step may
+    #     have a `Status` message for error reporting.
     #
-    #  - Batch operations. If a client uses batch request and batch response, the
-    #      `Status` message should be used directly inside batch response, one for
-    #      each error sub-response.
+    # - Batch operations. If a client uses batch request and batch response, the
+    #     `Status` message should be used directly inside batch response, one for
+    #     each error sub-response.
     #
-    #  - Asynchronous operations. If an API call embeds asynchronous operation
-    #      results in its response, the status of those operations should be
-    #      represented directly using the `Status` message.
+    # - Asynchronous operations. If an API call embeds asynchronous operation
+    #     results in its response, the status of those operations should be
+    #     represented directly using the `Status` message.
     #
-    #  - Logging. If some API errors are stored in logs, the message `Status` could
-    #      be used directly after any stripping needed for security/privacy reasons.
+    # - Logging. If some API errors are stored in logs, the message `Status` could
+    #     be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]
     #     The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
     # @!attribute [rw] message
     #   @return [String]
     #     A developer-facing error message, which should be in English. Any
-    #      user-facing error message should be localized and sent in the
-    #      [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+    #     user-facing error message should be localized and sent in the
+    #     [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
     # @!attribute [rw] details
     #   @return [Google::Protobuf::Any]
     #     A list of messages that carry the error details.  There is a common set of
-    #      message types for APIs to use.
+    #     message types for APIs to use.
     class Status
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -143,19 +143,19 @@ module Google
 
             ##
             # Performs synchronous speech recognition: receive results after all audio
-            #  has been sent and processed.
+            # has been sent and processed.
             #
             # @overload recognize(request, options: nil)
             #   @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
             #     Performs synchronous speech recognition: receive results after all audio
-            #      has been sent and processed.
+            #     has been sent and processed.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload recognize(config: nil, audio: nil, options: nil)
             #   @param config [Google::Cloud::Speech::V1::RecognitionConfig | Hash]
             #     *Required* Provides information to the recognizer that specifies how to
-            #      process the request.
+            #     process the request.
             #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
             #     *Required* The audio data to be recognized.
             #   @param options [Google::Gax::CallOptions]
@@ -184,23 +184,23 @@ module Google
 
             ##
             # Performs asynchronous speech recognition: receive results via the
-            #  google.longrunning.Operations interface. Returns either an
-            #  `Operation.error` or an `Operation.response` which contains
-            #  a `LongRunningRecognizeResponse` message.
+            # google.longrunning.Operations interface. Returns either an
+            # `Operation.error` or an `Operation.response` which contains
+            # a `LongRunningRecognizeResponse` message.
             #
             # @overload long_running_recognize(request, options: nil)
             #   @param request [Google::Cloud::Speech::V1::LongRunningRecognizeRequest | Hash]
             #     Performs asynchronous speech recognition: receive results via the
-            #      google.longrunning.Operations interface. Returns either an
-            #      `Operation.error` or an `Operation.response` which contains
-            #      a `LongRunningRecognizeResponse` message.
+            #     google.longrunning.Operations interface. Returns either an
+            #     `Operation.error` or an `Operation.response` which contains
+            #     a `LongRunningRecognizeResponse` message.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload long_running_recognize(config: nil, audio: nil, options: nil)
             #   @param config [Google::Cloud::Speech::V1::RecognitionConfig | Hash]
             #     *Required* Provides information to the recognizer that specifies how to
-            #      process the request.
+            #     process the request.
             #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
             #     *Required* The audio data to be recognized.
             #   @param options [Google::Gax::CallOptions]
@@ -234,7 +234,7 @@ module Google
 
             ##
             # Performs bidirectional streaming speech recognition: receive results while
-            #  sending audio. This method is only available via the gRPC API (not REST).
+            # sending audio. This method is only available via the gRPC API (not REST).
             #
             # @param requests [Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeRequest | Hash>]
             #   An enumerable of {Google::Cloud::Speech::V1::StreamingRecognizeRequest} instances.

--- a/shared/output/cloud/vision/lib/doc/google/api/http.rb
+++ b/shared/output/cloud/vision/lib/doc/google/api/http.rb
@@ -19,248 +19,248 @@ raise "This file is for documentation purposes only."
 module Google
   module Api
     # Defines the HTTP configuration for an API service. It contains a list of
-    #  [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
-    #  to one or more HTTP REST API methods.
+    # [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
+    # to one or more HTTP REST API methods.
     # @!attribute [rw] rules
     #   @return [Google::Api::HttpRule]
     #     A list of HTTP configuration rules that apply to individual API methods.
     #
-    #      **NOTE:** All service configuration rules follow "last one wins" order.
+    #     **NOTE:** All service configuration rules follow "last one wins" order.
     # @!attribute [rw] fully_decode_reserved_expansion
     #   @return [Boolean]
     #     When set to true, URL path parmeters will be fully URI-decoded except in
-    #      cases of single segment matches in reserved expansion, where "%2F" will be
-    #      left encoded.
+    #     cases of single segment matches in reserved expansion, where "%2F" will be
+    #     left encoded.
     #
-    #      The default behavior is to not decode RFC 6570 reserved characters in multi
-    #      segment matches.
+    #     The default behavior is to not decode RFC 6570 reserved characters in multi
+    #     segment matches.
     class Http
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
     # `HttpRule` defines the mapping of an RPC method to one or more HTTP
-    #  REST API methods. The mapping specifies how different portions of the RPC
-    #  request message are mapped to URL path, URL query parameters, and
-    #  HTTP request body. The mapping is typically specified as an
-    #  `google.api.http` annotation on the RPC method,
-    #  see "google/api/annotations.proto" for details.
+    # REST API methods. The mapping specifies how different portions of the RPC
+    # request message are mapped to URL path, URL query parameters, and
+    # HTTP request body. The mapping is typically specified as an
+    # `google.api.http` annotation on the RPC method,
+    # see "google/api/annotations.proto" for details.
     #
-    #  The mapping consists of a field specifying the path template and
-    #  method kind.  The path template can refer to fields in the request
-    #  message, as in the example below which describes a REST GET
-    #  operation on a resource collection of messages:
-    #
-    #
-    #      service Messaging {
-    #        rpc GetMessage(GetMessageRequest) returns (Message) {
-    #          option (google.api.http).get = "/v1/messages/{message_id}/{sub.subfield}";
-    #        }
-    #      }
-    #      message GetMessageRequest {
-    #        message SubMessage {
-    #          string subfield = 1;
-    #        }
-    #        string message_id = 1; // mapped to the URL
-    #        SubMessage sub = 2;    // `sub.subfield` is url-mapped
-    #      }
-    #      message Message {
-    #        string text = 1; // content of the resource
-    #      }
-    #
-    #  The same http annotation can alternatively be expressed inside the
-    #  `GRPC API Configuration` YAML file.
-    #
-    #      http:
-    #        rules:
-    #          - selector: <proto_package_name>.Messaging.GetMessage
-    #            get: /v1/messages/{message_id}/{sub.subfield}
-    #
-    #  This definition enables an automatic, bidrectional mapping of HTTP
-    #  JSON to RPC. Example:
-    #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `GET /v1/messages/123456/foo`  | `GetMessage(message_id: "123456" sub: SubMessage(subfield: "foo"))`
-    #
-    #  In general, not only fields but also field paths can be referenced
-    #  from a path pattern. Fields mapped to the path pattern cannot be
-    #  repeated and must have a primitive (non-message) type.
-    #
-    #  Any fields in the request message which are not bound by the path
-    #  pattern automatically become (optional) HTTP query
-    #  parameters. Assume the following definition of the request message:
+    # The mapping consists of a field specifying the path template and
+    # method kind.  The path template can refer to fields in the request
+    # message, as in the example below which describes a REST GET
+    # operation on a resource collection of messages:
     #
     #
-    #      service Messaging {
-    #        rpc GetMessage(GetMessageRequest) returns (Message) {
-    #          option (google.api.http).get = "/v1/messages/{message_id}";
-    #        }
-    #      }
-    #      message GetMessageRequest {
-    #        message SubMessage {
-    #          string subfield = 1;
-    #        }
-    #        string message_id = 1; // mapped to the URL
-    #        int64 revision = 2;    // becomes a parameter
-    #        SubMessage sub = 3;    // `sub.subfield` becomes a parameter
-    #      }
+    #     service Messaging {
+    #       rpc GetMessage(GetMessageRequest) returns (Message) {
+    #         option (google.api.http).get = "/v1/messages/{message_id}/{sub.subfield}";
+    #       }
+    #     }
+    #     message GetMessageRequest {
+    #       message SubMessage {
+    #         string subfield = 1;
+    #       }
+    #       string message_id = 1; // mapped to the URL
+    #       SubMessage sub = 2;    // `sub.subfield` is url-mapped
+    #     }
+    #     message Message {
+    #       string text = 1; // content of the resource
+    #     }
+    #
+    # The same http annotation can alternatively be expressed inside the
+    # `GRPC API Configuration` YAML file.
+    #
+    #     http:
+    #       rules:
+    #         - selector: <proto_package_name>.Messaging.GetMessage
+    #           get: /v1/messages/{message_id}/{sub.subfield}
+    #
+    # This definition enables an automatic, bidrectional mapping of HTTP
+    # JSON to RPC. Example:
+    #
+    # HTTP | RPC
+    # -----|-----
+    # `GET /v1/messages/123456/foo`  | `GetMessage(message_id: "123456" sub: SubMessage(subfield: "foo"))`
+    #
+    # In general, not only fields but also field paths can be referenced
+    # from a path pattern. Fields mapped to the path pattern cannot be
+    # repeated and must have a primitive (non-message) type.
+    #
+    # Any fields in the request message which are not bound by the path
+    # pattern automatically become (optional) HTTP query
+    # parameters. Assume the following definition of the request message:
     #
     #
-    #  This enables a HTTP JSON to RPC mapping as below:
-    #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `GET /v1/messages/123456?revision=2&sub.subfield=foo` | `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield: "foo"))`
-    #
-    #  Note that fields which are mapped to HTTP parameters must have a
-    #  primitive type or a repeated primitive type. Message types are not
-    #  allowed. In the case of a repeated type, the parameter can be
-    #  repeated in the URL, as in `...?param=A&param=B`.
-    #
-    #  For HTTP method kinds which allow a request body, the `body` field
-    #  specifies the mapping. Consider a REST update method on the
-    #  message resource collection:
-    #
-    #
-    #      service Messaging {
-    #        rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
-    #          option (google.api.http) = {
-    #            put: "/v1/messages/{message_id}"
-    #            body: "message"
-    #          };
-    #        }
-    #      }
-    #      message UpdateMessageRequest {
-    #        string message_id = 1; // mapped to the URL
-    #        Message message = 2;   // mapped to the body
-    #      }
+    #     service Messaging {
+    #       rpc GetMessage(GetMessageRequest) returns (Message) {
+    #         option (google.api.http).get = "/v1/messages/{message_id}";
+    #       }
+    #     }
+    #     message GetMessageRequest {
+    #       message SubMessage {
+    #         string subfield = 1;
+    #       }
+    #       string message_id = 1; // mapped to the URL
+    #       int64 revision = 2;    // becomes a parameter
+    #       SubMessage sub = 3;    // `sub.subfield` becomes a parameter
+    #     }
     #
     #
-    #  The following HTTP JSON to RPC mapping is enabled, where the
-    #  representation of the JSON in the request body is determined by
-    #  protos JSON encoding:
+    # This enables a HTTP JSON to RPC mapping as below:
     #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `PUT /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
+    # HTTP | RPC
+    # -----|-----
+    # `GET /v1/messages/123456?revision=2&sub.subfield=foo` | `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield: "foo"))`
     #
-    #  The special name `*` can be used in the body mapping to define that
-    #  every field not bound by the path template should be mapped to the
-    #  request body.  This enables the following alternative definition of
-    #  the update method:
+    # Note that fields which are mapped to HTTP parameters must have a
+    # primitive type or a repeated primitive type. Message types are not
+    # allowed. In the case of a repeated type, the parameter can be
+    # repeated in the URL, as in `...?param=A&param=B`.
     #
-    #      service Messaging {
-    #        rpc UpdateMessage(Message) returns (Message) {
-    #          option (google.api.http) = {
-    #            put: "/v1/messages/{message_id}"
-    #            body: "*"
-    #          };
-    #        }
-    #      }
-    #      message Message {
-    #        string message_id = 1;
-    #        string text = 2;
-    #      }
+    # For HTTP method kinds which allow a request body, the `body` field
+    # specifies the mapping. Consider a REST update method on the
+    # message resource collection:
     #
     #
-    #  The following HTTP JSON to RPC mapping is enabled:
-    #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `PUT /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" text: "Hi!")`
-    #
-    #  Note that when using `*` in the body mapping, it is not possible to
-    #  have HTTP parameters, as all fields not bound by the path end in
-    #  the body. This makes this option more rarely used in practice of
-    #  defining REST APIs. The common usage of `*` is in custom methods
-    #  which don't use the URL at all for transferring data.
-    #
-    #  It is possible to define multiple HTTP methods for one RPC by using
-    #  the `additional_bindings` option. Example:
-    #
-    #      service Messaging {
-    #        rpc GetMessage(GetMessageRequest) returns (Message) {
-    #          option (google.api.http) = {
-    #            get: "/v1/messages/{message_id}"
-    #            additional_bindings {
-    #              get: "/v1/users/{user_id}/messages/{message_id}"
-    #            }
-    #          };
-    #        }
-    #      }
-    #      message GetMessageRequest {
-    #        string message_id = 1;
-    #        string user_id = 2;
-    #      }
+    #     service Messaging {
+    #       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+    #         option (google.api.http) = {
+    #           put: "/v1/messages/{message_id}"
+    #           body: "message"
+    #         };
+    #       }
+    #     }
+    #     message UpdateMessageRequest {
+    #       string message_id = 1; // mapped to the URL
+    #       Message message = 2;   // mapped to the body
+    #     }
     #
     #
-    #  This enables the following two alternative HTTP JSON to RPC
-    #  mappings:
+    # The following HTTP JSON to RPC mapping is enabled, where the
+    # representation of the JSON in the request body is determined by
+    # protos JSON encoding:
     #
-    #  HTTP | RPC
-    #  -----|-----
-    #  `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
-    #  `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id: "123456")`
+    # HTTP | RPC
+    # -----|-----
+    # `PUT /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
     #
-    #  # Rules for HTTP mapping
+    # The special name `*` can be used in the body mapping to define that
+    # every field not bound by the path template should be mapped to the
+    # request body.  This enables the following alternative definition of
+    # the update method:
     #
-    #  The rules for mapping HTTP path, query parameters, and body fields
-    #  to the request message are as follows:
+    #     service Messaging {
+    #       rpc UpdateMessage(Message) returns (Message) {
+    #         option (google.api.http) = {
+    #           put: "/v1/messages/{message_id}"
+    #           body: "*"
+    #         };
+    #       }
+    #     }
+    #     message Message {
+    #       string message_id = 1;
+    #       string text = 2;
+    #     }
     #
-    #  1. The `body` field specifies either `*` or a field path, or is
-    #     omitted. If omitted, it indicates there is no HTTP request body.
-    #  2. Leaf fields (recursive expansion of nested messages in the
-    #     request) can be classified into three types:
-    #      (a) Matched in the URL template.
-    #      (b) Covered by body (if body is `*`, everything except (a) fields;
-    #          else everything under the body field)
-    #      (c) All other fields.
-    #  3. URL query parameters found in the HTTP request are mapped to (c) fields.
-    #  4. Any body sent with an HTTP request can contain only (b) fields.
     #
-    #  The syntax of the path template is as follows:
+    # The following HTTP JSON to RPC mapping is enabled:
     #
-    #      Template = "/" Segments [ Verb ] ;
-    #      Segments = Segment { "/" Segment } ;
-    #      Segment  = "*" | "**" | LITERAL | Variable ;
-    #      Variable = "{" FieldPath [ "=" Segments ] "}" ;
-    #      FieldPath = IDENT { "." IDENT } ;
-    #      Verb     = ":" LITERAL ;
+    # HTTP | RPC
+    # -----|-----
+    # `PUT /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id: "123456" text: "Hi!")`
     #
-    #  The syntax `*` matches a single path segment. The syntax `**` matches zero
-    #  or more path segments, which must be the last part of the path except the
-    #  `Verb`. The syntax `LITERAL` matches literal text in the path.
+    # Note that when using `*` in the body mapping, it is not possible to
+    # have HTTP parameters, as all fields not bound by the path end in
+    # the body. This makes this option more rarely used in practice of
+    # defining REST APIs. The common usage of `*` is in custom methods
+    # which don't use the URL at all for transferring data.
     #
-    #  The syntax `Variable` matches part of the URL path as specified by its
-    #  template. A variable template must not contain other variables. If a variable
-    #  matches a single path segment, its template may be omitted, e.g. `{var}`
-    #  is equivalent to `{var=*}`.
+    # It is possible to define multiple HTTP methods for one RPC by using
+    # the `additional_bindings` option. Example:
     #
-    #  If a variable contains exactly one path segment, such as `"{var}"` or
-    #  `"{var=*}"`, when such a variable is expanded into a URL path, all characters
-    #  except `[-_.~0-9a-zA-Z]` are percent-encoded. Such variables show up in the
-    #  Discovery Document as `{var}`.
+    #     service Messaging {
+    #       rpc GetMessage(GetMessageRequest) returns (Message) {
+    #         option (google.api.http) = {
+    #           get: "/v1/messages/{message_id}"
+    #           additional_bindings {
+    #             get: "/v1/users/{user_id}/messages/{message_id}"
+    #           }
+    #         };
+    #       }
+    #     }
+    #     message GetMessageRequest {
+    #       string message_id = 1;
+    #       string user_id = 2;
+    #     }
     #
-    #  If a variable contains one or more path segments, such as `"{var=foo/*}"`
-    #  or `"{var=**}"`, when such a variable is expanded into a URL path, all
-    #  characters except `[-_.~/0-9a-zA-Z]` are percent-encoded. Such variables
-    #  show up in the Discovery Document as `{+var}`.
     #
-    #  NOTE: While the single segment variable matches the semantics of
-    #  [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2
-    #  Simple String Expansion, the multi segment variable **does not** match
-    #  RFC 6570 Reserved Expansion. The reason is that the Reserved Expansion
-    #  does not expand special characters like `?` and `#`, which would lead
-    #  to invalid URLs.
+    # This enables the following two alternative HTTP JSON to RPC
+    # mappings:
     #
-    #  NOTE: the field paths in variables and in the `body` must not refer to
-    #  repeated fields or map fields.
+    # HTTP | RPC
+    # -----|-----
+    # `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
+    # `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id: "123456")`
+    #
+    # # Rules for HTTP mapping
+    #
+    # The rules for mapping HTTP path, query parameters, and body fields
+    # to the request message are as follows:
+    #
+    # 1. The `body` field specifies either `*` or a field path, or is
+    #    omitted. If omitted, it indicates there is no HTTP request body.
+    # 2. Leaf fields (recursive expansion of nested messages in the
+    #    request) can be classified into three types:
+    #     (a) Matched in the URL template.
+    #     (b) Covered by body (if body is `*`, everything except (a) fields;
+    #         else everything under the body field)
+    #     (c) All other fields.
+    # 3. URL query parameters found in the HTTP request are mapped to (c) fields.
+    # 4. Any body sent with an HTTP request can contain only (b) fields.
+    #
+    # The syntax of the path template is as follows:
+    #
+    #     Template = "/" Segments [ Verb ] ;
+    #     Segments = Segment { "/" Segment } ;
+    #     Segment  = "*" | "**" | LITERAL | Variable ;
+    #     Variable = "{" FieldPath [ "=" Segments ] "}" ;
+    #     FieldPath = IDENT { "." IDENT } ;
+    #     Verb     = ":" LITERAL ;
+    #
+    # The syntax `*` matches a single path segment. The syntax `**` matches zero
+    # or more path segments, which must be the last part of the path except the
+    # `Verb`. The syntax `LITERAL` matches literal text in the path.
+    #
+    # The syntax `Variable` matches part of the URL path as specified by its
+    # template. A variable template must not contain other variables. If a variable
+    # matches a single path segment, its template may be omitted, e.g. `{var}`
+    # is equivalent to `{var=*}`.
+    #
+    # If a variable contains exactly one path segment, such as `"{var}"` or
+    # `"{var=*}"`, when such a variable is expanded into a URL path, all characters
+    # except `[-_.~0-9a-zA-Z]` are percent-encoded. Such variables show up in the
+    # Discovery Document as `{var}`.
+    #
+    # If a variable contains one or more path segments, such as `"{var=foo/*}"`
+    # or `"{var=**}"`, when such a variable is expanded into a URL path, all
+    # characters except `[-_.~/0-9a-zA-Z]` are percent-encoded. Such variables
+    # show up in the Discovery Document as `{+var}`.
+    #
+    # NOTE: While the single segment variable matches the semantics of
+    # [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2
+    # Simple String Expansion, the multi segment variable **does not** match
+    # RFC 6570 Reserved Expansion. The reason is that the Reserved Expansion
+    # does not expand special characters like `?` and `#`, which would lead
+    # to invalid URLs.
+    #
+    # NOTE: the field paths in variables and in the `body` must not refer to
+    # repeated fields or map fields.
     # @!attribute [rw] selector
     #   @return [String]
     #     Selects methods to which this rule applies.
     #
-    #      Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+    #     Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
     # @!attribute [rw] get
     #   @return [String]
     #     Used for listing and getting information about resources.
@@ -279,25 +279,25 @@ module Google
     # @!attribute [rw] custom
     #   @return [Google::Api::CustomHttpPattern]
     #     The custom pattern is used for specifying an HTTP method that is not
-    #      included in the `pattern` field, such as HEAD, or "*" to leave the
-    #      HTTP method unspecified for this rule. The wild-card rule is useful
-    #      for services that provide content to Web (HTML) clients.
+    #     included in the `pattern` field, such as HEAD, or "*" to leave the
+    #     HTTP method unspecified for this rule. The wild-card rule is useful
+    #     for services that provide content to Web (HTML) clients.
     # @!attribute [rw] body
     #   @return [String]
     #     The name of the request field whose value is mapped to the HTTP body, or
-    #      `*` for mapping all fields not captured by the path pattern to the HTTP
-    #      body. NOTE: the referred field must not be a repeated field and must be
-    #      present at the top-level of request message type.
+    #     `*` for mapping all fields not captured by the path pattern to the HTTP
+    #     body. NOTE: the referred field must not be a repeated field and must be
+    #     present at the top-level of request message type.
     # @!attribute [rw] response_body
     #   @return [String]
     #     Optional. The name of the response field whose value is mapped to the HTTP
-    #      body of response. Other response fields are ignored. When
-    #      not set, the response message will be used as HTTP body of response.
+    #     body of response. Other response fields are ignored. When
+    #     not set, the response message will be used as HTTP body of response.
     # @!attribute [rw] additional_bindings
     #   @return [Google::Api::HttpRule]
     #     Additional HTTP bindings for the selector. Nested bindings must
-    #      not contain an `additional_bindings` field themselves (that is,
-    #      the nesting may only be one level deep).
+    #     not contain an `additional_bindings` field themselves (that is,
+    #     the nesting may only be one level deep).
     class HttpRule
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/vision/lib/doc/google/cloud/vision/v1/geometry.rb
+++ b/shared/output/cloud/vision/lib/doc/google/cloud/vision/v1/geometry.rb
@@ -21,7 +21,7 @@ module Google
     module Vision
       module V1
         # A vertex represents a 2D point in the image.
-        #  NOTE: the vertex coordinates are in the same scale as the original image.
+        # NOTE: the vertex coordinates are in the same scale as the original image.
         # @!attribute [rw] x
         #   @return [Integer]
         #     X coordinate.
@@ -34,8 +34,8 @@ module Google
         end
 
         # A vertex represents a 2D point in the image.
-        #  NOTE: the normalized vertex coordinates are relative to the original image
-        #  and range from 0 to 1.
+        # NOTE: the normalized vertex coordinates are relative to the original image
+        # and range from 0 to 1.
         # @!attribute [rw] x
         #   @return [Float]
         #     X coordinate.
@@ -60,8 +60,8 @@ module Google
         end
 
         # A 3D position in the image, used primarily for Face detection landmarks.
-        #  A valid Position must have both x and y coordinates.
-        #  The position coordinates are in the same scale as the original image.
+        # A valid Position must have both x and y coordinates.
+        # The position coordinates are in the same scale as the original image.
         # @!attribute [rw] x
         #   @return [Float]
         #     X coordinate.

--- a/shared/output/cloud/vision/lib/doc/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/cloud/vision/lib/doc/google/cloud/vision/v1/image_annotator.rb
@@ -21,20 +21,20 @@ module Google
     module Vision
       module V1
         # The type of Google Cloud Vision API detection to perform, and the maximum
-        #  number of results to return for that type. Multiple `Feature` objects can
-        #  be specified in the `features` list.
+        # number of results to return for that type. Multiple `Feature` objects can
+        # be specified in the `features` list.
         # @!attribute [rw] type
         #   @return [ENUM(Type)]
         #     The feature type.
         # @!attribute [rw] max_results
         #   @return [Integer]
         #     Maximum number of results of this type. Does not apply to
-        #      `TEXT_DETECTION`, `DOCUMENT_TEXT_DETECTION`, or `CROP_HINTS`.
+        #     `TEXT_DETECTION`, `DOCUMENT_TEXT_DETECTION`, or `CROP_HINTS`.
         # @!attribute [rw] model
         #   @return [String]
         #     Model to use for the feature.
-        #      Supported values: "builtin/stable" (the default if unset) and
-        #      "builtin/latest".
+        #     Supported values: "builtin/stable" (the default if unset) and
+        #     "builtin/latest".
         class Feature
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -57,20 +57,20 @@ module Google
             LABEL_DETECTION = 4
 
             # Run text detection / optical character recognition (OCR). Text detection
-            #  is optimized for areas of text within a larger image; if the image is
-            #  a document, use `DOCUMENT_TEXT_DETECTION` instead.
+            # is optimized for areas of text within a larger image; if the image is
+            # a document, use `DOCUMENT_TEXT_DETECTION` instead.
             TEXT_DETECTION = 5
 
             # Run dense text document OCR. Takes precedence when both
-            #  `DOCUMENT_TEXT_DETECTION` and `TEXT_DETECTION` are present.
+            # `DOCUMENT_TEXT_DETECTION` and `TEXT_DETECTION` are present.
             DOCUMENT_TEXT_DETECTION = 11
 
             # Run Safe Search to detect potentially unsafe
-            #  or undesirable content.
+            # or undesirable content.
             SAFE_SEARCH_DETECTION = 6
 
             # Compute a set of image properties, such as the
-            #  image's dominant colors.
+            # image's dominant colors.
             IMAGE_PROPERTIES = 7
 
             # Run crop hints.
@@ -92,29 +92,29 @@ module Google
         #   @return [String]
         #     **Use `image_uri` instead.**
         #
-        #      The Google Cloud Storage  URI of the form
-        #      `gs://bucket_name/object_name`. Object versioning is not supported. See
-        #      [Google Cloud Storage Request
-        #      URIs](https://cloud.google.com/storage/docs/reference-uris) for more info.
+        #     The Google Cloud Storage  URI of the form
+        #     `gs://bucket_name/object_name`. Object versioning is not supported. See
+        #     [Google Cloud Storage Request
+        #     URIs](https://cloud.google.com/storage/docs/reference-uris) for more info.
         # @!attribute [rw] image_uri
         #   @return [String]
         #     The URI of the source image. Can be either:
         #
-        #      1. A Google Cloud Storage URI of the form
-        #         `gs://bucket_name/object_name`. Object versioning is not supported. See
-        #         [Google Cloud Storage Request
-        #         URIs](https://cloud.google.com/storage/docs/reference-uris) for more
-        #         info.
+        #     1. A Google Cloud Storage URI of the form
+        #        `gs://bucket_name/object_name`. Object versioning is not supported. See
+        #        [Google Cloud Storage Request
+        #        URIs](https://cloud.google.com/storage/docs/reference-uris) for more
+        #        info.
         #
-        #      2. A publicly-accessible image HTTP/HTTPS URL. When fetching images from
-        #         HTTP/HTTPS URLs, Google cannot guarantee that the request will be
-        #         completed. Your request may fail if the specified host denies the
-        #         request (e.g. due to request throttling or DOS prevention), or if Google
-        #         throttles requests to the site for abuse prevention. You should not
-        #         depend on externally-hosted images for production applications.
+        #     2. A publicly-accessible image HTTP/HTTPS URL. When fetching images from
+        #        HTTP/HTTPS URLs, Google cannot guarantee that the request will be
+        #        completed. Your request may fail if the specified host denies the
+        #        request (e.g. due to request throttling or DOS prevention), or if Google
+        #        throttles requests to the site for abuse prevention. You should not
+        #        depend on externally-hosted images for production applications.
         #
-        #      When both `gcs_image_uri` and `image_uri` are specified, `image_uri` takes
-        #      precedence.
+        #     When both `gcs_image_uri` and `image_uri` are specified, `image_uri` takes
+        #     precedence.
         class ImageSource
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -124,13 +124,13 @@ module Google
         # @!attribute [rw] content
         #   @return [String]
         #     Image content, represented as a stream of bytes.
-        #      Note: As with all `bytes` fields, protobuffers use a pure binary
-        #      representation, whereas JSON representations use base64.
+        #     Note: As with all `bytes` fields, protobuffers use a pure binary
+        #     representation, whereas JSON representations use base64.
         # @!attribute [rw] source
         #   @return [Google::Cloud::Vision::V1::ImageSource]
         #     Google Cloud Storage image location, or publicly-accessible image
-        #      URL. If both `content` and `source` are provided for an image, `content`
-        #      takes precedence and is used to perform the image annotation request.
+        #     URL. If both `content` and `source` are provided for an image, `content`
+        #     takes precedence and is used to perform the image annotation request.
         class Image
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -140,37 +140,37 @@ module Google
         # @!attribute [rw] bounding_poly
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
         #     The bounding polygon around the face. The coordinates of the bounding box
-        #      are in the original image's scale, as returned in `ImageParams`.
-        #      The bounding box is computed to "frame" the face in accordance with human
-        #      expectations. It is based on the landmarker results.
-        #      Note that one or more x and/or y coordinates may not be generated in the
-        #      `BoundingPoly` (the polygon will be unbounded) if only a partial face
-        #      appears in the image to be annotated.
+        #     are in the original image's scale, as returned in `ImageParams`.
+        #     The bounding box is computed to "frame" the face in accordance with human
+        #     expectations. It is based on the landmarker results.
+        #     Note that one or more x and/or y coordinates may not be generated in the
+        #     `BoundingPoly` (the polygon will be unbounded) if only a partial face
+        #     appears in the image to be annotated.
         # @!attribute [rw] fd_bounding_poly
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
         #     The `fd_bounding_poly` bounding polygon is tighter than the
-        #      `boundingPoly`, and encloses only the skin part of the face. Typically, it
-        #      is used to eliminate the face from any image analysis that detects the
-        #      "amount of skin" visible in an image. It is not based on the
-        #      landmarker results, only on the initial face detection, hence
-        #      the <code>fd</code> (face detection) prefix.
+        #     `boundingPoly`, and encloses only the skin part of the face. Typically, it
+        #     is used to eliminate the face from any image analysis that detects the
+        #     "amount of skin" visible in an image. It is not based on the
+        #     landmarker results, only on the initial face detection, hence
+        #     the <code>fd</code> (face detection) prefix.
         # @!attribute [rw] landmarks
         #   @return [Google::Cloud::Vision::V1::FaceAnnotation::Landmark]
         #     Detected face landmarks.
         # @!attribute [rw] roll_angle
         #   @return [Float]
         #     Roll angle, which indicates the amount of clockwise/anti-clockwise rotation
-        #      of the face relative to the image vertical about the axis perpendicular to
-        #      the face. Range [-180,180].
+        #     of the face relative to the image vertical about the axis perpendicular to
+        #     the face. Range [-180,180].
         # @!attribute [rw] pan_angle
         #   @return [Float]
         #     Yaw angle, which indicates the leftward/rightward angle that the face is
-        #      pointing relative to the vertical plane perpendicular to the image. Range
-        #      [-180,180].
+        #     pointing relative to the vertical plane perpendicular to the image. Range
+        #     [-180,180].
         # @!attribute [rw] tilt_angle
         #   @return [Float]
         #     Pitch angle, which indicates the upwards/downwards angle that the face is
-        #      pointing relative to the image's horizontal plane. Range [-180,180].
+        #     pointing relative to the image's horizontal plane. Range [-180,180].
         # @!attribute [rw] detection_confidence
         #   @return [Float]
         #     Detection confidence. Range [0, 1].
@@ -214,9 +214,9 @@ module Google
             extend Google::Protobuf::MessageExts::ClassMethods
 
             # Face landmark (feature) type.
-            #  Left and right are defined from the vantage of the viewer of the image
-            #  without considering mirror projections typical of photos. So, `LEFT_EYE`,
-            #  typically, is the person's right eye.
+            # Left and right are defined from the vantage of the viewer of the image
+            # without considering mirror projections typical of photos. So, `LEFT_EYE`,
+            # typically, is the person's right eye.
             module Type
               # Unknown face landmark detected. Should not be filled.
               UNKNOWN_LANDMARK = 0
@@ -354,12 +354,12 @@ module Google
         # @!attribute [rw] mid
         #   @return [String]
         #     Opaque entity ID. Some IDs may be available in
-        #      [Google Knowledge Graph Search
-        #      API](https://developers.google.com/knowledge-graph/).
+        #     [Google Knowledge Graph Search
+        #     API](https://developers.google.com/knowledge-graph/).
         # @!attribute [rw] locale
         #   @return [String]
         #     The language code for the locale in which the entity textual
-        #      `description` is expressed.
+        #     `description` is expressed.
         # @!attribute [rw] description
         #   @return [String]
         #     Entity textual description, expressed in its `locale` language.
@@ -369,32 +369,32 @@ module Google
         # @!attribute [rw] confidence
         #   @return [Float]
         #     **Deprecated. Use `score` instead.**
-        #      The accuracy of the entity detection in an image.
-        #      For example, for an image in which the "Eiffel Tower" entity is detected,
-        #      this field represents the confidence that there is a tower in the query
-        #      image. Range [0, 1].
+        #     The accuracy of the entity detection in an image.
+        #     For example, for an image in which the "Eiffel Tower" entity is detected,
+        #     this field represents the confidence that there is a tower in the query
+        #     image. Range [0, 1].
         # @!attribute [rw] topicality
         #   @return [Float]
         #     The relevancy of the ICA (Image Content Annotation) label to the
-        #      image. For example, the relevancy of "tower" is likely higher to an image
-        #      containing the detected "Eiffel Tower" than to an image containing a
-        #      detected distant towering building, even though the confidence that
-        #      there is a tower in each image may be the same. Range [0, 1].
+        #     image. For example, the relevancy of "tower" is likely higher to an image
+        #     containing the detected "Eiffel Tower" than to an image containing a
+        #     detected distant towering building, even though the confidence that
+        #     there is a tower in each image may be the same. Range [0, 1].
         # @!attribute [rw] bounding_poly
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
         #     Image region to which this entity belongs. Not produced
-        #      for `LABEL_DETECTION` features.
+        #     for `LABEL_DETECTION` features.
         # @!attribute [rw] locations
         #   @return [Google::Cloud::Vision::V1::LocationInfo]
         #     The location information for the detected entity. Multiple
-        #      `LocationInfo` elements can be present because one location may
-        #      indicate the location of the scene in the image, and another location
-        #      may indicate the location of the place where the image was taken.
-        #      Location information is usually present for landmarks.
+        #     `LocationInfo` elements can be present because one location may
+        #     indicate the location of the scene in the image, and another location
+        #     may indicate the location of the place where the image was taken.
+        #     Location information is usually present for landmarks.
         # @!attribute [rw] properties
         #   @return [Google::Cloud::Vision::V1::Property]
         #     Some entities may have optional user-supplied `Property` (name/value)
-        #      fields, such a score or string that qualifies the entity.
+        #     fields, such a score or string that qualifies the entity.
         class EntityAnnotation
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -407,8 +407,8 @@ module Google
         # @!attribute [rw] language_code
         #   @return [String]
         #     The BCP-47 language code, such as "en-US" or "sr-Latn". For more
-        #      information, see
-        #      http://www.unicode.org/reports/tr35/#Unicode_locale_identifier.
+        #     information, see
+        #     http://www.unicode.org/reports/tr35/#Unicode_locale_identifier.
         # @!attribute [rw] name
         #   @return [String]
         #     Object name, expressed in its `language_code` language.
@@ -424,18 +424,18 @@ module Google
         end
 
         # Set of features pertaining to the image, computed by computer vision
-        #  methods over safe-search verticals (for example, adult, spoof, medical,
-        #  violence).
+        # methods over safe-search verticals (for example, adult, spoof, medical,
+        # violence).
         # @!attribute [rw] adult
         #   @return [ENUM(Likelihood)]
         #     Represents the adult content likelihood for the image. Adult content may
-        #      contain elements such as nudity, pornographic images or cartoons, or
-        #      sexual activities.
+        #     contain elements such as nudity, pornographic images or cartoons, or
+        #     sexual activities.
         # @!attribute [rw] spoof
         #   @return [ENUM(Likelihood)]
         #     Spoof likelihood. The likelihood that an modification
-        #      was made to the image's canonical version to make it appear
-        #      funny or offensive.
+        #     was made to the image's canonical version to make it appear
+        #     funny or offensive.
         # @!attribute [rw] medical
         #   @return [ENUM(Likelihood)]
         #     Likelihood that this is a medical image.
@@ -445,9 +445,9 @@ module Google
         # @!attribute [rw] racy
         #   @return [ENUM(Likelihood)]
         #     Likelihood that the request image contains racy content. Racy content may
-        #      include (but is not limited to) skimpy or sheer clothing, strategically
-        #      covered nudity, lewd or provocative poses, or close-ups of sensitive
-        #      body areas.
+        #     include (but is not limited to) skimpy or sheer clothing, strategically
+        #     covered nudity, lewd or provocative poses, or close-ups of sensitive
+        #     body areas.
         class SafeSearchAnnotation
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -466,7 +466,7 @@ module Google
         end
 
         # Color information consists of RGB channels, score, and the fraction of
-        #  the image that the color occupies in the image.
+        # the image that the color occupies in the image.
         # @!attribute [rw] color
         #   @return [Google::Type::Color]
         #     RGB components of the color.
@@ -476,7 +476,7 @@ module Google
         # @!attribute [rw] pixel_fraction
         #   @return [Float]
         #     The fraction of pixels the color occupies in the image.
-        #      Value in range [0, 1].
+        #     Value in range [0, 1].
         class ColorInfo
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -504,14 +504,14 @@ module Google
         # @!attribute [rw] bounding_poly
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
         #     The bounding polygon for the crop region. The coordinates of the bounding
-        #      box are in the original image's scale, as returned in `ImageParams`.
+        #     box are in the original image's scale, as returned in `ImageParams`.
         # @!attribute [rw] confidence
         #   @return [Float]
         #     Confidence of this being a salient region.  Range [0, 1].
         # @!attribute [rw] importance_fraction
         #   @return [Float]
         #     Fraction of importance of this salient region with respect to the original
-        #      image.
+        #     image.
         class CropHint
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -530,11 +530,11 @@ module Google
         # @!attribute [rw] aspect_ratios
         #   @return [Float]
         #     Aspect ratios in floats, representing the ratio of the width to the height
-        #      of the image. For example, if the desired aspect ratio is 4/3, the
-        #      corresponding float value should be 1.33333.  If not specified, the
-        #      best possible crop is returned. The number of provided aspect ratios is
-        #      limited to a maximum of 16; any aspect ratios provided after the 16th are
-        #      ignored.
+        #     of the image. For example, if the desired aspect ratio is 4/3, the
+        #     corresponding float value should be 1.33333.  If not specified, the
+        #     best possible crop is returned. The number of provided aspect ratios is
+        #     limited to a maximum of 16; any aspect ratios provided after the 16th are
+        #     ignored.
         class CropHintsParams
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -556,13 +556,13 @@ module Google
         # @!attribute [rw] language_hints
         #   @return [String]
         #     List of languages to use for TEXT_DETECTION. In most cases, an empty value
-        #      yields the best results since it enables automatic language detection. For
-        #      languages based on the Latin alphabet, setting `language_hints` is not
-        #      needed. In rare cases, when the language of the text in the image is known,
-        #      setting a hint will help get better results (although it will be a
-        #      significant hindrance if the hint is wrong). Text detection returns an
-        #      error if one or more of the specified languages is not one of the
-        #      [supported languages](/vision/docs/languages).
+        #     yields the best results since it enables automatic language detection. For
+        #     languages based on the Latin alphabet, setting `language_hints` is not
+        #     needed. In rare cases, when the language of the text in the image is known,
+        #     setting a hint will help get better results (although it will be a
+        #     significant hindrance if the hint is wrong). Text detection returns an
+        #     error if one or more of the specified languages is not one of the
+        #     [supported languages](/vision/docs/languages).
         # @!attribute [rw] crop_hints_params
         #   @return [Google::Cloud::Vision::V1::CropHintsParam]
         #     Parameters for crop hints annotation request.
@@ -578,7 +578,7 @@ module Google
         end
 
         # Request for performing Google Cloud Vision API tasks over a user-provided
-        #  image, with user-requested features.
+        # image, with user-requested features.
         # @!attribute [rw] image
         #   @return [Google::Cloud::Vision::V1::Image]
         #     The image to be processed.
@@ -594,14 +594,14 @@ module Google
         end
 
         # If an image was produced from a file (e.g. a PDF), this message gives
-        #  information about the source of that image.
+        # information about the source of that image.
         # @!attribute [rw] uri
         #   @return [String]
         #     The URI of the file used to produce the image.
         # @!attribute [rw] page_number
         #   @return [Integer]
         #     If the file was a PDF or TIFF, this field gives the page number within
-        #      the file used to produce the image.
+        #     the file used to produce the image.
         class ImageAnnotationContext
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -623,16 +623,16 @@ module Google
         # @!attribute [rw] localized_object_annotations
         #   @return [Google::Cloud::Vision::V1::LocalizedObjectAnnotation]
         #     If present, localized object detection has completed successfully.
-        #      This will be sorted descending by confidence score.
+        #     This will be sorted descending by confidence score.
         # @!attribute [rw] text_annotations
         #   @return [Google::Cloud::Vision::V1::EntityAnnotation]
         #     If present, text (OCR) detection has completed successfully.
         # @!attribute [rw] full_text_annotation
         #   @return [Google::Cloud::Vision::V1::TextAnnotation]
         #     If present, text (OCR) detection or document (OCR) text detection has
-        #      completed successfully.
-        #      This annotation provides the structural hierarchy for the OCR detected
-        #      text.
+        #     completed successfully.
+        #     This annotation provides the structural hierarchy for the OCR detected
+        #     text.
         # @!attribute [rw] safe_search_annotation
         #   @return [Google::Cloud::Vision::V1::SafeSearchAnnotation]
         #     If present, safe-search annotation has completed successfully.
@@ -651,19 +651,19 @@ module Google
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]
         #     If set, represents the error message for the operation.
-        #      Note that filled-in image annotations are guaranteed to be
-        #      correct, even when `error` is set.
+        #     Note that filled-in image annotations are guaranteed to be
+        #     correct, even when `error` is set.
         # @!attribute [rw] context
         #   @return [Google::Cloud::Vision::V1::ImageAnnotationContext]
         #     If present, contextual information is needed to understand where this image
-        #      comes from.
+        #     comes from.
         class AnnotateImageResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
         # Response to a single file annotation request. A file may contain one or more
-        #  images, which individually have their own responses.
+        # images, which individually have their own responses.
         # @!attribute [rw] input_config
         #   @return [Google::Cloud::Vision::V1::InputConfig]
         #     Information about the file for which this response is generated.
@@ -721,7 +721,7 @@ module Google
         end
 
         # Multiple async file annotation requests are batched into a single service
-        #  call.
+        # call.
         # @!attribute [rw] requests
         #   @return [Google::Cloud::Vision::V1::AsyncAnnotateFileRequest]
         #     Individual async file annotation requests for this batch.
@@ -734,7 +734,7 @@ module Google
         # @!attribute [rw] responses
         #   @return [Google::Cloud::Vision::V1::AsyncAnnotateFileResponse]
         #     The list of file annotation responses, one for each request in
-        #      AsyncBatchAnnotateFilesRequest.
+        #     AsyncBatchAnnotateFilesRequest.
         class AsyncBatchAnnotateFilesResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -747,7 +747,7 @@ module Google
         # @!attribute [rw] mime_type
         #   @return [String]
         #     The type of the file. Currently only "application/pdf" and "image/tiff"
-        #      are supported. Wildcards are not supported.
+        #     are supported. Wildcards are not supported.
         class InputConfig
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -760,16 +760,16 @@ module Google
         # @!attribute [rw] batch_size
         #   @return [Integer]
         #     The max number of response protos to put into each output JSON file on
-        #      Google Cloud Storage.
-        #      The valid range is [1, 100]. If not specified, the default value is 20.
+        #     Google Cloud Storage.
+        #     The valid range is [1, 100]. If not specified, the default value is 20.
         #
-        #      For example, for one pdf file with 100 pages, 100 response protos will
-        #      be generated. If `batch_size` = 20, then 5 json files each
-        #      containing 20 response protos will be written under the prefix
-        #      `gcs_destination`.`uri`.
+        #     For example, for one pdf file with 100 pages, 100 response protos will
+        #     be generated. If `batch_size` = 20, then 5 json files each
+        #     containing 20 response protos will be written under the prefix
+        #     `gcs_destination`.`uri`.
         #
-        #      Currently, batch_size only applies to GcsDestination, with potential future
-        #      support for other output configurations.
+        #     Currently, batch_size only applies to GcsDestination, with potential future
+        #     support for other output configurations.
         class OutputConfig
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -779,7 +779,7 @@ module Google
         # @!attribute [rw] uri
         #   @return [String]
         #     Google Cloud Storage URI for the input file. This must only be a
-        #      Google Cloud Storage object. Wildcards are not currently supported.
+        #     Google Cloud Storage object. Wildcards are not currently supported.
         class GcsSource
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -789,20 +789,20 @@ module Google
         # @!attribute [rw] uri
         #   @return [String]
         #     Google Cloud Storage URI where the results will be stored. Results will
-        #      be in JSON format and preceded by its corresponding input URI. This field
-        #      can either represent a single file, or a prefix for multiple outputs.
-        #      Prefixes must end in a `/`.
+        #     be in JSON format and preceded by its corresponding input URI. This field
+        #     can either represent a single file, or a prefix for multiple outputs.
+        #     Prefixes must end in a `/`.
         #
-        #      Examples:
+        #     Examples:
         #
-        #      *    File: gs://bucket-name/filename.json
-        #      *    Prefix: gs://bucket-name/prefix/here/
-        #      *    File: gs://bucket-name/prefix/here
+        #     *    File: gs://bucket-name/filename.json
+        #     *    Prefix: gs://bucket-name/prefix/here/
+        #     *    File: gs://bucket-name/prefix/here
         #
-        #      If multiple outputs, each response is still AnnotateFileResponse, each of
-        #      which contains some subset of the full list of AnnotateImageResponse.
-        #      Multiple outputs can happen if, for example, the output JSON is too large
-        #      and overflows into multiple sharded files.
+        #     If multiple outputs, each response is still AnnotateFileResponse, each of
+        #     which contains some subset of the full list of AnnotateImageResponse.
+        #     Multiple outputs can happen if, for example, the output JSON is too large
+        #     and overflows into multiple sharded files.
         class GcsDestination
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -842,7 +842,7 @@ module Google
         end
 
         # A bucketized representation of likelihood, which is intended to give clients
-        #  highly stable results across model upgrades.
+        # highly stable results across model upgrades.
         module Likelihood
           # Unknown likelihood.
           UNKNOWN = 0

--- a/shared/output/cloud/vision/lib/doc/google/cloud/vision/v1/product_search.rb
+++ b/shared/output/cloud/vision/lib/doc/google/cloud/vision/v1/product_search.rb
@@ -24,27 +24,27 @@ module Google
         # @!attribute [rw] bounding_poly
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
         #     The bounding polygon around the area of interest in the image.
-        #      Optional. If it is not specified, system discretion will be applied.
+        #     Optional. If it is not specified, system discretion will be applied.
         # @!attribute [rw] product_set
         #   @return [String]
         #     The resource name of a [ProductSet][google.cloud.vision.v1.ProductSet] to
-        #      be searched for similar images.
+        #     be searched for similar images.
         #
-        #      Format is:
-        #      `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`.
+        #     Format is:
+        #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`.
         # @!attribute [rw] product_categories
         #   @return [String]
         #     The list of product categories to search in. Currently, we only consider
-        #      the first category, and either "homegoods", "apparel", or "toys" should be
-        #      specified.
+        #     the first category, and either "homegoods", "apparel", or "toys" should be
+        #     specified.
         # @!attribute [rw] filter
         #   @return [String]
         #     The filtering expression. This can be used to restrict search results based
-        #      on Product labels. We currently support an AND of OR of key-value
-        #      expressions, where each expression within an OR must have the same key.
+        #     on Product labels. We currently support an AND of OR of key-value
+        #     expressions, where each expression within an OR must have the same key.
         #
-        #      For example, "(color = red OR color = blue) AND brand = Google" is
-        #      acceptable, but not "(color = red OR brand = Google)" or "color: red".
+        #     For example, "(color = red OR color = blue) AND brand = Google" is
+        #     acceptable, but not "(color = red OR brand = Google)" or "color: red".
         class ProductSearchParams
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -54,16 +54,16 @@ module Google
         # @!attribute [rw] index_time
         #   @return [Google::Protobuf::Timestamp]
         #     Timestamp of the index which provided these results. Changes made after
-        #      this time are not reflected in the current results.
+        #     this time are not reflected in the current results.
         # @!attribute [rw] results
         #   @return [Google::Cloud::Vision::V1::ProductSearchResult::Result]
         #     List of results, one for each product match.
         # @!attribute [rw] product_grouped_results
         #   @return [Google::Cloud::Vision::V1::ProductSearchResult::GroupedResult]
         #     List of results grouped by products detected in the query image. Each entry
-        #      corresponds to one bounding polygon in the query image, and contains the
-        #      matching products specific to that region. There may be duplicate product
-        #      matches in the union of all the per-product results.
+        #     corresponds to one bounding polygon in the query image, and contains the
+        #     matching products specific to that region. There may be duplicate product
+        #     matches in the union of all the per-product results.
         class ProductSearchResults
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -75,18 +75,18 @@ module Google
           # @!attribute [rw] score
           #   @return [Float]
           #     A confidence level on the match, ranging from 0 (no confidence) to
-          #      1 (full confidence).
+          #     1 (full confidence).
           # @!attribute [rw] image
           #   @return [String]
           #     The resource name of the image from the product that is the closest match
-          #      to the query.
+          #     to the query.
           class Result
             include Google::Protobuf::MessageExts
             extend Google::Protobuf::MessageExts::ClassMethods
           end
 
           # Information about the products similar to a single product in a query
-          #  image.
+          # image.
           # @!attribute [rw] bounding_poly
           #   @return [Google::Cloud::Vision::V1::BoundingPoly]
           #     The bounding polygon around the product detected in the query image.

--- a/shared/output/cloud/vision/lib/doc/google/cloud/vision/v1/product_search_service.rb
+++ b/shared/output/cloud/vision/lib/doc/google/cloud/vision/v1/product_search_service.rb
@@ -25,35 +25,35 @@ module Google
         #   @return [String]
         #     The resource name of the product.
         #
-        #      Format is:
-        #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
+        #     Format is:
+        #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
         #
-        #      This field is ignored when creating a product.
+        #     This field is ignored when creating a product.
         # @!attribute [rw] display_name
         #   @return [String]
         #     The user-provided name for this Product. Must not be empty. Must be at most
-        #      4096 characters long.
+        #     4096 characters long.
         # @!attribute [rw] description
         #   @return [String]
         #     User-provided metadata to be stored with this product. Must be at most 4096
-        #      characters long.
+        #     characters long.
         # @!attribute [rw] product_category
         #   @return [String]
         #     The category for the product identified by the reference image. This should
-        #      be either "homegoods", "apparel", or "toys".
+        #     be either "homegoods", "apparel", or "toys".
         #
-        #      This field is immutable.
+        #     This field is immutable.
         # @!attribute [rw] product_labels
         #   @return [Google::Cloud::Vision::V1::Product::KeyValue]
         #     Key-value pairs that can be attached to a product. At query time,
-        #      constraints can be specified based on the product_labels.
+        #     constraints can be specified based on the product_labels.
         #
-        #      Note that integer values can be provided as strings, e.g. "1199". Only
-        #      strings with integer values can match a range-based restriction which is
-        #      to be supported soon.
+        #     Note that integer values can be provided as strings, e.g. "1199". Only
+        #     strings with integer values can match a range-based restriction which is
+        #     to be supported soon.
         #
-        #      Multiple values can be assigned to the same key. One product may have up to
-        #      100 product_labels.
+        #     Multiple values can be assigned to the same key. One product may have up to
+        #     100 product_labels.
         class Product
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -62,11 +62,11 @@ module Google
           # @!attribute [rw] key
           #   @return [String]
           #     The key of the label attached to the product. Cannot be empty and cannot
-          #      exceed 128 bytes.
+          #     exceed 128 bytes.
           # @!attribute [rw] value
           #   @return [String]
           #     The value of the label attached to the product. Cannot be empty and
-          #      cannot exceed 128 bytes.
+          #     cannot exceed 128 bytes.
           class KeyValue
             include Google::Protobuf::MessageExts
             extend Google::Protobuf::MessageExts::ClassMethods
@@ -74,66 +74,66 @@ module Google
         end
 
         # A ProductSet contains Products. A ProductSet can contain a maximum of 1
-        #  million reference images. If the limit is exceeded, periodic indexing will
-        #  fail.
+        # million reference images. If the limit is exceeded, periodic indexing will
+        # fail.
         # @!attribute [rw] name
         #   @return [String]
         #     The resource name of the ProductSet.
         #
-        #      Format is:
-        #      `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`.
+        #     Format is:
+        #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`.
         #
-        #      This field is ignored when creating a ProductSet.
+        #     This field is ignored when creating a ProductSet.
         # @!attribute [rw] display_name
         #   @return [String]
         #     The user-provided name for this ProductSet. Must not be empty. Must be at
-        #      most 4096 characters long.
+        #     most 4096 characters long.
         # @!attribute [rw] index_time
         #   @return [Google::Protobuf::Timestamp]
         #     Output only. The time at which this ProductSet was last indexed. Query
-        #      results will reflect all updates before this time. If this ProductSet has
-        #      never been indexed, this field is 0.
+        #     results will reflect all updates before this time. If this ProductSet has
+        #     never been indexed, this field is 0.
         #
-        #      This field is ignored when creating a ProductSet.
+        #     This field is ignored when creating a ProductSet.
         # @!attribute [rw] index_error
         #   @return [Google::Rpc::Status]
         #     Output only. If there was an error with indexing the product set, the field
-        #      is populated.
+        #     is populated.
         #
-        #      This field is ignored when creating a ProductSet.
+        #     This field is ignored when creating a ProductSet.
         class ProductSet
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
         # A `ReferenceImage` represents a product image and its associated metadata,
-        #  such as bounding boxes.
+        # such as bounding boxes.
         # @!attribute [rw] name
         #   @return [String]
         #     The resource name of the reference image.
         #
-        #      Format is:
+        #     Format is:
         #
-        #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
+        #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
         #
-        #      This field is ignored when creating a reference image.
+        #     This field is ignored when creating a reference image.
         # @!attribute [rw] uri
         #   @return [String]
         #     The Google Cloud Storage URI of the reference image.
         #
-        #      The URI must start with `gs://`.
+        #     The URI must start with `gs://`.
         #
-        #      Required.
+        #     Required.
         # @!attribute [rw] bounding_polys
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
         #     Bounding polygons around the areas of interest in the reference image.
-        #      Optional. If this field is empty, the system will try to detect regions of
-        #      interest. At most 10 bounding polygons will be used.
+        #     Optional. If this field is empty, the system will try to detect regions of
+        #     interest. At most 10 bounding polygons will be used.
         #
-        #      The provided shape is converted into a non-rotated rectangle. Once
-        #      converted, the small edge of the rectangle must be greater than or equal
-        #      to 300 pixels. The aspect ratio must be 1:4 or less (i.e. 1:3 is ok; 1:5
-        #      is not).
+        #     The provided shape is converted into a non-rotated rectangle. Once
+        #     converted, the small edge of the rectangle must be greater than or equal
+        #     to 300 pixels. The aspect ratio must be 1:4 or less (i.e. 1:3 is ok; 1:5
+        #     is not).
         class ReferenceImage
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -144,17 +144,17 @@ module Google
         #   @return [String]
         #     The project in which the Product should be created.
         #
-        #      Format is
-        #      `projects/PROJECT_ID/locations/LOC_ID`.
+        #     Format is
+        #     `projects/PROJECT_ID/locations/LOC_ID`.
         # @!attribute [rw] product
         #   @return [Google::Cloud::Vision::V1::Product]
         #     The product to create.
         # @!attribute [rw] product_id
         #   @return [String]
         #     A user-supplied resource id for this Product. If set, the server will
-        #      attempt to use this value as the resource id. If it is already in use, an
-        #      error is returned with code ALREADY_EXISTS. Must be at most 128 characters
-        #      long. It cannot contain the character `/`.
+        #     attempt to use this value as the resource id. If it is already in use, an
+        #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
+        #     long. It cannot contain the character `/`.
         class CreateProductRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -165,8 +165,8 @@ module Google
         #   @return [String]
         #     The project OR ProductSet from which Products should be listed.
         #
-        #      Format:
-        #      `projects/PROJECT_ID/locations/LOC_ID`
+        #     Format:
+        #     `projects/PROJECT_ID/locations/LOC_ID`
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     The maximum number of items to return. Default 10, maximum 100.
@@ -185,7 +185,7 @@ module Google
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     Token to retrieve the next page of results, or empty if there are no more
-        #      results in the list.
+        #     results in the list.
         class ListProductsResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -196,8 +196,8 @@ module Google
         #   @return [String]
         #     Resource name of the Product to get.
         #
-        #      Format is:
-        #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+        #     Format is:
+        #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
         class GetProductRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -207,14 +207,14 @@ module Google
         # @!attribute [rw] product
         #   @return [Google::Cloud::Vision::V1::Product]
         #     The Product resource which replaces the one on the server.
-        #      product.name is immutable.
+        #     product.name is immutable.
         # @!attribute [rw] update_mask
         #   @return [Google::Protobuf::FieldMask]
         #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields
-        #      to update.
-        #      If update_mask isn't specified, all mutable fields are to be updated.
-        #      Valid mask paths include `product_labels`, `display_name`, and
-        #      `description`.
+        #     to update.
+        #     If update_mask isn't specified, all mutable fields are to be updated.
+        #     Valid mask paths include `product_labels`, `display_name`, and
+        #     `description`.
         class UpdateProductRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -225,8 +225,8 @@ module Google
         #   @return [String]
         #     Resource name of product to delete.
         #
-        #      Format is:
-        #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+        #     Format is:
+        #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
         class DeleteProductRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -237,16 +237,16 @@ module Google
         #   @return [String]
         #     The project in which the ProductSet should be created.
         #
-        #      Format is `projects/PROJECT_ID/locations/LOC_ID`.
+        #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
         # @!attribute [rw] product_set
         #   @return [Google::Cloud::Vision::V1::ProductSet]
         #     The ProductSet to create.
         # @!attribute [rw] product_set_id
         #   @return [String]
         #     A user-supplied resource id for this ProductSet. If set, the server will
-        #      attempt to use this value as the resource id. If it is already in use, an
-        #      error is returned with code ALREADY_EXISTS. Must be at most 128 characters
-        #      long. It cannot contain the character `/`.
+        #     attempt to use this value as the resource id. If it is already in use, an
+        #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
+        #     long. It cannot contain the character `/`.
         class CreateProductSetRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -257,7 +257,7 @@ module Google
         #   @return [String]
         #     The project from which ProductSets should be listed.
         #
-        #      Format is `projects/PROJECT_ID/locations/LOC_ID`.
+        #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     The maximum number of items to return. Default 10, maximum 100.
@@ -276,7 +276,7 @@ module Google
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     Token to retrieve the next page of results, or empty if there are no more
-        #      results in the list.
+        #     results in the list.
         class ListProductSetsResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -287,8 +287,8 @@ module Google
         #   @return [String]
         #     Resource name of the ProductSet to get.
         #
-        #      Format is:
-        #      `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
+        #     Format is:
+        #     `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
         class GetProductSetRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -301,9 +301,9 @@ module Google
         # @!attribute [rw] update_mask
         #   @return [Google::Protobuf::FieldMask]
         #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields to
-        #      update.
-        #      If update_mask isn't specified, all mutable fields are to be updated.
-        #      Valid mask path is `display_name`.
+        #     update.
+        #     If update_mask isn't specified, all mutable fields are to be updated.
+        #     Valid mask path is `display_name`.
         class UpdateProductSetRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -314,8 +314,8 @@ module Google
         #   @return [String]
         #     Resource name of the ProductSet to delete.
         #
-        #      Format is:
-        #      `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+        #     Format is:
+        #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
         class DeleteProductSetRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -326,18 +326,18 @@ module Google
         #   @return [String]
         #     Resource name of the product in which to create the reference image.
         #
-        #      Format is
-        #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
+        #     Format is
+        #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
         # @!attribute [rw] reference_image
         #   @return [Google::Cloud::Vision::V1::ReferenceImage]
         #     The reference image to create.
-        #      If an image ID is specified, it is ignored.
+        #     If an image ID is specified, it is ignored.
         # @!attribute [rw] reference_image_id
         #   @return [String]
         #     A user-supplied resource id for the ReferenceImage to be added. If set,
-        #      the server will attempt to use this value as the resource id. If it is
-        #      already in use, an error is returned with code ALREADY_EXISTS. Must be at
-        #      most 128 characters long. It cannot contain the character `/`.
+        #     the server will attempt to use this value as the resource id. If it is
+        #     already in use, an error is returned with code ALREADY_EXISTS. Must be at
+        #     most 128 characters long. It cannot contain the character `/`.
         class CreateReferenceImageRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -348,17 +348,17 @@ module Google
         #   @return [String]
         #     Resource name of the product containing the reference images.
         #
-        #      Format is
-        #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
+        #     Format is
+        #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     The maximum number of items to return. Default 10, maximum 100.
         # @!attribute [rw] page_token
         #   @return [String]
         #     A token identifying a page of results to be returned. This is the value
-        #      of `nextPageToken` returned in a previous reference image list request.
+        #     of `nextPageToken` returned in a previous reference image list request.
         #
-        #      Defaults to the first page if not specified.
+        #     Defaults to the first page if not specified.
         class ListReferenceImagesRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -384,9 +384,9 @@ module Google
         #   @return [String]
         #     The resource name of the ReferenceImage to get.
         #
-        #      Format is:
+        #     Format is:
         #
-        #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
+        #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
         class GetReferenceImageRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -397,9 +397,9 @@ module Google
         #   @return [String]
         #     The resource name of the reference image to delete.
         #
-        #      Format is:
+        #     Format is:
         #
-        #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
+        #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
         class DeleteReferenceImageRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -410,14 +410,14 @@ module Google
         #   @return [String]
         #     The resource name for the ProductSet to modify.
         #
-        #      Format is:
-        #      `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+        #     Format is:
+        #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
         # @!attribute [rw] product
         #   @return [String]
         #     The resource name for the Product to be added to this ProductSet.
         #
-        #      Format is:
-        #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+        #     Format is:
+        #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
         class AddProductToProductSetRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -428,14 +428,14 @@ module Google
         #   @return [String]
         #     The resource name for the ProductSet to modify.
         #
-        #      Format is:
-        #      `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+        #     Format is:
+        #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
         # @!attribute [rw] product
         #   @return [String]
         #     The resource name for the Product to be removed from this ProductSet.
         #
-        #      Format is:
-        #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+        #     Format is:
+        #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
         class RemoveProductFromProductSetRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -446,8 +446,8 @@ module Google
         #   @return [String]
         #     The ProductSet resource for which to retrieve Products.
         #
-        #      Format is:
-        #      `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+        #     Format is:
+        #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     The maximum number of items to return. Default 10, maximum 100.
@@ -466,79 +466,79 @@ module Google
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     Token to retrieve the next page of results, or empty if there are no more
-        #      results in the list.
+        #     results in the list.
         class ListProductsInProductSetResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
         # The Google Cloud Storage location for a csv file which preserves a list of
-        #  ImportProductSetRequests in each line.
+        # ImportProductSetRequests in each line.
         # @!attribute [rw] csv_file_uri
         #   @return [String]
         #     The Google Cloud Storage URI of the input csv file.
         #
-        #      The URI must start with `gs://`.
+        #     The URI must start with `gs://`.
         #
-        #      The format of the input csv file should be one image per line.
-        #      In each line, there are 8 columns.
+        #     The format of the input csv file should be one image per line.
+        #     In each line, there are 8 columns.
         #
-        #      1.  image-uri
-        #      2.  image-id
-        #      3.  product-set-id
-        #      4.  product-id
-        #      5.  product-category
-        #      6.  product-display-name
-        #      7.  labels
-        #      8.  bounding-poly
+        #     1.  image-uri
+        #     2.  image-id
+        #     3.  product-set-id
+        #     4.  product-id
+        #     5.  product-category
+        #     6.  product-display-name
+        #     7.  labels
+        #     8.  bounding-poly
         #
-        #      The `image-uri`, `product-set-id`, `product-id`, and `product-category`
-        #      columns are required. All other columns are optional.
+        #     The `image-uri`, `product-set-id`, `product-id`, and `product-category`
+        #     columns are required. All other columns are optional.
         #
-        #      If the `ProductSet` or `Product` specified by the `product-set-id` and
-        #      `product-id` values does not exist, then the system will create a new
-        #      `ProductSet` or `Product` for the image. In this case, the
-        #      `product-display-name` column refers to
-        #      [display_name][google.cloud.vision.v1.Product.display_name], the
-        #      `product-category` column refers to
-        #      [product_category][google.cloud.vision.v1.Product.product_category], and
-        #      the `labels` column refers to
-        #      [product_labels][google.cloud.vision.v1.Product.product_labels].
+        #     If the `ProductSet` or `Product` specified by the `product-set-id` and
+        #     `product-id` values does not exist, then the system will create a new
+        #     `ProductSet` or `Product` for the image. In this case, the
+        #     `product-display-name` column refers to
+        #     [display_name][google.cloud.vision.v1.Product.display_name], the
+        #     `product-category` column refers to
+        #     [product_category][google.cloud.vision.v1.Product.product_category], and
+        #     the `labels` column refers to
+        #     [product_labels][google.cloud.vision.v1.Product.product_labels].
         #
-        #      The `image-id` column is optional but must be unique if provided. If it is
-        #      empty, the system will automatically assign a unique id to the image.
+        #     The `image-id` column is optional but must be unique if provided. If it is
+        #     empty, the system will automatically assign a unique id to the image.
         #
-        #      The `product-display-name` column is optional. If it is empty, the system
-        #      sets the [display_name][google.cloud.vision.v1.Product.display_name] field
-        #      for the product to a space (" "). You can update the `display_name` later
-        #      by using the API.
+        #     The `product-display-name` column is optional. If it is empty, the system
+        #     sets the [display_name][google.cloud.vision.v1.Product.display_name] field
+        #     for the product to a space (" "). You can update the `display_name` later
+        #     by using the API.
         #
-        #      If a `Product` with the specified `product-id` already exists, then the
-        #      system ignores the `product-display-name`, `product-category`, and `labels`
-        #      columns.
+        #     If a `Product` with the specified `product-id` already exists, then the
+        #     system ignores the `product-display-name`, `product-category`, and `labels`
+        #     columns.
         #
-        #      The `labels` column (optional) is a line containing a list of
-        #      comma-separated key-value pairs, in the following format:
+        #     The `labels` column (optional) is a line containing a list of
+        #     comma-separated key-value pairs, in the following format:
         #
-        #          "key_1=value_1,key_2=value_2,...,key_n=value_n"
+        #         "key_1=value_1,key_2=value_2,...,key_n=value_n"
         #
-        #      The `bounding-poly` column (optional) identifies one region of
-        #      interest from the image in the same manner as `CreateReferenceImage`. If
-        #      you do not specify the `bounding-poly` column, then the system will try to
-        #      detect regions of interest automatically.
+        #     The `bounding-poly` column (optional) identifies one region of
+        #     interest from the image in the same manner as `CreateReferenceImage`. If
+        #     you do not specify the `bounding-poly` column, then the system will try to
+        #     detect regions of interest automatically.
         #
-        #      At most one `bounding-poly` column is allowed per line. If the image
-        #      contains multiple regions of interest, add a line to the CSV file that
-        #      includes the same product information, and the `bounding-poly` values for
-        #      each region of interest.
+        #     At most one `bounding-poly` column is allowed per line. If the image
+        #     contains multiple regions of interest, add a line to the CSV file that
+        #     includes the same product information, and the `bounding-poly` values for
+        #     each region of interest.
         #
-        #      The `bounding-poly` column must contain an even number of comma-separated
-        #      numbers, in the format "p1_x,p1_y,p2_x,p2_y,...,pn_x,pn_y". Use
-        #      non-negative integers for absolute bounding polygons, and float values
-        #      in [0, 1] for normalized bounding polygons.
+        #     The `bounding-poly` column must contain an even number of comma-separated
+        #     numbers, in the format "p1_x,p1_y,p2_x,p2_y,...,pn_x,pn_y". Use
+        #     non-negative integers for absolute bounding polygons, and float values
+        #     in [0, 1] for normalized bounding polygons.
         #
-        #      The system will resize the image if the image resolution is too
-        #      large to process (larger than 20MP).
+        #     The system will resize the image if the image resolution is too
+        #     large to process (larger than 20MP).
         class ImportProductSetsGcsSource
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -548,7 +548,7 @@ module Google
         # @!attribute [rw] gcs_source
         #   @return [Google::Cloud::Vision::V1::ImportProductSetsGcsSource]
         #     The Google Cloud Storage location for a csv file which preserves a list
-        #      of ImportProductSetRequests in each line.
+        #     of ImportProductSetRequests in each line.
         class ImportProductSetsInputConfig
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -559,7 +559,7 @@ module Google
         #   @return [String]
         #     The project in which the ProductSets should be imported.
         #
-        #      Format is `projects/PROJECT_ID/locations/LOC_ID`.
+        #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
         # @!attribute [rw] input_config
         #   @return [Google::Cloud::Vision::V1::ImportProductSetsInputConfig]
         #     The input content for the list of requests.
@@ -570,22 +570,22 @@ module Google
 
         # Response message for the `ImportProductSets` method.
         #
-        #  This message is returned by the
-        #  [google.longrunning.Operations.GetOperation][google.longrunning.Operations.GetOperation]
-        #  method in the returned
-        #  [google.longrunning.Operation.response][google.longrunning.Operation.response]
-        #  field.
+        # This message is returned by the
+        # [google.longrunning.Operations.GetOperation][google.longrunning.Operations.GetOperation]
+        # method in the returned
+        # [google.longrunning.Operation.response][google.longrunning.Operation.response]
+        # field.
         # @!attribute [rw] reference_images
         #   @return [Google::Cloud::Vision::V1::ReferenceImage]
         #     The list of reference_images that are imported successfully.
         # @!attribute [rw] statuses
         #   @return [Google::Rpc::Status]
         #     The rpc status for each ImportProductSet request, including both successes
-        #      and errors.
+        #     and errors.
         #
-        #      The number of statuses here matches the number of lines in the csv file,
-        #      and statuses[i] stores the success or failure status of processing the i-th
-        #      line of the csv, starting from line 0.
+        #     The number of statuses here matches the number of lines in the csv file,
+        #     and statuses[i] stores the success or failure status of processing the i-th
+        #     line of the csv, starting from line 0.
         class ImportProductSetsResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -593,8 +593,8 @@ module Google
 
         # Metadata for the batch operations such as the current state.
         #
-        #  This is included in the `metadata` field of the `Operation` returned by the
-        #  `GetOperation` call of the `google::longrunning::Operations` service.
+        # This is included in the `metadata` field of the `Operation` returned by the
+        # `GetOperation` call of the `google::longrunning::Operations` service.
         # @!attribute [rw] state
         #   @return [ENUM(State)]
         #     The current state of the batch operation.
@@ -604,8 +604,8 @@ module Google
         # @!attribute [rw] end_time
         #   @return [Google::Protobuf::Timestamp]
         #     The time when the batch request is finished and
-        #      [google.longrunning.Operation.done][google.longrunning.Operation.done] is
-        #      set to true.
+        #     [google.longrunning.Operation.done][google.longrunning.Operation.done] is
+        #     set to true.
         class BatchOperationMetadata
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -619,15 +619,15 @@ module Google
             PROCESSING = 1
 
             # The request is done and at least one item has been successfully
-            #  processed.
+            # processed.
             SUCCESSFUL = 2
 
             # The request is done and no item has been successfully processed.
             FAILED = 3
 
             # The request is done after the longrunning.Operations.CancelOperation has
-            #  been called by the user.  Any records that were processed before the
-            #  cancel command are output as specified in the request.
+            # been called by the user.  Any records that were processed before the
+            # cancel command are output as specified in the request.
             CANCELLED = 4
           end
         end

--- a/shared/output/cloud/vision/lib/doc/google/cloud/vision/v1/text_annotation.rb
+++ b/shared/output/cloud/vision/lib/doc/google/cloud/vision/v1/text_annotation.rb
@@ -21,13 +21,13 @@ module Google
     module Vision
       module V1
         # TextAnnotation contains a structured representation of OCR extracted text.
-        #  The hierarchy of an OCR extracted text structure is like this:
-        #      TextAnnotation -> Page -> Block -> Paragraph -> Word -> Symbol
-        #  Each structural component, starting from Page, may further have their own
-        #  properties. Properties describe detected languages, breaks etc.. Please refer
-        #  to the
-        #  [TextAnnotation.TextProperty][google.cloud.vision.v1.TextAnnotation.TextProperty]
-        #  message definition below for more detail.
+        # The hierarchy of an OCR extracted text structure is like this:
+        #     TextAnnotation -> Page -> Block -> Paragraph -> Word -> Symbol
+        # Each structural component, starting from Page, may further have their own
+        # properties. Properties describe detected languages, breaks etc.. Please refer
+        # to the
+        # [TextAnnotation.TextProperty][google.cloud.vision.v1.TextAnnotation.TextProperty]
+        # message definition below for more detail.
         # @!attribute [rw] pages
         #   @return [Google::Cloud::Vision::V1::Page]
         #     List of pages detected by OCR.
@@ -42,8 +42,8 @@ module Google
           # @!attribute [rw] language_code
           #   @return [String]
           #     The BCP-47 language code, such as "en-US" or "sr-Latn". For more
-          #      information, see
-          #      http://www.unicode.org/reports/tr35/#Unicode_locale_identifier.
+          #     information, see
+          #     http://www.unicode.org/reports/tr35/#Unicode_locale_identifier.
           # @!attribute [rw] confidence
           #   @return [Float]
           #     Confidence of detected language. Range [0, 1].
@@ -78,7 +78,7 @@ module Google
               EOL_SURE_SPACE = 3
 
               # End-line hyphen that is not present in text; does not co-occur with
-              #  `SPACE`, `LEADER_SPACE`, or `LINE_BREAK`.
+              # `SPACE`, `LEADER_SPACE`, or `LINE_BREAK`.
               HYPHEN = 4
 
               # Line break that ends a paragraph.
@@ -106,11 +106,11 @@ module Google
         # @!attribute [rw] width
         #   @return [Integer]
         #     Page width. For PDFs the unit is points. For images (including
-        #      TIFFs) the unit is pixels.
+        #     TIFFs) the unit is pixels.
         # @!attribute [rw] height
         #   @return [Integer]
         #     Page height. For PDFs the unit is points. For images (including
-        #      TIFFs) the unit is pixels.
+        #     TIFFs) the unit is pixels.
         # @!attribute [rw] blocks
         #   @return [Google::Cloud::Vision::V1::Block]
         #     List of blocks of text, images etc on this page.
@@ -129,25 +129,25 @@ module Google
         # @!attribute [rw] bounding_box
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
         #     The bounding box for the block.
-        #      The vertices are in the order of top-left, top-right, bottom-right,
-        #      bottom-left. When a rotation of the bounding box is detected the rotation
-        #      is represented as around the top-left corner as defined when the text is
-        #      read in the 'natural' orientation.
-        #      For example:
+        #     The vertices are in the order of top-left, top-right, bottom-right,
+        #     bottom-left. When a rotation of the bounding box is detected the rotation
+        #     is represented as around the top-left corner as defined when the text is
+        #     read in the 'natural' orientation.
+        #     For example:
         #
-        #      * when the text is horizontal it might look like:
+        #     * when the text is horizontal it might look like:
         #
-        #              0----1
-        #              |    |
-        #              3----2
+        #             0----1
+        #             |    |
+        #             3----2
         #
-        #      * when it's rotated 180 degrees around the top-left corner it becomes:
+        #     * when it's rotated 180 degrees around the top-left corner it becomes:
         #
-        #              2----3
-        #              |    |
-        #              1----0
+        #             2----3
+        #             |    |
+        #             1----0
         #
-        #        and the vertex order will still be (0, 1, 2, 3).
+        #       and the vertex order will still be (0, 1, 2, 3).
         # @!attribute [rw] paragraphs
         #   @return [Google::Cloud::Vision::V1::Paragraph]
         #     List of paragraphs in this block (if this blocks is of type text).
@@ -190,20 +190,20 @@ module Google
         # @!attribute [rw] bounding_box
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
         #     The bounding box for the paragraph.
-        #      The vertices are in the order of top-left, top-right, bottom-right,
-        #      bottom-left. When a rotation of the bounding box is detected the rotation
-        #      is represented as around the top-left corner as defined when the text is
-        #      read in the 'natural' orientation.
-        #      For example:
-        #        * when the text is horizontal it might look like:
-        #           0----1
-        #           |    |
-        #           3----2
-        #        * when it's rotated 180 degrees around the top-left corner it becomes:
-        #           2----3
-        #           |    |
-        #           1----0
-        #        and the vertex order will still be (0, 1, 2, 3).
+        #     The vertices are in the order of top-left, top-right, bottom-right,
+        #     bottom-left. When a rotation of the bounding box is detected the rotation
+        #     is represented as around the top-left corner as defined when the text is
+        #     read in the 'natural' orientation.
+        #     For example:
+        #       * when the text is horizontal it might look like:
+        #          0----1
+        #          |    |
+        #          3----2
+        #       * when it's rotated 180 degrees around the top-left corner it becomes:
+        #          2----3
+        #          |    |
+        #          1----0
+        #       and the vertex order will still be (0, 1, 2, 3).
         # @!attribute [rw] words
         #   @return [Google::Cloud::Vision::V1::Word]
         #     List of words in this paragraph.
@@ -222,24 +222,24 @@ module Google
         # @!attribute [rw] bounding_box
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
         #     The bounding box for the word.
-        #      The vertices are in the order of top-left, top-right, bottom-right,
-        #      bottom-left. When a rotation of the bounding box is detected the rotation
-        #      is represented as around the top-left corner as defined when the text is
-        #      read in the 'natural' orientation.
-        #      For example:
-        #        * when the text is horizontal it might look like:
-        #           0----1
-        #           |    |
-        #           3----2
-        #        * when it's rotated 180 degrees around the top-left corner it becomes:
-        #           2----3
-        #           |    |
-        #           1----0
-        #        and the vertex order will still be (0, 1, 2, 3).
+        #     The vertices are in the order of top-left, top-right, bottom-right,
+        #     bottom-left. When a rotation of the bounding box is detected the rotation
+        #     is represented as around the top-left corner as defined when the text is
+        #     read in the 'natural' orientation.
+        #     For example:
+        #       * when the text is horizontal it might look like:
+        #          0----1
+        #          |    |
+        #          3----2
+        #       * when it's rotated 180 degrees around the top-left corner it becomes:
+        #          2----3
+        #          |    |
+        #          1----0
+        #       and the vertex order will still be (0, 1, 2, 3).
         # @!attribute [rw] symbols
         #   @return [Google::Cloud::Vision::V1::Symbol]
         #     List of symbols in the word.
-        #      The order of the symbols follows the natural reading order.
+        #     The order of the symbols follows the natural reading order.
         # @!attribute [rw] confidence
         #   @return [Float]
         #     Confidence of the OCR results for the word. Range [0, 1].
@@ -255,20 +255,20 @@ module Google
         # @!attribute [rw] bounding_box
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
         #     The bounding box for the symbol.
-        #      The vertices are in the order of top-left, top-right, bottom-right,
-        #      bottom-left. When a rotation of the bounding box is detected the rotation
-        #      is represented as around the top-left corner as defined when the text is
-        #      read in the 'natural' orientation.
-        #      For example:
-        #        * when the text is horizontal it might look like:
-        #           0----1
-        #           |    |
-        #           3----2
-        #        * when it's rotated 180 degrees around the top-left corner it becomes:
-        #           2----3
-        #           |    |
-        #           1----0
-        #        and the vertice order will still be (0, 1, 2, 3).
+        #     The vertices are in the order of top-left, top-right, bottom-right,
+        #     bottom-left. When a rotation of the bounding box is detected the rotation
+        #     is represented as around the top-left corner as defined when the text is
+        #     read in the 'natural' orientation.
+        #     For example:
+        #       * when the text is horizontal it might look like:
+        #          0----1
+        #          |    |
+        #          3----2
+        #       * when it's rotated 180 degrees around the top-left corner it becomes:
+        #          2----3
+        #          |    |
+        #          1----0
+        #       and the vertice order will still be (0, 1, 2, 3).
         # @!attribute [rw] text
         #   @return [String]
         #     The actual UTF-8 representation of the symbol.

--- a/shared/output/cloud/vision/lib/doc/google/cloud/vision/v1/web_detection.rb
+++ b/shared/output/cloud/vision/lib/doc/google/cloud/vision/v1/web_detection.rb
@@ -27,12 +27,12 @@ module Google
         # @!attribute [rw] full_matching_images
         #   @return [Google::Cloud::Vision::V1::WebDetection::WebImage]
         #     Fully matching images from the Internet.
-        #      Can include resized copies of the query image.
+        #     Can include resized copies of the query image.
         # @!attribute [rw] partial_matching_images
         #   @return [Google::Cloud::Vision::V1::WebDetection::WebImage]
         #     Partial matching images from the Internet.
-        #      Those images are similar enough to share some key-point features. For
-        #      example an original image will likely have partial matching for its crops.
+        #     Those images are similar enough to share some key-point features. For
+        #     example an original image will likely have partial matching for its crops.
         # @!attribute [rw] pages_with_matching_images
         #   @return [Google::Cloud::Vision::V1::WebDetection::WebPage]
         #     Web pages containing the matching images from the Internet.
@@ -42,7 +42,7 @@ module Google
         # @!attribute [rw] best_guess_labels
         #   @return [Google::Cloud::Vision::V1::WebDetection::WebLabel]
         #     The service's best guess as to the topic of the request image.
-        #      Inferred from similar images on the open web.
+        #     Inferred from similar images on the open web.
         class WebDetection
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -54,7 +54,7 @@ module Google
           # @!attribute [rw] score
           #   @return [Float]
           #     Overall relevancy score for the entity.
-          #      Not normalized and not comparable across different image queries.
+          #     Not normalized and not comparable across different image queries.
           # @!attribute [rw] description
           #   @return [String]
           #     Canonical description of the entity, in English.
@@ -88,13 +88,13 @@ module Google
           # @!attribute [rw] full_matching_images
           #   @return [Google::Cloud::Vision::V1::WebDetection::WebImage]
           #     Fully matching images on the page.
-          #      Can include resized copies of the query image.
+          #     Can include resized copies of the query image.
           # @!attribute [rw] partial_matching_images
           #   @return [Google::Cloud::Vision::V1::WebDetection::WebImage]
           #     Partial matching images on the page.
-          #      Those images are similar enough to share some key-point features. For
-          #      example an original image will likely have partial matching for its
-          #      crops.
+          #     Those images are similar enough to share some key-point features. For
+          #     example an original image will likely have partial matching for its
+          #     crops.
           class WebPage
             include Google::Protobuf::MessageExts
             extend Google::Protobuf::MessageExts::ClassMethods
@@ -107,8 +107,8 @@ module Google
           # @!attribute [rw] language_code
           #   @return [String]
           #     The BCP-47 language code for `label`, such as "en-US" or "sr-Latn".
-          #      For more information, see
-          #      http://www.unicode.org/reports/tr35/#Unicode_locale_identifier.
+          #     For more information, see
+          #     http://www.unicode.org/reports/tr35/#Unicode_locale_identifier.
           class WebLabel
             include Google::Protobuf::MessageExts
             extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/vision/lib/doc/google/longrunning/operations.rb
+++ b/shared/output/cloud/vision/lib/doc/google/longrunning/operations.rb
@@ -19,36 +19,36 @@ raise "This file is for documentation purposes only."
 module Google
   module Longrunning
     # This resource represents a long-running operation that is the result of a
-    #  network API call.
+    # network API call.
     # @!attribute [rw] name
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
-    #      originally returns it. If you use the default HTTP mapping, the
-    #      `name` should have the format of `operations/some/unique/name`.
+    #     originally returns it. If you use the default HTTP mapping, the
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
-    #      contains progress information and common metadata such as create time.
-    #      Some services might not provide such metadata.  Any method that returns a
-    #      long-running operation should document the metadata type, if any.
+    #     contains progress information and common metadata such as create time.
+    #     Some services might not provide such metadata.  Any method that returns a
+    #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [Boolean]
     #     If the value is `false`, it means the operation is still in progress.
-    #      If true, the operation is completed, and either `error` or `response` is
-    #      available.
+    #     If true, the operation is completed, and either `error` or `response` is
+    #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
     #     The error result of the operation in case of failure or cancellation.
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #      method returns no data on success, such as `Delete`, the response is
-    #      `google.protobuf.Empty`.  If the original method is standard
-    #      `Get`/`Create`/`Update`, the response should be the resource.  For other
-    #      methods, the response should have the type `XxxResponse`, where `Xxx`
-    #      is the original method name.  For example, if the original method name
-    #      is `TakeSnapshot()`, the inferred response type is
-    #      `TakeSnapshotResponse`.
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
+    #     is the original method name.  For example, if the original method name
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -113,34 +113,34 @@ module Google
 
     # A message representing the message types used by a long-running operation.
     #
-    #  Example:
+    # Example:
     #
-    #    rpc LongRunningRecognize(LongRunningRecognizeRequest)
-    #        returns (google.longrunning.Operation) {
-    #      option (google.longrunning.operation_info) = {
-    #        response_type: "LongRunningRecognizeResponse"
-    #        metadata_type: "LongRunningRecognizeMetadata"
-    #      };
-    #    }
+    #   rpc LongRunningRecognize(LongRunningRecognizeRequest)
+    #       returns (google.longrunning.Operation) {
+    #     option (google.longrunning.operation_info) = {
+    #       response_type: "LongRunningRecognizeResponse"
+    #       metadata_type: "LongRunningRecognizeMetadata"
+    #     };
+    #   }
     # @!attribute [rw] response_type
     #   @return [String]
     #     Required. The message name of the primary return type for this
-    #      long-running operation.
-    #      This type will be used to deserialize the LRO's response.
+    #     long-running operation.
+    #     This type will be used to deserialize the LRO's response.
     #
-    #      If the response is in a different package from the rpc, a fully-qualified
-    #      message name must be used (e.g. `google.protobuf.Struct`).
+    #     If the response is in a different package from the rpc, a fully-qualified
+    #     message name must be used (e.g. `google.protobuf.Struct`).
     #
-    #      Note: Altering this value constitutes a breaking change.
+    #     Note: Altering this value constitutes a breaking change.
     # @!attribute [rw] metadata_type
     #   @return [String]
     #     Required. The message name of the metadata type for this long-running
-    #      operation.
+    #     operation.
     #
-    #      If the response is in a different package from the rpc, a fully-qualified
-    #      message name must be used (e.g. `google.protobuf.Struct`).
+    #     If the response is in a different package from the rpc, a fully-qualified
+    #     message name must be used (e.g. `google.protobuf.Struct`).
     #
-    #      Note: Altering this value constitutes a breaking change.
+    #     Note: Altering this value constitutes a breaking change.
     class OperationInfo
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/vision/lib/doc/google/protobuf/any.rb
+++ b/shared/output/cloud/vision/lib/doc/google/protobuf/any.rb
@@ -19,112 +19,112 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # `Any` contains an arbitrary serialized protocol buffer message along with a
-    #  URL that describes the type of the serialized message.
+    # URL that describes the type of the serialized message.
     #
-    #  Protobuf library provides support to pack/unpack Any values in the form
-    #  of utility functions or additional generated methods of the Any type.
+    # Protobuf library provides support to pack/unpack Any values in the form
+    # of utility functions or additional generated methods of the Any type.
     #
-    #  Example 1: Pack and unpack a message in C++.
+    # Example 1: Pack and unpack a message in C++.
     #
-    #      Foo foo = ...;
-    #      Any any;
-    #      any.PackFrom(foo);
-    #      ...
-    #      if (any.UnpackTo(&foo)) {
-    #        ...
-    #      }
-    #
-    #  Example 2: Pack and unpack a message in Java.
-    #
-    #      Foo foo = ...;
-    #      Any any = Any.pack(foo);
-    #      ...
-    #      if (any.is(Foo.class)) {
-    #        foo = any.unpack(Foo.class);
-    #      }
-    #
-    #   Example 3: Pack and unpack a message in Python.
-    #
-    #      foo = Foo(...)
-    #      any = Any()
-    #      any.Pack(foo)
-    #      ...
-    #      if any.Is(Foo.DESCRIPTOR):
-    #        any.Unpack(foo)
-    #        ...
-    #
-    #   Example 4: Pack and unpack a message in Go
-    #
-    #       foo := &pb.Foo{...}
-    #       any, err := ptypes.MarshalAny(foo)
+    #     Foo foo = ...;
+    #     Any any;
+    #     any.PackFrom(foo);
+    #     ...
+    #     if (any.UnpackTo(&foo)) {
     #       ...
-    #       foo := &pb.Foo{}
-    #       if err := ptypes.UnmarshalAny(any, foo); err != nil {
-    #         ...
-    #       }
+    #     }
     #
-    #  The pack methods provided by protobuf library will by default use
-    #  'type.googleapis.com/full.type.name' as the type URL and the unpack
-    #  methods only use the fully qualified type name after the last '/'
-    #  in the type URL, for example "foo.bar.com/x/y.z" will yield type
-    #  name "y.z".
+    # Example 2: Pack and unpack a message in Java.
     #
+    #     Foo foo = ...;
+    #     Any any = Any.pack(foo);
+    #     ...
+    #     if (any.is(Foo.class)) {
+    #       foo = any.unpack(Foo.class);
+    #     }
     #
-    #  JSON
-    #  ====
-    #  The JSON representation of an `Any` value uses the regular
-    #  representation of the deserialized, embedded message, with an
-    #  additional field `@type` which contains the type URL. Example:
+    #  Example 3: Pack and unpack a message in Python.
     #
-    #      package google.profile;
-    #      message Person {
-    #        string first_name = 1;
-    #        string last_name = 2;
+    #     foo = Foo(...)
+    #     any = Any()
+    #     any.Pack(foo)
+    #     ...
+    #     if any.Is(Foo.DESCRIPTOR):
+    #       any.Unpack(foo)
+    #       ...
+    #
+    #  Example 4: Pack and unpack a message in Go
+    #
+    #      foo := &pb.Foo{...}
+    #      any, err := ptypes.MarshalAny(foo)
+    #      ...
+    #      foo := &pb.Foo{}
+    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #        ...
     #      }
     #
-    #      {
-    #        "@type": "type.googleapis.com/google.profile.Person",
-    #        "firstName": <string>,
-    #        "lastName": <string>
-    #      }
+    # The pack methods provided by protobuf library will by default use
+    # 'type.googleapis.com/full.type.name' as the type URL and the unpack
+    # methods only use the fully qualified type name after the last '/'
+    # in the type URL, for example "foo.bar.com/x/y.z" will yield type
+    # name "y.z".
     #
-    #  If the embedded message type is well-known and has a custom JSON
-    #  representation, that representation will be embedded adding a field
-    #  `value` which holds the custom JSON in addition to the `@type`
-    #  field. Example (for message [google.protobuf.Duration][]):
     #
-    #      {
-    #        "@type": "type.googleapis.com/google.protobuf.Duration",
-    #        "value": "1.212s"
-    #      }
+    # JSON
+    # ====
+    # The JSON representation of an `Any` value uses the regular
+    # representation of the deserialized, embedded message, with an
+    # additional field `@type` which contains the type URL. Example:
+    #
+    #     package google.profile;
+    #     message Person {
+    #       string first_name = 1;
+    #       string last_name = 2;
+    #     }
+    #
+    #     {
+    #       "@type": "type.googleapis.com/google.profile.Person",
+    #       "firstName": <string>,
+    #       "lastName": <string>
+    #     }
+    #
+    # If the embedded message type is well-known and has a custom JSON
+    # representation, that representation will be embedded adding a field
+    # `value` which holds the custom JSON in addition to the `@type`
+    # field. Example (for message [google.protobuf.Duration][]):
+    #
+    #     {
+    #       "@type": "type.googleapis.com/google.protobuf.Duration",
+    #       "value": "1.212s"
+    #     }
     # @!attribute [rw] type_url
     #   @return [String]
     #     A URL/resource name that uniquely identifies the type of the serialized
-    #      protocol buffer message. The last segment of the URL's path must represent
-    #      the fully qualified name of the type (as in
-    #      `path/google.protobuf.Duration`). The name should be in a canonical form
-    #      (e.g., leading "." is not accepted).
+    #     protocol buffer message. The last segment of the URL's path must represent
+    #     the fully qualified name of the type (as in
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
+    #     (e.g., leading "." is not accepted).
     #
-    #      In practice, teams usually precompile into the binary all types that they
-    #      expect it to use in the context of Any. However, for URLs which use the
-    #      scheme `http`, `https`, or no scheme, one can optionally set up a type
-    #      server that maps type URLs to message definitions as follows:
+    #     In practice, teams usually precompile into the binary all types that they
+    #     expect it to use in the context of Any. However, for URLs which use the
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
+    #     server that maps type URLs to message definitions as follows:
     #
-    #      * If no scheme is provided, `https` is assumed.
-    #      * An HTTP GET on the URL must yield a [google.protobuf.Type][]
-    #        value in binary format, or produce an error.
-    #      * Applications are allowed to cache lookup results based on the
-    #        URL, or have them precompiled into a binary to avoid any
-    #        lookup. Therefore, binary compatibility needs to be preserved
-    #        on changes to types. (Use versioned type names to manage
-    #        breaking changes.)
+    #     * If no scheme is provided, `https` is assumed.
+    #     * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+    #       value in binary format, or produce an error.
+    #     * Applications are allowed to cache lookup results based on the
+    #       URL, or have them precompiled into a binary to avoid any
+    #       lookup. Therefore, binary compatibility needs to be preserved
+    #       on changes to types. (Use versioned type names to manage
+    #       breaking changes.)
     #
-    #      Note: this functionality is not currently available in the official
-    #      protobuf release, and it is not used for type URLs beginning with
-    #      type.googleapis.com.
+    #     Note: this functionality is not currently available in the official
+    #     protobuf release, and it is not used for type URLs beginning with
+    #     type.googleapis.com.
     #
-    #      Schemes other than `http`, `https` (or the empty scheme) might be
-    #      used with implementation specific semantics.
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
+    #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]
     #     Must be a valid serialized protocol buffer of the above specified type.

--- a/shared/output/cloud/vision/lib/doc/google/protobuf/descriptor.rb
+++ b/shared/output/cloud/vision/lib/doc/google/protobuf/descriptor.rb
@@ -19,7 +19,7 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # The protocol compiler can output a FileDescriptorSet containing the .proto
-    #  files it parses.
+    # files it parses.
     # @!attribute [rw] file
     #   @return [Google::Protobuf::FileDescriptorProto]
     class FileDescriptorSet
@@ -41,7 +41,7 @@ module Google
     # @!attribute [rw] weak_dependency
     #   @return [Integer]
     #     Indexes of the weak imported files in the dependency list.
-    #      For Google-internal migration only. Do not use.
+    #     For Google-internal migration only. Do not use.
     # @!attribute [rw] message_type
     #   @return [Google::Protobuf::DescriptorProto]
     #     All top-level definitions in this file.
@@ -56,13 +56,13 @@ module Google
     # @!attribute [rw] source_code_info
     #   @return [Google::Protobuf::SourceCodeInfo]
     #     This field contains optional information about the original source code.
-    #      You may safely remove this entire field without harming runtime
-    #      functionality of the descriptors -- the information is needed only by
-    #      development tools.
+    #     You may safely remove this entire field without harming runtime
+    #     functionality of the descriptors -- the information is needed only by
+    #     development tools.
     # @!attribute [rw] syntax
     #   @return [String]
     #     The syntax of the proto file.
-    #      The supported values are "proto2" and "proto3".
+    #     The supported values are "proto2" and "proto3".
     class FileDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -90,7 +90,7 @@ module Google
     # @!attribute [rw] reserved_name
     #   @return [String]
     #     Reserved field names, which may not be used by fields in the same message.
-    #      A given name may only be reserved once.
+    #     A given name may only be reserved once.
     class DescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -107,8 +107,8 @@ module Google
       end
 
       # Range of reserved tag numbers. Reserved tag numbers may not be used by
-      #  fields or extension ranges in the same message. Reserved ranges may
-      #  not overlap.
+      # fields or extension ranges in the same message. Reserved ranges may
+      # not overlap.
       # @!attribute [rw] start
       #   @return [Integer]
       # @!attribute [rw] end
@@ -137,35 +137,35 @@ module Google
     # @!attribute [rw] type
     #   @return [ENUM(Type)]
     #     If type_name is set, this need not be set.  If both this and type_name
-    #      are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
+    #     are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
     # @!attribute [rw] type_name
     #   @return [String]
     #     For message and enum types, this is the name of the type.  If the name
-    #      starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
-    #      rules are used to find the type (i.e. first the nested types within this
-    #      message are searched, then within the parent, on up to the root
-    #      namespace).
+    #     starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+    #     rules are used to find the type (i.e. first the nested types within this
+    #     message are searched, then within the parent, on up to the root
+    #     namespace).
     # @!attribute [rw] extendee
     #   @return [String]
     #     For extensions, this is the name of the type being extended.  It is
-    #      resolved in the same manner as type_name.
+    #     resolved in the same manner as type_name.
     # @!attribute [rw] default_value
     #   @return [String]
     #     For numeric types, contains the original text representation of the value.
-    #      For booleans, "true" or "false".
-    #      For strings, contains the default text contents (not escaped in any way).
-    #      For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
-    #      TODO(kenton):  Base-64 encode?
+    #     For booleans, "true" or "false".
+    #     For strings, contains the default text contents (not escaped in any way).
+    #     For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
+    #     TODO(kenton):  Base-64 encode?
     # @!attribute [rw] oneof_index
     #   @return [Integer]
     #     If set, gives the index of a oneof in the containing type's oneof_decl
-    #      list.  This field is a member of that oneof.
+    #     list.  This field is a member of that oneof.
     # @!attribute [rw] json_name
     #   @return [String]
     #     JSON name of this field. The value is set by protocol compiler. If the
-    #      user has set a "json_name" option on this field, that option's value
-    #      will be used. Otherwise, it's deduced from the field's name by converting
-    #      it to camelCase.
+    #     user has set a "json_name" option on this field, that option's value
+    #     will be used. Otherwise, it's deduced from the field's name by converting
+    #     it to camelCase.
     # @!attribute [rw] options
     #   @return [Google::Protobuf::FieldOption]
     class FieldDescriptorProto
@@ -174,19 +174,19 @@ module Google
 
       module Type
         # 0 is reserved for errors.
-        #  Order is weird for historical reasons.
+        # Order is weird for historical reasons.
         TYPE_DOUBLE = 1
 
         TYPE_FLOAT = 2
 
         # Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
-        #  negative values are likely.
+        # negative values are likely.
         TYPE_INT64 = 3
 
         TYPE_UINT64 = 4
 
         # Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
-        #  negative values are likely.
+        # negative values are likely.
         TYPE_INT32 = 5
 
         TYPE_FIXED64 = 6
@@ -198,9 +198,9 @@ module Google
         TYPE_STRING = 9
 
         # Tag-delimited aggregate.
-        #  Group type is deprecated and not supported in proto3. However, Proto3
-        #  implementations should still be able to parse the group wire format and
-        #  treat group fields as unknown fields.
+        # Group type is deprecated and not supported in proto3. However, Proto3
+        # implementations should still be able to parse the group wire format and
+        # treat group fields as unknown fields.
         TYPE_GROUP = 10
 
         TYPE_MESSAGE = 11
@@ -251,22 +251,22 @@ module Google
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::EnumDescriptorProto::EnumReservedRange]
     #     Range of reserved numeric values. Reserved numeric values may not be used
-    #      by enum values in the same enum declaration. Reserved ranges may not
-    #      overlap.
+    #     by enum values in the same enum declaration. Reserved ranges may not
+    #     overlap.
     # @!attribute [rw] reserved_name
     #   @return [String]
     #     Reserved enum value names, which may not be reused. A given name may only
-    #      be reserved once.
+    #     be reserved once.
     class EnumDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
 
       # Range of reserved numeric values. Reserved values may not be used by
-      #  entries in the same enum. Reserved ranges may not overlap.
+      # entries in the same enum. Reserved ranges may not overlap.
       #
-      #  Note that this is distinct from DescriptorProto.ReservedRange in that it
-      #  is inclusive such that it can appropriately represent the entire int32
-      #  domain.
+      # Note that this is distinct from DescriptorProto.ReservedRange in that it
+      # is inclusive such that it can appropriately represent the entire int32
+      # domain.
       # @!attribute [rw] start
       #   @return [Integer]
       # @!attribute [rw] end
@@ -307,7 +307,7 @@ module Google
     # @!attribute [rw] input_type
     #   @return [String]
     #     Input and output type names.  These are resolved in the same way as
-    #      FieldDescriptorProto.type_name, but must refer to a message type.
+    #     FieldDescriptorProto.type_name, but must refer to a message type.
     # @!attribute [rw] output_type
     #   @return [String]
     # @!attribute [rw] options
@@ -326,56 +326,56 @@ module Google
     # @!attribute [rw] java_package
     #   @return [String]
     #     Sets the Java package where classes generated from this .proto will be
-    #      placed.  By default, the proto package is used, but this is often
-    #      inappropriate because proto packages do not normally start with backwards
-    #      domain names.
+    #     placed.  By default, the proto package is used, but this is often
+    #     inappropriate because proto packages do not normally start with backwards
+    #     domain names.
     # @!attribute [rw] java_outer_classname
     #   @return [String]
     #     If set, all the classes from the .proto file are wrapped in a single
-    #      outer class with the given name.  This applies to both Proto1
-    #      (equivalent to the old "--one_java_file" option) and Proto2 (where
-    #      a .proto always translates to a single class, but you may want to
-    #      explicitly choose the class name).
+    #     outer class with the given name.  This applies to both Proto1
+    #     (equivalent to the old "--one_java_file" option) and Proto2 (where
+    #     a .proto always translates to a single class, but you may want to
+    #     explicitly choose the class name).
     # @!attribute [rw] java_multiple_files
     #   @return [Boolean]
     #     If set true, then the Java code generator will generate a separate .java
-    #      file for each top-level message, enum, and service defined in the .proto
-    #      file.  Thus, these types will *not* be nested inside the outer class
-    #      named by java_outer_classname.  However, the outer class will still be
-    #      generated to contain the file's getDescriptor() method as well as any
-    #      top-level extensions defined in the file.
+    #     file for each top-level message, enum, and service defined in the .proto
+    #     file.  Thus, these types will *not* be nested inside the outer class
+    #     named by java_outer_classname.  However, the outer class will still be
+    #     generated to contain the file's getDescriptor() method as well as any
+    #     top-level extensions defined in the file.
     # @!attribute [rw] java_generate_equals_and_hash
     #   @return [Boolean]
     #     This option does nothing.
     # @!attribute [rw] java_string_check_utf8
     #   @return [Boolean]
     #     If set true, then the Java2 code generator will generate code that
-    #      throws an exception whenever an attempt is made to assign a non-UTF-8
-    #      byte sequence to a string field.
-    #      Message reflection will do the same.
-    #      However, an extension field still accepts non-UTF-8 byte sequences.
-    #      This option has no effect on when used with the lite runtime.
+    #     throws an exception whenever an attempt is made to assign a non-UTF-8
+    #     byte sequence to a string field.
+    #     Message reflection will do the same.
+    #     However, an extension field still accepts non-UTF-8 byte sequences.
+    #     This option has no effect on when used with the lite runtime.
     # @!attribute [rw] optimize_for
     #   @return [ENUM(OptimizeMode)]
     # @!attribute [rw] go_package
     #   @return [String]
     #     Sets the Go package where structs generated from this .proto will be
-    #      placed. If omitted, the Go package will be derived from the following:
-    #        - The basename of the package import path, if provided.
-    #        - Otherwise, the package statement in the .proto file, if present.
-    #        - Otherwise, the basename of the .proto file, without extension.
+    #     placed. If omitted, the Go package will be derived from the following:
+    #       - The basename of the package import path, if provided.
+    #       - Otherwise, the package statement in the .proto file, if present.
+    #       - Otherwise, the basename of the .proto file, without extension.
     # @!attribute [rw] cc_generic_services
     #   @return [Boolean]
     #     Should generic services be generated in each language?  "Generic" services
-    #      are not specific to any particular RPC system.  They are generated by the
-    #      main code generators in each language (without additional plugins).
-    #      Generic services were the only kind of service generation supported by
-    #      early versions of google.protobuf.
+    #     are not specific to any particular RPC system.  They are generated by the
+    #     main code generators in each language (without additional plugins).
+    #     Generic services were the only kind of service generation supported by
+    #     early versions of google.protobuf.
     #
-    #      Generic services are now considered deprecated in favor of using plugins
-    #      that generate code specific to your particular RPC system.  Therefore,
-    #      these default to false.  Old code which depends on generic services should
-    #      explicitly set them to true.
+    #     Generic services are now considered deprecated in favor of using plugins
+    #     that generate code specific to your particular RPC system.  Therefore,
+    #     these default to false.  Old code which depends on generic services should
+    #     explicitly set them to true.
     # @!attribute [rw] java_generic_services
     #   @return [Boolean]
     # @!attribute [rw] py_generic_services
@@ -385,49 +385,49 @@ module Google
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this file deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for everything in the file, or it will be completely ignored; in the very
-    #      least, this is a formalization for deprecating files.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for everything in the file, or it will be completely ignored; in the very
+    #     least, this is a formalization for deprecating files.
     # @!attribute [rw] cc_enable_arenas
     #   @return [Boolean]
     #     Enables the use of arenas for the proto messages in this file. This applies
-    #      only to generated classes for C++.
+    #     only to generated classes for C++.
     # @!attribute [rw] objc_class_prefix
     #   @return [String]
     #     Sets the objective c class prefix which is prepended to all objective c
-    #      generated classes from this .proto. There is no default.
+    #     generated classes from this .proto. There is no default.
     # @!attribute [rw] csharp_namespace
     #   @return [String]
     #     Namespace for generated classes; defaults to the package.
     # @!attribute [rw] swift_prefix
     #   @return [String]
     #     By default Swift generators will take the proto package and CamelCase it
-    #      replacing '.' with underscore and use that to prefix the types/symbols
-    #      defined. When this options is provided, they will use this value instead
-    #      to prefix the types/symbols defined.
+    #     replacing '.' with underscore and use that to prefix the types/symbols
+    #     defined. When this options is provided, they will use this value instead
+    #     to prefix the types/symbols defined.
     # @!attribute [rw] php_class_prefix
     #   @return [String]
     #     Sets the php class prefix which is prepended to all php generated classes
-    #      from this .proto. Default is empty.
+    #     from this .proto. Default is empty.
     # @!attribute [rw] php_namespace
     #   @return [String]
     #     Use this option to change the namespace of php generated classes. Default
-    #      is empty. When this option is empty, the package name will be used for
-    #      determining the namespace.
+    #     is empty. When this option is empty, the package name will be used for
+    #     determining the namespace.
     # @!attribute [rw] php_metadata_namespace
     #   @return [String]
     #     Use this option to change the namespace of php generated metadata classes.
-    #      Default is empty. When this option is empty, the proto file name will be used
-    #      for determining the namespace.
+    #     Default is empty. When this option is empty, the proto file name will be used
+    #     for determining the namespace.
     # @!attribute [rw] ruby_package
     #   @return [String]
     #     Use this option to change the package of ruby generated classes. Default
-    #      is empty. When this option is not set, the package name will be used for
-    #      determining the ruby package.
+    #     is empty. When this option is not set, the package name will be used for
+    #     determining the ruby package.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here.
-    #      See the documentation for the "Options" section above.
+    #     See the documentation for the "Options" section above.
     class FileOptions
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -446,57 +446,57 @@ module Google
     # @!attribute [rw] message_set_wire_format
     #   @return [Boolean]
     #     Set true to use the old proto1 MessageSet wire format for extensions.
-    #      This is provided for backwards-compatibility with the MessageSet wire
-    #      format.  You should not use this for any other reason:  It's less
-    #      efficient, has fewer features, and is more complicated.
+    #     This is provided for backwards-compatibility with the MessageSet wire
+    #     format.  You should not use this for any other reason:  It's less
+    #     efficient, has fewer features, and is more complicated.
     #
-    #      The message must be defined exactly as follows:
-    #        message Foo {
-    #          option message_set_wire_format = true;
-    #          extensions 4 to max;
-    #        }
-    #      Note that the message cannot have any defined fields; MessageSets only
-    #      have extensions.
+    #     The message must be defined exactly as follows:
+    #       message Foo {
+    #         option message_set_wire_format = true;
+    #         extensions 4 to max;
+    #       }
+    #     Note that the message cannot have any defined fields; MessageSets only
+    #     have extensions.
     #
-    #      All extensions of your type must be singular messages; e.g. they cannot
-    #      be int32s, enums, or repeated messages.
+    #     All extensions of your type must be singular messages; e.g. they cannot
+    #     be int32s, enums, or repeated messages.
     #
-    #      Because this is an option, the above two restrictions are not enforced by
-    #      the protocol compiler.
+    #     Because this is an option, the above two restrictions are not enforced by
+    #     the protocol compiler.
     # @!attribute [rw] no_standard_descriptor_accessor
     #   @return [Boolean]
     #     Disables the generation of the standard "descriptor()" accessor, which can
-    #      conflict with a field of the same name.  This is meant to make migration
-    #      from proto1 easier; new code should avoid fields named "descriptor".
+    #     conflict with a field of the same name.  This is meant to make migration
+    #     from proto1 easier; new code should avoid fields named "descriptor".
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this message deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the message, or it will be completely ignored; in the very least,
-    #      this is a formalization for deprecating messages.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the message, or it will be completely ignored; in the very least,
+    #     this is a formalization for deprecating messages.
     # @!attribute [rw] map_entry
     #   @return [Boolean]
     #     Whether the message is an automatically generated map entry type for the
-    #      maps field.
+    #     maps field.
     #
-    #      For maps fields:
-    #          map<KeyType, ValueType> map_field = 1;
-    #      The parsed descriptor looks like:
-    #          message MapFieldEntry {
-    #              option map_entry = true;
-    #              optional KeyType key = 1;
-    #              optional ValueType value = 2;
-    #          }
-    #          repeated MapFieldEntry map_field = 1;
+    #     For maps fields:
+    #         map<KeyType, ValueType> map_field = 1;
+    #     The parsed descriptor looks like:
+    #         message MapFieldEntry {
+    #             option map_entry = true;
+    #             optional KeyType key = 1;
+    #             optional ValueType value = 2;
+    #         }
+    #         repeated MapFieldEntry map_field = 1;
     #
-    #      Implementations may choose not to generate the map_entry=true message, but
-    #      use a native map in the target language to hold the keys and values.
-    #      The reflection APIs in such implementions still need to work as
-    #      if the field is a repeated message field.
+    #     Implementations may choose not to generate the map_entry=true message, but
+    #     use a native map in the target language to hold the keys and values.
+    #     The reflection APIs in such implementions still need to work as
+    #     if the field is a repeated message field.
     #
-    #      NOTE: Do not set the option in .proto files. Always use the maps syntax
-    #      instead. The option should only be implicitly set by the proto compiler
-    #      parser.
+    #     NOTE: Do not set the option in .proto files. Always use the maps syntax
+    #     instead. The option should only be implicitly set by the proto compiler
+    #     parser.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here. See above.
@@ -508,65 +508,65 @@ module Google
     # @!attribute [rw] ctype
     #   @return [ENUM(CType)]
     #     The ctype option instructs the C++ code generator to use a different
-    #      representation of the field than it normally would.  See the specific
-    #      options below.  This option is not yet implemented in the open source
-    #      release -- sorry, we'll try to include it in a future version!
+    #     representation of the field than it normally would.  See the specific
+    #     options below.  This option is not yet implemented in the open source
+    #     release -- sorry, we'll try to include it in a future version!
     # @!attribute [rw] packed
     #   @return [Boolean]
     #     The packed option can be enabled for repeated primitive fields to enable
-    #      a more efficient representation on the wire. Rather than repeatedly
-    #      writing the tag and type for each element, the entire array is encoded as
-    #      a single length-delimited blob. In proto3, only explicit setting it to
-    #      false will avoid using packed encoding.
+    #     a more efficient representation on the wire. Rather than repeatedly
+    #     writing the tag and type for each element, the entire array is encoded as
+    #     a single length-delimited blob. In proto3, only explicit setting it to
+    #     false will avoid using packed encoding.
     # @!attribute [rw] jstype
     #   @return [ENUM(JSType)]
     #     The jstype option determines the JavaScript type used for values of the
-    #      field.  The option is permitted only for 64 bit integral and fixed types
-    #      (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
-    #      is represented as JavaScript string, which avoids loss of precision that
-    #      can happen when a large value is converted to a floating point JavaScript.
-    #      Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
-    #      use the JavaScript "number" type.  The behavior of the default option
-    #      JS_NORMAL is implementation dependent.
+    #     field.  The option is permitted only for 64 bit integral and fixed types
+    #     (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+    #     is represented as JavaScript string, which avoids loss of precision that
+    #     can happen when a large value is converted to a floating point JavaScript.
+    #     Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+    #     use the JavaScript "number" type.  The behavior of the default option
+    #     JS_NORMAL is implementation dependent.
     #
-    #      This option is an enum to permit additional types to be added, e.g.
-    #      goog.math.Integer.
+    #     This option is an enum to permit additional types to be added, e.g.
+    #     goog.math.Integer.
     # @!attribute [rw] lazy
     #   @return [Boolean]
     #     Should this field be parsed lazily?  Lazy applies only to message-type
-    #      fields.  It means that when the outer message is initially parsed, the
-    #      inner message's contents will not be parsed but instead stored in encoded
-    #      form.  The inner message will actually be parsed when it is first accessed.
+    #     fields.  It means that when the outer message is initially parsed, the
+    #     inner message's contents will not be parsed but instead stored in encoded
+    #     form.  The inner message will actually be parsed when it is first accessed.
     #
-    #      This is only a hint.  Implementations are free to choose whether to use
-    #      eager or lazy parsing regardless of the value of this option.  However,
-    #      setting this option true suggests that the protocol author believes that
-    #      using lazy parsing on this field is worth the additional bookkeeping
-    #      overhead typically needed to implement it.
+    #     This is only a hint.  Implementations are free to choose whether to use
+    #     eager or lazy parsing regardless of the value of this option.  However,
+    #     setting this option true suggests that the protocol author believes that
+    #     using lazy parsing on this field is worth the additional bookkeeping
+    #     overhead typically needed to implement it.
     #
-    #      This option does not affect the public interface of any generated code;
-    #      all method signatures remain the same.  Furthermore, thread-safety of the
-    #      interface is not affected by this option; const methods remain safe to
-    #      call from multiple threads concurrently, while non-const methods continue
-    #      to require exclusive access.
+    #     This option does not affect the public interface of any generated code;
+    #     all method signatures remain the same.  Furthermore, thread-safety of the
+    #     interface is not affected by this option; const methods remain safe to
+    #     call from multiple threads concurrently, while non-const methods continue
+    #     to require exclusive access.
     #
     #
-    #      Note that implementations may choose not to check required fields within
-    #      a lazy sub-message.  That is, calling IsInitialized() on the outer message
-    #      may return true even if the inner message has missing required fields.
-    #      This is necessary because otherwise the inner message would have to be
-    #      parsed in order to perform the check, defeating the purpose of lazy
-    #      parsing.  An implementation which chooses not to check required fields
-    #      must be consistent about it.  That is, for any particular sub-message, the
-    #      implementation must either *always* check its required fields, or *never*
-    #      check its required fields, regardless of whether or not the message has
-    #      been parsed.
+    #     Note that implementations may choose not to check required fields within
+    #     a lazy sub-message.  That is, calling IsInitialized() on the outer message
+    #     may return true even if the inner message has missing required fields.
+    #     This is necessary because otherwise the inner message would have to be
+    #     parsed in order to perform the check, defeating the purpose of lazy
+    #     parsing.  An implementation which chooses not to check required fields
+    #     must be consistent about it.  That is, for any particular sub-message, the
+    #     implementation must either *always* check its required fields, or *never*
+    #     check its required fields, regardless of whether or not the message has
+    #     been parsed.
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this field deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for accessors, or it will be completely ignored; in the very least, this
-    #      is a formalization for deprecating fields.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for accessors, or it will be completely ignored; in the very least, this
+    #     is a formalization for deprecating fields.
     # @!attribute [rw] weak
     #   @return [Boolean]
     #     For Google-internal migration only. Do not use.
@@ -609,13 +609,13 @@ module Google
     # @!attribute [rw] allow_alias
     #   @return [Boolean]
     #     Set this option to true to allow mapping different tag names to the same
-    #      value.
+    #     value.
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this enum deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the enum, or it will be completely ignored; in the very least, this
-    #      is a formalization for deprecating enums.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the enum, or it will be completely ignored; in the very least, this
+    #     is a formalization for deprecating enums.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here. See above.
@@ -627,9 +627,9 @@ module Google
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this enum value deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the enum value, or it will be completely ignored; in the very least,
-    #      this is a formalization for deprecating enum values.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the enum value, or it will be completely ignored; in the very least,
+    #     this is a formalization for deprecating enum values.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here. See above.
@@ -641,9 +641,9 @@ module Google
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this service deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the service, or it will be completely ignored; in the very least,
-    #      this is a formalization for deprecating services.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the service, or it will be completely ignored; in the very least,
+    #     this is a formalization for deprecating services.
     # @!attribute [rw] uninterpreted_option
     #   @return [Google::Protobuf::UninterpretedOption]
     #     The parser stores options it doesn't recognize here. See above.
@@ -655,9 +655,9 @@ module Google
     # @!attribute [rw] deprecated
     #   @return [Boolean]
     #     Is this method deprecated?
-    #      Depending on the target platform, this can emit Deprecated annotations
-    #      for the method, or it will be completely ignored; in the very least,
-    #      this is a formalization for deprecating methods.
+    #     Depending on the target platform, this can emit Deprecated annotations
+    #     for the method, or it will be completely ignored; in the very least,
+    #     this is a formalization for deprecating methods.
     # @!attribute [rw] idempotency_level
     #   @return [ENUM(IdempotencyLevel)]
     # @!attribute [rw] uninterpreted_option
@@ -668,8 +668,8 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
 
       # Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
-      #  or neither? HTTP based RPC implementation may choose GET verb for safe
-      #  methods, and PUT verb for idempotent methods instead of the default POST.
+      # or neither? HTTP based RPC implementation may choose GET verb for safe
+      # methods, and PUT verb for idempotent methods instead of the default POST.
       module IdempotencyLevel
         IDEMPOTENCY_UNKNOWN = 0
 
@@ -680,17 +680,17 @@ module Google
     end
 
     # A message representing a option the parser does not recognize. This only
-    #  appears in options protos created by the compiler::Parser class.
-    #  DescriptorPool resolves these when building Descriptor objects. Therefore,
-    #  options protos in descriptor objects (e.g. returned by Descriptor::options(),
-    #  or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
-    #  in them.
+    # appears in options protos created by the compiler::Parser class.
+    # DescriptorPool resolves these when building Descriptor objects. Therefore,
+    # options protos in descriptor objects (e.g. returned by Descriptor::options(),
+    # or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+    # in them.
     # @!attribute [rw] name
     #   @return [Google::Protobuf::UninterpretedOption::NamePart]
     # @!attribute [rw] identifier_value
     #   @return [String]
     #     The value of the uninterpreted option, in whatever type the tokenizer
-    #      identified it as during parsing. Exactly one of these should be set.
+    #     identified it as during parsing. Exactly one of these should be set.
     # @!attribute [rw] positive_int_value
     #   @return [Integer]
     # @!attribute [rw] negative_int_value
@@ -706,10 +706,10 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
 
       # The name of the uninterpreted option.  Each string represents a segment in
-      #  a dot-separated name.  is_extension is true iff a segment represents an
-      #  extension (denoted with parentheses in options specs in .proto files).
-      #  E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
-      #  "foo.(bar.baz).qux".
+      # a dot-separated name.  is_extension is true iff a segment represents an
+      # extension (denoted with parentheses in options specs in .proto files).
+      # E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
+      # "foo.(bar.baz).qux".
       # @!attribute [rw] name_part
       #   @return [String]
       # @!attribute [rw] is_extension
@@ -721,52 +721,52 @@ module Google
     end
 
     # Encapsulates information about the original source file from which a
-    #  FileDescriptorProto was generated.
+    # FileDescriptorProto was generated.
     # @!attribute [rw] location
     #   @return [Google::Protobuf::SourceCodeInfo::Location]
     #     A Location identifies a piece of source code in a .proto file which
-    #      corresponds to a particular definition.  This information is intended
-    #      to be useful to IDEs, code indexers, documentation generators, and similar
-    #      tools.
+    #     corresponds to a particular definition.  This information is intended
+    #     to be useful to IDEs, code indexers, documentation generators, and similar
+    #     tools.
     #
-    #      For example, say we have a file like:
-    #        message Foo {
-    #          optional string foo = 1;
-    #        }
-    #      Let's look at just the field definition:
-    #        optional string foo = 1;
-    #        ^       ^^     ^^  ^  ^^^
-    #        a       bc     de  f  ghi
-    #      We have the following locations:
-    #        span   path               represents
-    #        [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
-    #        [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
-    #        [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
-    #        [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
-    #        [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+    #     For example, say we have a file like:
+    #       message Foo {
+    #         optional string foo = 1;
+    #       }
+    #     Let's look at just the field definition:
+    #       optional string foo = 1;
+    #       ^       ^^     ^^  ^  ^^^
+    #       a       bc     de  f  ghi
+    #     We have the following locations:
+    #       span   path               represents
+    #       [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+    #       [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+    #       [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+    #       [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+    #       [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
     #
-    #      Notes:
-    #      - A location may refer to a repeated field itself (i.e. not to any
-    #        particular index within it).  This is used whenever a set of elements are
-    #        logically enclosed in a single code segment.  For example, an entire
-    #        extend block (possibly containing multiple extension definitions) will
-    #        have an outer location whose path refers to the "extensions" repeated
-    #        field without an index.
-    #      - Multiple locations may have the same path.  This happens when a single
-    #        logical declaration is spread out across multiple places.  The most
-    #        obvious example is the "extend" block again -- there may be multiple
-    #        extend blocks in the same scope, each of which will have the same path.
-    #      - A location's span is not always a subset of its parent's span.  For
-    #        example, the "extendee" of an extension declaration appears at the
-    #        beginning of the "extend" block and is shared by all extensions within
-    #        the block.
-    #      - Just because a location's span is a subset of some other location's span
-    #        does not mean that it is a descendent.  For example, a "group" defines
-    #        both a type and a field in a single declaration.  Thus, the locations
-    #        corresponding to the type and field and their components will overlap.
-    #      - Code which tries to interpret locations should probably be designed to
-    #        ignore those that it doesn't understand, as more types of locations could
-    #        be recorded in the future.
+    #     Notes:
+    #     - A location may refer to a repeated field itself (i.e. not to any
+    #       particular index within it).  This is used whenever a set of elements are
+    #       logically enclosed in a single code segment.  For example, an entire
+    #       extend block (possibly containing multiple extension definitions) will
+    #       have an outer location whose path refers to the "extensions" repeated
+    #       field without an index.
+    #     - Multiple locations may have the same path.  This happens when a single
+    #       logical declaration is spread out across multiple places.  The most
+    #       obvious example is the "extend" block again -- there may be multiple
+    #       extend blocks in the same scope, each of which will have the same path.
+    #     - A location's span is not always a subset of its parent's span.  For
+    #       example, the "extendee" of an extension declaration appears at the
+    #       beginning of the "extend" block and is shared by all extensions within
+    #       the block.
+    #     - Just because a location's span is a subset of some other location's span
+    #       does not mean that it is a descendent.  For example, a "group" defines
+    #       both a type and a field in a single declaration.  Thus, the locations
+    #       corresponding to the type and field and their components will overlap.
+    #     - Code which tries to interpret locations should probably be designed to
+    #       ignore those that it doesn't understand, as more types of locations could
+    #       be recorded in the future.
     class SourceCodeInfo
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -774,84 +774,84 @@ module Google
       # @!attribute [rw] path
       #   @return [Integer]
       #     Identifies which part of the FileDescriptorProto was defined at this
-      #      location.
+      #     location.
       #
-      #      Each element is a field number or an index.  They form a path from
-      #      the root FileDescriptorProto to the place where the definition.  For
-      #      example, this path:
-      #        [ 4, 3, 2, 7, 1 ]
-      #      refers to:
-      #        file.message_type(3)  // 4, 3
-      #            .field(7)         // 2, 7
-      #            .name()           // 1
-      #      This is because FileDescriptorProto.message_type has field number 4:
-      #        repeated DescriptorProto message_type = 4;
-      #      and DescriptorProto.field has field number 2:
-      #        repeated FieldDescriptorProto field = 2;
-      #      and FieldDescriptorProto.name has field number 1:
-      #        optional string name = 1;
+      #     Each element is a field number or an index.  They form a path from
+      #     the root FileDescriptorProto to the place where the definition.  For
+      #     example, this path:
+      #       [ 4, 3, 2, 7, 1 ]
+      #     refers to:
+      #       file.message_type(3)  // 4, 3
+      #           .field(7)         // 2, 7
+      #           .name()           // 1
+      #     This is because FileDescriptorProto.message_type has field number 4:
+      #       repeated DescriptorProto message_type = 4;
+      #     and DescriptorProto.field has field number 2:
+      #       repeated FieldDescriptorProto field = 2;
+      #     and FieldDescriptorProto.name has field number 1:
+      #       optional string name = 1;
       #
-      #      Thus, the above path gives the location of a field name.  If we removed
-      #      the last element:
-      #        [ 4, 3, 2, 7 ]
-      #      this path refers to the whole field declaration (from the beginning
-      #      of the label to the terminating semicolon).
+      #     Thus, the above path gives the location of a field name.  If we removed
+      #     the last element:
+      #       [ 4, 3, 2, 7 ]
+      #     this path refers to the whole field declaration (from the beginning
+      #     of the label to the terminating semicolon).
       # @!attribute [rw] span
       #   @return [Integer]
       #     Always has exactly three or four elements: start line, start column,
-      #      end line (optional, otherwise assumed same as start line), end column.
-      #      These are packed into a single field for efficiency.  Note that line
-      #      and column numbers are zero-based -- typically you will want to add
-      #      1 to each before displaying to a user.
+      #     end line (optional, otherwise assumed same as start line), end column.
+      #     These are packed into a single field for efficiency.  Note that line
+      #     and column numbers are zero-based -- typically you will want to add
+      #     1 to each before displaying to a user.
       # @!attribute [rw] leading_comments
       #   @return [String]
       #     If this SourceCodeInfo represents a complete declaration, these are any
-      #      comments appearing before and after the declaration which appear to be
-      #      attached to the declaration.
+      #     comments appearing before and after the declaration which appear to be
+      #     attached to the declaration.
       #
-      #      A series of line comments appearing on consecutive lines, with no other
-      #      tokens appearing on those lines, will be treated as a single comment.
+      #     A series of line comments appearing on consecutive lines, with no other
+      #     tokens appearing on those lines, will be treated as a single comment.
       #
-      #      leading_detached_comments will keep paragraphs of comments that appear
-      #      before (but not connected to) the current element. Each paragraph,
-      #      separated by empty lines, will be one comment element in the repeated
-      #      field.
+      #     leading_detached_comments will keep paragraphs of comments that appear
+      #     before (but not connected to) the current element. Each paragraph,
+      #     separated by empty lines, will be one comment element in the repeated
+      #     field.
       #
-      #      Only the comment content is provided; comment markers (e.g. //) are
-      #      stripped out.  For block comments, leading whitespace and an asterisk
-      #      will be stripped from the beginning of each line other than the first.
-      #      Newlines are included in the output.
+      #     Only the comment content is provided; comment markers (e.g. //) are
+      #     stripped out.  For block comments, leading whitespace and an asterisk
+      #     will be stripped from the beginning of each line other than the first.
+      #     Newlines are included in the output.
       #
-      #      Examples:
+      #     Examples:
       #
-      #        optional int32 foo = 1;  // Comment attached to foo.
-      #        // Comment attached to bar.
-      #        optional int32 bar = 2;
+      #       optional int32 foo = 1;  // Comment attached to foo.
+      #       // Comment attached to bar.
+      #       optional int32 bar = 2;
       #
-      #        optional string baz = 3;
-      #        // Comment attached to baz.
-      #        // Another line attached to baz.
+      #       optional string baz = 3;
+      #       // Comment attached to baz.
+      #       // Another line attached to baz.
       #
-      #        // Comment attached to qux.
-      #        //
-      #        // Another line attached to qux.
-      #        optional double qux = 4;
+      #       // Comment attached to qux.
+      #       //
+      #       // Another line attached to qux.
+      #       optional double qux = 4;
       #
-      #        // Detached comment for corge. This is not leading or trailing comments
-      #        // to qux or corge because there are blank lines separating it from
-      #        // both.
+      #       // Detached comment for corge. This is not leading or trailing comments
+      #       // to qux or corge because there are blank lines separating it from
+      #       // both.
       #
-      #        // Detached comment for corge paragraph 2.
+      #       // Detached comment for corge paragraph 2.
       #
-      #        optional string corge = 5;
-      #        /* Block comment attached
-      #         * to corge.  Leading asterisks
-      #         * will be removed. */
-      #        /* Block comment attached to
-      #         * grault. */
-      #        optional int32 grault = 6;
+      #       optional string corge = 5;
+      #       /* Block comment attached
+      #        * to corge.  Leading asterisks
+      #        * will be removed. */
+      #       /* Block comment attached to
+      #        * grault. */
+      #       optional int32 grault = 6;
       #
-      #        // ignored detached comments.
+      #       // ignored detached comments.
       # @!attribute [rw] trailing_comments
       #   @return [String]
       # @!attribute [rw] leading_detached_comments
@@ -863,12 +863,12 @@ module Google
     end
 
     # Describes the relationship between generated code and its original source
-    #  file. A GeneratedCodeInfo message is associated with only one generated
-    #  source file, but may contain references to different source .proto files.
+    # file. A GeneratedCodeInfo message is associated with only one generated
+    # source file, but may contain references to different source .proto files.
     # @!attribute [rw] annotation
     #   @return [Google::Protobuf::GeneratedCodeInfo::Annotation]
     #     An Annotation connects some span of text in generated code to an element
-    #      of its generating .proto file.
+    #     of its generating .proto file.
     class GeneratedCodeInfo
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -876,19 +876,19 @@ module Google
       # @!attribute [rw] path
       #   @return [Integer]
       #     Identifies the element in the original source .proto file. This field
-      #      is formatted the same as SourceCodeInfo.Location.path.
+      #     is formatted the same as SourceCodeInfo.Location.path.
       # @!attribute [rw] source_file
       #   @return [String]
       #     Identifies the filesystem path to the original source .proto.
       # @!attribute [rw] begin
       #   @return [Integer]
       #     Identifies the starting offset in bytes in the generated code
-      #      that relates to the identified object.
+      #     that relates to the identified object.
       # @!attribute [rw] end
       #   @return [Integer]
       #     Identifies the ending offset in bytes in the generated code that
-      #      relates to the identified offset. The end offset should be one past
-      #      the last relevant byte (so the length of the text = end - begin).
+      #     relates to the identified offset. The end offset should be one past
+      #     the last relevant byte (so the length of the text = end - begin).
       class Annotation
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/vision/lib/doc/google/protobuf/empty.rb
+++ b/shared/output/cloud/vision/lib/doc/google/protobuf/empty.rb
@@ -19,14 +19,14 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # A generic empty message that you can re-use to avoid defining duplicated
-    #  empty messages in your APIs. A typical example is to use it as the request
-    #  or the response type of an API method. For instance:
+    # empty messages in your APIs. A typical example is to use it as the request
+    # or the response type of an API method. For instance:
     #
-    #      service Foo {
-    #        rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-    #      }
+    #     service Foo {
+    #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+    #     }
     #
-    #  The JSON representation for `Empty` is empty JSON object `{}`.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/vision/lib/doc/google/protobuf/field_mask.rb
+++ b/shared/output/cloud/vision/lib/doc/google/protobuf/field_mask.rb
@@ -20,211 +20,211 @@ module Google
   module Protobuf
     # `FieldMask` represents a set of symbolic field paths, for example:
     #
-    #      paths: "f.a"
-    #      paths: "f.b.d"
+    #     paths: "f.a"
+    #     paths: "f.b.d"
     #
-    #  Here `f` represents a field in some root message, `a` and `b`
-    #  fields in the message found in `f`, and `d` a field found in the
-    #  message in `f.b`.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
-    #  Field masks are used to specify a subset of fields that should be
-    #  returned by a get operation or modified by an update operation.
-    #  Field masks also have a custom JSON encoding (see below).
+    # Field masks are used to specify a subset of fields that should be
+    # returned by a get operation or modified by an update operation.
+    # Field masks also have a custom JSON encoding (see below).
     #
-    #  # Field Masks in Projections
+    # # Field Masks in Projections
     #
-    #  When used in the context of a projection, a response message or
-    #  sub-message is filtered by the API to only contain those fields as
-    #  specified in the mask. For example, if the mask in the previous
-    #  example is applied to a response message as follows:
+    # When used in the context of a projection, a response message or
+    # sub-message is filtered by the API to only contain those fields as
+    # specified in the mask. For example, if the mask in the previous
+    # example is applied to a response message as follows:
     #
-    #      f {
-    #        a : 22
-    #        b {
-    #          d : 1
-    #          x : 2
-    #        }
-    #        y : 13
-    #      }
-    #      z: 8
+    #     f {
+    #       a : 22
+    #       b {
+    #         d : 1
+    #         x : 2
+    #       }
+    #       y : 13
+    #     }
+    #     z: 8
     #
-    #  The result will not contain specific values for fields x,y and z
-    #  (their value will be set to the default, and omitted in proto text
-    #  output):
+    # The result will not contain specific values for fields x,y and z
+    # (their value will be set to the default, and omitted in proto text
+    # output):
     #
     #
-    #      f {
-    #        a : 22
-    #        b {
-    #          d : 1
-    #        }
-    #      }
+    #     f {
+    #       a : 22
+    #       b {
+    #         d : 1
+    #       }
+    #     }
     #
-    #  A repeated field is not allowed except at the last position of a
-    #  paths string.
+    # A repeated field is not allowed except at the last position of a
+    # paths string.
     #
-    #  If a FieldMask object is not present in a get operation, the
-    #  operation applies to all fields (as if a FieldMask of all fields
-    #  had been specified).
+    # If a FieldMask object is not present in a get operation, the
+    # operation applies to all fields (as if a FieldMask of all fields
+    # had been specified).
     #
-    #  Note that a field mask does not necessarily apply to the
-    #  top-level response message. In case of a REST get operation, the
-    #  field mask applies directly to the response, but in case of a REST
-    #  list operation, the mask instead applies to each individual message
-    #  in the returned resource list. In case of a REST custom method,
-    #  other definitions may be used. Where the mask applies will be
-    #  clearly documented together with its declaration in the API.  In
-    #  any case, the effect on the returned resource/resources is required
-    #  behavior for APIs.
+    # Note that a field mask does not necessarily apply to the
+    # top-level response message. In case of a REST get operation, the
+    # field mask applies directly to the response, but in case of a REST
+    # list operation, the mask instead applies to each individual message
+    # in the returned resource list. In case of a REST custom method,
+    # other definitions may be used. Where the mask applies will be
+    # clearly documented together with its declaration in the API.  In
+    # any case, the effect on the returned resource/resources is required
+    # behavior for APIs.
     #
-    #  # Field Masks in Update Operations
+    # # Field Masks in Update Operations
     #
-    #  A field mask in update operations specifies which fields of the
-    #  targeted resource are going to be updated. The API is required
-    #  to only change the values of the fields as specified in the mask
-    #  and leave the others untouched. If a resource is passed in to
-    #  describe the updated values, the API ignores the values of all
-    #  fields not covered by the mask.
+    # A field mask in update operations specifies which fields of the
+    # targeted resource are going to be updated. The API is required
+    # to only change the values of the fields as specified in the mask
+    # and leave the others untouched. If a resource is passed in to
+    # describe the updated values, the API ignores the values of all
+    # fields not covered by the mask.
     #
-    #  If a repeated field is specified for an update operation, the existing
-    #  repeated values in the target resource will be overwritten by the new values.
-    #  Note that a repeated field is only allowed in the last position of a `paths`
-    #  string.
+    # If a repeated field is specified for an update operation, the existing
+    # repeated values in the target resource will be overwritten by the new values.
+    # Note that a repeated field is only allowed in the last position of a `paths`
+    # string.
     #
-    #  If a sub-message is specified in the last position of the field mask for an
-    #  update operation, then the existing sub-message in the target resource is
-    #  overwritten. Given the target message:
+    # If a sub-message is specified in the last position of the field mask for an
+    # update operation, then the existing sub-message in the target resource is
+    # overwritten. Given the target message:
     #
-    #      f {
-    #        b {
-    #          d : 1
-    #          x : 2
-    #        }
-    #        c : 1
-    #      }
+    #     f {
+    #       b {
+    #         d : 1
+    #         x : 2
+    #       }
+    #       c : 1
+    #     }
     #
-    #  And an update message:
+    # And an update message:
     #
-    #      f {
-    #        b {
-    #          d : 10
-    #        }
-    #      }
+    #     f {
+    #       b {
+    #         d : 10
+    #       }
+    #     }
     #
-    #  then if the field mask is:
+    # then if the field mask is:
     #
-    #   paths: "f.b"
+    #  paths: "f.b"
     #
-    #  then the result will be:
+    # then the result will be:
     #
-    #      f {
-    #        b {
-    #          d : 10
-    #        }
-    #        c : 1
-    #      }
+    #     f {
+    #       b {
+    #         d : 10
+    #       }
+    #       c : 1
+    #     }
     #
-    #  However, if the update mask was:
+    # However, if the update mask was:
     #
-    #   paths: "f.b.d"
+    #  paths: "f.b.d"
     #
-    #  then the result would be:
+    # then the result would be:
     #
-    #      f {
-    #        b {
-    #          d : 10
-    #          x : 2
-    #        }
-    #        c : 1
-    #      }
+    #     f {
+    #       b {
+    #         d : 10
+    #         x : 2
+    #       }
+    #       c : 1
+    #     }
     #
-    #  In order to reset a field's value to the default, the field must
-    #  be in the mask and set to the default value in the provided resource.
-    #  Hence, in order to reset all fields of a resource, provide a default
-    #  instance of the resource and set all fields in the mask, or do
-    #  not provide a mask as described below.
+    # In order to reset a field's value to the default, the field must
+    # be in the mask and set to the default value in the provided resource.
+    # Hence, in order to reset all fields of a resource, provide a default
+    # instance of the resource and set all fields in the mask, or do
+    # not provide a mask as described below.
     #
-    #  If a field mask is not present on update, the operation applies to
-    #  all fields (as if a field mask of all fields has been specified).
-    #  Note that in the presence of schema evolution, this may mean that
-    #  fields the client does not know and has therefore not filled into
-    #  the request will be reset to their default. If this is unwanted
-    #  behavior, a specific service may require a client to always specify
-    #  a field mask, producing an error if not.
+    # If a field mask is not present on update, the operation applies to
+    # all fields (as if a field mask of all fields has been specified).
+    # Note that in the presence of schema evolution, this may mean that
+    # fields the client does not know and has therefore not filled into
+    # the request will be reset to their default. If this is unwanted
+    # behavior, a specific service may require a client to always specify
+    # a field mask, producing an error if not.
     #
-    #  As with get operations, the location of the resource which
-    #  describes the updated values in the request message depends on the
-    #  operation kind. In any case, the effect of the field mask is
-    #  required to be honored by the API.
+    # As with get operations, the location of the resource which
+    # describes the updated values in the request message depends on the
+    # operation kind. In any case, the effect of the field mask is
+    # required to be honored by the API.
     #
-    #  ## Considerations for HTTP REST
+    # ## Considerations for HTTP REST
     #
-    #  The HTTP kind of an update operation which uses a field mask must
-    #  be set to PATCH instead of PUT in order to satisfy HTTP semantics
-    #  (PUT must only be used for full updates).
+    # The HTTP kind of an update operation which uses a field mask must
+    # be set to PATCH instead of PUT in order to satisfy HTTP semantics
+    # (PUT must only be used for full updates).
     #
-    #  # JSON Encoding of Field Masks
+    # # JSON Encoding of Field Masks
     #
-    #  In JSON, a field mask is encoded as a single string where paths are
-    #  separated by a comma. Fields name in each path are converted
-    #  to/from lower-camel naming conventions.
+    # In JSON, a field mask is encoded as a single string where paths are
+    # separated by a comma. Fields name in each path are converted
+    # to/from lower-camel naming conventions.
     #
-    #  As an example, consider the following message declarations:
+    # As an example, consider the following message declarations:
     #
-    #      message Profile {
-    #        User user = 1;
-    #        Photo photo = 2;
-    #      }
-    #      message User {
-    #        string display_name = 1;
-    #        string address = 2;
-    #      }
+    #     message Profile {
+    #       User user = 1;
+    #       Photo photo = 2;
+    #     }
+    #     message User {
+    #       string display_name = 1;
+    #       string address = 2;
+    #     }
     #
-    #  In proto a field mask for `Profile` may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
-    #      mask {
-    #        paths: "user.display_name"
-    #        paths: "photo"
-    #      }
+    #     mask {
+    #       paths: "user.display_name"
+    #       paths: "photo"
+    #     }
     #
-    #  In JSON, the same mask is represented as below:
+    # In JSON, the same mask is represented as below:
     #
-    #      {
-    #        mask: "user.displayName,photo"
-    #      }
+    #     {
+    #       mask: "user.displayName,photo"
+    #     }
     #
-    #  # Field Masks and Oneof Fields
+    # # Field Masks and Oneof Fields
     #
-    #  Field masks treat fields in oneofs just as regular fields. Consider the
-    #  following message:
+    # Field masks treat fields in oneofs just as regular fields. Consider the
+    # following message:
     #
-    #      message SampleMessage {
-    #        oneof test_oneof {
-    #          string name = 4;
-    #          SubMessage sub_message = 9;
-    #        }
-    #      }
+    #     message SampleMessage {
+    #       oneof test_oneof {
+    #         string name = 4;
+    #         SubMessage sub_message = 9;
+    #       }
+    #     }
     #
-    #  The field mask can be:
+    # The field mask can be:
     #
-    #      mask {
-    #        paths: "name"
-    #      }
+    #     mask {
+    #       paths: "name"
+    #     }
     #
-    #  Or:
+    # Or:
     #
-    #      mask {
-    #        paths: "sub_message"
-    #      }
+    #     mask {
+    #       paths: "sub_message"
+    #     }
     #
-    #  Note that oneof type names ("test_oneof" in this case) cannot be used in
-    #  paths.
+    # Note that oneof type names ("test_oneof" in this case) cannot be used in
+    # paths.
     #
-    #  ## Field Mask Verification
+    # ## Field Mask Verification
     #
-    #  The implementation of any API method which has a FieldMask type field in the
-    #  request should verify the included field paths, and return an
-    #  `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
+    # The implementation of any API method which has a FieldMask type field in the
+    # request should verify the included field paths, and return an
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [String]
     #     The set of field mask paths.

--- a/shared/output/cloud/vision/lib/doc/google/protobuf/timestamp.rb
+++ b/shared/output/cloud/vision/lib/doc/google/protobuf/timestamp.rb
@@ -19,94 +19,94 @@ raise "This file is for documentation purposes only."
 module Google
   module Protobuf
     # A Timestamp represents a point in time independent of any time zone
-    #  or calendar, represented as seconds and fractions of seconds at
-    #  nanosecond resolution in UTC Epoch time. It is encoded using the
-    #  Proleptic Gregorian Calendar which extends the Gregorian calendar
-    #  backwards to year one. It is encoded assuming all minutes are 60
-    #  seconds long, i.e. leap seconds are "smeared" so that no leap second
-    #  table is needed for interpretation. Range is from
-    #  0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
-    #  By restricting to that range, we ensure that we can convert to
-    #  and from  RFC 3339 date strings.
-    #  See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
+    # or calendar, represented as seconds and fractions of seconds at
+    # nanosecond resolution in UTC Epoch time. It is encoded using the
+    # Proleptic Gregorian Calendar which extends the Gregorian calendar
+    # backwards to year one. It is encoded assuming all minutes are 60
+    # seconds long, i.e. leap seconds are "smeared" so that no leap second
+    # table is needed for interpretation. Range is from
+    # 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
+    # By restricting to that range, we ensure that we can convert to
+    # and from  RFC 3339 date strings.
+    # See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
     #
-    #  # Examples
+    # # Examples
     #
-    #  Example 1: Compute Timestamp from POSIX `time()`.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
-    #      Timestamp timestamp;
-    #      timestamp.set_seconds(time(NULL));
-    #      timestamp.set_nanos(0);
+    #     Timestamp timestamp;
+    #     timestamp.set_seconds(time(NULL));
+    #     timestamp.set_nanos(0);
     #
-    #  Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
-    #      struct timeval tv;
-    #      gettimeofday(&tv, NULL);
+    #     struct timeval tv;
+    #     gettimeofday(&tv, NULL);
     #
-    #      Timestamp timestamp;
-    #      timestamp.set_seconds(tv.tv_sec);
-    #      timestamp.set_nanos(tv.tv_usec * 1000);
+    #     Timestamp timestamp;
+    #     timestamp.set_seconds(tv.tv_sec);
+    #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    #  Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
-    #      FILETIME ft;
-    #      GetSystemTimeAsFileTime(&ft);
-    #      UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+    #     FILETIME ft;
+    #     GetSystemTimeAsFileTime(&ft);
+    #     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
     #
-    #      // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
-    #      // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
-    #      Timestamp timestamp;
-    #      timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
-    #      timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+    #     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+    #     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+    #     Timestamp timestamp;
+    #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+    #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    #  Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
-    #      long millis = System.currentTimeMillis();
+    #     long millis = System.currentTimeMillis();
     #
-    #      Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
-    #          .setNanos((int) ((millis % 1000) * 1000000)).build();
+    #     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+    #         .setNanos((int) ((millis % 1000) * 1000000)).build();
     #
     #
-    #  Example 5: Compute Timestamp from current time in Python.
+    # Example 5: Compute Timestamp from current time in Python.
     #
-    #      timestamp = Timestamp()
-    #      timestamp.GetCurrentTime()
+    #     timestamp = Timestamp()
+    #     timestamp.GetCurrentTime()
     #
-    #  # JSON Mapping
+    # # JSON Mapping
     #
-    #  In JSON format, the Timestamp type is encoded as a string in the
-    #  [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    #  format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    #  where {year} is always expressed using four digits while {month}, {day},
-    #  {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
-    #  seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
-    #  are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
-    #  is required. A proto3 JSON serializer should always use UTC (as indicated by
-    #  "Z") when printing the Timestamp type and a proto3 JSON parser should be
-    #  able to accept both UTC and other timezones (as indicated by an offset).
+    # In JSON format, the Timestamp type is encoded as a string in the
+    # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+    # where {year} is always expressed using four digits while {month}, {day},
+    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+    # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+    # is required. A proto3 JSON serializer should always use UTC (as indicated by
+    # "Z") when printing the Timestamp type and a proto3 JSON parser should be
+    # able to accept both UTC and other timezones (as indicated by an offset).
     #
-    #  For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
-    #  01:30 UTC on January 15, 2017.
+    # For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+    # 01:30 UTC on January 15, 2017.
     #
-    #  In JavaScript, one can convert a Date object to this format using the
-    #  standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    #  method. In Python, a standard `datetime.datetime` object can be converted
-    #  to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
-    #  with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    #  can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
-    #  http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
-    #  ) to obtain a formatter capable of generating timestamps in this format.
+    # In JavaScript, one can convert a Date object to this format using the
+    # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
+    # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
+    # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
+    # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds
     #   @return [Integer]
     #     Represents seconds of UTC time since Unix epoch
-    #      1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-    #      9999-12-31T23:59:59Z inclusive.
+    #     1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+    #     9999-12-31T23:59:59Z inclusive.
     # @!attribute [rw] nanos
     #   @return [Integer]
     #     Non-negative fractions of a second at nanosecond resolution. Negative
-    #      second values with fractions must still have non-negative nanos values
-    #      that count forward in time. Must be from 0 to 999,999,999
-    #      inclusive.
+    #     second values with fractions must still have non-negative nanos values
+    #     that count forward in time. Must be from 0 to 999,999,999
+    #     inclusive.
     class Timestamp
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/vision/lib/doc/google/protobuf/wrappers.rb
+++ b/shared/output/cloud/vision/lib/doc/google/protobuf/wrappers.rb
@@ -20,7 +20,7 @@ module Google
   module Protobuf
     # Wrapper message for `double`.
     #
-    #  The JSON representation for `DoubleValue` is JSON number.
+    # The JSON representation for `DoubleValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The double value.
@@ -31,7 +31,7 @@ module Google
 
     # Wrapper message for `float`.
     #
-    #  The JSON representation for `FloatValue` is JSON number.
+    # The JSON representation for `FloatValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The float value.
@@ -42,7 +42,7 @@ module Google
 
     # Wrapper message for `int64`.
     #
-    #  The JSON representation for `Int64Value` is JSON string.
+    # The JSON representation for `Int64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int64 value.
@@ -53,7 +53,7 @@ module Google
 
     # Wrapper message for `uint64`.
     #
-    #  The JSON representation for `UInt64Value` is JSON string.
+    # The JSON representation for `UInt64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint64 value.
@@ -64,7 +64,7 @@ module Google
 
     # Wrapper message for `int32`.
     #
-    #  The JSON representation for `Int32Value` is JSON number.
+    # The JSON representation for `Int32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int32 value.
@@ -75,7 +75,7 @@ module Google
 
     # Wrapper message for `uint32`.
     #
-    #  The JSON representation for `UInt32Value` is JSON number.
+    # The JSON representation for `UInt32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint32 value.
@@ -86,7 +86,7 @@ module Google
 
     # Wrapper message for `bool`.
     #
-    #  The JSON representation for `BoolValue` is JSON `true` and `false`.
+    # The JSON representation for `BoolValue` is JSON `true` and `false`.
     # @!attribute [rw] value
     #   @return [Boolean]
     #     The bool value.
@@ -97,7 +97,7 @@ module Google
 
     # Wrapper message for `string`.
     #
-    #  The JSON representation for `StringValue` is JSON string.
+    # The JSON representation for `StringValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The string value.
@@ -108,7 +108,7 @@ module Google
 
     # Wrapper message for `bytes`.
     #
-    #  The JSON representation for `BytesValue` is JSON string.
+    # The JSON representation for `BytesValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The bytes value.

--- a/shared/output/cloud/vision/lib/doc/google/rpc/status.rb
+++ b/shared/output/cloud/vision/lib/doc/google/rpc/status.rb
@@ -19,69 +19,69 @@ raise "This file is for documentation purposes only."
 module Google
   module Rpc
     # The `Status` type defines a logical error model that is suitable for different
-    #  programming environments, including REST APIs and RPC APIs. It is used by
-    #  [gRPC](https://github.com/grpc). The error model is designed to be:
+    # programming environments, including REST APIs and RPC APIs. It is used by
+    # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
-    #  - Simple to use and understand for most users
-    #  - Flexible enough to meet unexpected needs
+    # - Simple to use and understand for most users
+    # - Flexible enough to meet unexpected needs
     #
-    #  # Overview
+    # # Overview
     #
-    #  The `Status` message contains three pieces of data: error code, error message,
-    #  and error details. The error code should be an enum value of
-    #  [google.rpc.Code][google.rpc.Code], but it may accept additional error codes if needed.  The
-    #  error message should be a developer-facing English message that helps
-    #  developers *understand* and *resolve* the error. If a localized user-facing
-    #  error message is needed, put the localized message in the error details or
-    #  localize it in the client. The optional error details may contain arbitrary
-    #  information about the error. There is a predefined set of error detail types
-    #  in the package `google.rpc` that can be used for common error conditions.
+    # The `Status` message contains three pieces of data: error code, error message,
+    # and error details. The error code should be an enum value of
+    # [google.rpc.Code][google.rpc.Code], but it may accept additional error codes if needed.  The
+    # error message should be a developer-facing English message that helps
+    # developers *understand* and *resolve* the error. If a localized user-facing
+    # error message is needed, put the localized message in the error details or
+    # localize it in the client. The optional error details may contain arbitrary
+    # information about the error. There is a predefined set of error detail types
+    # in the package `google.rpc` that can be used for common error conditions.
     #
-    #  # Language mapping
+    # # Language mapping
     #
-    #  The `Status` message is the logical representation of the error model, but it
-    #  is not necessarily the actual wire format. When the `Status` message is
-    #  exposed in different client libraries and different wire protocols, it can be
-    #  mapped differently. For example, it will likely be mapped to some exceptions
-    #  in Java, but more likely mapped to some error codes in C.
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
+    # exposed in different client libraries and different wire protocols, it can be
+    # mapped differently. For example, it will likely be mapped to some exceptions
+    # in Java, but more likely mapped to some error codes in C.
     #
-    #  # Other uses
+    # # Other uses
     #
-    #  The error model and the `Status` message can be used in a variety of
-    #  environments, either with or without APIs, to provide a
-    #  consistent developer experience across different environments.
+    # The error model and the `Status` message can be used in a variety of
+    # environments, either with or without APIs, to provide a
+    # consistent developer experience across different environments.
     #
-    #  Example uses of this error model include:
+    # Example uses of this error model include:
     #
-    #  - Partial errors. If a service needs to return partial errors to the client,
-    #      it may embed the `Status` in the normal response to indicate the partial
-    #      errors.
+    # - Partial errors. If a service needs to return partial errors to the client,
+    #     it may embed the `Status` in the normal response to indicate the partial
+    #     errors.
     #
-    #  - Workflow errors. A typical workflow has multiple steps. Each step may
-    #      have a `Status` message for error reporting.
+    # - Workflow errors. A typical workflow has multiple steps. Each step may
+    #     have a `Status` message for error reporting.
     #
-    #  - Batch operations. If a client uses batch request and batch response, the
-    #      `Status` message should be used directly inside batch response, one for
-    #      each error sub-response.
+    # - Batch operations. If a client uses batch request and batch response, the
+    #     `Status` message should be used directly inside batch response, one for
+    #     each error sub-response.
     #
-    #  - Asynchronous operations. If an API call embeds asynchronous operation
-    #      results in its response, the status of those operations should be
-    #      represented directly using the `Status` message.
+    # - Asynchronous operations. If an API call embeds asynchronous operation
+    #     results in its response, the status of those operations should be
+    #     represented directly using the `Status` message.
     #
-    #  - Logging. If some API errors are stored in logs, the message `Status` could
-    #      be used directly after any stripping needed for security/privacy reasons.
+    # - Logging. If some API errors are stored in logs, the message `Status` could
+    #     be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]
     #     The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
     # @!attribute [rw] message
     #   @return [String]
     #     A developer-facing error message, which should be in English. Any
-    #      user-facing error message should be localized and sent in the
-    #      [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+    #     user-facing error message should be localized and sent in the
+    #     [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
     # @!attribute [rw] details
     #   @return [Google::Protobuf::Any]
     #     A list of messages that carry the error details.  There is a common set of
-    #      message types for APIs to use.
+    #     message types for APIs to use.
     class Status
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/vision/lib/doc/google/type/color.rb
+++ b/shared/output/cloud/vision/lib/doc/google/type/color.rb
@@ -19,119 +19,119 @@ raise "This file is for documentation purposes only."
 module Google
   module Type
     # Represents a color in the RGBA color space. This representation is designed
-    #  for simplicity of conversion to/from color representations in various
-    #  languages over compactness; for example, the fields of this representation
-    #  can be trivially provided to the constructor of "java.awt.Color" in Java; it
-    #  can also be trivially provided to UIColor's "+colorWithRed:green:blue:alpha"
-    #  method in iOS; and, with just a little work, it can be easily formatted into
-    #  a CSS "rgba()" string in JavaScript, as well. Here are some examples:
+    # for simplicity of conversion to/from color representations in various
+    # languages over compactness; for example, the fields of this representation
+    # can be trivially provided to the constructor of "java.awt.Color" in Java; it
+    # can also be trivially provided to UIColor's "+colorWithRed:green:blue:alpha"
+    # method in iOS; and, with just a little work, it can be easily formatted into
+    # a CSS "rgba()" string in JavaScript, as well. Here are some examples:
     #
-    #  Example (Java):
+    # Example (Java):
     #
-    #       import com.google.type.Color;
+    #      import com.google.type.Color;
     #
-    #       // ...
-    #       public static java.awt.Color fromProto(Color protocolor) {
-    #         float alpha = protocolor.hasAlpha()
-    #             ? protocolor.getAlpha().getValue()
-    #             : 1.0;
+    #      // ...
+    #      public static java.awt.Color fromProto(Color protocolor) {
+    #        float alpha = protocolor.hasAlpha()
+    #            ? protocolor.getAlpha().getValue()
+    #            : 1.0;
     #
-    #         return new java.awt.Color(
-    #             protocolor.getRed(),
-    #             protocolor.getGreen(),
-    #             protocolor.getBlue(),
-    #             alpha);
-    #       }
+    #        return new java.awt.Color(
+    #            protocolor.getRed(),
+    #            protocolor.getGreen(),
+    #            protocolor.getBlue(),
+    #            alpha);
+    #      }
     #
-    #       public static Color toProto(java.awt.Color color) {
-    #         float red = (float) color.getRed();
-    #         float green = (float) color.getGreen();
-    #         float blue = (float) color.getBlue();
-    #         float denominator = 255.0;
-    #         Color.Builder resultBuilder =
-    #             Color
-    #                 .newBuilder()
-    #                 .setRed(red / denominator)
-    #                 .setGreen(green / denominator)
-    #                 .setBlue(blue / denominator);
-    #         int alpha = color.getAlpha();
-    #         if (alpha != 255) {
-    #           result.setAlpha(
-    #               FloatValue
-    #                   .newBuilder()
-    #                   .setValue(((float) alpha) / denominator)
-    #                   .build());
-    #         }
-    #         return resultBuilder.build();
-    #       }
-    #       // ...
-    #
-    #  Example (iOS / Obj-C):
-    #
-    #       // ...
-    #       static UIColor* fromProto(Color* protocolor) {
-    #          float red = [protocolor red];
-    #          float green = [protocolor green];
-    #          float blue = [protocolor blue];
-    #          FloatValue* alpha_wrapper = [protocolor alpha];
-    #          float alpha = 1.0;
-    #          if (alpha_wrapper != nil) {
-    #            alpha = [alpha_wrapper value];
-    #          }
-    #          return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
-    #       }
-    #
-    #       static Color* toProto(UIColor* color) {
-    #           CGFloat red, green, blue, alpha;
-    #           if (![color getRed:&red green:&green blue:&blue alpha:&alpha]) {
-    #             return nil;
-    #           }
-    #           Color* result = [Color alloc] init];
-    #           [result setRed:red];
-    #           [result setGreen:green];
-    #           [result setBlue:blue];
-    #           if (alpha <= 0.9999) {
-    #             [result setAlpha:floatWrapperWithValue(alpha)];
-    #           }
-    #           [result autorelease];
-    #           return result;
+    #      public static Color toProto(java.awt.Color color) {
+    #        float red = (float) color.getRed();
+    #        float green = (float) color.getGreen();
+    #        float blue = (float) color.getBlue();
+    #        float denominator = 255.0;
+    #        Color.Builder resultBuilder =
+    #            Color
+    #                .newBuilder()
+    #                .setRed(red / denominator)
+    #                .setGreen(green / denominator)
+    #                .setBlue(blue / denominator);
+    #        int alpha = color.getAlpha();
+    #        if (alpha != 255) {
+    #          result.setAlpha(
+    #              FloatValue
+    #                  .newBuilder()
+    #                  .setValue(((float) alpha) / denominator)
+    #                  .build());
+    #        }
+    #        return resultBuilder.build();
     #      }
     #      // ...
     #
-    #   Example (JavaScript):
+    # Example (iOS / Obj-C):
     #
     #      // ...
-    #
-    #      var protoToCssColor = function(rgb_color) {
-    #         var redFrac = rgb_color.red || 0.0;
-    #         var greenFrac = rgb_color.green || 0.0;
-    #         var blueFrac = rgb_color.blue || 0.0;
-    #         var red = Math.floor(redFrac * 255);
-    #         var green = Math.floor(greenFrac * 255);
-    #         var blue = Math.floor(blueFrac * 255);
-    #
-    #         if (!('alpha' in rgb_color)) {
-    #            return rgbToCssColor_(red, green, blue);
+    #      static UIColor* fromProto(Color* protocolor) {
+    #         float red = [protocolor red];
+    #         float green = [protocolor green];
+    #         float blue = [protocolor blue];
+    #         FloatValue* alpha_wrapper = [protocolor alpha];
+    #         float alpha = 1.0;
+    #         if (alpha_wrapper != nil) {
+    #           alpha = [alpha_wrapper value];
     #         }
+    #         return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
+    #      }
     #
-    #         var alphaFrac = rgb_color.alpha.value || 0.0;
-    #         var rgbParams = [red, green, blue].join(',');
-    #         return ['rgba(', rgbParams, ',', alphaFrac, ')'].join('');
-    #      };
+    #      static Color* toProto(UIColor* color) {
+    #          CGFloat red, green, blue, alpha;
+    #          if (![color getRed:&red green:&green blue:&blue alpha:&alpha]) {
+    #            return nil;
+    #          }
+    #          Color* result = [Color alloc] init];
+    #          [result setRed:red];
+    #          [result setGreen:green];
+    #          [result setBlue:blue];
+    #          if (alpha <= 0.9999) {
+    #            [result setAlpha:floatWrapperWithValue(alpha)];
+    #          }
+    #          [result autorelease];
+    #          return result;
+    #     }
+    #     // ...
     #
-    #      var rgbToCssColor_ = function(red, green, blue) {
-    #        var rgbNumber = new Number((red << 16) | (green << 8) | blue);
-    #        var hexString = rgbNumber.toString(16);
-    #        var missingZeros = 6 - hexString.length;
-    #        var resultBuilder = ['#'];
-    #        for (var i = 0; i < missingZeros; i++) {
-    #           resultBuilder.push('0');
+    #  Example (JavaScript):
+    #
+    #     // ...
+    #
+    #     var protoToCssColor = function(rgb_color) {
+    #        var redFrac = rgb_color.red || 0.0;
+    #        var greenFrac = rgb_color.green || 0.0;
+    #        var blueFrac = rgb_color.blue || 0.0;
+    #        var red = Math.floor(redFrac * 255);
+    #        var green = Math.floor(greenFrac * 255);
+    #        var blue = Math.floor(blueFrac * 255);
+    #
+    #        if (!('alpha' in rgb_color)) {
+    #           return rgbToCssColor_(red, green, blue);
     #        }
-    #        resultBuilder.push(hexString);
-    #        return resultBuilder.join('');
-    #      };
     #
-    #      // ...
+    #        var alphaFrac = rgb_color.alpha.value || 0.0;
+    #        var rgbParams = [red, green, blue].join(',');
+    #        return ['rgba(', rgbParams, ',', alphaFrac, ')'].join('');
+    #     };
+    #
+    #     var rgbToCssColor_ = function(red, green, blue) {
+    #       var rgbNumber = new Number((red << 16) | (green << 8) | blue);
+    #       var hexString = rgbNumber.toString(16);
+    #       var missingZeros = 6 - hexString.length;
+    #       var resultBuilder = ['#'];
+    #       for (var i = 0; i < missingZeros; i++) {
+    #          resultBuilder.push('0');
+    #       }
+    #       resultBuilder.push(hexString);
+    #       return resultBuilder.join('');
+    #     };
+    #
+    #     // ...
     # @!attribute [rw] red
     #   @return [Float]
     #     The amount of red in the color as a value in the interval [0, 1].
@@ -144,16 +144,16 @@ module Google
     # @!attribute [rw] alpha
     #   @return [Google::Protobuf::FloatValue]
     #     The fraction of this color that should be applied to the pixel. That is,
-    #      the final pixel color is defined by the equation:
+    #     the final pixel color is defined by the equation:
     #
-    #        pixel color = alpha * (this color) + (1.0 - alpha) * (background color)
+    #       pixel color = alpha * (this color) + (1.0 - alpha) * (background color)
     #
-    #      This means that a value of 1.0 corresponds to a solid color, whereas
-    #      a value of 0.0 corresponds to a completely transparent color. This
-    #      uses a wrapper message rather than a simple float scalar so that it is
-    #      possible to distinguish between a default value and the value being unset.
-    #      If omitted, this color object is to be rendered as a solid color
-    #      (as if the alpha value had been explicitly given with a value of 1.0).
+    #     This means that a value of 1.0 corresponds to a solid color, whereas
+    #     a value of 0.0 corresponds to a completely transparent color. This
+    #     uses a wrapper message rather than a simple float scalar so that it is
+    #     possible to distinguish between a default value and the value being unset.
+    #     If omitted, this color object is to be rendered as a solid color
+    #     (as if the alpha value had been explicitly given with a value of 1.0).
     class Color
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/vision/lib/doc/google/type/latlng.rb
+++ b/shared/output/cloud/vision/lib/doc/google/type/latlng.rb
@@ -19,44 +19,44 @@ raise "This file is for documentation purposes only."
 module Google
   module Type
     # An object representing a latitude/longitude pair. This is expressed as a pair
-    #  of doubles representing degrees latitude and degrees longitude. Unless
-    #  specified otherwise, this must conform to the
-    #  <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
-    #  standard</a>. Values must be within normalized ranges.
+    # of doubles representing degrees latitude and degrees longitude. Unless
+    # specified otherwise, this must conform to the
+    # <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
+    # standard</a>. Values must be within normalized ranges.
     #
-    #  Example of normalization code in Python:
+    # Example of normalization code in Python:
     #
-    #      def NormalizeLongitude(longitude):
-    #        """Wraps decimal degrees longitude to [-180.0, 180.0]."""
-    #        q, r = divmod(longitude, 360.0)
-    #        if r > 180.0 or (r == 180.0 and q <= -1.0):
-    #          return r - 360.0
-    #        return r
+    #     def NormalizeLongitude(longitude):
+    #       """Wraps decimal degrees longitude to [-180.0, 180.0]."""
+    #       q, r = divmod(longitude, 360.0)
+    #       if r > 180.0 or (r == 180.0 and q <= -1.0):
+    #         return r - 360.0
+    #       return r
     #
-    #      def NormalizeLatLng(latitude, longitude):
-    #        """Wraps decimal degrees latitude and longitude to
-    #        [-90.0, 90.0] and [-180.0, 180.0], respectively."""
-    #        r = latitude % 360.0
-    #        if r <= 90.0:
-    #          return r, NormalizeLongitude(longitude)
-    #        elif r >= 270.0:
-    #          return r - 360, NormalizeLongitude(longitude)
-    #        else:
-    #          return 180 - r, NormalizeLongitude(longitude + 180.0)
+    #     def NormalizeLatLng(latitude, longitude):
+    #       """Wraps decimal degrees latitude and longitude to
+    #       [-90.0, 90.0] and [-180.0, 180.0], respectively."""
+    #       r = latitude % 360.0
+    #       if r <= 90.0:
+    #         return r, NormalizeLongitude(longitude)
+    #       elif r >= 270.0:
+    #         return r - 360, NormalizeLongitude(longitude)
+    #       else:
+    #         return 180 - r, NormalizeLongitude(longitude + 180.0)
     #
-    #      assert 180.0 == NormalizeLongitude(180.0)
-    #      assert -180.0 == NormalizeLongitude(-180.0)
-    #      assert -179.0 == NormalizeLongitude(181.0)
-    #      assert (0.0, 0.0) == NormalizeLatLng(360.0, 0.0)
-    #      assert (0.0, 0.0) == NormalizeLatLng(-360.0, 0.0)
-    #      assert (85.0, 180.0) == NormalizeLatLng(95.0, 0.0)
-    #      assert (-85.0, -170.0) == NormalizeLatLng(-95.0, 10.0)
-    #      assert (90.0, 10.0) == NormalizeLatLng(90.0, 10.0)
-    #      assert (-90.0, -10.0) == NormalizeLatLng(-90.0, -10.0)
-    #      assert (0.0, -170.0) == NormalizeLatLng(-180.0, 10.0)
-    #      assert (0.0, -170.0) == NormalizeLatLng(180.0, 10.0)
-    #      assert (-90.0, 10.0) == NormalizeLatLng(270.0, 10.0)
-    #      assert (90.0, 10.0) == NormalizeLatLng(-270.0, 10.0)
+    #     assert 180.0 == NormalizeLongitude(180.0)
+    #     assert -180.0 == NormalizeLongitude(-180.0)
+    #     assert -179.0 == NormalizeLongitude(181.0)
+    #     assert (0.0, 0.0) == NormalizeLatLng(360.0, 0.0)
+    #     assert (0.0, 0.0) == NormalizeLatLng(-360.0, 0.0)
+    #     assert (85.0, 180.0) == NormalizeLatLng(95.0, 0.0)
+    #     assert (-85.0, -170.0) == NormalizeLatLng(-95.0, 10.0)
+    #     assert (90.0, 10.0) == NormalizeLatLng(90.0, 10.0)
+    #     assert (-90.0, -10.0) == NormalizeLatLng(-90.0, -10.0)
+    #     assert (0.0, -170.0) == NormalizeLatLng(-180.0, 10.0)
+    #     assert (0.0, -170.0) == NormalizeLatLng(180.0, 10.0)
+    #     assert (-90.0, 10.0) == NormalizeLatLng(270.0, 10.0)
+    #     assert (90.0, 10.0) == NormalizeLatLng(-270.0, 10.0)
     # @!attribute [rw] latitude
     #   @return [Float]
     #     The latitude in degrees. It must be in the range [-90.0, +90.0].

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -174,20 +174,20 @@ module Google
 
             ##
             # Run asynchronous image detection and annotation for a list of generic
-            #  files, such as PDF files, which may contain multiple pages and multiple
-            #  images per page. Progress and results can be retrieved through the
-            #  `google.longrunning.Operations` interface.
-            #  `Operation.metadata` contains `OperationMetadata` (metadata).
-            #  `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
+            # files, such as PDF files, which may contain multiple pages and multiple
+            # images per page. Progress and results can be retrieved through the
+            # `google.longrunning.Operations` interface.
+            # `Operation.metadata` contains `OperationMetadata` (metadata).
+            # `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
             #
             # @overload async_batch_annotate_files(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest | Hash]
             #     Run asynchronous image detection and annotation for a list of generic
-            #      files, such as PDF files, which may contain multiple pages and multiple
-            #      images per page. Progress and results can be retrieved through the
-            #      `google.longrunning.Operations` interface.
-            #      `Operation.metadata` contains `OperationMetadata` (metadata).
-            #      `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
+            #     files, such as PDF files, which may contain multiple pages and multiple
+            #     images per page. Progress and results can be retrieved through the
+            #     `google.longrunning.Operations` interface.
+            #     `Operation.metadata` contains `OperationMetadata` (metadata).
+            #     `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -219,19 +219,19 @@ module Google
             ##
             # Creates and returns a new ProductSet resource.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
-            #    4096 characters.
+            # * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
+            #   4096 characters.
             #
             # @overload create_product_set(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::CreateProductSetRequest | Hash]
             #     Creates and returns a new ProductSet resource.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
-            #        4096 characters.
+            #     * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
+            #       4096 characters.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -239,14 +239,14 @@ module Google
             #   @param parent [String]
             #     The project in which the ProductSet should be created.
             #
-            #      Format is `projects/PROJECT_ID/locations/LOC_ID`.
+            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
             #   @param product_set [Google::Cloud::Vision::V1::ProductSet | Hash]
             #     The ProductSet to create.
             #   @param product_set_id [String]
             #     A user-supplied resource id for this ProductSet. If set, the server will
-            #      attempt to use this value as the resource id. If it is already in use, an
-            #      error is returned with code ALREADY_EXISTS. Must be at most 128 characters
-            #      long. It cannot contain the character `/`.
+            #     attempt to use this value as the resource id. If it is already in use, an
+            #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
+            #     long. It cannot contain the character `/`.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -274,19 +274,19 @@ module Google
             ##
             # Lists ProductSets in an unspecified order.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
-            #    than 1.
+            # * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
+            #   than 1.
             #
             # @overload list_product_sets(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::ListProductSetsRequest | Hash]
             #     Lists ProductSets in an unspecified order.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
-            #        than 1.
+            #     * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
+            #       than 1.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -294,7 +294,7 @@ module Google
             #   @param parent [String]
             #     The project from which ProductSets should be listed.
             #
-            #      Format is `projects/PROJECT_ID/locations/LOC_ID`.
+            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
             #   @param page_size [Integer]
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
@@ -326,17 +326,17 @@ module Google
             ##
             # Gets information associated with a ProductSet.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns NOT_FOUND if the ProductSet does not exist.
+            # * Returns NOT_FOUND if the ProductSet does not exist.
             #
             # @overload get_product_set(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::GetProductSetRequest | Hash]
             #     Gets information associated with a ProductSet.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns NOT_FOUND if the ProductSet does not exist.
+            #     * Returns NOT_FOUND if the ProductSet does not exist.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -344,8 +344,8 @@ module Google
             #   @param name [String]
             #     Resource name of the ProductSet to get.
             #
-            #      Format is:
-            #      `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -372,24 +372,24 @@ module Google
 
             ##
             # Makes changes to a ProductSet resource.
-            #  Only display_name can be updated currently.
+            # Only display_name can be updated currently.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns NOT_FOUND if the ProductSet does not exist.
-            #  * Returns INVALID_ARGUMENT if display_name is present in update_mask but
-            #    missing from the request or longer than 4096 characters.
+            # * Returns NOT_FOUND if the ProductSet does not exist.
+            # * Returns INVALID_ARGUMENT if display_name is present in update_mask but
+            #   missing from the request or longer than 4096 characters.
             #
             # @overload update_product_set(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::UpdateProductSetRequest | Hash]
             #     Makes changes to a ProductSet resource.
-            #      Only display_name can be updated currently.
+            #     Only display_name can be updated currently.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns NOT_FOUND if the ProductSet does not exist.
-            #      * Returns INVALID_ARGUMENT if display_name is present in update_mask but
-            #        missing from the request or longer than 4096 characters.
+            #     * Returns NOT_FOUND if the ProductSet does not exist.
+            #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but
+            #       missing from the request or longer than 4096 characters.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -398,9 +398,9 @@ module Google
             #     The ProductSet resource which replaces the one on the server.
             #   @param update_mask [Google::Protobuf::FieldMask | Hash]
             #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields to
-            #      update.
-            #      If update_mask isn't specified, all mutable fields are to be updated.
-            #      Valid mask path is `display_name`.
+            #     update.
+            #     If update_mask isn't specified, all mutable fields are to be updated.
+            #     Valid mask path is `display_name`.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -427,24 +427,24 @@ module Google
 
             ##
             # Permanently deletes a ProductSet. Products and ReferenceImages in the
-            #  ProductSet are not deleted.
+            # ProductSet are not deleted.
             #
-            #  The actual image files are not deleted from Google Cloud Storage.
+            # The actual image files are not deleted from Google Cloud Storage.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns NOT_FOUND if the ProductSet does not exist.
+            # * Returns NOT_FOUND if the ProductSet does not exist.
             #
             # @overload delete_product_set(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::DeleteProductSetRequest | Hash]
             #     Permanently deletes a ProductSet. Products and ReferenceImages in the
-            #      ProductSet are not deleted.
+            #     ProductSet are not deleted.
             #
-            #      The actual image files are not deleted from Google Cloud Storage.
+            #     The actual image files are not deleted from Google Cloud Storage.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns NOT_FOUND if the ProductSet does not exist.
+            #     * Returns NOT_FOUND if the ProductSet does not exist.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -452,8 +452,8 @@ module Google
             #   @param name [String]
             #     Resource name of the ProductSet to delete.
             #
-            #      Format is:
-            #      `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -481,23 +481,23 @@ module Google
             ##
             # Creates and returns a new product resource.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
-            #    characters.
-            #  * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
-            #  * Returns INVALID_ARGUMENT if product_category is missing or invalid.
+            # * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
+            #   characters.
+            # * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
+            # * Returns INVALID_ARGUMENT if product_category is missing or invalid.
             #
             # @overload create_product(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::CreateProductRequest | Hash]
             #     Creates and returns a new product resource.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
-            #        characters.
-            #      * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
-            #      * Returns INVALID_ARGUMENT if product_category is missing or invalid.
+            #     * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
+            #       characters.
+            #     * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
+            #     * Returns INVALID_ARGUMENT if product_category is missing or invalid.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -505,15 +505,15 @@ module Google
             #   @param parent [String]
             #     The project in which the Product should be created.
             #
-            #      Format is
-            #      `projects/PROJECT_ID/locations/LOC_ID`.
+            #     Format is
+            #     `projects/PROJECT_ID/locations/LOC_ID`.
             #   @param product [Google::Cloud::Vision::V1::Product | Hash]
             #     The product to create.
             #   @param product_id [String]
             #     A user-supplied resource id for this Product. If set, the server will
-            #      attempt to use this value as the resource id. If it is already in use, an
-            #      error is returned with code ALREADY_EXISTS. Must be at most 128 characters
-            #      long. It cannot contain the character `/`.
+            #     attempt to use this value as the resource id. If it is already in use, an
+            #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
+            #     long. It cannot contain the character `/`.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -541,17 +541,17 @@ module Google
             ##
             # Lists products in an unspecified order.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            # * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #
             # @overload list_products(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::ListProductsRequest | Hash]
             #     Lists products in an unspecified order.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -559,8 +559,8 @@ module Google
             #   @param parent [String]
             #     The project OR ProductSet from which Products should be listed.
             #
-            #      Format:
-            #      `projects/PROJECT_ID/locations/LOC_ID`
+            #     Format:
+            #     `projects/PROJECT_ID/locations/LOC_ID`
             #   @param page_size [Integer]
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
@@ -592,17 +592,17 @@ module Google
             ##
             # Gets information associated with a Product.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns NOT_FOUND if the Product does not exist.
+            # * Returns NOT_FOUND if the Product does not exist.
             #
             # @overload get_product(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::GetProductRequest | Hash]
             #     Gets information associated with a Product.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns NOT_FOUND if the Product does not exist.
+            #     * Returns NOT_FOUND if the Product does not exist.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -610,8 +610,8 @@ module Google
             #   @param name [String]
             #     Resource name of the Product to get.
             #
-            #      Format is:
-            #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -638,51 +638,51 @@ module Google
 
             ##
             # Makes changes to a Product resource.
-            #  Only the `display_name`, `description`, and `labels` fields can be updated
-            #  right now.
+            # Only the `display_name`, `description`, and `labels` fields can be updated
+            # right now.
             #
-            #  If labels are updated, the change will not be reflected in queries until
-            #  the next index time.
+            # If labels are updated, the change will not be reflected in queries until
+            # the next index time.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns NOT_FOUND if the Product does not exist.
-            #  * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
-            #    missing from the request or longer than 4096 characters.
-            #  * Returns INVALID_ARGUMENT if description is present in update_mask but is
-            #    longer than 4096 characters.
-            #  * Returns INVALID_ARGUMENT if product_category is present in update_mask.
+            # * Returns NOT_FOUND if the Product does not exist.
+            # * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
+            #   missing from the request or longer than 4096 characters.
+            # * Returns INVALID_ARGUMENT if description is present in update_mask but is
+            #   longer than 4096 characters.
+            # * Returns INVALID_ARGUMENT if product_category is present in update_mask.
             #
             # @overload update_product(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::UpdateProductRequest | Hash]
             #     Makes changes to a Product resource.
-            #      Only the `display_name`, `description`, and `labels` fields can be updated
-            #      right now.
+            #     Only the `display_name`, `description`, and `labels` fields can be updated
+            #     right now.
             #
-            #      If labels are updated, the change will not be reflected in queries until
-            #      the next index time.
+            #     If labels are updated, the change will not be reflected in queries until
+            #     the next index time.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns NOT_FOUND if the Product does not exist.
-            #      * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
-            #        missing from the request or longer than 4096 characters.
-            #      * Returns INVALID_ARGUMENT if description is present in update_mask but is
-            #        longer than 4096 characters.
-            #      * Returns INVALID_ARGUMENT if product_category is present in update_mask.
+            #     * Returns NOT_FOUND if the Product does not exist.
+            #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
+            #       missing from the request or longer than 4096 characters.
+            #     * Returns INVALID_ARGUMENT if description is present in update_mask but is
+            #       longer than 4096 characters.
+            #     * Returns INVALID_ARGUMENT if product_category is present in update_mask.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload update_product(product: nil, update_mask: nil, options: nil)
             #   @param product [Google::Cloud::Vision::V1::Product | Hash]
             #     The Product resource which replaces the one on the server.
-            #      product.name is immutable.
+            #     product.name is immutable.
             #   @param update_mask [Google::Protobuf::FieldMask | Hash]
             #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields
-            #      to update.
-            #      If update_mask isn't specified, all mutable fields are to be updated.
-            #      Valid mask paths include `product_labels`, `display_name`, and
-            #      `description`.
+            #     to update.
+            #     If update_mask isn't specified, all mutable fields are to be updated.
+            #     Valid mask paths include `product_labels`, `display_name`, and
+            #     `description`.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -710,25 +710,25 @@ module Google
             ##
             # Permanently deletes a product and its reference images.
             #
-            #  Metadata of the product and all its images will be deleted right away, but
-            #  search queries against ProductSets containing the product may still work
-            #  until all related caches are refreshed.
+            # Metadata of the product and all its images will be deleted right away, but
+            # search queries against ProductSets containing the product may still work
+            # until all related caches are refreshed.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns NOT_FOUND if the product does not exist.
+            # * Returns NOT_FOUND if the product does not exist.
             #
             # @overload delete_product(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::DeleteProductRequest | Hash]
             #     Permanently deletes a product and its reference images.
             #
-            #      Metadata of the product and all its images will be deleted right away, but
-            #      search queries against ProductSets containing the product may still work
-            #      until all related caches are refreshed.
+            #     Metadata of the product and all its images will be deleted right away, but
+            #     search queries against ProductSets containing the product may still work
+            #     until all related caches are refreshed.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns NOT_FOUND if the product does not exist.
+            #     * Returns NOT_FOUND if the product does not exist.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -736,8 +736,8 @@ module Google
             #   @param name [String]
             #     Resource name of product to delete.
             #
-            #      Format is:
-            #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -765,45 +765,45 @@ module Google
             ##
             # Creates and returns a new ReferenceImage resource.
             #
-            #  The `bounding_poly` field is optional. If `bounding_poly` is not specified,
-            #  the system will try to detect regions of interest in the image that are
-            #  compatible with the product_category on the parent product. If it is
-            #  specified, detection is ALWAYS skipped. The system converts polygons into
-            #  non-rotated rectangles.
+            # The `bounding_poly` field is optional. If `bounding_poly` is not specified,
+            # the system will try to detect regions of interest in the image that are
+            # compatible with the product_category on the parent product. If it is
+            # specified, detection is ALWAYS skipped. The system converts polygons into
+            # non-rotated rectangles.
             #
-            #  Note that the pipeline will resize the image if the image resolution is too
-            #  large to process (above 50MP).
+            # Note that the pipeline will resize the image if the image resolution is too
+            # large to process (above 50MP).
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
-            #    characters.
-            #  * Returns INVALID_ARGUMENT if the product does not exist.
-            #  * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
-            #    compatible with the parent product's product_category is detected.
-            #  * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
+            # * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
+            #   characters.
+            # * Returns INVALID_ARGUMENT if the product does not exist.
+            # * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
+            #   compatible with the parent product's product_category is detected.
+            # * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
             #
             # @overload create_reference_image(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::CreateReferenceImageRequest | Hash]
             #     Creates and returns a new ReferenceImage resource.
             #
-            #      The `bounding_poly` field is optional. If `bounding_poly` is not specified,
-            #      the system will try to detect regions of interest in the image that are
-            #      compatible with the product_category on the parent product. If it is
-            #      specified, detection is ALWAYS skipped. The system converts polygons into
-            #      non-rotated rectangles.
+            #     The `bounding_poly` field is optional. If `bounding_poly` is not specified,
+            #     the system will try to detect regions of interest in the image that are
+            #     compatible with the product_category on the parent product. If it is
+            #     specified, detection is ALWAYS skipped. The system converts polygons into
+            #     non-rotated rectangles.
             #
-            #      Note that the pipeline will resize the image if the image resolution is too
-            #      large to process (above 50MP).
+            #     Note that the pipeline will resize the image if the image resolution is too
+            #     large to process (above 50MP).
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
-            #        characters.
-            #      * Returns INVALID_ARGUMENT if the product does not exist.
-            #      * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
-            #        compatible with the parent product's product_category is detected.
-            #      * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
+            #     * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
+            #       characters.
+            #     * Returns INVALID_ARGUMENT if the product does not exist.
+            #     * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
+            #       compatible with the parent product's product_category is detected.
+            #     * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -811,16 +811,16 @@ module Google
             #   @param parent [String]
             #     Resource name of the product in which to create the reference image.
             #
-            #      Format is
-            #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
+            #     Format is
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
             #   @param reference_image [Google::Cloud::Vision::V1::ReferenceImage | Hash]
             #     The reference image to create.
-            #      If an image ID is specified, it is ignored.
+            #     If an image ID is specified, it is ignored.
             #   @param reference_image_id [String]
             #     A user-supplied resource id for the ReferenceImage to be added. If set,
-            #      the server will attempt to use this value as the resource id. If it is
-            #      already in use, an error is returned with code ALREADY_EXISTS. Must be at
-            #      most 128 characters long. It cannot contain the character `/`.
+            #     the server will attempt to use this value as the resource id. If it is
+            #     already in use, an error is returned with code ALREADY_EXISTS. Must be at
+            #     most 128 characters long. It cannot contain the character `/`.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -848,29 +848,29 @@ module Google
             ##
             # Permanently deletes a reference image.
             #
-            #  The image metadata will be deleted right away, but search queries
-            #  against ProductSets containing the image may still work until all related
-            #  caches are refreshed.
+            # The image metadata will be deleted right away, but search queries
+            # against ProductSets containing the image may still work until all related
+            # caches are refreshed.
             #
-            #  The actual image files are not deleted from Google Cloud Storage.
+            # The actual image files are not deleted from Google Cloud Storage.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns NOT_FOUND if the reference image does not exist.
+            # * Returns NOT_FOUND if the reference image does not exist.
             #
             # @overload delete_reference_image(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::DeleteReferenceImageRequest | Hash]
             #     Permanently deletes a reference image.
             #
-            #      The image metadata will be deleted right away, but search queries
-            #      against ProductSets containing the image may still work until all related
-            #      caches are refreshed.
+            #     The image metadata will be deleted right away, but search queries
+            #     against ProductSets containing the image may still work until all related
+            #     caches are refreshed.
             #
-            #      The actual image files are not deleted from Google Cloud Storage.
+            #     The actual image files are not deleted from Google Cloud Storage.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns NOT_FOUND if the reference image does not exist.
+            #     * Returns NOT_FOUND if the reference image does not exist.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -878,9 +878,9 @@ module Google
             #   @param name [String]
             #     The resource name of the reference image to delete.
             #
-            #      Format is:
+            #     Format is:
             #
-            #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -908,21 +908,21 @@ module Google
             ##
             # Lists reference images.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns NOT_FOUND if the parent product does not exist.
-            #  * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
-            #    than 1.
+            # * Returns NOT_FOUND if the parent product does not exist.
+            # * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
+            #   than 1.
             #
             # @overload list_reference_images(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::ListReferenceImagesRequest | Hash]
             #     Lists reference images.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns NOT_FOUND if the parent product does not exist.
-            #      * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
-            #        than 1.
+            #     * Returns NOT_FOUND if the parent product does not exist.
+            #     * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
+            #       than 1.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -930,15 +930,15 @@ module Google
             #   @param parent [String]
             #     Resource name of the product containing the reference images.
             #
-            #      Format is
-            #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
+            #     Format is
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
             #   @param page_size [Integer]
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
             #     A token identifying a page of results to be returned. This is the value
-            #      of `nextPageToken` returned in a previous reference image list request.
+            #     of `nextPageToken` returned in a previous reference image list request.
             #
-            #      Defaults to the first page if not specified.
+            #     Defaults to the first page if not specified.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -966,17 +966,17 @@ module Google
             ##
             # Gets information associated with a ReferenceImage.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns NOT_FOUND if the specified image does not exist.
+            # * Returns NOT_FOUND if the specified image does not exist.
             #
             # @overload get_reference_image(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::GetReferenceImageRequest | Hash]
             #     Gets information associated with a ReferenceImage.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns NOT_FOUND if the specified image does not exist.
+            #     * Returns NOT_FOUND if the specified image does not exist.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -984,9 +984,9 @@ module Google
             #   @param name [String]
             #     The resource name of the ReferenceImage to get.
             #
-            #      Format is:
+            #     Format is:
             #
-            #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -1013,24 +1013,24 @@ module Google
 
             ##
             # Adds a Product to the specified ProductSet. If the Product is already
-            #  present, no change is made.
+            # present, no change is made.
             #
-            #  One Product can be added to at most 100 ProductSets.
+            # One Product can be added to at most 100 ProductSets.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
+            # * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
             #
             # @overload add_product_to_product_set(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::AddProductToProductSetRequest | Hash]
             #     Adds a Product to the specified ProductSet. If the Product is already
-            #      present, no change is made.
+            #     present, no change is made.
             #
-            #      One Product can be added to at most 100 ProductSets.
+            #     One Product can be added to at most 100 ProductSets.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
+            #     * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -1038,13 +1038,13 @@ module Google
             #   @param name [String]
             #     The resource name for the ProductSet to modify.
             #
-            #      Format is:
-            #      `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
             #   @param product [String]
             #     The resource name for the Product to be added to this ProductSet.
             #
-            #      Format is:
-            #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -1072,17 +1072,17 @@ module Google
             ##
             # Removes a Product from the specified ProductSet.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns NOT_FOUND If the Product is not found under the ProductSet.
+            # * Returns NOT_FOUND If the Product is not found under the ProductSet.
             #
             # @overload remove_product_from_product_set(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest | Hash]
             #     Removes a Product from the specified ProductSet.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns NOT_FOUND If the Product is not found under the ProductSet.
+            #     * Returns NOT_FOUND If the Product is not found under the ProductSet.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -1090,13 +1090,13 @@ module Google
             #   @param name [String]
             #     The resource name for the ProductSet to modify.
             #
-            #      Format is:
-            #      `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
             #   @param product [String]
             #     The resource name for the Product to be removed from this ProductSet.
             #
-            #      Format is:
-            #      `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -1123,22 +1123,22 @@ module Google
 
             ##
             # Lists the Products in a ProductSet, in an unspecified order. If the
-            #  ProductSet does not exist, the products field of the response will be
-            #  empty.
+            # ProductSet does not exist, the products field of the response will be
+            # empty.
             #
-            #  Possible errors:
+            # Possible errors:
             #
-            #  * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            # * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #
             # @overload list_products_in_product_set(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::ListProductsInProductSetRequest | Hash]
             #     Lists the Products in a ProductSet, in an unspecified order. If the
-            #      ProductSet does not exist, the products field of the response will be
-            #      empty.
+            #     ProductSet does not exist, the products field of the response will be
+            #     empty.
             #
-            #      Possible errors:
+            #     Possible errors:
             #
-            #      * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -1146,8 +1146,8 @@ module Google
             #   @param name [String]
             #     The ProductSet resource for which to retrieve Products.
             #
-            #      Format is:
-            #      `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
             #   @param page_size [Integer]
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
@@ -1178,30 +1178,30 @@ module Google
 
             ##
             # Asynchronous API that imports a list of reference images to specified
-            #  product sets based on a list of image information.
+            # product sets based on a list of image information.
             #
-            #  The [google.longrunning.Operation][google.longrunning.Operation] API can be
-            #  used to keep track of the progress and results of the request.
-            #  `Operation.metadata` contains `BatchOperationMetadata`. (progress)
-            #  `Operation.response` contains `ImportProductSetsResponse`. (results)
+            # The [google.longrunning.Operation][google.longrunning.Operation] API can be
+            # used to keep track of the progress and results of the request.
+            # `Operation.metadata` contains `BatchOperationMetadata`. (progress)
+            # `Operation.response` contains `ImportProductSetsResponse`. (results)
             #
-            #  The input source of this method is a csv file on Google Cloud Storage.
-            #  For the format of the csv file please see
-            #  [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+            # The input source of this method is a csv file on Google Cloud Storage.
+            # For the format of the csv file please see
+            # [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
             #
             # @overload import_product_sets(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::ImportProductSetsRequest | Hash]
             #     Asynchronous API that imports a list of reference images to specified
-            #      product sets based on a list of image information.
+            #     product sets based on a list of image information.
             #
-            #      The [google.longrunning.Operation][google.longrunning.Operation] API can be
-            #      used to keep track of the progress and results of the request.
-            #      `Operation.metadata` contains `BatchOperationMetadata`. (progress)
-            #      `Operation.response` contains `ImportProductSetsResponse`. (results)
+            #     The [google.longrunning.Operation][google.longrunning.Operation] API can be
+            #     used to keep track of the progress and results of the request.
+            #     `Operation.metadata` contains `BatchOperationMetadata`. (progress)
+            #     `Operation.response` contains `ImportProductSetsResponse`. (results)
             #
-            #      The input source of this method is a csv file on Google Cloud Storage.
-            #      For the format of the csv file please see
-            #      [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+            #     The input source of this method is a csv file on Google Cloud Storage.
+            #     For the format of the csv file please see
+            #     [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
             #   @param options [Google::Gax::CallOptions]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
@@ -1209,7 +1209,7 @@ module Google
             #   @param parent [String]
             #     The project in which the ProductSets should be imported.
             #
-            #      Format is `projects/PROJECT_ID/locations/LOC_ID`.
+            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
             #   @param input_config [Google::Cloud::Vision::V1::ImportProductSetsInputConfig | Hash]
             #     The input content for the list of requests.
             #   @param options [Google::Gax::CallOptions]


### PR DESCRIPTION
The proto comments usually had a leading space on each line. This was causing weird things to happen when running yard.