### PR TITLE
Update Cloud for Refactor ApiCall

### DIFF
--- a/gapic-generator-cloud/templates/cloud/client/_class.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_class.erb
@@ -87,18 +87,13 @@ class <%= service.client_class_name %>
     )
   end
 
-  def default_settings timeout, metadata, lib_name, lib_version
-    google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-    google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-    google_api_client << "gapic/#{<%= service.gem.version_name_full %>}"
-    google_api_client << "gax/#{Google::Gax::VERSION}"
-    google_api_client << "grpc/#{GRPC::VERSION}"
-    google_api_client.join " "
-
-    headers = { "x-goog-api-client": google_api_client }
-    headers.merge! metadata unless metadata.nil?
-
-    Google::Gax.const_get(:CallSettings).new metadata: headers
+  def x_goog_api_client_header lib_name, lib_version
+    x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+    x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+    x_goog_api_client_header << "gapic/#{<%= service.gem.version_name_full %>}"
+    x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+    x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+    x_goog_api_client_header.join " "
   end
 end
 

--- a/gapic-generator-cloud/templates/cloud/client/_class.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_class.erb
@@ -87,8 +87,7 @@ class <%= service.client_class_name %>
     )
   end
 
-  def default_settings client_config, timeout, metadata, lib_name,
-                        lib_version
+  def default_settings timeout, metadata, lib_name, lib_version
     google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
     google_api_client << "#{lib_name}/#{lib_version}" if lib_name
     google_api_client << "gapic/#{<%= service.gem.version_name_full %>}"

--- a/gapic-generator-cloud/templates/cloud/client/_init.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_init.erb
@@ -23,16 +23,12 @@
 # @param metadata [Hash]
 #   Default metadata to be sent with each request. This can be overridden on a
 #   per call basis.
-# @param exception_transformer [Proc]
-#   An optional proc that intercepts any exceptions raised during an API call to
-#   inject custom error handling.
 #
 def initialize \
     credentials: nil,
     scopes: ALL_SCOPES,
     timeout: DEFAULT_TIMEOUT,
     metadata: nil,
-    exception_transformer: nil,
     lib_name: nil,
     lib_version: ""
   # These require statements are intentionally placed here to initialize

--- a/gapic-generator-cloud/templates/cloud/client/_init.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_init.erb
@@ -44,9 +44,7 @@ def initialize \
 <%- end -%>
   @<%= service.stub_name %> = create_stub credentials, scopes
 
-  defaults = default_settings timeout, metadata, lib_name, lib_version
-
-<%- service.methods.each do |method| -%>
-<%= indent render(partial: "client/method/init", locals: { service: service, method: method }), "  " %>
-<%- end -%>
+  @timeout = timeout
+  @metadata = metadata.to_h
+  @metadata["x-goog-api-client".freeze] ||= x_goog_api_client_header lib_name, lib_version
 end

--- a/gapic-generator-cloud/templates/cloud/client/_init.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_init.erb
@@ -18,10 +18,6 @@
 # @param scopes [Array<String>]
 #   The OAuth scopes for this service. This parameter is ignored if an
 #   updater_proc is supplied.
-# @param client_config [Hash]
-#   A Hash for call options for each method. See Google::Gax#construct_settings
-#   for the structure of this data. Falls back to the default config if not
-#   specified or the specified config is missing data points.
 # @param timeout [Numeric]
 #   The default timeout, in seconds, for calls made through this client.
 # @param metadata [Hash]
@@ -34,7 +30,6 @@
 def initialize \
     credentials: nil,
     scopes: ALL_SCOPES,
-    client_config: {},
     timeout: DEFAULT_TIMEOUT,
     metadata: nil,
     exception_transformer: nil,
@@ -53,7 +48,7 @@ def initialize \
 <%- end -%>
   @<%= service.stub_name %> = create_stub credentials, scopes
 
-  defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
+  defaults = default_settings timeout, metadata, lib_name, lib_version
 
 <%- service.methods.each do |method| -%>
 <%= indent render(partial: "client/method/init", locals: { service: service, method: method }), "  " %>

--- a/gapic-generator-cloud/templates/cloud/client/_new.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_new.erb
@@ -27,9 +27,6 @@ require "<%= service.client_class_require %>"
 # @param metadata [Hash]
 #   Default metadata to be sent with each request. This can be overridden on a
 #   per call basis.
-# @param exception_transformer [Proc]
-#   An optional proc that intercepts any exceptions raised during an API call to
-#   inject custom error handling.
 #
 def self.new *args
   Client.new *args

--- a/gapic-generator-cloud/templates/cloud/client/_new.erb
+++ b/gapic-generator-cloud/templates/cloud/client/_new.erb
@@ -22,10 +22,6 @@ require "<%= service.client_class_require %>"
 # @param scopes [Array<String>]
 #   The OAuth scopes for this service. This parameter is ignored if an
 #   updater_proc is supplied.
-# @param client_config [Hash]
-#   A Hash for call options for each method. See Google::Gax#construct_settings
-#   for the structure of this data. Falls back to the default config if not
-#   specified or the specified config is missing data points.
 # @param timeout [Numeric]
 #   The default timeout, in seconds, for calls made through this client.
 # @param metadata [Hash]

