### PR TITLE
Rename Gapic::Template to Gapic::PathTemplate

### DIFF
--- a/gapic-generator-cloud/templates/cloud/client/_resource.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_resource.erb
@@ -4,7 +4,7 @@
 #
 # The resource will be in the following format:
 #
-# `<%= resource.template %>`
+# `<%= resource.path_template %>`
 #
 <%- resource.arguments.each do |arg| -%>
 # @param <%= arg.name %> [String]

--- a/gapic-generator-cloud/templates/cloud/helpers/presenters/resource_presenter.rb
+++ b/gapic-generator-cloud/templates/cloud/helpers/presenters/resource_presenter.rb
@@ -14,24 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "google/gapic/template"
+require "google/gapic/path_template"
 require "ostruct"
 require "active_support/inflector"
 
 class ResourcePresenter
-  def initialize name, template
+  def initialize name, path_template
     @name     = name
-    @template = template
-    @segments = Google::Gapic::Template.parse template
+    @path_template = path_template
+    @segments = Google::Gapic::PathTemplate.parse path_template
 
-    # Template verification for expected proto resource usage
+    # URI path template verification for expected proto resource usage
     if positional_args? @segments
       raise ArgumentError, "only resources with named segments are supported, " \
-                           " not #{template}"
+                           " not #{path_template}"
     end
     if named_arg_patterns? @segments
       raise ArgumentError, "only resources without named patterns are supported, " \
-                           " not #{template}"
+                           " not #{path_template}"
     end
   end
 
@@ -39,8 +39,8 @@ class ResourcePresenter
     @name
   end
 
-  def template
-    @template
+  def path_template
+    @path_template
   end
 
   def path_helper
@@ -62,7 +62,7 @@ class ResourcePresenter
 
   def path_string
     @segments.map do |segment|
-      if segment.is_a? Google::Gapic::Template::Segment
+      if segment.is_a? Google::Gapic::PathTemplate::Segment
         "\#{#{segment.name}}"
       else
         # Should be a String
@@ -74,7 +74,7 @@ class ResourcePresenter
   private
 
   def arg_segments segments
-    segments.select { |segment| segment.is_a? Google::Gapic::Template::Segment }
+    segments.select { |segment| segment.is_a? Google::Gapic::PathTemplate::Segment }
   end
 
   def positional_args? segments

--- a/gapic-generator/Rakefile
+++ b/gapic-generator/Rakefile
@@ -89,7 +89,7 @@ task :gen do
   Rake::Task["gen:gem_creation"].invoke
 end
 namespace :gen do
-  desc "Generate the expected output for template tests"
+  desc "Generate the expected output for templates tests"
   task :templates do
     generate_default_templates "speech"
     generate_default_templates "vision"

--- a/gapic-generator/lib/google/gapic/generators/default_generator.rb
+++ b/gapic-generator/lib/google/gapic/generators/default_generator.rb
@@ -32,7 +32,7 @@ module Google
           use_templates! File.expand_path \
             File.join __dir__, "../../../../templates/default"
 
-          # Configure to use a custom template directory
+          # Configure to use a custom templates directory
           custom_templates = api.protoc_options[:templates]
           use_templates! custom_templates if custom_templates
 

--- a/gapic-generator/lib/google/gapic/path_template.rb
+++ b/gapic-generator/lib/google/gapic/path_template.rb
@@ -14,18 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "google/gapic/template/parser"
+require "google/gapic/path_template/parser"
 
 module Google
   module Gapic
-    module Template
-      # Parse a URI template.
+    module PathTemplate
+      # Parse a URI path template.
       #
-      # @param template [String] The template to be parsed.
+      # @see https://tools.ietf.org/html/rfc6570 URI Template
       #
-      # @return [Array<Template::Segment|String>] The segments of the template.
-      def self.parse template
-        Parser.new(template).segments
+      # @param path_template [String] The URI path template to be parsed.
+      #
+      # @return [Array<Template::Segment|String>] The segments of the URI path
+      #   template.
+      def self.parse path_template
+        Parser.new(path_template).segments
       end
     end
   end

