### PR TITLE
Run rubocop autocorrect on a dir rather than per file

### DIFF
--- a/gapic-generator-cloud/lib/google/gapic/generators/cloud_generator.rb
+++ b/gapic-generator-cloud/lib/google/gapic/generators/cloud_generator.rb
@@ -88,6 +88,8 @@ module Google
           files << g("rubocop.erb",  ".rubocop",                    gem: gem)
           files << g("license.erb",  "LICENSE.md",                  gem: gem)
 
+          format_files files
+
           files
         end
 

--- a/gapic-generator/lib/google/gapic/file_formatter.rb
+++ b/gapic-generator/lib/google/gapic/file_formatter.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "tmpdir"
+require "fileutils"
+
+module Google
+  module Gapic
+    ##
+    # File Formatter
+    class FileFormatter
+      attr_reader :configuration, :files
+
+      ##
+      # Create a new file formatter object
+      #
+      # @param path_template [String] The URI path template to be parsed.
+      def initialize configuration, files
+        @configuration = configuration
+        @files = format! configuration, files
+      end
+
+      protected
+
+      def format! configuration, files
+        Dir.mktmpdir do |dir|
+          files.each do |file|
+            write_file dir, file
+          end
+
+          system "rubocop --auto-correct #{dir} -o #{dir}/rubocop.out " \
+                 "-c #{configuration}"
+
+          files.each do |file|
+            read_file dir, file
+          end
+        end
+      end
+
+      def write_file dir, file
+        tmp_file = File.join dir, file.name
+        FileUtils.mkdir_p File.dirname tmp_file
+        File.write tmp_file, file.content
+      end
+
+      def read_file dir, file
+        tmp_file = File.join dir, file.name
+        file.content = File.read tmp_file
+      end
+    end
+  end
+end

--- a/gapic-generator/lib/google/gapic/generators/base_generator.rb
+++ b/gapic-generator/lib/google/gapic/generators/base_generator.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "google/gapic/file_formatter"
 require "action_controller"
 require "google/protobuf/compiler/plugin.pb"
 require "tempfile"
@@ -80,23 +81,7 @@ module Google
         alias_method :g, :generate_file
 
         def format_files files
-          require "tmpdir"
-          require "fileutils"
-          Dir.mktmpdir do |dir|
-            files.each do |file|
-              tmp_file = File.join dir, file.name
-              FileUtils.mkdir_p File.dirname tmp_file
-              File.write tmp_file, file.content
-            end
-
-            system "rubocop --auto-correct #{dir} -o #{dir}/rubocop.out" \
-                   " -c #{format_config}"
-
-            files.each do |file|
-              tmp_file = File.join dir, file.name
-              file.content = File.read tmp_file
-            end
-          end
+          FileFormatter.new(format_config, files).files
         end
 
         def format_config

--- a/gapic-generator/lib/google/gapic/generators/default_generator.rb
+++ b/gapic-generator/lib/google/gapic/generators/default_generator.rb
@@ -53,6 +53,8 @@ module Google
                        api: @api, service: service)
           end
 
+          format_files files
+
           files
         end
       end


### PR DESCRIPTION
I have been having some pain regenerating the libraries since it takes quite a while since rubocop runs individually per file making it really slow.

#### Before
```sh
$ time bundle exec rake gen
...
> bundle exec rake gen  134.99s user 52.76s system 98% cpu 3:10.42 total
```

#### After
```sh
$ time bundle exec rake gen
...
> bundle exec rake gen  35.73s user 8.23s system 98% cpu 44.503 total
```