--- a/gapic-generator-cloud/templates/cloud/client/lro/_init.erb
+++ b/gapic-generator-cloud/templates/cloud/client/lro/_init.erb
@@ -1,7 +1,6 @@
 @operations_client = OperationsClient.new(
   credentials: credentials,
   scopes: scopes,
-  client_config: client_config,
   timeout: timeout,
   lib_name: lib_name,
   lib_version: lib_version

--- a/gapic-generator-cloud/templates/cloud/client/method/_init.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/_init.erb
@@ -1,5 +1,0 @@
-<%- assert_locals method -%>
-<%= method.ivar %> = Google::Gax::ApiCall.new(
-  @<%= method.service.stub_name %>.method(:<%= method.name %>),
-  defaults
-)

--- a/gapic-generator-cloud/templates/cloud/client/method/_init.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/_init.erb
@@ -1,6 +1,5 @@
 <%- assert_locals method -%>
 <%= method.ivar %> = Google::Gax.create_api_call(
   @<%= method.service.stub_name %>.method(:<%= method.name %>),
-  defaults,
-  exception_transformer: exception_transformer
+  defaults
 )

--- a/gapic-generator-cloud/templates/cloud/client/method/_init.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/_init.erb
@@ -1,5 +1,5 @@
 <%- assert_locals method -%>
-<%= method.ivar %> = Google::Gax.create_api_call(
+<%= method.ivar %> = Google::Gax::ApiCall.new(
   @<%= method.service.stub_name %>.method(:<%= method.name %>),
   defaults
 )

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
@@ -6,7 +6,7 @@
 <%- end -%>
 # @param requests [Enumerable<<%= method.request_type %> | Hash>]
 #   An enumerable of {<%= method.request_type %>} instances.
-# @param options [Google::Gax::CallOptions]
+# @param options [Google::Gax::ApiCall::Options]
 #   Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
 # @return [Enumerable<<%= method.return_type %>>]

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
@@ -6,18 +6,22 @@
 <%- end -%>
 # @param requests [Google::Gax::StreamInput, Enumerable<<%= method.request_type %> | Hash>]
 #   An enumerable of {<%= method.request_type %>} instances.
-# @param options [Google::Gax::ApiCall::Options]
+# @param options [Google::Gax::ApiCall::Options, Hash]
 #   Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
-# @return [Enumerable<<%= method.return_type %>>]
-#   An enumerable of {<%= method.return_type %>} instances.
+# @yield [response] Called on each streaming responses, when provided.
+# @yieldparam response [<%= method.return_type %>]
+#
+# @return [Enumerable<<%= method.return_type %>, Thread>]
+#   An enumerable of {<%= method.return_type %>} instances when a block is not provided.
+#   When a block is provided a thread running the block for every streamed response is returned.
 #
 # @raise [Google::Gax::GaxError] if the RPC is aborted.
 #
 # @example
 <%= indent method.code_example, "#   " %>
 #
-def <%= method.name %> requests, options: nil
+def <%= method.name %> requests, options: nil, &block
   unless requests.is_a? Enumerable
     if requests.respond_to? :to_enum
       requests = requests.to_enum
@@ -30,5 +34,14 @@ def <%= method.name %> requests, options: nil
     Google::Gax.to_proto request, <%= method.request_type %>
   end
 
-  <%= method.ivar %>.call(requests, options)
+  # Converts hash and nil to an options object
+  options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+  header_params = {} # { name: request.name }
+  request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+  metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
+  retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+  <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>
+  <%= method.ivar %>.call(requests, options: options, stream_callback: block)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_bidi.erb
@@ -4,7 +4,7 @@
 <%= indent method.doc_description, "# " %>
 #
 <%- end -%>
-# @param requests [Enumerable<<%= method.request_type %> | Hash>]
+# @param requests [Google::Gax::StreamInput, Enumerable<<%= method.request_type %> | Hash>]
 #   An enumerable of {<%= method.request_type %>} instances.
 # @param options [Google::Gax::ApiCall::Options]
 #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -19,7 +19,11 @@
 #
 def <%= method.name %> requests, options: nil
   unless requests.is_a? Enumerable
-    raise ArgumentError, "requests must be an Enumerable"
+    if requests.respond_to? :to_enum
+      requests = requests.to_enum
+    else
+      raise ArgumentError, "requests must be an Enumerable"
+    end
   end
 
   requests = requests.lazy.map do |request|

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
@@ -6,11 +6,11 @@
 <%- end -%>
 # @param requests [Google::Gax::StreamInput, Enumerable<<%= method.request_type %> | Hash>]
 #   An enumerable of {<%= method.request_type %>} instances.
-# @param options [Google::Gax::ApiCall::Options]
+# @param options [Google::Gax::ApiCall::Options, Hash]
 #   Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
-# @yield [result, operation] Access the result along with the RPC operation
-# @yieldparam result [<%= method.return_type %>]
+# @yield [response, operation] Access the result along with the RPC operation
+# @yieldparam response [<%= method.return_type %>]
 # @yieldparam operation [GRPC::ActiveCall::Operation]
 #
 # @return [<%= method.return_type %>]
@@ -33,5 +33,14 @@ def <%= method.name %> requests, options: nil, &block
     Google::Gax.to_proto request, <%= method.request_type %>
   end
 
-  <%= method.ivar %>.call(requests, options, &block)
+  # Converts hash and nil to an options object
+  options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+  header_params = {} # { name: request.name }
+  request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+  metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
+  retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+  <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>
+  <%= method.ivar %>.call(requests, options: options, operation_callback: block)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
@@ -6,7 +6,7 @@
 <%- end -%>
 # @param requests [Enumerable<<%= method.request_type %> | Hash>]
 #   An enumerable of {<%= method.request_type %>} instances.
-# @param options [Google::Gax::CallOptions]
+# @param options [Google::Gax::ApiCall::Options]
 #   Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
 # @yield [result, operation] Access the result along with the RPC operation

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_client.erb
@@ -4,7 +4,7 @@
 <%= indent method.doc_description, "# " %>
 #
 <%- end -%>
-# @param requests [Enumerable<<%= method.request_type %> | Hash>]
+# @param requests [Google::Gax::StreamInput, Enumerable<<%= method.request_type %> | Hash>]
 #   An enumerable of {<%= method.request_type %>} instances.
 # @param options [Google::Gax::ApiCall::Options]
 #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -22,7 +22,11 @@
 #
 def <%= method.name %> requests, options: nil, &block
   unless requests.is_a? Enumerable
-    raise ArgumentError, "requests must be an Enumerable"
+    if requests.respond_to? :to_enum
+      requests = requests.to_enum
+    else
+      raise ArgumentError, "requests must be an Enumerable"
+    end
   end
 
   requests = requests.lazy.map do |request|

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_lro.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_lro.erb
@@ -9,7 +9,7 @@
 <%- if method.doc_description -%>
 <%= indent method.doc_description, "#     " %>
 <%- end -%>
-#   @param options [Google::Gax::ApiCall::Options]
+#   @param options [Google::Gax::ApiCall::Options, Hash]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
 <%- arg_list = method.arguments.map { |arg| "#{arg.name}: nil"}.join ", " -%>
@@ -20,7 +20,7 @@
 <%= indent arg.doc_description, "#     " %>
 <%- end -%>
 <%- end -%>
-#   @param options [Google::Gax::ApiCall::Options]
+#   @param options [Google::Gax::ApiCall::Options, Hash]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 <%- if method.arguments.find { |arg| arg.name == "options" } -%>
 #
@@ -29,15 +29,16 @@
 #     named arguments.
 <%- end -%>
 #
-# @yield [operation] Register a callback to be run when an operation is done.
-# @yieldparam operation [Google::Gax::Operation]
+# @yield [response, operation] Access the result along with the RPC operation
+# @yieldparam response [Google::Gax::Operation]
+# @yieldparam operation [GRPC::ActiveCall::Operation]
 #
 # @return [Google::Gax::Operation]
 # @raise [Google::Gax::GaxError] if the RPC is aborted.
 # @example
 <%= indent method.code_example, "#   " %>
 #
-def <%= method.name %> request = nil, options: nil, **request_fields
+def <%= method.name %> request = nil, options: nil, **request_fields, &block
   if request.nil? && request_fields.empty?
     raise ArgumentError, "request must be provided"
   end
@@ -46,13 +47,19 @@ def <%= method.name %> request = nil, options: nil, **request_fields
   end
 
   request ||= request_fields
+  # request = Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
   request = Google::Gax.to_proto request, <%= method.request_type %>
 
-  operation = Google::Gax::Operation.new(
-    <%= method.ivar %>.call(request, options),
-    @operations_client,
-    call_options: options
-  )
-  operation.on_done { |operation| yield operation } if block_given?
-  operation
+  # Converts hash and nil to an options object
+  options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+  header_params = {} # { name: request.name }
+  request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+  metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
+  retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+  format_response = ->(response) { Google::Gax::Operation.new(response, @operations_client, options) }
+
+  <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>
+  <%= method.ivar %>.call(request, options: options, operation_callback: block, format_response: format_response)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_lro.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_lro.erb
@@ -47,7 +47,6 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   end
 
   request ||= request_fields
-  # request = Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
   request = Google::Gax.to_proto request, <%= method.request_type %>
 
   # Converts hash and nil to an options object

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_lro.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_lro.erb
@@ -9,7 +9,7 @@
 <%- if method.doc_description -%>
 <%= indent method.doc_description, "#     " %>
 <%- end -%>
-#   @param options [Google::Gax::CallOptions]
+#   @param options [Google::Gax::ApiCall::Options]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
 <%- arg_list = method.arguments.map { |arg| "#{arg.name}: nil"}.join ", " -%>
@@ -20,7 +20,7 @@
 <%= indent arg.doc_description, "#     " %>
 <%- end -%>
 <%- end -%>
-#   @param options [Google::Gax::CallOptions]
+#   @param options [Google::Gax::ApiCall::Options]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 <%- if method.arguments.find { |arg| arg.name == "options" } -%>
 #

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_normal.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_normal.erb
@@ -47,7 +47,6 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   end
 
   request ||= request_fields
-  # request = Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
   request = Google::Gax.to_proto request, <%= method.request_type %>
 
   # Converts hash and nil to an options object

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_normal.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_normal.erb
@@ -9,7 +9,7 @@
 <%- if method.doc_description -%>
 <%= indent method.doc_description, "#     " %>
 <%- end -%>
-#   @param options [Google::Gax::CallOptions]
+#   @param options [Google::Gax::ApiCall::Options]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
 <%- arg_list = method.arguments.map { |arg| "#{arg.name}: nil"}.join ", " -%>
@@ -20,7 +20,7 @@
 <%= indent arg.doc_description, "#     " %>
 <%- end -%>
 <%- end -%>
-#   @param options [Google::Gax::CallOptions]
+#   @param options [Google::Gax::ApiCall::Options]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 <%- if method.arguments.find { |arg| arg.name == "options" } -%>
 #

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_normal.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_normal.erb
@@ -9,7 +9,7 @@
 <%- if method.doc_description -%>
 <%= indent method.doc_description, "#     " %>
 <%- end -%>
-#   @param options [Google::Gax::ApiCall::Options]
+#   @param options [Google::Gax::ApiCall::Options, Hash]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
 <%- arg_list = method.arguments.map { |arg| "#{arg.name}: nil"}.join ", " -%>
@@ -20,7 +20,7 @@
 <%= indent arg.doc_description, "#     " %>
 <%- end -%>
 <%- end -%>
-#   @param options [Google::Gax::ApiCall::Options]
+#   @param options [Google::Gax::ApiCall::Options, Hash]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 <%- if method.arguments.find { |arg| arg.name == "options" } -%>
 #
@@ -29,8 +29,8 @@
 #     named arguments.
 <%- end -%>
 #
-# @yield [result, operation] Access the result along with the RPC operation
-# @yieldparam result [<%= method.return_type %>]
+# @yield [response, operation] Access the result along with the RPC operation
+# @yieldparam response [<%= method.return_type %>]
 # @yieldparam operation [GRPC::ActiveCall::Operation]
 #
 # @return [<%= method.return_type %>]
@@ -47,7 +47,19 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   end
 
   request ||= request_fields
+  # request = Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
   request = Google::Gax.to_proto request, <%= method.request_type %>
 
-  <%= method.ivar %>.call(request, options, &block)
+  # Converts hash and nil to an options object
+  options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+  # Customize the options with defaults
+  header_params = {} # { name: request.name }
+  request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+  metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
+  retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+  <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>
+  <%= method.ivar %>.call(request, options: options, operation_callback: block)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
@@ -50,7 +50,6 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   end
 
   request ||= request_fields
-  # request = Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
   request = Google::Gax.to_proto request, <%= method.request_type %>
 
   # Converts hash and nil to an options object

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
@@ -9,7 +9,7 @@
 <%- if method.doc_description -%>
 <%= indent method.doc_description, "#     " %>
 <%- end -%>
-#   @param options [Google::Gax::ApiCall::Options]
+#   @param options [Google::Gax::ApiCall::Options, Hash]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
 <%- arg_list = method.arguments.map { |arg| "#{arg.name}: nil"}.join ", " -%>
@@ -20,7 +20,7 @@
 <%= indent arg.doc_description, "#     " %>
 <%- end -%>
 <%- end -%>
-#   @param options [Google::Gax::ApiCall::Options]
+#   @param options [Google::Gax::ApiCall::Options, Hash]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 <%- if method.arguments.find { |arg| arg.name == "options" } -%>
 #
@@ -29,15 +29,19 @@
 #     named arguments.
 <%- end -%>
 #
-# @return [Enumerable<<%= method.return_type %>>]
-#   An enumerable of {<%= method.return_type %>} instances.
+# @yield [response] Called on each streaming responses, when provided.
+# @yieldparam response [<%= method.return_type %>]
+#
+# @return [Enumerable<<%= method.return_type %>, Thread>]
+#   An enumerable of {<%= method.return_type %>} instances when a block is not provided.
+#   When a block is provided a thread running the block for every streamed response is returned.
 #
 # @raise [Google::Gax::GaxError] if the RPC is aborted.
 #
 # @example
 <%= indent method.code_example, "#   " %>
 #
-def <%= method.name %> request = nil, options: nil, **request_fields
+def <%= method.name %> request = nil, options: nil, **request_fields, &block
   if request.nil? && request_fields.empty?
     raise ArgumentError, "request must be provided"
   end
@@ -46,7 +50,17 @@ def <%= method.name %> request = nil, options: nil, **request_fields
   end
 
   request ||= request_fields
+  # request = Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
   request = Google::Gax.to_proto request, <%= method.request_type %>
 
-  <%= method.ivar %>.call(request, options)
+  # Converts hash and nil to an options object
+  options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+  header_params = {} # { name: request.name }
+  request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+  metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
+  retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+  options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+  <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>
+  <%= method.ivar %>.call(request, options: options, stream_callback: block)
 end

--- a/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
+++ b/gapic-generator-cloud/templates/cloud/client/method/def/_server.erb
@@ -9,7 +9,7 @@
 <%- if method.doc_description -%>
 <%= indent method.doc_description, "#     " %>
 <%- end -%>
-#   @param options [Google::Gax::CallOptions]
+#   @param options [Google::Gax::ApiCall::Options]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 #
 <%- arg_list = method.arguments.map { |arg| "#{arg.name}: nil"}.join ", " -%>
@@ -20,7 +20,7 @@
 <%= indent arg.doc_description, "#     " %>
 <%- end -%>
 <%- end -%>
-#   @param options [Google::Gax::CallOptions]
+#   @param options [Google::Gax::ApiCall::Options]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc.
 <%- if method.arguments.find { |arg| arg.name == "options" } -%>
 #

--- a/gapic-generator/templates/default/shared/_client.erb
+++ b/gapic-generator/templates/default/shared/_client.erb
@@ -120,7 +120,7 @@ class <%= service.name %>Client
 
 <% service.methods.each do |method| %>
 <% method_name = method.descriptor.name.underscore %>
-@<%= method_name %> = Google::Gax.create_api_call(
+@<%= method_name %> = Google::Gax::ApiCall.new(
 @<%= service.name.underscore %>_stub.method(:<%= method_name %>),
 CallSettings.new,
 exception_transformer: exception_transformer

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,6 +6,6 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", "~> 1.0"
+gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/refactor-api_call"
 gem "grpc-tools", "~> 1.18"
 gem "rake", "~> 10.0"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,6 +6,6 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/refactor-api_call"
+gem "google-gax", github: "googleapis/gax-ruby"
 gem "grpc-tools", "~> 1.18"
 gem "rake", "~> 10.0"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo.rb
@@ -45,9 +45,6 @@ module Google
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a
         #   per call basis.
-        # @param exception_transformer [Proc]
-        #   An optional proc that intercepts any exceptions raised during an API call to
-        #   inject custom error handling.
         #
         def self.new *args
           Client.new *args

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo.rb
@@ -40,10 +40,6 @@ module Google
         # @param scopes [Array<String>]
         #   The OAuth scopes for this service. This parameter is ignored if an
         #   updater_proc is supplied.
-        # @param client_config [Hash]
-        #   A Hash for call options for each method. See Google::Gax#construct_settings
-        #   for the structure of this data. Falls back to the default config if not
-        #   specified or the specified config is missing data points.
         # @param timeout [Numeric]
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -109,32 +109,9 @@ module Google
             )
             @echo_stub = create_stub credentials, scopes
 
-            defaults = default_settings timeout, metadata, lib_name, lib_version
-
-            @echo = Google::Gax::ApiCall.new(
-              @echo_stub.method(:echo),
-              defaults
-            )
-            @expand = Google::Gax::ApiCall.new(
-              @echo_stub.method(:expand),
-              defaults
-            )
-            @collect = Google::Gax::ApiCall.new(
-              @echo_stub.method(:collect),
-              defaults
-            )
-            @chat = Google::Gax::ApiCall.new(
-              @echo_stub.method(:chat),
-              defaults
-            )
-            @paged_expand = Google::Gax::ApiCall.new(
-              @echo_stub.method(:paged_expand),
-              defaults
-            )
-            @wait = Google::Gax::ApiCall.new(
-              @echo_stub.method(:wait),
-              defaults
-            )
+            @timeout = timeout
+            @metadata = metadata.to_h
+            @metadata["x-goog-api-client"] ||= x_goog_api_client_header lib_name, lib_version
           end
 
           # Service calls
@@ -145,7 +122,7 @@ module Google
           # @overload echo(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
           #     This method simply echos the request. This method is showcases unary rpcs.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload echo(content: nil, error: nil, options: nil)
@@ -153,11 +130,11 @@ module Google
           #     The content to be echoed by the server.
           #   @param error [Google::Rpc::Status | Hash]
           #     The error to be thrown by the server.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::EchoResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::EchoResponse]
@@ -172,9 +149,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::EchoRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
 
-            @echo.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @echo ||= Google::Gax::ApiCall.new @echo_stub.method :echo
+            @echo.call request, options: options, operation_callback: block
           end
 
           ##
@@ -185,7 +174,7 @@ module Google
           #   @param request [Google::Showcase::V1alpha3::ExpandRequest | Hash]
           #     This method split the given content into words and will pass each word back
           #     through the stream. This method showcases server-side streaming rpcs.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload expand(content: nil, error: nil, options: nil)
@@ -193,27 +182,41 @@ module Google
           #     The content that will be split into words and returned on the stream.
           #   @param error [Google::Rpc::Status | Hash]
           #     The error that is thrown after all words are sent on the stream.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @return [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
-          #   An enumerable of {Google::Showcase::V1alpha3::EchoResponse} instances.
+          # @yield [response] Called on each streaming responses, when provided.
+          # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
+          #
+          # @return [Enumerable<Google::Showcase::V1alpha3::EchoResponse, Thread>]
+          #   An enumerable of {Google::Showcase::V1alpha3::EchoResponse} instances when a block is not provided.
+          #   When a block is provided a thread running the block for every streamed response is returned.
           #
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           #
           # @example
           #   TODO
           #
-          def expand request = nil, options: nil, **request_fields
+          def expand request = nil, options: nil, **request_fields, &block
             raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ExpandRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ExpandRequest
 
-            @expand.call request, options
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @expand ||= Google::Gax::ApiCall.new @echo_stub.method :expand
+            @expand.call request, options: options, stream_callback: block
           end
 
           ##
@@ -223,11 +226,11 @@ module Google
           #
           # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
-          # @param options [Google::Gax::ApiCall::Options]
+          # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::EchoResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::EchoResponse]
@@ -250,7 +253,16 @@ module Google
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
             end
 
-            @collect.call(requests, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @collect ||= Google::Gax::ApiCall.new @echo_stub.method :collect
+            @collect.call requests, options: options, operation_callback: block
           end
 
           ##
@@ -260,18 +272,22 @@ module Google
           #
           # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
-          # @param options [Google::Gax::ApiCall::Options]
+          # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @return [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
-          #   An enumerable of {Google::Showcase::V1alpha3::EchoResponse} instances.
+          # @yield [response] Called on each streaming responses, when provided.
+          # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
+          #
+          # @return [Enumerable<Google::Showcase::V1alpha3::EchoResponse, Thread>]
+          #   An enumerable of {Google::Showcase::V1alpha3::EchoResponse} instances when a block is not provided.
+          #   When a block is provided a thread running the block for every streamed response is returned.
           #
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           #
           # @example
           #   TODO
           #
-          def chat requests, options: nil
+          def chat requests, options: nil, &block
             unless requests.is_a? Enumerable
               if requests.respond_to? :to_enum
                 requests = requests.to_enum
@@ -284,7 +300,16 @@ module Google
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
             end
 
-            @chat.call requests, options
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @chat ||= Google::Gax::ApiCall.new @echo_stub.method :chat
+            @chat.call requests, options: options, stream_callback: block
           end
 
           ##
@@ -295,7 +320,7 @@ module Google
           #   @param request [Google::Showcase::V1alpha3::PagedExpandRequest | Hash]
           #     This is similar to the Expand method but instead of returning a stream of
           #     expanded words, this method returns a paged list of expanded words.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload paged_expand(content: nil, page_size: nil, page_token: nil, options: nil)
@@ -305,11 +330,11 @@ module Google
           #     The amount of words to returned in each page.
           #   @param page_token [String]
           #     The position of the page to be returned.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::PagedExpandResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::PagedExpandResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::PagedExpandResponse]
@@ -324,9 +349,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::PagedExpandRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::PagedExpandRequest
 
-            @paged_expand.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @paged_expand ||= Google::Gax::ApiCall.new @echo_stub.method :paged_expand
+            @paged_expand.call request, options: options, operation_callback: block
           end
 
           ##
@@ -337,7 +374,7 @@ module Google
           #   @param request [Google::Showcase::V1alpha3::WaitRequest | Hash]
           #     This method will wait the requested amount of and then return.
           #     This method showcases how a client handles a request timing out.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload wait(end_time: nil, ttl: nil, error: nil, success: nil, options: nil)
@@ -350,33 +387,40 @@ module Google
           #     to be the OK rpc code, an empty response will be returned.
           #   @param success [Google::Showcase::V1alpha3::WaitResponse | Hash]
           #     The response to be returned on operation completion.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [operation] Register a callback to be run when an operation is done.
-          # @yieldparam operation [Google::Gax::Operation]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Gax::Operation]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Gax::Operation]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
           #
-          def wait request = nil, options: nil, **request_fields
+          def wait request = nil, options: nil, **request_fields, &block
             raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::WaitRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::WaitRequest
 
-            operation = Google::Gax::Operation.new(
-              @wait.call(request, options),
-              @operations_client,
-              call_options: options
-            )
-            operation.on_done { |operation| yield operation } if block_given?
-            operation
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            format_response = ->(response) { Google::Gax::Operation.new response, @operations_client, options }
+
+            @wait ||= Google::Gax::ApiCall.new @echo_stub.method :wait
+            @wait.call request, options: options, operation_callback: block, format_response: format_response
           end
 
           protected
@@ -411,18 +455,13 @@ module Google
             )
           end
 
-          def default_settings _timeout, metadata, lib_name, lib_version
-            google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-            google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-            google_api_client << "gapic/#{Google::Showcase::VERSION}"
-            google_api_client << "gax/#{Google::Gax::VERSION}"
-            google_api_client << "grpc/#{GRPC::VERSION}"
-            google_api_client.join " "
-
-            headers = { "x-goog-api-client": google_api_client }
-            headers.merge! metadata unless metadata.nil?
-
-            Google::Gax.const_get(:CallSettings).new metadata: headers
+          def x_goog_api_client_header lib_name, lib_version
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            x_goog_api_client_header.join " "
           end
         end
       end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -149,7 +149,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::EchoRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
 
             # Converts hash and nil to an options object
@@ -204,7 +203,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ExpandRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ExpandRequest
 
             # Converts hash and nil to an options object
@@ -349,7 +347,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::PagedExpandRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::PagedExpandRequest
 
             # Converts hash and nil to an options object
@@ -406,7 +403,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::WaitRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::WaitRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -84,16 +84,12 @@ module Google
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a
           #   per call basis.
-          # @param exception_transformer [Proc]
-          #   An optional proc that intercepts any exceptions raised during an API call to
-          #   inject custom error handling.
           #
           def initialize \
               credentials: nil,
               scopes: ALL_SCOPES,
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
-              exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
             # These require statements are intentionally placed here to initialize
@@ -117,33 +113,27 @@ module Google
 
             @echo = Google::Gax.create_api_call(
               @echo_stub.method(:echo),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @expand = Google::Gax.create_api_call(
               @echo_stub.method(:expand),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @collect = Google::Gax.create_api_call(
               @echo_stub.method(:collect),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @chat = Google::Gax.create_api_call(
               @echo_stub.method(:chat),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @paged_expand = Google::Gax.create_api_call(
               @echo_stub.method(:paged_expand),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @wait = Google::Gax.create_api_call(
               @echo_stub.method(:wait),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
           end
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -79,10 +79,6 @@ module Google
           # @param scopes [Array<String>]
           #   The OAuth scopes for this service. This parameter is ignored if an
           #   updater_proc is supplied.
-          # @param client_config [Hash]
-          #   A Hash for call options for each method. See Google::Gax#construct_settings
-          #   for the structure of this data. Falls back to the default config if not
-          #   specified or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
@@ -95,7 +91,6 @@ module Google
           def initialize \
               credentials: nil,
               scopes: ALL_SCOPES,
-              client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
               exception_transformer: nil,
@@ -110,16 +105,15 @@ module Google
             credentials ||= Credentials.default
 
             @operations_client = OperationsClient.new(
-              credentials:   credentials,
-              scopes:        scopes,
-              client_config: client_config,
-              timeout:       timeout,
-              lib_name:      lib_name,
-              lib_version:   lib_version
+              credentials: credentials,
+              scopes:      scopes,
+              timeout:     timeout,
+              lib_name:    lib_name,
+              lib_version: lib_version
             )
             @echo_stub = create_stub credentials, scopes
 
-            defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
+            defaults = default_settings timeout, metadata, lib_name, lib_version
 
             @echo = Google::Gax.create_api_call(
               @echo_stub.method(:echo),
@@ -415,8 +409,7 @@ module Google
             )
           end
 
-          def default_settings _client_config, _timeout, metadata, lib_name,
-                               lib_version
+          def default_settings _timeout, metadata, lib_name, lib_version
             google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
             google_api_client << "#{lib_name}/#{lib_version}" if lib_name
             google_api_client << "gapic/#{Google::Showcase::VERSION}"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -111,27 +111,27 @@ module Google
 
             defaults = default_settings timeout, metadata, lib_name, lib_version
 
-            @echo = Google::Gax.create_api_call(
+            @echo = Google::Gax::ApiCall.new(
               @echo_stub.method(:echo),
               defaults
             )
-            @expand = Google::Gax.create_api_call(
+            @expand = Google::Gax::ApiCall.new(
               @echo_stub.method(:expand),
               defaults
             )
-            @collect = Google::Gax.create_api_call(
+            @collect = Google::Gax::ApiCall.new(
               @echo_stub.method(:collect),
               defaults
             )
-            @chat = Google::Gax.create_api_call(
+            @chat = Google::Gax::ApiCall.new(
               @echo_stub.method(:chat),
               defaults
             )
-            @paged_expand = Google::Gax.create_api_call(
+            @paged_expand = Google::Gax::ApiCall.new(
               @echo_stub.method(:paged_expand),
               defaults
             )
-            @wait = Google::Gax.create_api_call(
+            @wait = Google::Gax::ApiCall.new(
               @echo_stub.method(:wait),
               defaults
             )

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -145,7 +145,7 @@ module Google
           # @overload echo(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
           #     This method simply echos the request. This method is showcases unary rpcs.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload echo(content: nil, error: nil, options: nil)
@@ -153,7 +153,7 @@ module Google
           #     The content to be echoed by the server.
           #   @param error [Google::Rpc::Status | Hash]
           #     The error to be thrown by the server.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -185,7 +185,7 @@ module Google
           #   @param request [Google::Showcase::V1alpha3::ExpandRequest | Hash]
           #     This method split the given content into words and will pass each word back
           #     through the stream. This method showcases server-side streaming rpcs.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload expand(content: nil, error: nil, options: nil)
@@ -193,7 +193,7 @@ module Google
           #     The content that will be split into words and returned on the stream.
           #   @param error [Google::Rpc::Status | Hash]
           #     The error that is thrown after all words are sent on the stream.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @return [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -223,7 +223,7 @@ module Google
           #
           # @param requests [Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
-          # @param options [Google::Gax::CallOptions]
+          # @param options [Google::Gax::ApiCall::Options]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -254,7 +254,7 @@ module Google
           #
           # @param requests [Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
-          # @param options [Google::Gax::CallOptions]
+          # @param options [Google::Gax::ApiCall::Options]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @return [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -283,7 +283,7 @@ module Google
           #   @param request [Google::Showcase::V1alpha3::PagedExpandRequest | Hash]
           #     This is similar to the Expand method but instead of returning a stream of
           #     expanded words, this method returns a paged list of expanded words.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload paged_expand(content: nil, page_size: nil, page_token: nil, options: nil)
@@ -293,7 +293,7 @@ module Google
           #     The amount of words to returned in each page.
           #   @param page_token [String]
           #     The position of the page to be returned.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -325,7 +325,7 @@ module Google
           #   @param request [Google::Showcase::V1alpha3::WaitRequest | Hash]
           #     This method will wait the requested amount of and then return.
           #     This method showcases how a client handles a request timing out.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload wait(end_time: nil, ttl: nil, error: nil, success: nil, options: nil)
@@ -338,7 +338,7 @@ module Google
           #     to be the OK rpc code, an empty response will be returned.
           #   @param success [Google::Showcase::V1alpha3::WaitResponse | Hash]
           #     The response to be returned on operation completion.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [operation] Register a callback to be run when an operation is done.

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -221,7 +221,7 @@ module Google
           # by the client, this method will return the a concatenation of the strings
           # passed to it. This method showcases client-side streaming rpcs.
           #
-          # @param requests [Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
+          # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
           # @param options [Google::Gax::ApiCall::Options]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -238,7 +238,13 @@ module Google
           #   TODO
           #
           def collect requests, options: nil, &block
-            raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
+            unless requests.is_a? Enumerable
+              if requests.respond_to? :to_enum
+                requests = requests.to_enum
+              else
+                raise ArgumentError, "requests must be an Enumerable"
+              end
+            end
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
@@ -252,7 +258,7 @@ module Google
           # be passed  back on the stream. This method showcases bidirectional
           # streaming rpcs.
           #
-          # @param requests [Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
+          # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
           # @param options [Google::Gax::ApiCall::Options]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -266,7 +272,13 @@ module Google
           #   TODO
           #
           def chat requests, options: nil
-            raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
+            unless requests.is_a? Enumerable
+              if requests.respond_to? :to_enum
+                requests = requests.to_enum
+              else
+                raise ArgumentError, "requests must be an Enumerable"
+              end
+            end
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity.rb
@@ -45,9 +45,6 @@ module Google
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a
         #   per call basis.
-        # @param exception_transformer [Proc]
-        #   An optional proc that intercepts any exceptions raised during an API call to
-        #   inject custom error handling.
         #
         def self.new *args
           Client.new *args

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity.rb
@@ -40,10 +40,6 @@ module Google
         # @param scopes [Array<String>]
         #   The OAuth scopes for this service. This parameter is ignored if an
         #   updater_proc is supplied.
-        # @param client_config [Hash]
-        #   A Hash for call options for each method. See Google::Gax#construct_settings
-        #   for the structure of this data. Falls back to the default config if not
-        #   specified or the specified config is missing data points.
         # @param timeout [Numeric]
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -144,13 +144,13 @@ module Google
           # @overload create_user(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
           #     Creates a user.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload create_user(user: nil, options: nil)
           #   @param user [Google::Showcase::V1alpha3::User | Hash]
           #     The user to create.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -180,13 +180,13 @@ module Google
           # @overload get_user(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
           #     Retrieves the User with the given uri.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload get_user(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested user.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -216,7 +216,7 @@ module Google
           # @overload update_user(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
           #     Updates a user.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload update_user(user: nil, update_mask: nil, options: nil)
@@ -225,7 +225,7 @@ module Google
           #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -255,13 +255,13 @@ module Google
           # @overload delete_user(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
           #     Deletes a user, their profile, and all of their authored messages.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_user(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the user to delete.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -291,7 +291,7 @@ module Google
           # @overload list_users(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
           #     Lists all users.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_users(page_size: nil, page_token: nil, options: nil)
@@ -302,7 +302,7 @@ module Google
           #     The value of google.showcase.v1alpha3.ListUsersResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Identity\ListUsers` method.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -114,23 +114,23 @@ module Google
 
             defaults = default_settings timeout, metadata, lib_name, lib_version
 
-            @create_user = Google::Gax.create_api_call(
+            @create_user = Google::Gax::ApiCall.new(
               @identity_stub.method(:create_user),
               defaults
             )
-            @get_user = Google::Gax.create_api_call(
+            @get_user = Google::Gax::ApiCall.new(
               @identity_stub.method(:get_user),
               defaults
             )
-            @update_user = Google::Gax.create_api_call(
+            @update_user = Google::Gax::ApiCall.new(
               @identity_stub.method(:update_user),
               defaults
             )
-            @delete_user = Google::Gax.create_api_call(
+            @delete_user = Google::Gax::ApiCall.new(
               @identity_stub.method(:delete_user),
               defaults
             )
-            @list_users = Google::Gax.create_api_call(
+            @list_users = Google::Gax::ApiCall.new(
               @identity_stub.method(:list_users),
               defaults
             )

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -82,10 +82,6 @@ module Google
           # @param scopes [Array<String>]
           #   The OAuth scopes for this service. This parameter is ignored if an
           #   updater_proc is supplied.
-          # @param client_config [Hash]
-          #   A Hash for call options for each method. See Google::Gax#construct_settings
-          #   for the structure of this data. Falls back to the default config if not
-          #   specified or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
@@ -98,7 +94,6 @@ module Google
           def initialize \
               credentials: nil,
               scopes: ALL_SCOPES,
-              client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
               exception_transformer: nil,
@@ -113,16 +108,15 @@ module Google
             credentials ||= Credentials.default
 
             @operations_client = OperationsClient.new(
-              credentials:   credentials,
-              scopes:        scopes,
-              client_config: client_config,
-              timeout:       timeout,
-              lib_name:      lib_name,
-              lib_version:   lib_version
+              credentials: credentials,
+              scopes:      scopes,
+              timeout:     timeout,
+              lib_name:    lib_name,
+              lib_version: lib_version
             )
             @identity_stub = create_stub credentials, scopes
 
-            defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
+            defaults = default_settings timeout, metadata, lib_name, lib_version
 
             @create_user = Google::Gax.create_api_call(
               @identity_stub.method(:create_user),
@@ -373,8 +367,7 @@ module Google
             )
           end
 
-          def default_settings _client_config, _timeout, metadata, lib_name,
-                               lib_version
+          def default_settings _timeout, metadata, lib_name, lib_version
             google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
             google_api_client << "#{lib_name}/#{lib_version}" if lib_name
             google_api_client << "gapic/#{Google::Showcase::VERSION}"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -150,7 +150,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateUserRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateUserRequest
 
             # Converts hash and nil to an options object
@@ -198,7 +197,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetUserRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetUserRequest
 
             # Converts hash and nil to an options object
@@ -249,7 +247,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateUserRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateUserRequest
 
             # Converts hash and nil to an options object
@@ -297,7 +294,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteUserRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteUserRequest
 
             # Converts hash and nil to an options object
@@ -350,7 +346,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListUsersRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListUsersRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -87,16 +87,12 @@ module Google
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a
           #   per call basis.
-          # @param exception_transformer [Proc]
-          #   An optional proc that intercepts any exceptions raised during an API call to
-          #   inject custom error handling.
           #
           def initialize \
               credentials: nil,
               scopes: ALL_SCOPES,
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
-              exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
             # These require statements are intentionally placed here to initialize
@@ -120,28 +116,23 @@ module Google
 
             @create_user = Google::Gax.create_api_call(
               @identity_stub.method(:create_user),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @get_user = Google::Gax.create_api_call(
               @identity_stub.method(:get_user),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @update_user = Google::Gax.create_api_call(
               @identity_stub.method(:update_user),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @delete_user = Google::Gax.create_api_call(
               @identity_stub.method(:delete_user),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @list_users = Google::Gax.create_api_call(
               @identity_stub.method(:list_users),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
           end
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -112,28 +112,9 @@ module Google
             )
             @identity_stub = create_stub credentials, scopes
 
-            defaults = default_settings timeout, metadata, lib_name, lib_version
-
-            @create_user = Google::Gax::ApiCall.new(
-              @identity_stub.method(:create_user),
-              defaults
-            )
-            @get_user = Google::Gax::ApiCall.new(
-              @identity_stub.method(:get_user),
-              defaults
-            )
-            @update_user = Google::Gax::ApiCall.new(
-              @identity_stub.method(:update_user),
-              defaults
-            )
-            @delete_user = Google::Gax::ApiCall.new(
-              @identity_stub.method(:delete_user),
-              defaults
-            )
-            @list_users = Google::Gax::ApiCall.new(
-              @identity_stub.method(:list_users),
-              defaults
-            )
+            @timeout = timeout
+            @metadata = metadata.to_h
+            @metadata["x-goog-api-client"] ||= x_goog_api_client_header lib_name, lib_version
           end
 
           # Service calls
@@ -144,17 +125,17 @@ module Google
           # @overload create_user(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
           #     Creates a user.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload create_user(user: nil, options: nil)
           #   @param user [Google::Showcase::V1alpha3::User | Hash]
           #     The user to create.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::User]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::User]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::User]
@@ -169,9 +150,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateUserRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateUserRequest
 
-            @create_user.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @create_user ||= Google::Gax::ApiCall.new @identity_stub.method :create_user
+            @create_user.call request, options: options, operation_callback: block
           end
 
           ##
@@ -180,17 +173,17 @@ module Google
           # @overload get_user(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
           #     Retrieves the User with the given uri.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload get_user(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested user.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::User]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::User]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::User]
@@ -205,9 +198,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetUserRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetUserRequest
 
-            @get_user.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @get_user ||= Google::Gax::ApiCall.new @identity_stub.method :get_user
+            @get_user.call request, options: options, operation_callback: block
           end
 
           ##
@@ -216,7 +221,7 @@ module Google
           # @overload update_user(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
           #     Updates a user.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload update_user(user: nil, update_mask: nil, options: nil)
@@ -225,11 +230,11 @@ module Google
           #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::User]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::User]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::User]
@@ -244,9 +249,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateUserRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateUserRequest
 
-            @update_user.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @update_user ||= Google::Gax::ApiCall.new @identity_stub.method :update_user
+            @update_user.call request, options: options, operation_callback: block
           end
 
           ##
@@ -255,17 +272,17 @@ module Google
           # @overload delete_user(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
           #     Deletes a user, their profile, and all of their authored messages.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_user(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the user to delete.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Protobuf::Empty]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Protobuf::Empty]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Protobuf::Empty]
@@ -280,9 +297,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteUserRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteUserRequest
 
-            @delete_user.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @delete_user ||= Google::Gax::ApiCall.new @identity_stub.method :delete_user
+            @delete_user.call request, options: options, operation_callback: block
           end
 
           ##
@@ -291,7 +320,7 @@ module Google
           # @overload list_users(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
           #     Lists all users.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_users(page_size: nil, page_token: nil, options: nil)
@@ -302,11 +331,11 @@ module Google
           #     The value of google.showcase.v1alpha3.ListUsersResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Identity\ListUsers` method.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::ListUsersResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::ListUsersResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::ListUsersResponse]
@@ -321,9 +350,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListUsersRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListUsersRequest
 
-            @list_users.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @list_users ||= Google::Gax::ApiCall.new @identity_stub.method :list_users
+            @list_users.call request, options: options, operation_callback: block
           end
 
           protected
@@ -358,18 +399,13 @@ module Google
             )
           end
 
-          def default_settings _timeout, metadata, lib_name, lib_version
-            google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-            google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-            google_api_client << "gapic/#{Google::Showcase::VERSION}"
-            google_api_client << "gax/#{Google::Gax::VERSION}"
-            google_api_client << "grpc/#{GRPC::VERSION}"
-            google_api_client.join " "
-
-            headers = { "x-goog-api-client": google_api_client }
-            headers.merge! metadata unless metadata.nil?
-
-            Google::Gax.const_get(:CallSettings).new metadata: headers
+          def x_goog_api_client_header lib_name, lib_version
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            x_goog_api_client_header.join " "
           end
         end
       end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging.rb
@@ -45,9 +45,6 @@ module Google
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a
         #   per call basis.
-        # @param exception_transformer [Proc]
-        #   An optional proc that intercepts any exceptions raised during an API call to
-        #   inject custom error handling.
         #
         def self.new *args
           Client.new *args

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging.rb
@@ -40,10 +40,6 @@ module Google
         # @param scopes [Array<String>]
         #   The OAuth scopes for this service. This parameter is ignored if an
         #   updater_proc is supplied.
-        # @param client_config [Hash]
-        #   A Hash for call options for each method. See Google::Gax#construct_settings
-        #   for the structure of this data. Falls back to the default config if not
-        #   specified or the specified config is missing data points.
         # @param timeout [Numeric]
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -82,10 +82,6 @@ module Google
           # @param scopes [Array<String>]
           #   The OAuth scopes for this service. This parameter is ignored if an
           #   updater_proc is supplied.
-          # @param client_config [Hash]
-          #   A Hash for call options for each method. See Google::Gax#construct_settings
-          #   for the structure of this data. Falls back to the default config if not
-          #   specified or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
@@ -98,7 +94,6 @@ module Google
           def initialize \
               credentials: nil,
               scopes: ALL_SCOPES,
-              client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
               exception_transformer: nil,
@@ -113,16 +108,15 @@ module Google
             credentials ||= Credentials.default
 
             @operations_client = OperationsClient.new(
-              credentials:   credentials,
-              scopes:        scopes,
-              client_config: client_config,
-              timeout:       timeout,
-              lib_name:      lib_name,
-              lib_version:   lib_version
+              credentials: credentials,
+              scopes:      scopes,
+              timeout:     timeout,
+              lib_name:    lib_name,
+              lib_version: lib_version
             )
             @messaging_stub = create_stub credentials, scopes
 
-            defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
+            defaults = default_settings timeout, metadata, lib_name, lib_version
 
             @create_room = Google::Gax.create_api_call(
               @messaging_stub.method(:create_room),
@@ -774,8 +768,7 @@ module Google
             )
           end
 
-          def default_settings _client_config, _timeout, metadata, lib_name,
-                               lib_version
+          def default_settings _timeout, metadata, lib_name, lib_version
             google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
             google_api_client << "#{lib_name}/#{lib_version}" if lib_name
             google_api_client << "gapic/#{Google::Showcase::VERSION}"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -87,16 +87,12 @@ module Google
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a
           #   per call basis.
-          # @param exception_transformer [Proc]
-          #   An optional proc that intercepts any exceptions raised during an API call to
-          #   inject custom error handling.
           #
           def initialize \
               credentials: nil,
               scopes: ALL_SCOPES,
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
-              exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
             # These require statements are intentionally placed here to initialize
@@ -120,73 +116,59 @@ module Google
 
             @create_room = Google::Gax.create_api_call(
               @messaging_stub.method(:create_room),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @get_room = Google::Gax.create_api_call(
               @messaging_stub.method(:get_room),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @update_room = Google::Gax.create_api_call(
               @messaging_stub.method(:update_room),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @delete_room = Google::Gax.create_api_call(
               @messaging_stub.method(:delete_room),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @list_rooms = Google::Gax.create_api_call(
               @messaging_stub.method(:list_rooms),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @create_blurb = Google::Gax.create_api_call(
               @messaging_stub.method(:create_blurb),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @get_blurb = Google::Gax.create_api_call(
               @messaging_stub.method(:get_blurb),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @update_blurb = Google::Gax.create_api_call(
               @messaging_stub.method(:update_blurb),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @delete_blurb = Google::Gax.create_api_call(
               @messaging_stub.method(:delete_blurb),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @list_blurbs = Google::Gax.create_api_call(
               @messaging_stub.method(:list_blurbs),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @search_blurbs = Google::Gax.create_api_call(
               @messaging_stub.method(:search_blurbs),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @stream_blurbs = Google::Gax.create_api_call(
               @messaging_stub.method(:stream_blurbs),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @send_blurbs = Google::Gax.create_api_call(
               @messaging_stub.method(:send_blurbs),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @connect = Google::Gax.create_api_call(
               @messaging_stub.method(:connect),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
           end
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -150,7 +150,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateRoomRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateRoomRequest
 
             # Converts hash and nil to an options object
@@ -198,7 +197,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetRoomRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetRoomRequest
 
             # Converts hash and nil to an options object
@@ -249,7 +247,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateRoomRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateRoomRequest
 
             # Converts hash and nil to an options object
@@ -297,7 +294,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteRoomRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteRoomRequest
 
             # Converts hash and nil to an options object
@@ -350,7 +346,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListRoomsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListRoomsRequest
 
             # Converts hash and nil to an options object
@@ -405,7 +400,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateBlurbRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
 
             # Converts hash and nil to an options object
@@ -453,7 +447,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetBlurbRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetBlurbRequest
 
             # Converts hash and nil to an options object
@@ -504,7 +497,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateBlurbRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateBlurbRequest
 
             # Converts hash and nil to an options object
@@ -552,7 +544,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteBlurbRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteBlurbRequest
 
             # Converts hash and nil to an options object
@@ -610,7 +601,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListBlurbsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListBlurbsRequest
 
             # Converts hash and nil to an options object
@@ -675,7 +665,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::SearchBlurbsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::SearchBlurbsRequest
 
             # Converts hash and nil to an options object
@@ -730,7 +719,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::StreamBlurbsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::StreamBlurbsRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -180,13 +180,13 @@ module Google
           # @overload create_room(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
           #     Creates a room.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload create_room(room: nil, options: nil)
           #   @param room [Google::Showcase::V1alpha3::Room | Hash]
           #     The room to create.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -216,13 +216,13 @@ module Google
           # @overload get_room(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
           #     Retrieves the Room with the given resource name.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload get_room(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested room.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -252,7 +252,7 @@ module Google
           # @overload update_room(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
           #     Updates a room.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload update_room(room: nil, update_mask: nil, options: nil)
@@ -261,7 +261,7 @@ module Google
           #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -291,13 +291,13 @@ module Google
           # @overload delete_room(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
           #     Deletes a room and all of its blurbs.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_room(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested room.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -327,7 +327,7 @@ module Google
           # @overload list_rooms(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
           #     Lists all chat rooms.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_rooms(page_size: nil, page_token: nil, options: nil)
@@ -338,7 +338,7 @@ module Google
           #     The value of google.showcase.v1alpha3.ListRoomsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\ListRooms` method.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -372,7 +372,7 @@ module Google
           #     Creates a blurb. If the parent is a room, the blurb is understood to be a
           #     message in that room. If the parent is a profile, the blurb is understood
           #     to be a post on the profile.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload create_blurb(parent: nil, blurb: nil, options: nil)
@@ -381,7 +381,7 @@ module Google
           #     be tied to.
           #   @param blurb [Google::Showcase::V1alpha3::Blurb | Hash]
           #     The blurb to create.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -411,13 +411,13 @@ module Google
           # @overload get_blurb(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
           #     Retrieves the Blurb with the given resource name.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload get_blurb(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested blurb.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -447,7 +447,7 @@ module Google
           # @overload update_blurb(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
           #     Updates a blurb.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload update_blurb(blurb: nil, update_mask: nil, options: nil)
@@ -456,7 +456,7 @@ module Google
           #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -486,13 +486,13 @@ module Google
           # @overload delete_blurb(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
           #     Deletes a blurb.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_blurb(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested blurb.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -524,7 +524,7 @@ module Google
           #   @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
           #     Lists blurbs for a specific chat room or user profile depending on the
           #     parent resource name.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_blurbs(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -538,7 +538,7 @@ module Google
           #     The value of google.showcase.v1alpha3.ListBlurbsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\ListBlurbs` method.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -572,7 +572,7 @@ module Google
           #     This method searches through all blurbs across all rooms and profiles
           #     for blurbs containing to words found in the query. Only posts that
           #     contain an exact match of a queried word will be returned.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload search_blurbs(query: nil, parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -591,7 +591,7 @@ module Google
           #     google.showcase.v1alpha3.SearchBlurbsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\SearchBlurbs` method.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [operation] Register a callback to be run when an operation is done.
@@ -628,7 +628,7 @@ module Google
           #   @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
           #     This returns a stream that emits the blurbs that are created for a
           #     particular chat room or user profile.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload stream_blurbs(name: nil, expire_time: nil, options: nil)
@@ -636,7 +636,7 @@ module Google
           #     The resource name of a chat room or user profile whose blurbs to stream.
           #   @param expire_time [Google::Protobuf::Timestamp | Hash]
           #     The time at which this stream will close.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @return [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]
@@ -665,7 +665,7 @@ module Google
           #
           # @param requests [Enumerable<Google::Showcase::V1alpha3::CreateBlurbRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::CreateBlurbRequest} instances.
-          # @param options [Google::Gax::CallOptions]
+          # @param options [Google::Gax::ApiCall::Options]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -697,7 +697,7 @@ module Google
           #
           # @param requests [Enumerable<Google::Showcase::V1alpha3::ConnectRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::ConnectRequest} instances.
-          # @param options [Google::Gax::CallOptions]
+          # @param options [Google::Gax::ApiCall::Options]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @return [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -112,64 +112,9 @@ module Google
             )
             @messaging_stub = create_stub credentials, scopes
 
-            defaults = default_settings timeout, metadata, lib_name, lib_version
-
-            @create_room = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:create_room),
-              defaults
-            )
-            @get_room = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:get_room),
-              defaults
-            )
-            @update_room = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:update_room),
-              defaults
-            )
-            @delete_room = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:delete_room),
-              defaults
-            )
-            @list_rooms = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:list_rooms),
-              defaults
-            )
-            @create_blurb = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:create_blurb),
-              defaults
-            )
-            @get_blurb = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:get_blurb),
-              defaults
-            )
-            @update_blurb = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:update_blurb),
-              defaults
-            )
-            @delete_blurb = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:delete_blurb),
-              defaults
-            )
-            @list_blurbs = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:list_blurbs),
-              defaults
-            )
-            @search_blurbs = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:search_blurbs),
-              defaults
-            )
-            @stream_blurbs = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:stream_blurbs),
-              defaults
-            )
-            @send_blurbs = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:send_blurbs),
-              defaults
-            )
-            @connect = Google::Gax::ApiCall.new(
-              @messaging_stub.method(:connect),
-              defaults
-            )
+            @timeout = timeout
+            @metadata = metadata.to_h
+            @metadata["x-goog-api-client"] ||= x_goog_api_client_header lib_name, lib_version
           end
 
           # Service calls
@@ -180,17 +125,17 @@ module Google
           # @overload create_room(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
           #     Creates a room.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload create_room(room: nil, options: nil)
           #   @param room [Google::Showcase::V1alpha3::Room | Hash]
           #     The room to create.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Room]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Room]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Room]
@@ -205,9 +150,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateRoomRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateRoomRequest
 
-            @create_room.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @create_room ||= Google::Gax::ApiCall.new @messaging_stub.method :create_room
+            @create_room.call request, options: options, operation_callback: block
           end
 
           ##
@@ -216,17 +173,17 @@ module Google
           # @overload get_room(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
           #     Retrieves the Room with the given resource name.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload get_room(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested room.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Room]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Room]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Room]
@@ -241,9 +198,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetRoomRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetRoomRequest
 
-            @get_room.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @get_room ||= Google::Gax::ApiCall.new @messaging_stub.method :get_room
+            @get_room.call request, options: options, operation_callback: block
           end
 
           ##
@@ -252,7 +221,7 @@ module Google
           # @overload update_room(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
           #     Updates a room.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload update_room(room: nil, update_mask: nil, options: nil)
@@ -261,11 +230,11 @@ module Google
           #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Room]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Room]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Room]
@@ -280,9 +249,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateRoomRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateRoomRequest
 
-            @update_room.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @update_room ||= Google::Gax::ApiCall.new @messaging_stub.method :update_room
+            @update_room.call request, options: options, operation_callback: block
           end
 
           ##
@@ -291,17 +272,17 @@ module Google
           # @overload delete_room(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
           #     Deletes a room and all of its blurbs.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_room(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested room.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Protobuf::Empty]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Protobuf::Empty]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Protobuf::Empty]
@@ -316,9 +297,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteRoomRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteRoomRequest
 
-            @delete_room.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @delete_room ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_room
+            @delete_room.call request, options: options, operation_callback: block
           end
 
           ##
@@ -327,7 +320,7 @@ module Google
           # @overload list_rooms(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
           #     Lists all chat rooms.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_rooms(page_size: nil, page_token: nil, options: nil)
@@ -338,11 +331,11 @@ module Google
           #     The value of google.showcase.v1alpha3.ListRoomsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\ListRooms` method.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::ListRoomsResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::ListRoomsResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::ListRoomsResponse]
@@ -357,9 +350,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListRoomsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListRoomsRequest
 
-            @list_rooms.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @list_rooms ||= Google::Gax::ApiCall.new @messaging_stub.method :list_rooms
+            @list_rooms.call request, options: options, operation_callback: block
           end
 
           ##
@@ -372,7 +377,7 @@ module Google
           #     Creates a blurb. If the parent is a room, the blurb is understood to be a
           #     message in that room. If the parent is a profile, the blurb is understood
           #     to be a post on the profile.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload create_blurb(parent: nil, blurb: nil, options: nil)
@@ -381,11 +386,11 @@ module Google
           #     be tied to.
           #   @param blurb [Google::Showcase::V1alpha3::Blurb | Hash]
           #     The blurb to create.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Blurb]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Blurb]
@@ -400,9 +405,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateBlurbRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
 
-            @create_blurb.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @create_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :create_blurb
+            @create_blurb.call request, options: options, operation_callback: block
           end
 
           ##
@@ -411,17 +428,17 @@ module Google
           # @overload get_blurb(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
           #     Retrieves the Blurb with the given resource name.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload get_blurb(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested blurb.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Blurb]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Blurb]
@@ -436,9 +453,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetBlurbRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetBlurbRequest
 
-            @get_blurb.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @get_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :get_blurb
+            @get_blurb.call request, options: options, operation_callback: block
           end
 
           ##
@@ -447,7 +476,7 @@ module Google
           # @overload update_blurb(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
           #     Updates a blurb.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload update_blurb(blurb: nil, update_mask: nil, options: nil)
@@ -456,11 +485,11 @@ module Google
           #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Blurb]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Blurb]
@@ -475,9 +504,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateBlurbRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateBlurbRequest
 
-            @update_blurb.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @update_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :update_blurb
+            @update_blurb.call request, options: options, operation_callback: block
           end
 
           ##
@@ -486,17 +527,17 @@ module Google
           # @overload delete_blurb(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
           #     Deletes a blurb.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_blurb(name: nil, options: nil)
           #   @param name [String]
           #     The resource name of the requested blurb.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Protobuf::Empty]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Protobuf::Empty]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Protobuf::Empty]
@@ -511,9 +552,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteBlurbRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteBlurbRequest
 
-            @delete_blurb.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @delete_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_blurb
+            @delete_blurb.call request, options: options, operation_callback: block
           end
 
           ##
@@ -524,7 +577,7 @@ module Google
           #   @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
           #     Lists blurbs for a specific chat room or user profile depending on the
           #     parent resource name.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_blurbs(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -538,11 +591,11 @@ module Google
           #     The value of google.showcase.v1alpha3.ListBlurbsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\ListBlurbs` method.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::ListBlurbsResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::ListBlurbsResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::ListBlurbsResponse]
@@ -557,9 +610,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListBlurbsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListBlurbsRequest
 
-            @list_blurbs.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @list_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :list_blurbs
+            @list_blurbs.call request, options: options, operation_callback: block
           end
 
           ##
@@ -572,7 +637,7 @@ module Google
           #     This method searches through all blurbs across all rooms and profiles
           #     for blurbs containing to words found in the query. Only posts that
           #     contain an exact match of a queried word will be returned.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload search_blurbs(query: nil, parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -591,33 +656,40 @@ module Google
           #     google.showcase.v1alpha3.SearchBlurbsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\SearchBlurbs` method.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [operation] Register a callback to be run when an operation is done.
-          # @yieldparam operation [Google::Gax::Operation]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Gax::Operation]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Gax::Operation]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
           #
-          def search_blurbs request = nil, options: nil, **request_fields
+          def search_blurbs request = nil, options: nil, **request_fields, &block
             raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::SearchBlurbsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::SearchBlurbsRequest
 
-            operation = Google::Gax::Operation.new(
-              @search_blurbs.call(request, options),
-              @operations_client,
-              call_options: options
-            )
-            operation.on_done { |operation| yield operation } if block_given?
-            operation
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            format_response = ->(response) { Google::Gax::Operation.new response, @operations_client, options }
+
+            @search_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :search_blurbs
+            @search_blurbs.call request, options: options, operation_callback: block, format_response: format_response
           end
 
           ##
@@ -628,7 +700,7 @@ module Google
           #   @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
           #     This returns a stream that emits the blurbs that are created for a
           #     particular chat room or user profile.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload stream_blurbs(name: nil, expire_time: nil, options: nil)
@@ -636,27 +708,41 @@ module Google
           #     The resource name of a chat room or user profile whose blurbs to stream.
           #   @param expire_time [Google::Protobuf::Timestamp | Hash]
           #     The time at which this stream will close.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @return [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]
-          #   An enumerable of {Google::Showcase::V1alpha3::StreamBlurbsResponse} instances.
+          # @yield [response] Called on each streaming responses, when provided.
+          # @yieldparam response [Google::Showcase::V1alpha3::StreamBlurbsResponse]
+          #
+          # @return [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse, Thread>]
+          #   An enumerable of {Google::Showcase::V1alpha3::StreamBlurbsResponse} instances when a block is not provided.
+          #   When a block is provided a thread running the block for every streamed response is returned.
           #
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           #
           # @example
           #   TODO
           #
-          def stream_blurbs request = nil, options: nil, **request_fields
+          def stream_blurbs request = nil, options: nil, **request_fields, &block
             raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
             if !request.nil? && !request_fields.empty?
               raise ArgumentError, "cannot pass both request object and named arguments"
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::StreamBlurbsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::StreamBlurbsRequest
 
-            @stream_blurbs.call request, options
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @stream_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :stream_blurbs
+            @stream_blurbs.call request, options: options, stream_callback: block
           end
 
           ##
@@ -665,11 +751,11 @@ module Google
           #
           # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::CreateBlurbRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::CreateBlurbRequest} instances.
-          # @param options [Google::Gax::ApiCall::Options]
+          # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::SendBlurbsResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::SendBlurbsResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::SendBlurbsResponse]
@@ -692,7 +778,16 @@ module Google
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
             end
 
-            @send_blurbs.call(requests, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @send_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :send_blurbs
+            @send_blurbs.call requests, options: options, operation_callback: block
           end
 
           ##
@@ -703,18 +798,22 @@ module Google
           #
           # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::ConnectRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::ConnectRequest} instances.
-          # @param options [Google::Gax::ApiCall::Options]
+          # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @return [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]
-          #   An enumerable of {Google::Showcase::V1alpha3::StreamBlurbsResponse} instances.
+          # @yield [response] Called on each streaming responses, when provided.
+          # @yieldparam response [Google::Showcase::V1alpha3::StreamBlurbsResponse]
+          #
+          # @return [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse, Thread>]
+          #   An enumerable of {Google::Showcase::V1alpha3::StreamBlurbsResponse} instances when a block is not provided.
+          #   When a block is provided a thread running the block for every streamed response is returned.
           #
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           #
           # @example
           #   TODO
           #
-          def connect requests, options: nil
+          def connect requests, options: nil, &block
             unless requests.is_a? Enumerable
               if requests.respond_to? :to_enum
                 requests = requests.to_enum
@@ -727,7 +826,16 @@ module Google
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::ConnectRequest
             end
 
-            @connect.call requests, options
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @connect ||= Google::Gax::ApiCall.new @messaging_stub.method :connect
+            @connect.call requests, options: options, stream_callback: block
           end
 
           protected
@@ -762,18 +870,13 @@ module Google
             )
           end
 
-          def default_settings _timeout, metadata, lib_name, lib_version
-            google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-            google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-            google_api_client << "gapic/#{Google::Showcase::VERSION}"
-            google_api_client << "gax/#{Google::Gax::VERSION}"
-            google_api_client << "grpc/#{GRPC::VERSION}"
-            google_api_client.join " "
-
-            headers = { "x-goog-api-client": google_api_client }
-            headers.merge! metadata unless metadata.nil?
-
-            Google::Gax.const_get(:CallSettings).new metadata: headers
+          def x_goog_api_client_header lib_name, lib_version
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            x_goog_api_client_header.join " "
           end
         end
       end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -114,59 +114,59 @@ module Google
 
             defaults = default_settings timeout, metadata, lib_name, lib_version
 
-            @create_room = Google::Gax.create_api_call(
+            @create_room = Google::Gax::ApiCall.new(
               @messaging_stub.method(:create_room),
               defaults
             )
-            @get_room = Google::Gax.create_api_call(
+            @get_room = Google::Gax::ApiCall.new(
               @messaging_stub.method(:get_room),
               defaults
             )
-            @update_room = Google::Gax.create_api_call(
+            @update_room = Google::Gax::ApiCall.new(
               @messaging_stub.method(:update_room),
               defaults
             )
-            @delete_room = Google::Gax.create_api_call(
+            @delete_room = Google::Gax::ApiCall.new(
               @messaging_stub.method(:delete_room),
               defaults
             )
-            @list_rooms = Google::Gax.create_api_call(
+            @list_rooms = Google::Gax::ApiCall.new(
               @messaging_stub.method(:list_rooms),
               defaults
             )
-            @create_blurb = Google::Gax.create_api_call(
+            @create_blurb = Google::Gax::ApiCall.new(
               @messaging_stub.method(:create_blurb),
               defaults
             )
-            @get_blurb = Google::Gax.create_api_call(
+            @get_blurb = Google::Gax::ApiCall.new(
               @messaging_stub.method(:get_blurb),
               defaults
             )
-            @update_blurb = Google::Gax.create_api_call(
+            @update_blurb = Google::Gax::ApiCall.new(
               @messaging_stub.method(:update_blurb),
               defaults
             )
-            @delete_blurb = Google::Gax.create_api_call(
+            @delete_blurb = Google::Gax::ApiCall.new(
               @messaging_stub.method(:delete_blurb),
               defaults
             )
-            @list_blurbs = Google::Gax.create_api_call(
+            @list_blurbs = Google::Gax::ApiCall.new(
               @messaging_stub.method(:list_blurbs),
               defaults
             )
-            @search_blurbs = Google::Gax.create_api_call(
+            @search_blurbs = Google::Gax::ApiCall.new(
               @messaging_stub.method(:search_blurbs),
               defaults
             )
-            @stream_blurbs = Google::Gax.create_api_call(
+            @stream_blurbs = Google::Gax::ApiCall.new(
               @messaging_stub.method(:stream_blurbs),
               defaults
             )
-            @send_blurbs = Google::Gax.create_api_call(
+            @send_blurbs = Google::Gax::ApiCall.new(
               @messaging_stub.method(:send_blurbs),
               defaults
             )
-            @connect = Google::Gax.create_api_call(
+            @connect = Google::Gax::ApiCall.new(
               @messaging_stub.method(:connect),
               defaults
             )

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -663,7 +663,7 @@ module Google
           # This is a stream to create multiple blurbs. If an invalid blurb is
           # requested to be created, the stream will close with an error.
           #
-          # @param requests [Enumerable<Google::Showcase::V1alpha3::CreateBlurbRequest | Hash>]
+          # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::CreateBlurbRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::CreateBlurbRequest} instances.
           # @param options [Google::Gax::ApiCall::Options]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -680,7 +680,13 @@ module Google
           #   TODO
           #
           def send_blurbs requests, options: nil, &block
-            raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
+            unless requests.is_a? Enumerable
+              if requests.respond_to? :to_enum
+                requests = requests.to_enum
+              else
+                raise ArgumentError, "requests must be an Enumerable"
+              end
+            end
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
@@ -695,7 +701,7 @@ module Google
           # blurbs. If an invalid blurb is requested to be created, the stream will
           # close with an error.
           #
-          # @param requests [Enumerable<Google::Showcase::V1alpha3::ConnectRequest | Hash>]
+          # @param requests [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::ConnectRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::ConnectRequest} instances.
           # @param options [Google::Gax::ApiCall::Options]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -709,7 +715,13 @@ module Google
           #   TODO
           #
           def connect requests, options: nil
-            raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
+            unless requests.is_a? Enumerable
+              if requests.respond_to? :to_enum
+                requests = requests.to_enum
+              else
+                raise ArgumentError, "requests must be an Enumerable"
+              end
+            end
 
             requests = requests.lazy.map do |request|
               Google::Gax.to_proto request, Google::Showcase::V1alpha3::ConnectRequest

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing.rb
@@ -45,9 +45,6 @@ module Google
         # @param metadata [Hash]
         #   Default metadata to be sent with each request. This can be overridden on a
         #   per call basis.
-        # @param exception_transformer [Proc]
-        #   An optional proc that intercepts any exceptions raised during an API call to
-        #   inject custom error handling.
         #
         def self.new *args
           Client.new *args

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing.rb
@@ -40,10 +40,6 @@ module Google
         # @param scopes [Array<String>]
         #   The OAuth scopes for this service. This parameter is ignored if an
         #   updater_proc is supplied.
-        # @param client_config [Hash]
-        #   A Hash for call options for each method. See Google::Gax#construct_settings
-        #   for the structure of this data. Falls back to the default config if not
-        #   specified or the specified config is missing data points.
         # @param timeout [Numeric]
         #   The default timeout, in seconds, for calls made through this client.
         # @param metadata [Hash]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -152,7 +152,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateSessionRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateSessionRequest
 
             # Converts hash and nil to an options object
@@ -200,7 +199,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetSessionRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetSessionRequest
 
             # Converts hash and nil to an options object
@@ -250,7 +248,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListSessionsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListSessionsRequest
 
             # Converts hash and nil to an options object
@@ -298,7 +295,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteSessionRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteSessionRequest
 
             # Converts hash and nil to an options object
@@ -350,7 +346,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ReportSessionRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ReportSessionRequest
 
             # Converts hash and nil to an options object
@@ -402,7 +397,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListTestsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListTestsRequest
 
             # Converts hash and nil to an options object
@@ -460,7 +454,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteTestRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteTestRequest
 
             # Converts hash and nil to an options object
@@ -518,7 +511,6 @@ module Google
             end
 
             request ||= request_fields
-            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::VerifyTestRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::VerifyTestRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -82,10 +82,6 @@ module Google
           # @param scopes [Array<String>]
           #   The OAuth scopes for this service. This parameter is ignored if an
           #   updater_proc is supplied.
-          # @param client_config [Hash]
-          #   A Hash for call options for each method. See Google::Gax#construct_settings
-          #   for the structure of this data. Falls back to the default config if not
-          #   specified or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
@@ -98,7 +94,6 @@ module Google
           def initialize \
               credentials: nil,
               scopes: ALL_SCOPES,
-              client_config: {},
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
               exception_transformer: nil,
@@ -113,16 +108,15 @@ module Google
             credentials ||= Credentials.default
 
             @operations_client = OperationsClient.new(
-              credentials:   credentials,
-              scopes:        scopes,
-              client_config: client_config,
-              timeout:       timeout,
-              lib_name:      lib_name,
-              lib_version:   lib_version
+              credentials: credentials,
+              scopes:      scopes,
+              timeout:     timeout,
+              lib_name:    lib_name,
+              lib_version: lib_version
             )
             @testing_stub = create_stub credentials, scopes
 
-            defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
+            defaults = default_settings timeout, metadata, lib_name, lib_version
 
             @create_session = Google::Gax.create_api_call(
               @testing_stub.method(:create_session),
@@ -520,8 +514,7 @@ module Google
             )
           end
 
-          def default_settings _client_config, _timeout, metadata, lib_name,
-                               lib_version
+          def default_settings _timeout, metadata, lib_name, lib_version
             google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
             google_api_client << "#{lib_name}/#{lib_version}" if lib_name
             google_api_client << "gapic/#{Google::Showcase::VERSION}"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -112,40 +112,9 @@ module Google
             )
             @testing_stub = create_stub credentials, scopes
 
-            defaults = default_settings timeout, metadata, lib_name, lib_version
-
-            @create_session = Google::Gax::ApiCall.new(
-              @testing_stub.method(:create_session),
-              defaults
-            )
-            @get_session = Google::Gax::ApiCall.new(
-              @testing_stub.method(:get_session),
-              defaults
-            )
-            @list_sessions = Google::Gax::ApiCall.new(
-              @testing_stub.method(:list_sessions),
-              defaults
-            )
-            @delete_session = Google::Gax::ApiCall.new(
-              @testing_stub.method(:delete_session),
-              defaults
-            )
-            @report_session = Google::Gax::ApiCall.new(
-              @testing_stub.method(:report_session),
-              defaults
-            )
-            @list_tests = Google::Gax::ApiCall.new(
-              @testing_stub.method(:list_tests),
-              defaults
-            )
-            @delete_test = Google::Gax::ApiCall.new(
-              @testing_stub.method(:delete_test),
-              defaults
-            )
-            @verify_test = Google::Gax::ApiCall.new(
-              @testing_stub.method(:verify_test),
-              defaults
-            )
+            @timeout = timeout
+            @metadata = metadata.to_h
+            @metadata["x-goog-api-client"] ||= x_goog_api_client_header lib_name, lib_version
           end
 
           # Service calls
@@ -156,7 +125,7 @@ module Google
           # @overload create_session(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
           #     Creates a new testing session.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload create_session(session: nil, options: nil)
@@ -164,11 +133,11 @@ module Google
           #     The session to be created.
           #     Sessions are immutable once they are created (although they can
           #     be deleted).
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Session]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Session]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Session]
@@ -183,9 +152,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateSessionRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateSessionRequest
 
-            @create_session.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @create_session ||= Google::Gax::ApiCall.new @testing_stub.method :create_session
+            @create_session.call request, options: options, operation_callback: block
           end
 
           ##
@@ -194,17 +175,17 @@ module Google
           # @overload get_session(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
           #     Gets a testing session.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload get_session(name: nil, options: nil)
           #   @param name [String]
           #     The session to be retrieved.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::Session]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::Session]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::Session]
@@ -219,9 +200,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetSessionRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetSessionRequest
 
-            @get_session.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @get_session ||= Google::Gax::ApiCall.new @testing_stub.method :get_session
+            @get_session.call request, options: options, operation_callback: block
           end
 
           ##
@@ -230,7 +223,7 @@ module Google
           # @overload list_sessions(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
           #     Lists the current test sessions.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_sessions(page_size: nil, page_token: nil, options: nil)
@@ -238,11 +231,11 @@ module Google
           #     The maximum number of sessions to return per page.
           #   @param page_token [String]
           #     The page token, for retrieving subsequent pages.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::ListSessionsResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::ListSessionsResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::ListSessionsResponse]
@@ -257,9 +250,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListSessionsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListSessionsRequest
 
-            @list_sessions.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @list_sessions ||= Google::Gax::ApiCall.new @testing_stub.method :list_sessions
+            @list_sessions.call request, options: options, operation_callback: block
           end
 
           ##
@@ -268,17 +273,17 @@ module Google
           # @overload delete_session(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
           #     Delete a test session.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_session(name: nil, options: nil)
           #   @param name [String]
           #     The session to be deleted.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Protobuf::Empty]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Protobuf::Empty]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Protobuf::Empty]
@@ -293,9 +298,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteSessionRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteSessionRequest
 
-            @delete_session.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @delete_session ||= Google::Gax::ApiCall.new @testing_stub.method :delete_session
+            @delete_session.call request, options: options, operation_callback: block
           end
 
           ##
@@ -308,17 +325,17 @@ module Google
           #     Report on the status of a session.
           #     This generates a report detailing which tests have been completed,
           #     and an overall rollup.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload report_session(name: nil, options: nil)
           #   @param name [String]
           #     The session to be reported on.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::ReportSessionResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::ReportSessionResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::ReportSessionResponse]
@@ -333,9 +350,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ReportSessionRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ReportSessionRequest
 
-            @report_session.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @report_session ||= Google::Gax::ApiCall.new @testing_stub.method :report_session
+            @report_session.call request, options: options, operation_callback: block
           end
 
           ##
@@ -344,7 +373,7 @@ module Google
           # @overload list_tests(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
           #     List the tests of a sessesion.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_tests(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -354,11 +383,11 @@ module Google
           #     The maximum number of tests to return per page.
           #   @param page_token [String]
           #     The page token, for retrieving subsequent pages.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::ListTestsResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::ListTestsResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::ListTestsResponse]
@@ -373,9 +402,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListTestsRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListTestsRequest
 
-            @list_tests.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @list_tests ||= Google::Gax::ApiCall.new @testing_stub.method :list_tests
+            @list_tests.call request, options: options, operation_callback: block
           end
 
           ##
@@ -394,17 +435,17 @@ module Google
           #     attempting to do the test will error.
           #
           #     This method will error if attempting to delete a required test.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_test(name: nil, options: nil)
           #   @param name [String]
           #     The test to be deleted.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Protobuf::Empty]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Protobuf::Empty]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Protobuf::Empty]
@@ -419,9 +460,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteTestRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteTestRequest
 
-            @delete_test.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @delete_test ||= Google::Gax::ApiCall.new @testing_stub.method :delete_test
+            @delete_test.call request, options: options, operation_callback: block
           end
 
           ##
@@ -436,7 +489,7 @@ module Google
           #
           #     In cases where a test involves registering a final answer at the
           #     end of the test, this method provides the means to do so.
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload verify_test(name: nil, answer: nil, answers: nil, options: nil)
@@ -446,11 +499,11 @@ module Google
           #     The answer from the test.
           #   @param answers [String]
           #     The answers from the test if multiple are to be checked
-          #   @param options [Google::Gax::ApiCall::Options]
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
-          # @yield [result, operation] Access the result along with the RPC operation
-          # @yieldparam result [Google::Showcase::V1alpha3::VerifyTestResponse]
+          # @yield [response, operation] Access the result along with the RPC operation
+          # @yieldparam response [Google::Showcase::V1alpha3::VerifyTestResponse]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
           # @return [Google::Showcase::V1alpha3::VerifyTestResponse]
@@ -465,9 +518,21 @@ module Google
             end
 
             request ||= request_fields
+            # request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::VerifyTestRequest
             request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::VerifyTestRequest
 
-            @verify_test.call(request, options, &block)
+            # Converts hash and nil to an options object
+            options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+            # Customize the options with defaults
+            header_params = {} # { name: request.name }
+            request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+            metadata = @metadata.merge "x-goog-request-params" => request_params_header
+            retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+            options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+            @verify_test ||= Google::Gax::ApiCall.new @testing_stub.method :verify_test
+            @verify_test.call request, options: options, operation_callback: block
           end
 
           protected
@@ -502,18 +567,13 @@ module Google
             )
           end
 
-          def default_settings _timeout, metadata, lib_name, lib_version
-            google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-            google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-            google_api_client << "gapic/#{Google::Showcase::VERSION}"
-            google_api_client << "gax/#{Google::Gax::VERSION}"
-            google_api_client << "grpc/#{GRPC::VERSION}"
-            google_api_client.join " "
-
-            headers = { "x-goog-api-client": google_api_client }
-            headers.merge! metadata unless metadata.nil?
-
-            Google::Gax.const_get(:CallSettings).new metadata: headers
+          def x_goog_api_client_header lib_name, lib_version
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            x_goog_api_client_header.join " "
           end
         end
       end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -87,16 +87,12 @@ module Google
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a
           #   per call basis.
-          # @param exception_transformer [Proc]
-          #   An optional proc that intercepts any exceptions raised during an API call to
-          #   inject custom error handling.
           #
           def initialize \
               credentials: nil,
               scopes: ALL_SCOPES,
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
-              exception_transformer: nil,
               lib_name: nil,
               lib_version: ""
             # These require statements are intentionally placed here to initialize
@@ -120,43 +116,35 @@ module Google
 
             @create_session = Google::Gax.create_api_call(
               @testing_stub.method(:create_session),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @get_session = Google::Gax.create_api_call(
               @testing_stub.method(:get_session),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @list_sessions = Google::Gax.create_api_call(
               @testing_stub.method(:list_sessions),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @delete_session = Google::Gax.create_api_call(
               @testing_stub.method(:delete_session),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @report_session = Google::Gax.create_api_call(
               @testing_stub.method(:report_session),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @list_tests = Google::Gax.create_api_call(
               @testing_stub.method(:list_tests),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @delete_test = Google::Gax.create_api_call(
               @testing_stub.method(:delete_test),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
             @verify_test = Google::Gax.create_api_call(
               @testing_stub.method(:verify_test),
-              defaults,
-              exception_transformer: exception_transformer
+              defaults
             )
           end
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -114,35 +114,35 @@ module Google
 
             defaults = default_settings timeout, metadata, lib_name, lib_version
 
-            @create_session = Google::Gax.create_api_call(
+            @create_session = Google::Gax::ApiCall.new(
               @testing_stub.method(:create_session),
               defaults
             )
-            @get_session = Google::Gax.create_api_call(
+            @get_session = Google::Gax::ApiCall.new(
               @testing_stub.method(:get_session),
               defaults
             )
-            @list_sessions = Google::Gax.create_api_call(
+            @list_sessions = Google::Gax::ApiCall.new(
               @testing_stub.method(:list_sessions),
               defaults
             )
-            @delete_session = Google::Gax.create_api_call(
+            @delete_session = Google::Gax::ApiCall.new(
               @testing_stub.method(:delete_session),
               defaults
             )
-            @report_session = Google::Gax.create_api_call(
+            @report_session = Google::Gax::ApiCall.new(
               @testing_stub.method(:report_session),
               defaults
             )
-            @list_tests = Google::Gax.create_api_call(
+            @list_tests = Google::Gax::ApiCall.new(
               @testing_stub.method(:list_tests),
               defaults
             )
-            @delete_test = Google::Gax.create_api_call(
+            @delete_test = Google::Gax::ApiCall.new(
               @testing_stub.method(:delete_test),
               defaults
             )
-            @verify_test = Google::Gax.create_api_call(
+            @verify_test = Google::Gax::ApiCall.new(
               @testing_stub.method(:verify_test),
               defaults
             )

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -156,7 +156,7 @@ module Google
           # @overload create_session(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
           #     Creates a new testing session.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload create_session(session: nil, options: nil)
@@ -164,7 +164,7 @@ module Google
           #     The session to be created.
           #     Sessions are immutable once they are created (although they can
           #     be deleted).
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -194,13 +194,13 @@ module Google
           # @overload get_session(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
           #     Gets a testing session.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload get_session(name: nil, options: nil)
           #   @param name [String]
           #     The session to be retrieved.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -230,7 +230,7 @@ module Google
           # @overload list_sessions(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
           #     Lists the current test sessions.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_sessions(page_size: nil, page_token: nil, options: nil)
@@ -238,7 +238,7 @@ module Google
           #     The maximum number of sessions to return per page.
           #   @param page_token [String]
           #     The page token, for retrieving subsequent pages.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -268,13 +268,13 @@ module Google
           # @overload delete_session(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
           #     Delete a test session.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_session(name: nil, options: nil)
           #   @param name [String]
           #     The session to be deleted.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -308,13 +308,13 @@ module Google
           #     Report on the status of a session.
           #     This generates a report detailing which tests have been completed,
           #     and an overall rollup.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload report_session(name: nil, options: nil)
           #   @param name [String]
           #     The session to be reported on.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -344,7 +344,7 @@ module Google
           # @overload list_tests(request, options: nil)
           #   @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
           #     List the tests of a sessesion.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload list_tests(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -354,7 +354,7 @@ module Google
           #     The maximum number of tests to return per page.
           #   @param page_token [String]
           #     The page token, for retrieving subsequent pages.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -394,13 +394,13 @@ module Google
           #     attempting to do the test will error.
           #
           #     This method will error if attempting to delete a required test.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload delete_test(name: nil, options: nil)
           #   @param name [String]
           #     The test to be deleted.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation
@@ -436,7 +436,7 @@ module Google
           #
           #     In cases where a test involves registering a final answer at the
           #     end of the test, this method provides the means to do so.
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @overload verify_test(name: nil, answer: nil, answers: nil, options: nil)
@@ -446,7 +446,7 @@ module Google
           #     The answer from the test.
           #   @param answers [String]
           #     The answers from the test if multiple are to be checked
-          #   @param options [Google::Gax::CallOptions]
+          #   @param options [Google::Gax::ApiCall::Options]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [result, operation] Access the result along with the RPC operation

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech.rb
@@ -41,10 +41,6 @@ module Google
           # @param scopes [Array<String>]
           #   The OAuth scopes for this service. This parameter is ignored if an
           #   updater_proc is supplied.
-          # @param client_config [Hash]
-          #   A Hash for call options for each method. See Google::Gax#construct_settings
-          #   for the structure of this data. Falls back to the default config if not
-          #   specified or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech.rb
@@ -46,9 +46,6 @@ module Google
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a
           #   per call basis.
-          # @param exception_transformer [Proc]
-          #   An optional proc that intercepts any exceptions raised during an API call to
-          #   inject custom error handling.
           #
           def self.new *args
             Client.new *args

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -223,7 +223,7 @@ module Google
             # Performs bidirectional streaming speech recognition: receive results while
             # sending audio. This method is only available via the gRPC API (not REST).
             #
-            # @param requests [Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeRequest | Hash>]
+            # @param requests [Google::Gax::StreamInput, Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeRequest | Hash>]
             #   An enumerable of {Google::Cloud::Speech::V1::StreamingRecognizeRequest} instances.
             # @param options [Google::Gax::ApiCall::Options]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc.
@@ -237,7 +237,13 @@ module Google
             #   TODO
             #
             def streaming_recognize requests, options: nil
-              raise ArgumentError, "requests must be an Enumerable" unless requests.is_a? Enumerable
+              unless requests.is_a? Enumerable
+                if requests.respond_to? :to_enum
+                  requests = requests.to_enum
+                else
+                  raise ArgumentError, "requests must be an Enumerable"
+                end
+              end
 
               requests = requests.lazy.map do |request|
                 Google::Gax.to_proto request, Google::Cloud::Speech::V1::StreamingRecognizeRequest

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -85,16 +85,12 @@ module Google
             # @param metadata [Hash]
             #   Default metadata to be sent with each request. This can be overridden on a
             #   per call basis.
-            # @param exception_transformer [Proc]
-            #   An optional proc that intercepts any exceptions raised during an API call to
-            #   inject custom error handling.
             #
             def initialize \
                 credentials: nil,
                 scopes: ALL_SCOPES,
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
-                exception_transformer: nil,
                 lib_name: nil,
                 lib_version: ""
               # These require statements are intentionally placed here to initialize
@@ -118,18 +114,15 @@ module Google
 
               @recognize = Google::Gax.create_api_call(
                 @speech_stub.method(:recognize),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @long_running_recognize = Google::Gax.create_api_call(
                 @speech_stub.method(:long_running_recognize),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @streaming_recognize = Google::Gax.create_api_call(
                 @speech_stub.method(:streaming_recognize),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
             end
 

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -80,10 +80,6 @@ module Google
             # @param scopes [Array<String>]
             #   The OAuth scopes for this service. This parameter is ignored if an
             #   updater_proc is supplied.
-            # @param client_config [Hash]
-            #   A Hash for call options for each method. See Google::Gax#construct_settings
-            #   for the structure of this data. Falls back to the default config if not
-            #   specified or the specified config is missing data points.
             # @param timeout [Numeric]
             #   The default timeout, in seconds, for calls made through this client.
             # @param metadata [Hash]
@@ -96,7 +92,6 @@ module Google
             def initialize \
                 credentials: nil,
                 scopes: ALL_SCOPES,
-                client_config: {},
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
                 exception_transformer: nil,
@@ -111,16 +106,15 @@ module Google
               credentials ||= Credentials.default
 
               @operations_client = OperationsClient.new(
-                credentials:   credentials,
-                scopes:        scopes,
-                client_config: client_config,
-                timeout:       timeout,
-                lib_name:      lib_name,
-                lib_version:   lib_version
+                credentials: credentials,
+                scopes:      scopes,
+                timeout:     timeout,
+                lib_name:    lib_name,
+                lib_version: lib_version
               )
               @speech_stub = create_stub credentials, scopes
 
-              defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
+              defaults = default_settings timeout, metadata, lib_name, lib_version
 
               @recognize = Google::Gax.create_api_call(
                 @speech_stub.method(:recognize),
@@ -291,8 +285,7 @@ module Google
               )
             end
 
-            def default_settings _client_config, _timeout, metadata, lib_name,
-                                 lib_version
+            def default_settings _timeout, metadata, lib_name, lib_version
               google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
               google_api_client << "#{lib_name}/#{lib_version}" if lib_name
               google_api_client << "gapic/#{Google::Cloud::Speech::VERSION}"

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -112,15 +112,15 @@ module Google
 
               defaults = default_settings timeout, metadata, lib_name, lib_version
 
-              @recognize = Google::Gax.create_api_call(
+              @recognize = Google::Gax::ApiCall.new(
                 @speech_stub.method(:recognize),
                 defaults
               )
-              @long_running_recognize = Google::Gax.create_api_call(
+              @long_running_recognize = Google::Gax::ApiCall.new(
                 @speech_stub.method(:long_running_recognize),
                 defaults
               )
-              @streaming_recognize = Google::Gax.create_api_call(
+              @streaming_recognize = Google::Gax::ApiCall.new(
                 @speech_stub.method(:streaming_recognize),
                 defaults
               )

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -153,7 +153,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::RecognizeRequest
               request = Google::Gax.to_proto request, Google::Cloud::Speech::V1::RecognizeRequest
 
               # Converts hash and nil to an options object
@@ -210,7 +209,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::LongRunningRecognizeRequest
               request = Google::Gax.to_proto request, Google::Cloud::Speech::V1::LongRunningRecognizeRequest
 
               # Converts hash and nil to an options object

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -136,7 +136,7 @@ module Google
             #   @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
             #     Performs synchronous speech recognition: receive results after all audio
             #     has been sent and processed.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload recognize(config: nil, audio: nil, options: nil)
@@ -145,7 +145,7 @@ module Google
             #     process the request.
             #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
             #     *Required* The audio data to be recognized.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -181,7 +181,7 @@ module Google
             #     google.longrunning.Operations interface. Returns either an
             #     `Operation.error` or an `Operation.response` which contains
             #     a `LongRunningRecognizeResponse` message.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload long_running_recognize(config: nil, audio: nil, options: nil)
@@ -190,7 +190,7 @@ module Google
             #     process the request.
             #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
             #     *Required* The audio data to be recognized.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [operation] Register a callback to be run when an operation is done.
@@ -225,7 +225,7 @@ module Google
             #
             # @param requests [Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeRequest | Hash>]
             #   An enumerable of {Google::Cloud::Speech::V1::StreamingRecognizeRequest} instances.
-            # @param options [Google::Gax::CallOptions]
+            # @param options [Google::Gax::ApiCall::Options]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @return [Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeResponse>]

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator.rb
@@ -41,10 +41,6 @@ module Google
           # @param scopes [Array<String>]
           #   The OAuth scopes for this service. This parameter is ignored if an
           #   updater_proc is supplied.
-          # @param client_config [Hash]
-          #   A Hash for call options for each method. See Google::Gax#construct_settings
-          #   for the structure of this data. Falls back to the default config if not
-          #   specified or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator.rb
@@ -46,9 +46,6 @@ module Google
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a
           #   per call basis.
-          # @param exception_transformer [Proc]
-          #   An optional proc that intercepts any exceptions raised during an API call to
-          #   inject custom error handling.
           #
           def self.new *args
             Client.new *args

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -148,7 +148,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
 
               # Converts hash and nil to an options object
@@ -206,7 +205,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
 
               # Converts hash and nil to an options object

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -80,10 +80,6 @@ module Google
             # @param scopes [Array<String>]
             #   The OAuth scopes for this service. This parameter is ignored if an
             #   updater_proc is supplied.
-            # @param client_config [Hash]
-            #   A Hash for call options for each method. See Google::Gax#construct_settings
-            #   for the structure of this data. Falls back to the default config if not
-            #   specified or the specified config is missing data points.
             # @param timeout [Numeric]
             #   The default timeout, in seconds, for calls made through this client.
             # @param metadata [Hash]
@@ -96,7 +92,6 @@ module Google
             def initialize \
                 credentials: nil,
                 scopes: ALL_SCOPES,
-                client_config: {},
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
                 exception_transformer: nil,
@@ -111,16 +106,15 @@ module Google
               credentials ||= Credentials.default
 
               @operations_client = OperationsClient.new(
-                credentials:   credentials,
-                scopes:        scopes,
-                client_config: client_config,
-                timeout:       timeout,
-                lib_name:      lib_name,
-                lib_version:   lib_version
+                credentials: credentials,
+                scopes:      scopes,
+                timeout:     timeout,
+                lib_name:    lib_name,
+                lib_version: lib_version
               )
               @image_annotator_stub = create_stub credentials, scopes
 
-              defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
+              defaults = default_settings timeout, metadata, lib_name, lib_version
 
               @batch_annotate_images = Google::Gax.create_api_call(
                 @image_annotator_stub.method(:batch_annotate_images),
@@ -255,8 +249,7 @@ module Google
               )
             end
 
-            def default_settings _client_config, _timeout, metadata, lib_name,
-                                 lib_version
+            def default_settings _timeout, metadata, lib_name, lib_version
               google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
               google_api_client << "#{lib_name}/#{lib_version}" if lib_name
               google_api_client << "gapic/#{Google::Cloud::Vision::VERSION}"

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -110,16 +110,9 @@ module Google
               )
               @image_annotator_stub = create_stub credentials, scopes
 
-              defaults = default_settings timeout, metadata, lib_name, lib_version
-
-              @batch_annotate_images = Google::Gax::ApiCall.new(
-                @image_annotator_stub.method(:batch_annotate_images),
-                defaults
-              )
-              @async_batch_annotate_files = Google::Gax::ApiCall.new(
-                @image_annotator_stub.method(:async_batch_annotate_files),
-                defaults
-              )
+              @timeout = timeout
+              @metadata = metadata.to_h
+              @metadata["x-goog-api-client"] ||= x_goog_api_client_header lib_name, lib_version
             end
 
             # Service calls
@@ -130,17 +123,17 @@ module Google
             # @overload batch_annotate_images(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
             #     Run image detection and annotation for a batch of images.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload batch_annotate_images(requests: nil, options: nil)
             #   @param requests [Google::Cloud::Vision::V1::AnnotateImageRequest | Hash]
             #     Individual image annotation requests for this batch.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
@@ -155,9 +148,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
 
-              @batch_annotate_images.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @batch_annotate_images ||= Google::Gax::ApiCall.new @image_annotator_stub.method :batch_annotate_images
+              @batch_annotate_images.call request, options: options, operation_callback: block
             end
 
             ##
@@ -176,39 +181,46 @@ module Google
             #     `google.longrunning.Operations` interface.
             #     `Operation.metadata` contains `OperationMetadata` (metadata).
             #     `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload async_batch_annotate_files(requests: nil, options: nil)
             #   @param requests [Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash]
             #     Individual async file annotation requests for this batch.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [operation] Register a callback to be run when an operation is done.
-            # @yieldparam operation [Google::Gax::Operation]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Gax::Operation]
+            # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Gax::Operation]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   TODO
             #
-            def async_batch_annotate_files request = nil, options: nil, **request_fields
+            def async_batch_annotate_files request = nil, options: nil, **request_fields, &block
               raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
 
-              operation = Google::Gax::Operation.new(
-                @async_batch_annotate_files.call(request, options),
-                @operations_client,
-                call_options: options
-              )
-              operation.on_done { |operation| yield operation } if block_given?
-              operation
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              format_response = ->(response) { Google::Gax::Operation.new response, @operations_client, options }
+
+              @async_batch_annotate_files ||= Google::Gax::ApiCall.new @image_annotator_stub.method :async_batch_annotate_files
+              @async_batch_annotate_files.call request, options: options, operation_callback: block, format_response: format_response
             end
 
             protected
@@ -243,18 +255,13 @@ module Google
               )
             end
 
-            def default_settings _timeout, metadata, lib_name, lib_version
-              google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-              google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-              google_api_client << "gapic/#{Google::Cloud::Vision::VERSION}"
-              google_api_client << "gax/#{Google::Gax::VERSION}"
-              google_api_client << "grpc/#{GRPC::VERSION}"
-              google_api_client.join " "
-
-              headers = { "x-goog-api-client": google_api_client }
-              headers.merge! metadata unless metadata.nil?
-
-              Google::Gax.const_get(:CallSettings).new metadata: headers
+            def x_goog_api_client_header lib_name, lib_version
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              x_goog_api_client_header.join " "
             end
           end
         end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -130,13 +130,13 @@ module Google
             # @overload batch_annotate_images(request, options: nil)
             #   @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
             #     Run image detection and annotation for a batch of images.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload batch_annotate_images(requests: nil, options: nil)
             #   @param requests [Google::Cloud::Vision::V1::AnnotateImageRequest | Hash]
             #     Individual image annotation requests for this batch.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -176,13 +176,13 @@ module Google
             #     `google.longrunning.Operations` interface.
             #     `Operation.metadata` contains `OperationMetadata` (metadata).
             #     `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload async_batch_annotate_files(requests: nil, options: nil)
             #   @param requests [Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash]
             #     Individual async file annotation requests for this batch.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [operation] Register a callback to be run when an operation is done.

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -85,16 +85,12 @@ module Google
             # @param metadata [Hash]
             #   Default metadata to be sent with each request. This can be overridden on a
             #   per call basis.
-            # @param exception_transformer [Proc]
-            #   An optional proc that intercepts any exceptions raised during an API call to
-            #   inject custom error handling.
             #
             def initialize \
                 credentials: nil,
                 scopes: ALL_SCOPES,
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
-                exception_transformer: nil,
                 lib_name: nil,
                 lib_version: ""
               # These require statements are intentionally placed here to initialize
@@ -118,13 +114,11 @@ module Google
 
               @batch_annotate_images = Google::Gax.create_api_call(
                 @image_annotator_stub.method(:batch_annotate_images),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @async_batch_annotate_files = Google::Gax.create_api_call(
                 @image_annotator_stub.method(:async_batch_annotate_files),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
             end
 

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -112,11 +112,11 @@ module Google
 
               defaults = default_settings timeout, metadata, lib_name, lib_version
 
-              @batch_annotate_images = Google::Gax.create_api_call(
+              @batch_annotate_images = Google::Gax::ApiCall.new(
                 @image_annotator_stub.method(:batch_annotate_images),
                 defaults
               )
-              @async_batch_annotate_files = Google::Gax.create_api_call(
+              @async_batch_annotate_files = Google::Gax::ApiCall.new(
                 @image_annotator_stub.method(:async_batch_annotate_files),
                 defaults
               )

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search.rb
@@ -41,10 +41,6 @@ module Google
           # @param scopes [Array<String>]
           #   The OAuth scopes for this service. This parameter is ignored if an
           #   updater_proc is supplied.
-          # @param client_config [Hash]
-          #   A Hash for call options for each method. See Google::Gax#construct_settings
-          #   for the structure of this data. Falls back to the default config if not
-          #   specified or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search.rb
@@ -46,9 +46,6 @@ module Google
           # @param metadata [Hash]
           #   Default metadata to be sent with each request. This can be overridden on a
           #   per call basis.
-          # @param exception_transformer [Proc]
-          #   An optional proc that intercepts any exceptions raised during an API call to
-          #   inject custom error handling.
           #
           def self.new *args
             Client.new *args

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -80,10 +80,6 @@ module Google
             # @param scopes [Array<String>]
             #   The OAuth scopes for this service. This parameter is ignored if an
             #   updater_proc is supplied.
-            # @param client_config [Hash]
-            #   A Hash for call options for each method. See Google::Gax#construct_settings
-            #   for the structure of this data. Falls back to the default config if not
-            #   specified or the specified config is missing data points.
             # @param timeout [Numeric]
             #   The default timeout, in seconds, for calls made through this client.
             # @param metadata [Hash]
@@ -96,7 +92,6 @@ module Google
             def initialize \
                 credentials: nil,
                 scopes: ALL_SCOPES,
-                client_config: {},
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
                 exception_transformer: nil,
@@ -111,16 +106,15 @@ module Google
               credentials ||= Credentials.default
 
               @operations_client = OperationsClient.new(
-                credentials:   credentials,
-                scopes:        scopes,
-                client_config: client_config,
-                timeout:       timeout,
-                lib_name:      lib_name,
-                lib_version:   lib_version
+                credentials: credentials,
+                scopes:      scopes,
+                timeout:     timeout,
+                lib_name:    lib_name,
+                lib_version: lib_version
               )
               @product_search_stub = create_stub credentials, scopes
 
-              defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
+              defaults = default_settings timeout, metadata, lib_name, lib_version
 
               @create_product_set = Google::Gax.create_api_call(
                 @product_search_stub.method(:create_product_set),
@@ -1273,8 +1267,7 @@ module Google
               )
             end
 
-            def default_settings _client_config, _timeout, metadata, lib_name,
-                                 lib_version
+            def default_settings _timeout, metadata, lib_name, lib_version
               google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
               google_api_client << "#{lib_name}/#{lib_version}" if lib_name
               google_api_client << "gapic/#{Google::Cloud::Vision::VERSION}"

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -110,80 +110,9 @@ module Google
               )
               @product_search_stub = create_stub credentials, scopes
 
-              defaults = default_settings timeout, metadata, lib_name, lib_version
-
-              @create_product_set = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:create_product_set),
-                defaults
-              )
-              @list_product_sets = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:list_product_sets),
-                defaults
-              )
-              @get_product_set = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:get_product_set),
-                defaults
-              )
-              @update_product_set = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:update_product_set),
-                defaults
-              )
-              @delete_product_set = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:delete_product_set),
-                defaults
-              )
-              @create_product = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:create_product),
-                defaults
-              )
-              @list_products = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:list_products),
-                defaults
-              )
-              @get_product = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:get_product),
-                defaults
-              )
-              @update_product = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:update_product),
-                defaults
-              )
-              @delete_product = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:delete_product),
-                defaults
-              )
-              @create_reference_image = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:create_reference_image),
-                defaults
-              )
-              @delete_reference_image = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:delete_reference_image),
-                defaults
-              )
-              @list_reference_images = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:list_reference_images),
-                defaults
-              )
-              @get_reference_image = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:get_reference_image),
-                defaults
-              )
-              @add_product_to_product_set = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:add_product_to_product_set),
-                defaults
-              )
-              @remove_product_from_product_set = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:remove_product_from_product_set),
-                defaults
-              )
-              @list_products_in_product_set = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:list_products_in_product_set),
-                defaults
-              )
-              @import_product_sets = Google::Gax::ApiCall.new(
-                @product_search_stub.method(:import_product_sets),
-                defaults
-              )
+              @timeout = timeout
+              @metadata = metadata.to_h
+              @metadata["x-goog-api-client"] ||= x_goog_api_client_header lib_name, lib_version
             end
 
             # Service calls
@@ -204,7 +133,7 @@ module Google
             #
             #     * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
             #       4096 characters.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload create_product_set(parent: nil, product_set: nil, product_set_id: nil, options: nil)
@@ -219,11 +148,11 @@ module Google
             #     attempt to use this value as the resource id. If it is already in use, an
             #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
             #     long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ProductSet]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ProductSet]
@@ -238,9 +167,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateProductSetRequest
 
-              @create_product_set.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @create_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :create_product_set
+              @create_product_set.call request, options: options, operation_callback: block
             end
 
             ##
@@ -259,7 +200,7 @@ module Google
             #
             #     * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
             #       than 1.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload list_product_sets(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -271,11 +212,11 @@ module Google
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ListProductSetsResponse]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ListProductSetsResponse]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ListProductSetsResponse]
@@ -290,9 +231,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductSetsRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductSetsRequest
 
-              @list_product_sets.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @list_product_sets ||= Google::Gax::ApiCall.new @product_search_stub.method :list_product_sets
+              @list_product_sets.call request, options: options, operation_callback: block
             end
 
             ##
@@ -309,7 +262,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the ProductSet does not exist.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload get_product_set(name: nil, options: nil)
@@ -318,11 +271,11 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ProductSet]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ProductSet]
@@ -337,9 +290,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetProductSetRequest
 
-              @get_product_set.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @get_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :get_product_set
+              @get_product_set.call request, options: options, operation_callback: block
             end
 
             ##
@@ -362,7 +327,7 @@ module Google
             #     * Returns NOT_FOUND if the ProductSet does not exist.
             #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but
             #       missing from the request or longer than 4096 characters.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload update_product_set(product_set: nil, update_mask: nil, options: nil)
@@ -373,11 +338,11 @@ module Google
             #     update.
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask path is `display_name`.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ProductSet]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ProductSet]
@@ -392,9 +357,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::UpdateProductSetRequest
 