--- a/gapic-generator/lib/google/gapic/path_template.rb
+++ b/gapic-generator/lib/google/gapic/path_template.rb
@@ -25,8 +25,8 @@ module Google
       #
       # @param path_template [String] The URI path template to be parsed.
       #
-      # @return [Array<Template::Segment|String>] The segments of the URI path
-      #   template.
+      # @return [Array<PathTemplate::Segment|String>] The segments of the URI
+      #   path template.
       def self.parse path_template
         Parser.new(path_template).segments
       end

--- a/gapic-generator/lib/google/gapic/path_template/parser.rb
+++ b/gapic-generator/lib/google/gapic/path_template/parser.rb
@@ -30,12 +30,12 @@ module Google
       #     template.
       class Parser
         # @private
-        # /((?<positional>\*\*?)|{(?<name>[^\/]+?)(?:=(?<path_template>.+?))?})/
-        TEMPLATE = %r{
+        # /((?<positional>\*\*?)|{(?<name>[^\/]+?)(?:=(?<template>.+?))?})/
+        PATH_TEMPLATE = %r{
           (
             (?<positional>\*\*?)
             |
-            {(?<name>[^\/]+?)(?:=(?<path_template>.+?))?}
+            {(?<name>[^\/]+?)(?:=(?<template>.+?))?}
           )
         }x.freeze
 
@@ -56,7 +56,7 @@ module Google
           segments = []
           segment_pos = 0
 
-          while (match = TEMPLATE.match path_template)
+          while (match = PATH_TEMPLATE.match path_template)
             # The String before the match needs to be added to the segments
             segments << match.pre_match unless match.pre_match.empty?
 
@@ -76,7 +76,7 @@ module Google
           if match[:positional]
             [Segment.new(pos, match[:positional]), pos + 1]
           else
-            [Segment.new(match[:name], match[:path_template]), pos]
+            [Segment.new(match[:name], match[:template]), pos]
           end
         end
       end

--- a/gapic-generator/lib/google/gapic/path_template/parser.rb
+++ b/gapic-generator/lib/google/gapic/path_template/parser.rb
@@ -14,57 +14,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "google/gapic/template/segment"
+require "google/gapic/path_template/segment"
 
 module Google
   module Gapic
-    module Template
-      # A URI template parser.
+    module PathTemplate
+      # A URI path template parser.
       #
-      # @!attribute [r] template
-      #   @return [String] The template to be parsed.
+      # @see https://tools.ietf.org/html/rfc6570 URI Template
+      #
+      # @!attribute [r] path_template
+      #   @return [String] The URI path template to be parsed.
       # @!attribute [r] segments
-      #   @return [Array<Segment|String>] The segments of the parsed template.
+      #   @return [Array<Segment|String>] The segments of the parsed URI path
+      #     template.
       class Parser
         # @private
-        # /((?<positional>\*\*?)|{(?<name>[^\/]+?)(?:=(?<template>.+?))?})/
+        # /((?<positional>\*\*?)|{(?<name>[^\/]+?)(?:=(?<path_template>.+?))?})/
         TEMPLATE = %r{
           (
             (?<positional>\*\*?)
             |
-            {(?<name>[^\/]+?)(?:=(?<template>.+?))?}
+            {(?<name>[^\/]+?)(?:=(?<path_template>.+?))?}
           )
         }x.freeze
 
-        attr_reader :template, :segments
+        attr_reader :path_template, :segments
 
-        # Create a new URI template parser.
+        # Create a new URI path template parser.
         #
-        # @param template [String] The template to be parsed.
-        def initialize template
-          @template = template
-          @segments = parse! template
+        # @param path_template [String] The URI path template to be parsed.
+        def initialize path_template
+          @path_template = path_template
+          @segments = parse! path_template
         end
 
         protected
 
-        def parse! template
+        def parse! path_template
           # segments contain either Strings or segment objects
           segments = []
           segment_pos = 0
 
-          while (match = TEMPLATE.match template)
+          while (match = TEMPLATE.match path_template)
             # The String before the match needs to be added to the segments
             segments << match.pre_match unless match.pre_match.empty?
 
             segment, segment_pos = segment_and_pos_from_match match, segment_pos
             segments << segment
 
-            template = match.post_match
+            path_template = match.post_match
           end
 
           # Whatever String is unmatched needs to be added to the segments
-          segments << template unless template.empty?
+          segments << path_template unless path_template.empty?
 
           segments
         end
@@ -73,7 +76,7 @@ module Google
           if match[:positional]
             [Segment.new(pos, match[:positional]), pos + 1]
           else
-            [Segment.new(match[:name], match[:template]), pos]
+            [Segment.new(match[:name], match[:path_template]), pos]
           end
         end
       end

--- a/gapic-generator/lib/google/gapic/path_template/segment.rb
+++ b/gapic-generator/lib/google/gapic/path_template/segment.rb
@@ -16,8 +16,10 @@
 
 module Google
   module Gapic
-    module Template
-      # A segment in a URI template.
+    module PathTemplate
+      # A segment in a URI path template.
+      #
+      # @see https://tools.ietf.org/html/rfc6570 URI Template
       #
       # @!attribute [r] name
       #   @return [String, Integer] The name of a named segment, or the position
@@ -48,7 +50,7 @@ module Google
 
         # Determines if the segment has a pattern. Positional segments always
         # have a pattern. Named segments may have a pattern if provided in the
-        # template.
+        # URI path template.
         #
         # @return [Boolean]
         def pattern?

--- a/gapic-generator/test/google/gapic/path_template/empty_path_template_test.rb
+++ b/gapic-generator/test/google/gapic/path_template/empty_path_template_test.rb
@@ -16,9 +16,9 @@
 
 require "test_helper"
 
-class EmptyTemplateTest < TemplateTest
-  def test_empty_template
-    assert_template(
+class EmptyPathTemplateTest < PathTemplateTest
+  def test_empty_path_template
+    assert_path_template(
       "hello/world",
       "hello/world"
     )

--- a/gapic-generator/test/google/gapic/path_template/named_path_template_test.rb
+++ b/gapic-generator/test/google/gapic/path_template/named_path_template_test.rb
@@ -16,55 +16,55 @@
 
 require "test_helper"
 
-class NamedTemplateTest < TemplateTest
-  def test_simple_template
-    assert_template(
+class NamedPathTemplateTest < PathTemplateTest
+  def test_simple_path_template
+    assert_path_template(
       "foo/{bar}/baz/{bif}",
       "foo/",
-      Google::Gapic::Template::Segment.new("bar", nil),
+      Google::Gapic::PathTemplate::Segment.new("bar", nil),
       "/baz/",
-      Google::Gapic::Template::Segment.new("bif", nil)
+      Google::Gapic::PathTemplate::Segment.new("bif", nil)
     )
   end
 
-  def test_pattern_template
-    assert_template(
+  def test_pattern_path_template
+    assert_path_template(
       "hello/{name=foo/*/bar/**}/world",
       "hello/",
-      Google::Gapic::Template::Segment.new("name", "foo/*/bar/**"),
+      Google::Gapic::PathTemplate::Segment.new("name", "foo/*/bar/**"),
       "/world"
     )
   end
 
   def test_prefix_path_template
-    assert_template(
+    assert_path_template(
       "{foo}/bar/{baz}/bif/{qux}",
-      Google::Gapic::Template::Segment.new("foo", nil),
+      Google::Gapic::PathTemplate::Segment.new("foo", nil),
       "/bar/",
-      Google::Gapic::Template::Segment.new("baz", nil),
+      Google::Gapic::PathTemplate::Segment.new("baz", nil),
       "/bif/",
-      Google::Gapic::Template::Segment.new("qux", nil)
+      Google::Gapic::PathTemplate::Segment.new("qux", nil)
     )
   end
 
   def test_trailing_path_template
-    assert_template(
+    assert_path_template(
       "foo/{bar}/baz/{bif}/qux",
       "foo/",
-      Google::Gapic::Template::Segment.new("bar", nil),
+      Google::Gapic::PathTemplate::Segment.new("bar", nil),
       "/baz/",
-      Google::Gapic::Template::Segment.new("bif", nil),
+      Google::Gapic::PathTemplate::Segment.new("bif", nil),
       "/qux"
     )
   end
 
-  def test_more_than_two_names_template
-    # This is a bad template, it can be parsed but not matched
-    assert_template(
+  def test_more_than_two_names_path_template
+    # This is a bad URI path template, it can be parsed but not matched
+    assert_path_template(
       "hello/{foo}{bar}/world",
       "hello/",
-      Google::Gapic::Template::Segment.new("foo", nil),
-      Google::Gapic::Template::Segment.new("bar", nil),
+      Google::Gapic::PathTemplate::Segment.new("foo", nil),
+      Google::Gapic::PathTemplate::Segment.new("bar", nil),
       "/world"
     )
   end

--- a/gapic-generator/test/google/gapic/path_template/positional_path_template_test.rb
+++ b/gapic-generator/test/google/gapic/path_template/positional_path_template_test.rb
@@ -16,46 +16,46 @@
 
 require "test_helper"
 
-class PositionalTemplateTest < TemplateTest
-  def test_simple_template
-    assert_template(
+class PositionalPathTemplateTest < PathTemplateTest
+  def test_simple_path_template
+    assert_path_template(
       "hello/*/world/**",
       "hello/",
-      Google::Gapic::Template::Segment.new(0, "*"),
+      Google::Gapic::PathTemplate::Segment.new(0, "*"),
       "/world/",
-      Google::Gapic::Template::Segment.new(1, "**")
+      Google::Gapic::PathTemplate::Segment.new(1, "**")
     )
   end
 
   def test_prefix_path_template
-    assert_template(
+    assert_path_template(
       "*/bar/*/bif/*",
-      Google::Gapic::Template::Segment.new(0, "*"),
+      Google::Gapic::PathTemplate::Segment.new(0, "*"),
       "/bar/",
-      Google::Gapic::Template::Segment.new(1, "*"),
+      Google::Gapic::PathTemplate::Segment.new(1, "*"),
       "/bif/",
-      Google::Gapic::Template::Segment.new(2, "*")
+      Google::Gapic::PathTemplate::Segment.new(2, "*")
     )
   end
 
   def test_trailing_path_template
-    assert_template(
+    assert_path_template(
       "foo/*/baz/*/qux",
       "foo/",
-      Google::Gapic::Template::Segment.new(0, "*"),
+      Google::Gapic::PathTemplate::Segment.new(0, "*"),
       "/baz/",
-      Google::Gapic::Template::Segment.new(1, "*"),
+      Google::Gapic::PathTemplate::Segment.new(1, "*"),
       "/qux"
     )
   end
 
-  def test_more_than_two_stars_template
-    # This is a bad template, it can be parsed but not matched
-    assert_template(
+  def test_more_than_two_stars_path_template
+    # This is a bad URI path template, it can be parsed but not matched
+    assert_path_template(
       "hello/***/world",
       "hello/",
-      Google::Gapic::Template::Segment.new(0, "**"),
-      Google::Gapic::Template::Segment.new(1, "*"),
+      Google::Gapic::PathTemplate::Segment.new(0, "**"),
+      Google::Gapic::PathTemplate::Segment.new(1, "*"),
       "/world"
     )
   end

--- a/gapic-generator/test/test_helper.rb
+++ b/gapic-generator/test/test_helper.rb
@@ -17,7 +17,7 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "google/gapic/schema/api"
 require "google/gapic/generator"
-require "google/gapic/template"
+require "google/gapic/path_template"
 require "action_controller"
 require "action_view"
 
@@ -62,9 +62,14 @@ class GemTest < Minitest::Test
   end
 end
 
-class TemplateTest < Minitest::Test
-  def assert_template template, *exp_segments
-    act_segments = Google::Gapic::Template.parse template
+##
+# Test for URI path template parsing.
+#
+# @see https://tools.ietf.org/html/rfc6570 URI Template
+#
+class PathTemplateTest < Minitest::Test
+  def assert_path_template path_template, *exp_segments
+    act_segments = Google::Gapic::PathTemplate.parse path_template
 
     assert_valid_segments act_segments
     assert_equal exp_segments, act_segments


### PR DESCRIPTION
To mitigate a major naming conflict with ERB templates:

* Rename `Template` to `PathTemplate`, including variable names, accessors, tests, etc.
* Update documentation with links to URI Template spec.