-              @update_product_set.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @update_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :update_product_set
+              @update_product_set.call request, options: options, operation_callback: block
             end
 
             ##
@@ -417,7 +394,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the ProductSet does not exist.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload delete_product_set(name: nil, options: nil)
@@ -426,11 +403,11 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Protobuf::Empty]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Protobuf::Empty]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Protobuf::Empty]
@@ -445,9 +422,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteProductSetRequest
 
-              @delete_product_set.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @delete_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_product_set
+              @delete_product_set.call request, options: options, operation_callback: block
             end
 
             ##
@@ -470,7 +459,7 @@ module Google
             #       characters.
             #     * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
             #     * Returns INVALID_ARGUMENT if product_category is missing or invalid.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload create_product(parent: nil, product: nil, product_id: nil, options: nil)
@@ -486,11 +475,11 @@ module Google
             #     attempt to use this value as the resource id. If it is already in use, an
             #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
             #     long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::Product]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::Product]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::Product]
@@ -505,9 +494,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateProductRequest
 
-              @create_product.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @create_product ||= Google::Gax::ApiCall.new @product_search_stub.method :create_product
+              @create_product.call request, options: options, operation_callback: block
             end
 
             ##
@@ -524,7 +525,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload list_products(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -537,11 +538,11 @@ module Google
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ListProductsResponse]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ListProductsResponse]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ListProductsResponse]
@@ -556,9 +557,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductsRequest
 
-              @list_products.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @list_products ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products
+              @list_products.call request, options: options, operation_callback: block
             end
 
             ##
@@ -575,7 +588,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the Product does not exist.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload get_product(name: nil, options: nil)
@@ -584,11 +597,11 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::Product]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::Product]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::Product]
@@ -603,9 +616,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetProductRequest
 
-              @get_product.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @get_product ||= Google::Gax::ApiCall.new @product_search_stub.method :get_product
+              @get_product.call request, options: options, operation_callback: block
             end
 
             ##
@@ -642,7 +667,7 @@ module Google
             #     * Returns INVALID_ARGUMENT if description is present in update_mask but is
             #       longer than 4096 characters.
             #     * Returns INVALID_ARGUMENT if product_category is present in update_mask.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload update_product(product: nil, update_mask: nil, options: nil)
@@ -655,11 +680,11 @@ module Google
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask paths include `product_labels`, `display_name`, and
             #     `description`.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::Product]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::Product]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::Product]
@@ -674,9 +699,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::UpdateProductRequest
 
-              @update_product.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @update_product ||= Google::Gax::ApiCall.new @product_search_stub.method :update_product
+              @update_product.call request, options: options, operation_callback: block
             end
 
             ##
@@ -701,7 +738,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the product does not exist.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload delete_product(name: nil, options: nil)
@@ -710,11 +747,11 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Protobuf::Empty]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Protobuf::Empty]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Protobuf::Empty]
@@ -729,9 +766,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteProductRequest
 
-              @delete_product.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @delete_product ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_product
+              @delete_product.call request, options: options, operation_callback: block
             end
 
             ##
@@ -776,7 +825,7 @@ module Google
             #     * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
             #       compatible with the parent product's product_category is detected.
             #     * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload create_reference_image(parent: nil, reference_image: nil, reference_image_id: nil, options: nil)
@@ -793,11 +842,11 @@ module Google
             #     the server will attempt to use this value as the resource id. If it is
             #     already in use, an error is returned with code ALREADY_EXISTS. Must be at
             #     most 128 characters long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ReferenceImage]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ReferenceImage]
@@ -812,9 +861,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateReferenceImageRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateReferenceImageRequest
 
-              @create_reference_image.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @create_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :create_reference_image
+              @create_reference_image.call request, options: options, operation_callback: block
             end
 
             ##
@@ -843,7 +904,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the reference image does not exist.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload delete_reference_image(name: nil, options: nil)
@@ -853,11 +914,11 @@ module Google
             #     Format is:
             #
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Protobuf::Empty]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Protobuf::Empty]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Protobuf::Empty]
@@ -872,9 +933,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteReferenceImageRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteReferenceImageRequest
 
-              @delete_reference_image.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @delete_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_reference_image
+              @delete_reference_image.call request, options: options, operation_callback: block
             end
 
             ##
@@ -895,7 +968,7 @@ module Google
             #     * Returns NOT_FOUND if the parent product does not exist.
             #     * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
             #       than 1.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload list_reference_images(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -911,11 +984,11 @@ module Google
             #     of `nextPageToken` returned in a previous reference image list request.
             #
             #     Defaults to the first page if not specified.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ListReferenceImagesResponse]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ListReferenceImagesResponse]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ListReferenceImagesResponse]
@@ -930,9 +1003,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListReferenceImagesRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListReferenceImagesRequest
 
-              @list_reference_images.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @list_reference_images ||= Google::Gax::ApiCall.new @product_search_stub.method :list_reference_images
+              @list_reference_images.call request, options: options, operation_callback: block
             end
 
             ##
@@ -949,7 +1034,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the specified image does not exist.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload get_reference_image(name: nil, options: nil)
@@ -959,11 +1044,11 @@ module Google
             #     Format is:
             #
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ReferenceImage]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ReferenceImage]
@@ -978,9 +1063,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetReferenceImageRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetReferenceImageRequest
 
-              @get_reference_image.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @get_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :get_reference_image
+              @get_reference_image.call request, options: options, operation_callback: block
             end
 
             ##
@@ -1003,7 +1100,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload add_product_to_product_set(name: nil, product: nil, options: nil)
@@ -1017,11 +1114,11 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Protobuf::Empty]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Protobuf::Empty]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Protobuf::Empty]
@@ -1036,9 +1133,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AddProductToProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::AddProductToProductSetRequest
 
-              @add_product_to_product_set.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @add_product_to_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :add_product_to_product_set
+              @add_product_to_product_set.call request, options: options, operation_callback: block
             end
 
             ##
@@ -1055,7 +1164,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND If the Product is not found under the ProductSet.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload remove_product_from_product_set(name: nil, product: nil, options: nil)
@@ -1069,11 +1178,11 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Protobuf::Empty]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Protobuf::Empty]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Protobuf::Empty]
@@ -1088,9 +1197,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
 
-              @remove_product_from_product_set.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @remove_product_from_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :remove_product_from_product_set
+              @remove_product_from_product_set.call request, options: options, operation_callback: block
             end
 
             ##
@@ -1111,7 +1232,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload list_products_in_product_set(name: nil, page_size: nil, page_token: nil, options: nil)
@@ -1124,11 +1245,11 @@ module Google
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [result, operation] Access the result along with the RPC operation
-            # @yieldparam result [Google::Cloud::Vision::V1::ListProductsInProductSetResponse]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Cloud::Vision::V1::ListProductsInProductSetResponse]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Cloud::Vision::V1::ListProductsInProductSetResponse]
@@ -1143,9 +1264,21 @@ module Google
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsInProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductsInProductSetRequest
 
-              @list_products_in_product_set.call(request, options, &block)
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+
+              # Customize the options with defaults
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              @list_products_in_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products_in_product_set
+              @list_products_in_product_set.call request, options: options, operation_callback: block
             end
 
             ##
@@ -1174,7 +1307,7 @@ module Google
             #     The input source of this method is a csv file on Google Cloud Storage.
             #     For the format of the csv file please see
             #     [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload import_product_sets(parent: nil, input_config: nil, options: nil)
@@ -1184,33 +1317,40 @@ module Google
             #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
             #   @param input_config [Google::Cloud::Vision::V1::ImportProductSetsInputConfig | Hash]
             #     The input content for the list of requests.
-            #   @param options [Google::Gax::ApiCall::Options]
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
-            # @yield [operation] Register a callback to be run when an operation is done.
-            # @yieldparam operation [Google::Gax::Operation]
+            # @yield [response, operation] Access the result along with the RPC operation
+            # @yieldparam response [Google::Gax::Operation]
+            # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
             # @return [Google::Gax::Operation]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   TODO
             #
-            def import_product_sets request = nil, options: nil, **request_fields
+            def import_product_sets request = nil, options: nil, **request_fields, &block
               raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
               if !request.nil? && !request_fields.empty?
                 raise ArgumentError, "cannot pass both request object and named arguments"
               end
 
               request ||= request_fields
+              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ImportProductSetsRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ImportProductSetsRequest
 
-              operation = Google::Gax::Operation.new(
-                @import_product_sets.call(request, options),
-                @operations_client,
-                call_options: options
-              )
-              operation.on_done { |operation| yield operation } if block_given?
-              operation
+              # Converts hash and nil to an options object
+              options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
+              header_params = {} # { name: request.name }
+              request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
+              metadata = @metadata.merge "x-goog-request-params" => request_params_header
+              retry_policy = {} # retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
+              options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
+
+              format_response = ->(response) { Google::Gax::Operation.new response, @operations_client, options }
+
+              @import_product_sets ||= Google::Gax::ApiCall.new @product_search_stub.method :import_product_sets
+              @import_product_sets.call request, options: options, operation_callback: block, format_response: format_response
             end
 
             protected
@@ -1245,18 +1385,13 @@ module Google
               )
             end
 
-            def default_settings _timeout, metadata, lib_name, lib_version
-              google_api_client = ["gl-ruby/#{RUBY_VERSION}"]
-              google_api_client << "#{lib_name}/#{lib_version}" if lib_name
-              google_api_client << "gapic/#{Google::Cloud::Vision::VERSION}"
-              google_api_client << "gax/#{Google::Gax::VERSION}"
-              google_api_client << "grpc/#{GRPC::VERSION}"
-              google_api_client.join " "
-
-              headers = { "x-goog-api-client": google_api_client }
-              headers.merge! metadata unless metadata.nil?
-
-              Google::Gax.const_get(:CallSettings).new metadata: headers
+            def x_goog_api_client_header lib_name, lib_version
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              x_goog_api_client_header.join " "
             end
           end
         end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -167,7 +167,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateProductSetRequest
 
               # Converts hash and nil to an options object
@@ -231,7 +230,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductSetsRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductSetsRequest
 
               # Converts hash and nil to an options object
@@ -290,7 +288,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetProductSetRequest
 
               # Converts hash and nil to an options object
@@ -357,7 +354,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::UpdateProductSetRequest
 
               # Converts hash and nil to an options object
@@ -422,7 +418,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteProductSetRequest
 
               # Converts hash and nil to an options object
@@ -494,7 +489,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateProductRequest
 
               # Converts hash and nil to an options object
@@ -557,7 +551,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductsRequest
 
               # Converts hash and nil to an options object
@@ -616,7 +609,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetProductRequest
 
               # Converts hash and nil to an options object
@@ -699,7 +691,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::UpdateProductRequest
 
               # Converts hash and nil to an options object
@@ -766,7 +757,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteProductRequest
 
               # Converts hash and nil to an options object
@@ -861,7 +851,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateReferenceImageRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateReferenceImageRequest
 
               # Converts hash and nil to an options object
@@ -933,7 +922,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteReferenceImageRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteReferenceImageRequest
 
               # Converts hash and nil to an options object
@@ -1003,7 +991,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListReferenceImagesRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListReferenceImagesRequest
 
               # Converts hash and nil to an options object
@@ -1063,7 +1050,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetReferenceImageRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetReferenceImageRequest
 
               # Converts hash and nil to an options object
@@ -1133,7 +1119,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AddProductToProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::AddProductToProductSetRequest
 
               # Converts hash and nil to an options object
@@ -1197,7 +1182,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
 
               # Converts hash and nil to an options object
@@ -1264,7 +1248,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsInProductSetRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductsInProductSetRequest
 
               # Converts hash and nil to an options object
@@ -1336,7 +1319,6 @@ module Google
               end
 
               request ||= request_fields
-              # request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ImportProductSetsRequest
               request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ImportProductSetsRequest
 
               # Converts hash and nil to an options object

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -204,7 +204,7 @@ module Google
             #
             #     * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
             #       4096 characters.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload create_product_set(parent: nil, product_set: nil, product_set_id: nil, options: nil)
@@ -219,7 +219,7 @@ module Google
             #     attempt to use this value as the resource id. If it is already in use, an
             #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
             #     long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -259,7 +259,7 @@ module Google
             #
             #     * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
             #       than 1.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload list_product_sets(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -271,7 +271,7 @@ module Google
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -309,7 +309,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the ProductSet does not exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload get_product_set(name: nil, options: nil)
@@ -318,7 +318,7 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -362,7 +362,7 @@ module Google
             #     * Returns NOT_FOUND if the ProductSet does not exist.
             #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but
             #       missing from the request or longer than 4096 characters.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload update_product_set(product_set: nil, update_mask: nil, options: nil)
@@ -373,7 +373,7 @@ module Google
             #     update.
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask path is `display_name`.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -417,7 +417,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the ProductSet does not exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload delete_product_set(name: nil, options: nil)
@@ -426,7 +426,7 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -470,7 +470,7 @@ module Google
             #       characters.
             #     * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
             #     * Returns INVALID_ARGUMENT if product_category is missing or invalid.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload create_product(parent: nil, product: nil, product_id: nil, options: nil)
@@ -486,7 +486,7 @@ module Google
             #     attempt to use this value as the resource id. If it is already in use, an
             #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
             #     long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -524,7 +524,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload list_products(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -537,7 +537,7 @@ module Google
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -575,7 +575,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the Product does not exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload get_product(name: nil, options: nil)
@@ -584,7 +584,7 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -642,7 +642,7 @@ module Google
             #     * Returns INVALID_ARGUMENT if description is present in update_mask but is
             #       longer than 4096 characters.
             #     * Returns INVALID_ARGUMENT if product_category is present in update_mask.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload update_product(product: nil, update_mask: nil, options: nil)
@@ -655,7 +655,7 @@ module Google
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask paths include `product_labels`, `display_name`, and
             #     `description`.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -701,7 +701,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the product does not exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload delete_product(name: nil, options: nil)
@@ -710,7 +710,7 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -776,7 +776,7 @@ module Google
             #     * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
             #       compatible with the parent product's product_category is detected.
             #     * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload create_reference_image(parent: nil, reference_image: nil, reference_image_id: nil, options: nil)
@@ -793,7 +793,7 @@ module Google
             #     the server will attempt to use this value as the resource id. If it is
             #     already in use, an error is returned with code ALREADY_EXISTS. Must be at
             #     most 128 characters long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -843,7 +843,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the reference image does not exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload delete_reference_image(name: nil, options: nil)
@@ -853,7 +853,7 @@ module Google
             #     Format is:
             #
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -895,7 +895,7 @@ module Google
             #     * Returns NOT_FOUND if the parent product does not exist.
             #     * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
             #       than 1.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload list_reference_images(parent: nil, page_size: nil, page_token: nil, options: nil)
@@ -911,7 +911,7 @@ module Google
             #     of `nextPageToken` returned in a previous reference image list request.
             #
             #     Defaults to the first page if not specified.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -949,7 +949,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the specified image does not exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload get_reference_image(name: nil, options: nil)
@@ -959,7 +959,7 @@ module Google
             #     Format is:
             #
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -1003,7 +1003,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload add_product_to_product_set(name: nil, product: nil, options: nil)
@@ -1017,7 +1017,7 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -1055,7 +1055,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns NOT_FOUND If the Product is not found under the ProductSet.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload remove_product_from_product_set(name: nil, product: nil, options: nil)
@@ -1069,7 +1069,7 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -1111,7 +1111,7 @@ module Google
             #     Possible errors:
             #
             #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload list_products_in_product_set(name: nil, page_size: nil, page_token: nil, options: nil)
@@ -1124,7 +1124,7 @@ module Google
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [result, operation] Access the result along with the RPC operation
@@ -1174,7 +1174,7 @@ module Google
             #     The input source of this method is a csv file on Google Cloud Storage.
             #     For the format of the csv file please see
             #     [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @overload import_product_sets(parent: nil, input_config: nil, options: nil)
@@ -1184,7 +1184,7 @@ module Google
             #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
             #   @param input_config [Google::Cloud::Vision::V1::ImportProductSetsInputConfig | Hash]
             #     The input content for the list of requests.
-            #   @param options [Google::Gax::CallOptions]
+            #   @param options [Google::Gax::ApiCall::Options]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [operation] Register a callback to be run when an operation is done.

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -85,16 +85,12 @@ module Google
             # @param metadata [Hash]
             #   Default metadata to be sent with each request. This can be overridden on a
             #   per call basis.
-            # @param exception_transformer [Proc]
-            #   An optional proc that intercepts any exceptions raised during an API call to
-            #   inject custom error handling.
             #
             def initialize \
                 credentials: nil,
                 scopes: ALL_SCOPES,
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
-                exception_transformer: nil,
                 lib_name: nil,
                 lib_version: ""
               # These require statements are intentionally placed here to initialize
@@ -118,93 +114,75 @@ module Google
 
               @create_product_set = Google::Gax.create_api_call(
                 @product_search_stub.method(:create_product_set),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @list_product_sets = Google::Gax.create_api_call(
                 @product_search_stub.method(:list_product_sets),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @get_product_set = Google::Gax.create_api_call(
                 @product_search_stub.method(:get_product_set),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @update_product_set = Google::Gax.create_api_call(
                 @product_search_stub.method(:update_product_set),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @delete_product_set = Google::Gax.create_api_call(
                 @product_search_stub.method(:delete_product_set),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @create_product = Google::Gax.create_api_call(
                 @product_search_stub.method(:create_product),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @list_products = Google::Gax.create_api_call(
                 @product_search_stub.method(:list_products),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @get_product = Google::Gax.create_api_call(
                 @product_search_stub.method(:get_product),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @update_product = Google::Gax.create_api_call(
                 @product_search_stub.method(:update_product),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @delete_product = Google::Gax.create_api_call(
                 @product_search_stub.method(:delete_product),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @create_reference_image = Google::Gax.create_api_call(
                 @product_search_stub.method(:create_reference_image),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @delete_reference_image = Google::Gax.create_api_call(
                 @product_search_stub.method(:delete_reference_image),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @list_reference_images = Google::Gax.create_api_call(
                 @product_search_stub.method(:list_reference_images),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @get_reference_image = Google::Gax.create_api_call(
                 @product_search_stub.method(:get_reference_image),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @add_product_to_product_set = Google::Gax.create_api_call(
                 @product_search_stub.method(:add_product_to_product_set),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @remove_product_from_product_set = Google::Gax.create_api_call(
                 @product_search_stub.method(:remove_product_from_product_set),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @list_products_in_product_set = Google::Gax.create_api_call(
                 @product_search_stub.method(:list_products_in_product_set),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
               @import_product_sets = Google::Gax.create_api_call(
                 @product_search_stub.method(:import_product_sets),
-                defaults,
-                exception_transformer: exception_transformer
+                defaults
               )
             end
 

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -112,75 +112,75 @@ module Google
 
               defaults = default_settings timeout, metadata, lib_name, lib_version
 
-              @create_product_set = Google::Gax.create_api_call(
+              @create_product_set = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:create_product_set),
                 defaults
               )
-              @list_product_sets = Google::Gax.create_api_call(
+              @list_product_sets = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:list_product_sets),
                 defaults
               )
-              @get_product_set = Google::Gax.create_api_call(
+              @get_product_set = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:get_product_set),
                 defaults
               )
-              @update_product_set = Google::Gax.create_api_call(
+              @update_product_set = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:update_product_set),
                 defaults
               )
-              @delete_product_set = Google::Gax.create_api_call(
+              @delete_product_set = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:delete_product_set),
                 defaults
               )
-              @create_product = Google::Gax.create_api_call(
+              @create_product = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:create_product),
                 defaults
               )
-              @list_products = Google::Gax.create_api_call(
+              @list_products = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:list_products),
                 defaults
               )
-              @get_product = Google::Gax.create_api_call(
+              @get_product = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:get_product),
                 defaults
               )
-              @update_product = Google::Gax.create_api_call(
+              @update_product = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:update_product),
                 defaults
               )
-              @delete_product = Google::Gax.create_api_call(
+              @delete_product = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:delete_product),
                 defaults
               )
-              @create_reference_image = Google::Gax.create_api_call(
+              @create_reference_image = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:create_reference_image),
                 defaults
               )
-              @delete_reference_image = Google::Gax.create_api_call(
+              @delete_reference_image = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:delete_reference_image),
                 defaults
               )
-              @list_reference_images = Google::Gax.create_api_call(
+              @list_reference_images = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:list_reference_images),
                 defaults
               )
-              @get_reference_image = Google::Gax.create_api_call(
+              @get_reference_image = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:get_reference_image),
                 defaults
               )
-              @add_product_to_product_set = Google::Gax.create_api_call(
+              @add_product_to_product_set = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:add_product_to_product_set),
                 defaults
               )
-              @remove_product_from_product_set = Google::Gax.create_api_call(
+              @remove_product_from_product_set = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:remove_product_from_product_set),
                 defaults
               )
-              @list_products_in_product_set = Google::Gax.create_api_call(
+              @list_products_in_product_set = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:list_products_in_product_set),
                 defaults
               )
-              @import_product_sets = Google::Gax.create_api_call(
+              @import_product_sets = Google::Gax::ApiCall.new(
                 @product_search_stub.method(:import_product_sets),
                 defaults
               )

--- a/shared/output/gapic/templates/garbage/endless/trash/forever/garbage_service.rb
+++ b/shared/output/gapic/templates/garbage/endless/trash/forever/garbage_service.rb
@@ -116,42 +116,42 @@ module Endless
 
           defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
 
-          @get_simple_garbage = Google::Gax.create_api_call(
+          @get_simple_garbage = Google::Gax::ApiCall.new(
             @garbage_service_stub.method(:get_simple_garbage),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @get_specific_garbage = Google::Gax.create_api_call(
+          @get_specific_garbage = Google::Gax::ApiCall.new(
             @garbage_service_stub.method(:get_specific_garbage),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @get_nested_garbage = Google::Gax.create_api_call(
+          @get_nested_garbage = Google::Gax::ApiCall.new(
             @garbage_service_stub.method(:get_nested_garbage),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @get_repeated_garbage = Google::Gax.create_api_call(
+          @get_repeated_garbage = Google::Gax::ApiCall.new(
             @garbage_service_stub.method(:get_repeated_garbage),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @long_running_garbage = Google::Gax.create_api_call(
+          @long_running_garbage = Google::Gax::ApiCall.new(
             @garbage_service_stub.method(:long_running_garbage),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @client_garbage = Google::Gax.create_api_call(
+          @client_garbage = Google::Gax::ApiCall.new(
             @garbage_service_stub.method(:client_garbage),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @server_garbage = Google::Gax.create_api_call(
+          @server_garbage = Google::Gax::ApiCall.new(
             @garbage_service_stub.method(:server_garbage),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @bidi_garbage = Google::Gax.create_api_call(
+          @bidi_garbage = Google::Gax::ApiCall.new(
             @garbage_service_stub.method(:bidi_garbage),
             CallSettings.new,
             exception_transformer: exception_transformer

--- a/shared/output/gapic/templates/showcase/google/showcase/v1alpha3/echo.rb
+++ b/shared/output/gapic/templates/showcase/google/showcase/v1alpha3/echo.rb
@@ -121,32 +121,32 @@ module Google
           )
           @echo_stub = create_stub credentials, scopes
 
-          @echo = Google::Gax.create_api_call(
+          @echo = Google::Gax::ApiCall.new(
             @echo_stub.method(:echo),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @expand = Google::Gax.create_api_call(
+          @expand = Google::Gax::ApiCall.new(
             @echo_stub.method(:expand),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @collect = Google::Gax.create_api_call(
+          @collect = Google::Gax::ApiCall.new(
             @echo_stub.method(:collect),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @chat = Google::Gax.create_api_call(
+          @chat = Google::Gax::ApiCall.new(
             @echo_stub.method(:chat),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @paged_expand = Google::Gax.create_api_call(
+          @paged_expand = Google::Gax::ApiCall.new(
             @echo_stub.method(:paged_expand),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @wait = Google::Gax.create_api_call(
+          @wait = Google::Gax::ApiCall.new(
             @echo_stub.method(:wait),
             CallSettings.new,
             exception_transformer: exception_transformer

--- a/shared/output/gapic/templates/showcase/google/showcase/v1alpha3/identity.rb
+++ b/shared/output/gapic/templates/showcase/google/showcase/v1alpha3/identity.rb
@@ -112,27 +112,27 @@ module Google
           )
           @identity_stub = create_stub credentials, scopes
 
-          @create_user = Google::Gax.create_api_call(
+          @create_user = Google::Gax::ApiCall.new(
             @identity_stub.method(:create_user),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @get_user = Google::Gax.create_api_call(
+          @get_user = Google::Gax::ApiCall.new(
             @identity_stub.method(:get_user),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @update_user = Google::Gax.create_api_call(
+          @update_user = Google::Gax::ApiCall.new(
             @identity_stub.method(:update_user),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @delete_user = Google::Gax.create_api_call(
+          @delete_user = Google::Gax::ApiCall.new(
             @identity_stub.method(:delete_user),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @list_users = Google::Gax.create_api_call(
+          @list_users = Google::Gax::ApiCall.new(
             @identity_stub.method(:list_users),
             CallSettings.new,
             exception_transformer: exception_transformer

--- a/shared/output/gapic/templates/showcase/google/showcase/v1alpha3/messaging.rb
+++ b/shared/output/gapic/templates/showcase/google/showcase/v1alpha3/messaging.rb
@@ -115,72 +115,72 @@ module Google
           )
           @messaging_stub = create_stub credentials, scopes
 
-          @create_room = Google::Gax.create_api_call(
+          @create_room = Google::Gax::ApiCall.new(
             @messaging_stub.method(:create_room),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @get_room = Google::Gax.create_api_call(
+          @get_room = Google::Gax::ApiCall.new(
             @messaging_stub.method(:get_room),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @update_room = Google::Gax.create_api_call(
+          @update_room = Google::Gax::ApiCall.new(
             @messaging_stub.method(:update_room),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @delete_room = Google::Gax.create_api_call(
+          @delete_room = Google::Gax::ApiCall.new(
             @messaging_stub.method(:delete_room),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @list_rooms = Google::Gax.create_api_call(
+          @list_rooms = Google::Gax::ApiCall.new(
             @messaging_stub.method(:list_rooms),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @create_blurb = Google::Gax.create_api_call(
+          @create_blurb = Google::Gax::ApiCall.new(
             @messaging_stub.method(:create_blurb),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @get_blurb = Google::Gax.create_api_call(
+          @get_blurb = Google::Gax::ApiCall.new(
             @messaging_stub.method(:get_blurb),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @update_blurb = Google::Gax.create_api_call(
+          @update_blurb = Google::Gax::ApiCall.new(
             @messaging_stub.method(:update_blurb),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @delete_blurb = Google::Gax.create_api_call(
+          @delete_blurb = Google::Gax::ApiCall.new(
             @messaging_stub.method(:delete_blurb),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @list_blurbs = Google::Gax.create_api_call(
+          @list_blurbs = Google::Gax::ApiCall.new(
             @messaging_stub.method(:list_blurbs),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @search_blurbs = Google::Gax.create_api_call(
+          @search_blurbs = Google::Gax::ApiCall.new(
             @messaging_stub.method(:search_blurbs),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @stream_blurbs = Google::Gax.create_api_call(
+          @stream_blurbs = Google::Gax::ApiCall.new(
             @messaging_stub.method(:stream_blurbs),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @send_blurbs = Google::Gax.create_api_call(
+          @send_blurbs = Google::Gax::ApiCall.new(
             @messaging_stub.method(:send_blurbs),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @connect = Google::Gax.create_api_call(
+          @connect = Google::Gax::ApiCall.new(
             @messaging_stub.method(:connect),
             CallSettings.new,
             exception_transformer: exception_transformer

--- a/shared/output/gapic/templates/showcase/google/showcase/v1alpha3/testing.rb
+++ b/shared/output/gapic/templates/showcase/google/showcase/v1alpha3/testing.rb
@@ -113,42 +113,42 @@ module Google
           )
           @testing_stub = create_stub credentials, scopes
 
-          @create_session = Google::Gax.create_api_call(
+          @create_session = Google::Gax::ApiCall.new(
             @testing_stub.method(:create_session),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @get_session = Google::Gax.create_api_call(
+          @get_session = Google::Gax::ApiCall.new(
             @testing_stub.method(:get_session),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @list_sessions = Google::Gax.create_api_call(
+          @list_sessions = Google::Gax::ApiCall.new(
             @testing_stub.method(:list_sessions),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @delete_session = Google::Gax.create_api_call(
+          @delete_session = Google::Gax::ApiCall.new(
             @testing_stub.method(:delete_session),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @report_session = Google::Gax.create_api_call(
+          @report_session = Google::Gax::ApiCall.new(
             @testing_stub.method(:report_session),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @list_tests = Google::Gax.create_api_call(
+          @list_tests = Google::Gax::ApiCall.new(
             @testing_stub.method(:list_tests),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @delete_test = Google::Gax.create_api_call(
+          @delete_test = Google::Gax::ApiCall.new(
             @testing_stub.method(:delete_test),
             CallSettings.new,
             exception_transformer: exception_transformer
           )
-          @verify_test = Google::Gax.create_api_call(
+          @verify_test = Google::Gax::ApiCall.new(
             @testing_stub.method(:verify_test),
             CallSettings.new,
             exception_transformer: exception_transformer

--- a/shared/output/gapic/templates/speech/google/cloud/speech/v1/speech.rb
+++ b/shared/output/gapic/templates/speech/google/cloud/speech/v1/speech.rb
@@ -117,17 +117,17 @@ module Google
 
             defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
 
-            @recognize = Google::Gax.create_api_call(
+            @recognize = Google::Gax::ApiCall.new(
               @speech_stub.method(:recognize),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @long_running_recognize = Google::Gax.create_api_call(
+            @long_running_recognize = Google::Gax::ApiCall.new(
               @speech_stub.method(:long_running_recognize),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @streaming_recognize = Google::Gax.create_api_call(
+            @streaming_recognize = Google::Gax::ApiCall.new(
               @speech_stub.method(:streaming_recognize),
               CallSettings.new,
               exception_transformer: exception_transformer

--- a/shared/output/gapic/templates/vision/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/gapic/templates/vision/google/cloud/vision/v1/image_annotator.rb
@@ -119,12 +119,12 @@ module Google
 
             defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
 
-            @batch_annotate_images = Google::Gax.create_api_call(
+            @batch_annotate_images = Google::Gax::ApiCall.new(
               @image_annotator_stub.method(:batch_annotate_images),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @async_batch_annotate_files = Google::Gax.create_api_call(
+            @async_batch_annotate_files = Google::Gax::ApiCall.new(
               @image_annotator_stub.method(:async_batch_annotate_files),
               CallSettings.new,
               exception_transformer: exception_transformer

--- a/shared/output/gapic/templates/vision/google/cloud/vision/v1/product_search.rb
+++ b/shared/output/gapic/templates/vision/google/cloud/vision/v1/product_search.rb
@@ -132,92 +132,92 @@ module Google
 
             defaults = default_settings client_config, timeout, metadata, lib_name, lib_version
 
-            @create_product_set = Google::Gax.create_api_call(
+            @create_product_set = Google::Gax::ApiCall.new(
               @product_search_stub.method(:create_product_set),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @list_product_sets = Google::Gax.create_api_call(
+            @list_product_sets = Google::Gax::ApiCall.new(
               @product_search_stub.method(:list_product_sets),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @get_product_set = Google::Gax.create_api_call(
+            @get_product_set = Google::Gax::ApiCall.new(
               @product_search_stub.method(:get_product_set),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @update_product_set = Google::Gax.create_api_call(
+            @update_product_set = Google::Gax::ApiCall.new(
               @product_search_stub.method(:update_product_set),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @delete_product_set = Google::Gax.create_api_call(
+            @delete_product_set = Google::Gax::ApiCall.new(
               @product_search_stub.method(:delete_product_set),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @create_product = Google::Gax.create_api_call(
+            @create_product = Google::Gax::ApiCall.new(
               @product_search_stub.method(:create_product),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @list_products = Google::Gax.create_api_call(
+            @list_products = Google::Gax::ApiCall.new(
               @product_search_stub.method(:list_products),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @get_product = Google::Gax.create_api_call(
+            @get_product = Google::Gax::ApiCall.new(
               @product_search_stub.method(:get_product),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @update_product = Google::Gax.create_api_call(
+            @update_product = Google::Gax::ApiCall.new(
               @product_search_stub.method(:update_product),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @delete_product = Google::Gax.create_api_call(
+            @delete_product = Google::Gax::ApiCall.new(
               @product_search_stub.method(:delete_product),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @create_reference_image = Google::Gax.create_api_call(
+            @create_reference_image = Google::Gax::ApiCall.new(
               @product_search_stub.method(:create_reference_image),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @delete_reference_image = Google::Gax.create_api_call(
+            @delete_reference_image = Google::Gax::ApiCall.new(
               @product_search_stub.method(:delete_reference_image),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @list_reference_images = Google::Gax.create_api_call(
+            @list_reference_images = Google::Gax::ApiCall.new(
               @product_search_stub.method(:list_reference_images),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @get_reference_image = Google::Gax.create_api_call(
+            @get_reference_image = Google::Gax::ApiCall.new(
               @product_search_stub.method(:get_reference_image),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @add_product_to_product_set = Google::Gax.create_api_call(
+            @add_product_to_product_set = Google::Gax::ApiCall.new(
               @product_search_stub.method(:add_product_to_product_set),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @remove_product_from_product_set = Google::Gax.create_api_call(
+            @remove_product_from_product_set = Google::Gax::ApiCall.new(
               @product_search_stub.method(:remove_product_from_product_set),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @list_products_in_product_set = Google::Gax.create_api_call(
+            @list_products_in_product_set = Google::Gax::ApiCall.new(
               @product_search_stub.method(:list_products_in_product_set),
               CallSettings.new,
               exception_transformer: exception_transformer
             )
-            @import_product_sets = Google::Gax.create_api_call(
+            @import_product_sets = Google::Gax::ApiCall.new(
               @product_search_stub.method(:import_product_sets),
               CallSettings.new,
               exception_transformer: exception_transformer


### PR DESCRIPTION
This PR implements the changes in the generator for the GAX changes made in googleapis/gax-ruby#178.

* Refactor how generated client defines methods
* Use ApiCall.new
* Use ApiCall::Options
* Document StreamInput for client streaming requests
* Remove client_config
* Remove exception_transformer
