### PR TITLE
Add protobuf files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,15 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-desc "Check that the necessary protobuf files exist."
-task :check_protos do
-  Dir.chdir "gapic-generator" do
-    Bundler.with_clean_env do
-      sh "bundle exec rake check_protos"
-    end
-  end
-end
-
 desc "Builds all gems."
 task :build do
   gem_dirs.each do |gem|
@@ -65,7 +56,6 @@ task :test do
     end
   end
 end
-Rake::Task[:test].enhance [:check_protos]
 
 desc "Runs file generation for binary input files and all gems."
 task :gen do
@@ -85,7 +75,6 @@ task :gen do
     end
   end
 end
-Rake::Task[:gen].enhance [:check_protos]
 
 desc "Runs rubocop for all gems."
 task :rubocop do
@@ -98,7 +87,6 @@ task :rubocop do
     end
   end
 end
-Rake::Task[:rubocop].enhance [:check_protos]
 
 desc "Runs CI for all gems."
 task :ci do
@@ -118,7 +106,6 @@ task :ci do
     end
   end
 end
-Rake::Task[:ci].enhance [:check_protos]
 
 desc "Runs bundle update for all gems."
 task :update do

--- a/gapic-generator-cloud/Rakefile
+++ b/gapic-generator-cloud/Rakefile
@@ -18,22 +18,12 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 require "rake/testtask"
 
-desc "Check that the necessary protobuf files exist."
-task :check_protos do
-  Dir.chdir "../gapic-generator" do
-    Bundler.with_clean_env do
-      sh "bundle exec rake check_protos"
-    end
-  end
-end
-
 RuboCop::RakeTask.new # Configuration is in .rubocop.yml
 Rake::TestTask.new :test do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
 end
-Rake::Task[:test].enhance [:check_protos]
 
 desc "Run the CI build"
 task :ci do
@@ -43,7 +33,6 @@ task :ci do
   puts "\ngapic-generator-cloud test\n"
   Rake::Task[:test].invoke
 end
-Rake::Task[:ci].enhance [:check_protos]
 
 desc "Generate the expected output for tests"
 task :gen do
@@ -58,8 +47,6 @@ namespace :gen do
     # generate_cloud_templates "garbage"
   end
 end
-Rake::Task[:gen].enhance [:check_protos]
-Rake::Task["gen:templates"].enhance [:check_protos]
 
 desc "Start an interactive shell."
 task :console do
@@ -79,7 +66,6 @@ task :console do
   ARGV.clear
   IRB.start
 end
-Rake::Task[:console].enhance [:check_protos]
 
 def api service
   require "google/gapic/schema/api"

--- a/gapic-generator/.gitignore
+++ b/gapic-generator/.gitignore
@@ -9,7 +9,4 @@ Gemfile.lock
 /spec/reports/
 /tmp/
 Gemfile.lock
-
-# Ignore generated protobuf files
-*.pb.rb
 mkmf.log

--- a/gapic-generator/README.md
+++ b/gapic-generator/README.md
@@ -7,20 +7,17 @@ but there are currently no guarantees of stability or support.
 
 ## Usage
 
-### Build and Install the Generator
-This tool is in pre-alpha so it is not yet released to RubyGems. You will have to
-build the generator from scratch. Building the gem requires the proto compiler to be installed
-as shown in the previous section.
+### Install the Generator
+
+This tool is in pre-alpha so it is not yet released to RubyGems.
 
 ```sh
 $ git clone https://github.com/googleapis/gapic-generator-ruby.git
 $ cd gapic-generator-ruby
 $ git submodule update --init
-$ bundle install
-$ bundle exec rake
 $ cd gapic-generator
-$ gem build gapic-generator.gemspec
-$ gem install gapic-generator-0.1.0.gem
+$ bundle install
+$ bundle exec rake install
 $ which protoc-gen-ruby_gapic
 > {Non-empty path}
 ```

--- a/gapic-generator/README.md
+++ b/gapic-generator/README.md
@@ -23,23 +23,36 @@ $ which protoc-gen-ruby_gapic
 ```
 
 ### Generate an API
+
 Installing this generator exposes `protoc-gen-ruby_gapic` on the PATH. By doing
 so, it gives the protobuf compiler the CLI option `--ruby_gapic_out` on which
 you can specify an output path for this generator.
 
 If you want to experiment with an already-existing API, one example is available.
-Note: You need to clone the googleapis repository from GitHub, and change
-to a special branch:
+First you should get the protos and dependencies:
+
 ```sh
-# Get the protos and it's dependencies.
 $ git clone git@github.com:googleapis/api-common-protos.git
 $ git clone git@github.com:googleapis/googleapis.git
-$ cd googleapis
-$ git checkout --track -b input-contract origin/input-contract
+```
 
-# Now you're ready to compile the API.
+Now you're ready to compile the API:
+
+```sh
 $ protoc google/cloud/vision/v1/*.proto \
-    --proto_path=../api-common-protos/ --proto_path=. \
+    --proto_path=api-common-protos/ \
+    --proto_path=googleapis/ \
+    --ruby_gapic_out=/dest/
+```
+
+Or, if you don't have `protoc` installed, you can use `grpc_tools_ruby_protoc`
+from the `grpc-tools` gem:
+
+```sh
+$ gem install grpc-tools
+$ grpc_tools_ruby_protoc google/cloud/vision/v1/*.proto \
+    --proto_path=api-common-protos/ \
+    --proto_path=googleapis/ \
     --ruby_gapic_out=/dest/
 ```
 

--- a/gapic-generator/Rakefile
+++ b/gapic-generator/Rakefile
@@ -85,6 +85,7 @@ desc "Generate the expected output for tests"
 task :gen do
   Rake::Task["gen:templates"].invoke
   Rake::Task["gen:gem_creation"].invoke
+  Rake::Task["gen:protos"].invoke
 end
 namespace :gen do
   desc "Generate the expected output for templates tests"
@@ -98,6 +99,11 @@ namespace :gen do
   desc "Generate the expected output for gem creation tests"
   task :gem_creation do
     generate_gem "my_plugin"
+  end
+
+  desc "Generate the protobuf files used in the gem"
+  task :protos do
+    Rake::Task["compile_protos"].invoke
   end
 end
 Rake::Task[:gen].enhance [:check_protos]

--- a/gapic-generator/Rakefile
+++ b/gapic-generator/Rakefile
@@ -16,7 +16,6 @@
 
 require "bundler/gem_tasks"
 require "fileutils"
-require "mkmf"
 require "rake/testtask"
 require "rubocop/rake_task"
 
@@ -27,11 +26,66 @@ Rake::TestTask.new :test do |t|
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
-desc "Compile the necessary protobuf files."
-task :compile_protos do
-  Rake::Task[:clean_protos].invoke
+desc "Run the CI build"
+task :ci do
+  puts "\ngapic-generator rubocop\n"
+  Rake::Task[:rubocop].invoke
+  puts "\ngapic-generator test\n"
+  Rake::Task[:test].invoke
+end
 
-  # TODO: Add check to ensure protoc-gen-ruby and protoc are installed.
+task default: :ci
+
+desc "Generate the expected output for tests"
+task :gen do
+  Rake::Task["gen:protos"].invoke
+  Rake::Task["gen:templates"].invoke
+  Rake::Task["gen:gem_creation"].invoke
+end
+namespace :gen do
+  desc "Generate the protobuf files used in the gem"
+  task :protos do
+    generate_protos
+  end
+
+  desc "Generate the expected output for templates tests"
+  task :templates do
+    generate_default_templates "speech"
+    generate_default_templates "vision"
+    generate_default_templates "showcase"
+    # generate_default_templates "garbage"
+  end
+
+  desc "Generate the expected output for gem creation tests"
+  task :gem_creation do
+    generate_gem "my_plugin"
+  end
+end
+
+desc "Start an interactive shell."
+task :console do
+  require "irb"
+  require "irb/completion"
+  require "pp"
+
+  $LOAD_PATH.unshift "lib"
+
+  require "google/gapic/schema"
+  def schema service
+    bin_proto = File.binread "proto_input/#{service}_desc.bin"
+    request = Google::Protobuf::Compiler::CodeGeneratorRequest.decode bin_proto
+    Google::Gapic::Schema::Api.new request
+  end
+
+  ARGV.clear
+  IRB.start
+end
+
+def generate_protos
+  require "mkmf" # needed for find_executable
+
+  # Remove old generated files.
+  FileUtils.rm Dir.glob(File.join("lib", "**", "*.pb.rb"))
 
   plugin_executable = find_executable "protoc-gen-ruby"
   plugin = "protoc-gen-ruby-protobuf=#{plugin_executable}"
@@ -54,81 +108,6 @@ task :compile_protos do
   puts full_command
   puts `#{full_command}`
 end
-
-desc "Remove the compiled protos."
-task :clean_protos do
-  FileUtils.rm Dir.glob(File.join("lib", "**", "*.pb.rb"))
-end
-
-desc "Check that the necessary protobuf files exist."
-task :check_protos do
-  Rake::Task[:compile_protos].invoke unless File.exist? "lib/google/api/annotations.pb.rb"
-end
-
-Rake::Task[:build].enhance [:compile_protos]
-Rake::Task[:clean].enhance [:clean_protos]
-
-desc "Run the CI build"
-task :ci do
-  puts "\nBUILDING gapic-generator\n"
-  Rake::Task[:compile_protos].invoke
-  puts "\ngapic-generator rubocop\n"
-  Rake::Task[:rubocop].invoke
-  puts "\ngapic-generator test\n"
-  Rake::Task[:test].invoke
-end
-Rake::Task[:ci].enhance [:check_protos]
-
-task default: :ci
-
-desc "Generate the expected output for tests"
-task :gen do
-  Rake::Task["gen:templates"].invoke
-  Rake::Task["gen:gem_creation"].invoke
-  Rake::Task["gen:protos"].invoke
-end
-namespace :gen do
-  desc "Generate the expected output for templates tests"
-  task :templates do
-    generate_default_templates "speech"
-    generate_default_templates "vision"
-    generate_default_templates "showcase"
-    # generate_default_templates "garbage"
-  end
-
-  desc "Generate the expected output for gem creation tests"
-  task :gem_creation do
-    generate_gem "my_plugin"
-  end
-
-  desc "Generate the protobuf files used in the gem"
-  task :protos do
-    Rake::Task["compile_protos"].invoke
-  end
-end
-Rake::Task[:gen].enhance [:check_protos]
-Rake::Task["gen:templates"].enhance [:check_protos]
-Rake::Task["gen:gem_creation"].enhance [:check_protos]
-
-desc "Start an interactive shell."
-task :console do
-  require "irb"
-  require "irb/completion"
-  require "pp"
-
-  $LOAD_PATH.unshift "lib"
-
-  require "google/gapic/schema"
-  def schema service
-    bin_proto = File.binread "proto_input/#{service}_desc.bin"
-    request = Google::Protobuf::Compiler::CodeGeneratorRequest.decode bin_proto
-    Google::Gapic::Schema::Api.new request
-  end
-
-  ARGV.clear
-  IRB.start
-end
-Rake::Task[:console].enhance [:check_protos]
 
 def generate_default_templates service
   require "google/gapic/schema/api"

--- a/gapic-generator/lib/google/api/annotations.pb.rb
+++ b/gapic-generator/lib/google/api/annotations.pb.rb
@@ -1,0 +1,39 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+
+##
+# Imports
+#
+require 'google/api/http.pb'
+require 'google/protobuf/descriptor.pb'
+
+module Google
+  module Api
+    ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
+
+    ##
+    # File Options
+    #
+    set_option :java_package, "com.google.api"
+    set_option :java_outer_classname, "AnnotationsProto"
+    set_option :java_multiple_files, true
+    set_option :go_package, "google.golang.org/genproto/googleapis/api/annotations;annotations"
+    set_option :objc_class_prefix, "GAPI"
+
+
+    ##
+    # Extended Message Fields
+    #
+    class ::Google::Protobuf::MethodOptions < ::Protobuf::Message
+      optional ::Google::Api::HttpRule, :".google.api.http", 72295728, :extension => true
+    end
+
+  end
+
+end
+

--- a/gapic-generator/lib/google/api/client.pb.rb
+++ b/gapic-generator/lib/google/api/client.pb.rb
@@ -1,0 +1,64 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+
+##
+# Imports
+#
+require 'google/protobuf/descriptor.pb'
+
+module Google
+  module Api
+    ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
+
+    ##
+    # Message Classes
+    #
+    class Package < ::Protobuf::Message; end
+
+
+    ##
+    # File Options
+    #
+    set_option :java_package, "com.google.api"
+    set_option :java_outer_classname, "ClientProto"
+    set_option :java_multiple_files, true
+    set_option :go_package, "google.golang.org/genproto/googleapis/api/annotations;annotations"
+    set_option :objc_class_prefix, "GAPI"
+
+
+    ##
+    # Message Fields
+    #
+    class Package
+      optional :string, :title, 1
+      repeated :string, :namespace, 2
+      optional :string, :version, 3
+      optional :string, :product_title, 4
+    end
+
+
+    ##
+    # Extended Message Fields
+    #
+    class ::Google::Protobuf::FileOptions < ::Protobuf::Message
+      optional ::Google::Api::Package, :".google.api.client_package", 1048, :extension => true
+    end
+
+    class ::Google::Protobuf::ServiceOptions < ::Protobuf::Message
+      optional :string, :".google.api.default_host", 1049, :extension => true
+      optional :string, :".google.api.oauth_scopes", 1050, :extension => true
+    end
+
+    class ::Google::Protobuf::MethodOptions < ::Protobuf::Message
+      repeated :string, :".google.api.method_signature", 1051, :extension => true
+    end
+
+  end
+
+end
+

--- a/gapic-generator/lib/google/api/field_behavior.pb.rb
+++ b/gapic-generator/lib/google/api/field_behavior.pb.rb
@@ -1,0 +1,51 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+
+##
+# Imports
+#
+require 'google/protobuf/descriptor.pb'
+
+module Google
+  module Api
+    ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
+
+    ##
+    # Enum Classes
+    #
+    class FieldBehavior < ::Protobuf::Enum
+      define :FIELD_BEHAVIOR_UNSPECIFIED, 0
+      define :OPTIONAL, 1
+      define :REQUIRED, 2
+      define :OUTPUT_ONLY, 3
+      define :INPUT_ONLY, 4
+      define :IMMUTABLE, 5
+    end
+
+
+    ##
+    # File Options
+    #
+    set_option :java_package, "com.google.api"
+    set_option :java_outer_classname, "FieldBehaviorProto"
+    set_option :java_multiple_files, true
+    set_option :go_package, "google.golang.org/genproto/googleapis/api/annotations;annotations"
+    set_option :objc_class_prefix, "GAPI"
+
+
+    ##
+    # Extended Message Fields
+    #
+    class ::Google::Protobuf::FieldOptions < ::Protobuf::Message
+      repeated ::Google::Api::FieldBehavior, :".google.api.field_behavior", 1052, :extension => true
+    end
+
+  end
+
+end
+

--- a/gapic-generator/lib/google/api/http.pb.rb
+++ b/gapic-generator/lib/google/api/http.pb.rb
@@ -1,0 +1,60 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+module Google
+  module Api
+    ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
+
+    ##
+    # Message Classes
+    #
+    class Http < ::Protobuf::Message; end
+    class HttpRule < ::Protobuf::Message; end
+    class CustomHttpPattern < ::Protobuf::Message; end
+
+
+    ##
+    # File Options
+    #
+    set_option :java_package, "com.google.api"
+    set_option :java_outer_classname, "HttpProto"
+    set_option :java_multiple_files, true
+    set_option :go_package, "google.golang.org/genproto/googleapis/api/annotations;annotations"
+    set_option :cc_enable_arenas, true
+    set_option :objc_class_prefix, "GAPI"
+
+
+    ##
+    # Message Fields
+    #
+    class Http
+      repeated ::Google::Api::HttpRule, :rules, 1
+      optional :bool, :fully_decode_reserved_expansion, 2
+    end
+
+    class HttpRule
+      optional :string, :selector, 1
+      optional :string, :get, 2
+      optional :string, :put, 3
+      optional :string, :post, 4
+      optional :string, :delete, 5
+      optional :string, :patch, 6
+      optional ::Google::Api::CustomHttpPattern, :custom, 8
+      optional :string, :body, 7
+      optional :string, :response_body, 12
+      repeated ::Google::Api::HttpRule, :additional_bindings, 11
+    end
+
+    class CustomHttpPattern
+      optional :string, :kind, 1
+      optional :string, :path, 2
+    end
+
+  end
+
+end
+

--- a/gapic-generator/lib/google/api/resource.pb.rb
+++ b/gapic-generator/lib/google/api/resource.pb.rb
@@ -1,0 +1,67 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+
+##
+# Imports
+#
+require 'google/protobuf/descriptor.pb'
+
+module Google
+  module Api
+    ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
+
+    ##
+    # Message Classes
+    #
+    class Resource < ::Protobuf::Message; end
+    class ResourceSet < ::Protobuf::Message; end
+
+
+    ##
+    # File Options
+    #
+    set_option :java_package, "com.google.api"
+    set_option :java_outer_classname, "ResourceProto"
+    set_option :java_multiple_files, true
+    set_option :go_package, "google.golang.org/genproto/googleapis/api/annotations;annotations"
+    set_option :objc_class_prefix, "GAPI"
+    set_option :".google.api.resource_definition", [{ :pattern => "projects/{project}", :symbol => "Project" }, { :pattern => "organizations/{organization}", :symbol => "Organization" }]
+
+
+    ##
+    # Message Fields
+    #
+    class Resource
+      optional :string, :pattern, 1
+      optional :string, :symbol, 2
+    end
+
+    class ResourceSet
+      optional :string, :symbol, 1
+      repeated ::Google::Api::Resource, :resources, 2
+      repeated :string, :resource_references, 3
+    end
+
+
+    ##
+    # Extended Message Fields
+    #
+    class ::Google::Protobuf::FieldOptions < ::Protobuf::Message
+      optional ::Google::Api::Resource, :".google.api.resource", 1053, :extension => true
+      optional ::Google::Api::ResourceSet, :".google.api.resource_set", 1054, :extension => true
+      optional :string, :".google.api.resource_reference", 1055, :extension => true
+    end
+
+    class ::Google::Protobuf::FileOptions < ::Protobuf::Message
+      repeated ::Google::Api::Resource, :".google.api.resource_definition", 1053, :extension => true
+    end
+
+  end
+
+end
+

--- a/gapic-generator/lib/google/longrunning/operations.pb.rb
+++ b/gapic-generator/lib/google/longrunning/operations.pb.rb
@@ -1,0 +1,115 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+require 'protobuf/rpc/service'
+
+
+##
+# Imports
+#
+require 'google/api/annotations.pb'
+require 'google/protobuf/any.pb'
+require 'google/protobuf/descriptor.pb'
+require 'google/protobuf/empty.pb'
+require 'google/rpc/status.pb'
+
+module Google
+  module Longrunning
+    ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
+
+    ##
+    # Message Classes
+    #
+    class Operation < ::Protobuf::Message; end
+    class GetOperationRequest < ::Protobuf::Message; end
+    class ListOperationsRequest < ::Protobuf::Message; end
+    class ListOperationsResponse < ::Protobuf::Message; end
+    class CancelOperationRequest < ::Protobuf::Message; end
+    class DeleteOperationRequest < ::Protobuf::Message; end
+    class OperationInfo < ::Protobuf::Message; end
+
+
+    ##
+    # File Options
+    #
+    set_option :java_package, "com.google.longrunning"
+    set_option :java_outer_classname, "OperationsProto"
+    set_option :java_multiple_files, true
+    set_option :go_package, "google.golang.org/genproto/googleapis/longrunning;longrunning"
+    set_option :csharp_namespace, "Google.LongRunning"
+
+
+    ##
+    # Message Fields
+    #
+    class Operation
+      optional :string, :name, 1
+      optional ::Google::Protobuf::Any, :metadata, 2
+      optional :bool, :done, 3
+      optional ::Google::Rpc::Status, :error, 4
+      optional ::Google::Protobuf::Any, :response, 5
+    end
+
+    class GetOperationRequest
+      optional :string, :name, 1
+    end
+
+    class ListOperationsRequest
+      optional :string, :name, 4
+      optional :string, :filter, 1
+      optional :int32, :page_size, 2
+      optional :string, :page_token, 3
+    end
+
+    class ListOperationsResponse
+      repeated ::Google::Longrunning::Operation, :operations, 1
+      optional :string, :next_page_token, 2
+    end
+
+    class CancelOperationRequest
+      optional :string, :name, 1
+    end
+
+    class DeleteOperationRequest
+      optional :string, :name, 1
+    end
+
+    class OperationInfo
+      optional :string, :response_type, 1
+      optional :string, :metadata_type, 2
+    end
+
+
+    ##
+    # Extended Message Fields
+    #
+    class ::Google::Protobuf::MethodOptions < ::Protobuf::Message
+      optional ::Google::Longrunning::OperationInfo, :".google.longrunning.operation_info", 1049, :extension => true
+    end
+
+
+    ##
+    # Service Classes
+    #
+    class Operations < ::Protobuf::Rpc::Service
+      rpc :list_operations, ::Google::Longrunning::ListOperationsRequest, ::Google::Longrunning::ListOperationsResponse do
+        set_option :".google.api.http", { :get => "/v1/{name=operations}" }
+      end
+      rpc :get_operation, ::Google::Longrunning::GetOperationRequest, ::Google::Longrunning::Operation do
+        set_option :".google.api.http", { :get => "/v1/{name=operations/**}" }
+      end
+      rpc :delete_operation, ::Google::Longrunning::DeleteOperationRequest, ::Google::Protobuf::Empty do
+        set_option :".google.api.http", { :delete => "/v1/{name=operations/**}" }
+      end
+      rpc :cancel_operation, ::Google::Longrunning::CancelOperationRequest, ::Google::Protobuf::Empty do
+        set_option :".google.api.http", { :post => "/v1/{name=operations/**}:cancel", :body => "*" }
+      end
+    end
+
+  end
+
+end
+

--- a/gapic-generator/lib/google/protobuf/any.pb.rb
+++ b/gapic-generator/lib/google/protobuf/any.pb.rb
@@ -1,0 +1,40 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+module Google
+  module Protobuf
+    ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
+
+    ##
+    # Message Classes
+    #
+    class Any < ::Protobuf::Message; end
+
+
+    ##
+    # File Options
+    #
+    set_option :java_package, "com.google.protobuf"
+    set_option :java_outer_classname, "AnyProto"
+    set_option :java_multiple_files, true
+    set_option :go_package, "github.com/golang/protobuf/ptypes/any"
+    set_option :objc_class_prefix, "GPB"
+    set_option :csharp_namespace, "Google.Protobuf.WellKnownTypes"
+
+
+    ##
+    # Message Fields
+    #
+    class Any
+      optional :string, :type_url, 1
+      optional :bytes, :value, 2
+    end
+
+  end
+
+end
+

--- a/gapic-generator/lib/google/protobuf/compiler/plugin.pb.rb
+++ b/gapic-generator/lib/google/protobuf/compiler/plugin.pb.rb
@@ -1,0 +1,72 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+
+##
+# Imports
+#
+require 'google/protobuf/descriptor.pb'
+
+module Google
+  module Protobuf
+    module Compiler
+      ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
+
+      ##
+      # Message Classes
+      #
+      class Version < ::Protobuf::Message; end
+      class CodeGeneratorRequest < ::Protobuf::Message; end
+      class CodeGeneratorResponse < ::Protobuf::Message
+        class File < ::Protobuf::Message; end
+
+      end
+
+
+
+      ##
+      # File Options
+      #
+      set_option :java_package, "com.google.protobuf.compiler"
+      set_option :java_outer_classname, "PluginProtos"
+      set_option :go_package, "github.com/golang/protobuf/protoc-gen-go/plugin;plugin_go"
+
+
+      ##
+      # Message Fields
+      #
+      class Version
+        optional :int32, :major, 1
+        optional :int32, :minor, 2
+        optional :int32, :patch, 3
+        optional :string, :suffix, 4
+      end
+
+      class CodeGeneratorRequest
+        repeated :string, :file_to_generate, 1
+        optional :string, :parameter, 2
+        repeated ::Google::Protobuf::FileDescriptorProto, :proto_file, 15
+        optional ::Google::Protobuf::Compiler::Version, :compiler_version, 3
+      end
+
+      class CodeGeneratorResponse
+        class File
+          optional :string, :name, 1
+          optional :string, :insertion_point, 2
+          optional :string, :content, 15
+        end
+
+        optional :string, :error, 1
+        repeated ::Google::Protobuf::Compiler::CodeGeneratorResponse::File, :file, 15
+      end
+
+    end
+
+  end
+
+end
+

--- a/gapic-generator/lib/google/protobuf/descriptor.pb.rb
+++ b/gapic-generator/lib/google/protobuf/descriptor.pb.rb
@@ -1,0 +1,359 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+module Google
+  module Protobuf
+    ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
+
+    ##
+    # Message Classes
+    #
+    class FileDescriptorSet < ::Protobuf::Message; end
+    class FileDescriptorProto < ::Protobuf::Message; end
+    class DescriptorProto < ::Protobuf::Message
+      class ExtensionRange < ::Protobuf::Message; end
+      class ReservedRange < ::Protobuf::Message; end
+
+    end
+
+    class ExtensionRangeOptions < ::Protobuf::Message; end
+    class FieldDescriptorProto < ::Protobuf::Message
+      class Type < ::Protobuf::Enum
+        define :TYPE_DOUBLE, 1
+        define :TYPE_FLOAT, 2
+        define :TYPE_INT64, 3
+        define :TYPE_UINT64, 4
+        define :TYPE_INT32, 5
+        define :TYPE_FIXED64, 6
+        define :TYPE_FIXED32, 7
+        define :TYPE_BOOL, 8
+        define :TYPE_STRING, 9
+        define :TYPE_GROUP, 10
+        define :TYPE_MESSAGE, 11
+        define :TYPE_BYTES, 12
+        define :TYPE_UINT32, 13
+        define :TYPE_ENUM, 14
+        define :TYPE_SFIXED32, 15
+        define :TYPE_SFIXED64, 16
+        define :TYPE_SINT32, 17
+        define :TYPE_SINT64, 18
+      end
+
+      class Label < ::Protobuf::Enum
+        define :LABEL_OPTIONAL, 1
+        define :LABEL_REQUIRED, 2
+        define :LABEL_REPEATED, 3
+      end
+
+    end
+
+    class OneofDescriptorProto < ::Protobuf::Message; end
+    class EnumDescriptorProto < ::Protobuf::Message
+      class EnumReservedRange < ::Protobuf::Message; end
+
+    end
+
+    class EnumValueDescriptorProto < ::Protobuf::Message; end
+    class ServiceDescriptorProto < ::Protobuf::Message; end
+    class MethodDescriptorProto < ::Protobuf::Message; end
+    class FileOptions < ::Protobuf::Message
+      class OptimizeMode < ::Protobuf::Enum
+        define :SPEED, 1
+        define :CODE_SIZE, 2
+        define :LITE_RUNTIME, 3
+      end
+
+    end
+
+    class MessageOptions < ::Protobuf::Message; end
+    class FieldOptions < ::Protobuf::Message
+      class CType < ::Protobuf::Enum
+        define :STRING, 0
+        define :CORD, 1
+        define :STRING_PIECE, 2
+      end
+
+      class JSType < ::Protobuf::Enum
+        define :JS_NORMAL, 0
+        define :JS_STRING, 1
+        define :JS_NUMBER, 2
+      end
+
+    end
+
+    class OneofOptions < ::Protobuf::Message; end
+    class EnumOptions < ::Protobuf::Message; end
+    class EnumValueOptions < ::Protobuf::Message; end
+    class ServiceOptions < ::Protobuf::Message; end
+    class MethodOptions < ::Protobuf::Message
+      class IdempotencyLevel < ::Protobuf::Enum
+        define :IDEMPOTENCY_UNKNOWN, 0
+        define :NO_SIDE_EFFECTS, 1
+        define :IDEMPOTENT, 2
+      end
+
+    end
+
+    class UninterpretedOption < ::Protobuf::Message
+      class NamePart < ::Protobuf::Message; end
+
+    end
+
+    class SourceCodeInfo < ::Protobuf::Message
+      class Location < ::Protobuf::Message; end
+
+    end
+
+    class GeneratedCodeInfo < ::Protobuf::Message
+      class Annotation < ::Protobuf::Message; end
+
+    end
+
+
+
+    ##
+    # File Options
+    #
+    set_option :java_package, "com.google.protobuf"
+    set_option :java_outer_classname, "DescriptorProtos"
+    set_option :optimize_for, ::Google::Protobuf::FileOptions::OptimizeMode::SPEED
+    set_option :go_package, "github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor"
+    set_option :cc_enable_arenas, true
+    set_option :objc_class_prefix, "GPB"
+    set_option :csharp_namespace, "Google.Protobuf.Reflection"
+
+
+    ##
+    # Message Fields
+    #
+    class FileDescriptorSet
+      repeated ::Google::Protobuf::FileDescriptorProto, :file, 1
+    end
+
+    class FileDescriptorProto
+      optional :string, :name, 1
+      optional :string, :package, 2
+      repeated :string, :dependency, 3
+      repeated :int32, :public_dependency, 10
+      repeated :int32, :weak_dependency, 11
+      repeated ::Google::Protobuf::DescriptorProto, :message_type, 4
+      repeated ::Google::Protobuf::EnumDescriptorProto, :enum_type, 5
+      repeated ::Google::Protobuf::ServiceDescriptorProto, :service, 6
+      repeated ::Google::Protobuf::FieldDescriptorProto, :extension, 7
+      optional ::Google::Protobuf::FileOptions, :options, 8
+      optional ::Google::Protobuf::SourceCodeInfo, :source_code_info, 9
+      optional :string, :syntax, 12
+    end
+
+    class DescriptorProto
+      class ExtensionRange
+        optional :int32, :start, 1
+        optional :int32, :end, 2
+        optional ::Google::Protobuf::ExtensionRangeOptions, :options, 3
+      end
+
+      class ReservedRange
+        optional :int32, :start, 1
+        optional :int32, :end, 2
+      end
+
+      optional :string, :name, 1
+      repeated ::Google::Protobuf::FieldDescriptorProto, :field, 2
+      repeated ::Google::Protobuf::FieldDescriptorProto, :extension, 6
+      repeated ::Google::Protobuf::DescriptorProto, :nested_type, 3
+      repeated ::Google::Protobuf::EnumDescriptorProto, :enum_type, 4
+      repeated ::Google::Protobuf::DescriptorProto::ExtensionRange, :extension_range, 5
+      repeated ::Google::Protobuf::OneofDescriptorProto, :oneof_decl, 8
+      optional ::Google::Protobuf::MessageOptions, :options, 7
+      repeated ::Google::Protobuf::DescriptorProto::ReservedRange, :reserved_range, 9
+      repeated :string, :reserved_name, 10
+    end
+
+    class ExtensionRangeOptions
+      repeated ::Google::Protobuf::UninterpretedOption, :uninterpreted_option, 999
+      # Extension Fields
+      extensions 1000...536870912
+    end
+
+    class FieldDescriptorProto
+      optional :string, :name, 1
+      optional :int32, :number, 3
+      optional ::Google::Protobuf::FieldDescriptorProto::Label, :label, 4
+      optional ::Google::Protobuf::FieldDescriptorProto::Type, :type, 5
+      optional :string, :type_name, 6
+      optional :string, :extendee, 2
+      optional :string, :default_value, 7
+      optional :int32, :oneof_index, 9
+      optional :string, :json_name, 10
+      optional ::Google::Protobuf::FieldOptions, :options, 8
+    end
+
+    class OneofDescriptorProto
+      optional :string, :name, 1
+      optional ::Google::Protobuf::OneofOptions, :options, 2
+    end
+
+    class EnumDescriptorProto
+      class EnumReservedRange
+        optional :int32, :start, 1
+        optional :int32, :end, 2
+      end
+
+      optional :string, :name, 1
+      repeated ::Google::Protobuf::EnumValueDescriptorProto, :value, 2
+      optional ::Google::Protobuf::EnumOptions, :options, 3
+      repeated ::Google::Protobuf::EnumDescriptorProto::EnumReservedRange, :reserved_range, 4
+      repeated :string, :reserved_name, 5
+    end
+
+    class EnumValueDescriptorProto
+      optional :string, :name, 1
+      optional :int32, :number, 2
+      optional ::Google::Protobuf::EnumValueOptions, :options, 3
+    end
+
+    class ServiceDescriptorProto
+      optional :string, :name, 1
+      repeated ::Google::Protobuf::MethodDescriptorProto, :method, 2
+      optional ::Google::Protobuf::ServiceOptions, :options, 3
+    end
+
+    class MethodDescriptorProto
+      optional :string, :name, 1
+      optional :string, :input_type, 2
+      optional :string, :output_type, 3
+      optional ::Google::Protobuf::MethodOptions, :options, 4
+      optional :bool, :client_streaming, 5, :default => false
+      optional :bool, :server_streaming, 6, :default => false
+    end
+
+    class FileOptions
+      optional :string, :java_package, 1
+      optional :string, :java_outer_classname, 8
+      optional :bool, :java_multiple_files, 10, :default => false
+      optional :bool, :java_generate_equals_and_hash, 20, :deprecated => true
+      optional :bool, :java_string_check_utf8, 27, :default => false
+      optional ::Google::Protobuf::FileOptions::OptimizeMode, :optimize_for, 9, :default => ::Google::Protobuf::FileOptions::OptimizeMode::SPEED
+      optional :string, :go_package, 11
+      optional :bool, :cc_generic_services, 16, :default => false
+      optional :bool, :java_generic_services, 17, :default => false
+      optional :bool, :py_generic_services, 18, :default => false
+      optional :bool, :php_generic_services, 42, :default => false
+      optional :bool, :deprecated, 23, :default => false
+      optional :bool, :cc_enable_arenas, 31, :default => false
+      optional :string, :objc_class_prefix, 36
+      optional :string, :csharp_namespace, 37
+      optional :string, :swift_prefix, 39
+      optional :string, :php_class_prefix, 40
+      optional :string, :php_namespace, 41
+      optional :string, :php_metadata_namespace, 44
+      optional :string, :ruby_package, 45
+      repeated ::Google::Protobuf::UninterpretedOption, :uninterpreted_option, 999
+      # Extension Fields
+      extensions 1000...536870912
+    end
+
+    class MessageOptions
+      optional :bool, :message_set_wire_format, 1, :default => false
+      optional :bool, :no_standard_descriptor_accessor, 2, :default => false
+      optional :bool, :deprecated, 3, :default => false
+      optional :bool, :map_entry, 7
+      repeated ::Google::Protobuf::UninterpretedOption, :uninterpreted_option, 999
+      # Extension Fields
+      extensions 1000...536870912
+    end
+
+    class FieldOptions
+      optional ::Google::Protobuf::FieldOptions::CType, :ctype, 1, :default => ::Google::Protobuf::FieldOptions::CType::STRING
+      optional :bool, :packed, 2
+      optional ::Google::Protobuf::FieldOptions::JSType, :jstype, 6, :default => ::Google::Protobuf::FieldOptions::JSType::JS_NORMAL
+      optional :bool, :lazy, 5, :default => false
+      optional :bool, :deprecated, 3, :default => false
+      optional :bool, :weak, 10, :default => false
+      repeated ::Google::Protobuf::UninterpretedOption, :uninterpreted_option, 999
+      # Extension Fields
+      extensions 1000...536870912
+    end
+
+    class OneofOptions
+      repeated ::Google::Protobuf::UninterpretedOption, :uninterpreted_option, 999
+      # Extension Fields
+      extensions 1000...536870912
+    end
+
+    class EnumOptions
+      optional :bool, :allow_alias, 2
+      optional :bool, :deprecated, 3, :default => false
+      repeated ::Google::Protobuf::UninterpretedOption, :uninterpreted_option, 999
+      # Extension Fields
+      extensions 1000...536870912
+    end
+
+    class EnumValueOptions
+      optional :bool, :deprecated, 1, :default => false
+      repeated ::Google::Protobuf::UninterpretedOption, :uninterpreted_option, 999
+      # Extension Fields
+      extensions 1000...536870912
+    end
+
+    class ServiceOptions
+      optional :bool, :deprecated, 33, :default => false
+      repeated ::Google::Protobuf::UninterpretedOption, :uninterpreted_option, 999
+      # Extension Fields
+      extensions 1000...536870912
+    end
+
+    class MethodOptions
+      optional :bool, :deprecated, 33, :default => false
+      optional ::Google::Protobuf::MethodOptions::IdempotencyLevel, :idempotency_level, 34, :default => ::Google::Protobuf::MethodOptions::IdempotencyLevel::IDEMPOTENCY_UNKNOWN
+      repeated ::Google::Protobuf::UninterpretedOption, :uninterpreted_option, 999
+      # Extension Fields
+      extensions 1000...536870912
+    end
+
+    class UninterpretedOption
+      class NamePart
+        required :string, :name_part, 1
+        required :bool, :is_extension, 2
+      end
+
+      repeated ::Google::Protobuf::UninterpretedOption::NamePart, :name, 2
+      optional :string, :identifier_value, 3
+      optional :uint64, :positive_int_value, 4
+      optional :int64, :negative_int_value, 5
+      optional :double, :double_value, 6
+      optional :bytes, :string_value, 7
+      optional :string, :aggregate_value, 8
+    end
+
+    class SourceCodeInfo
+      class Location
+        repeated :int32, :path, 1, :packed => true
+        repeated :int32, :span, 2, :packed => true
+        optional :string, :leading_comments, 3
+        optional :string, :trailing_comments, 4
+        repeated :string, :leading_detached_comments, 6
+      end
+
+      repeated ::Google::Protobuf::SourceCodeInfo::Location, :location, 1
+    end
+
+    class GeneratedCodeInfo
+      class Annotation
+        repeated :int32, :path, 1, :packed => true
+        optional :string, :source_file, 2
+        optional :int32, :begin, 3
+        optional :int32, :end, 4
+      end
+
+      repeated ::Google::Protobuf::GeneratedCodeInfo::Annotation, :annotation, 1
+    end
+
+  end
+
+end
+

--- a/gapic-generator/lib/google/protobuf/empty.pb.rb
+++ b/gapic-generator/lib/google/protobuf/empty.pb.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+module Google
+  module Protobuf
+    ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
+
+    ##
+    # Message Classes
+    #
+    class Empty < ::Protobuf::Message; end
+
+
+    ##
+    # File Options
+    #
+    set_option :java_package, "com.google.protobuf"
+    set_option :java_outer_classname, "EmptyProto"
+    set_option :java_multiple_files, true
+    set_option :go_package, "github.com/golang/protobuf/ptypes/empty"
+    set_option :cc_enable_arenas, true
+    set_option :objc_class_prefix, "GPB"
+    set_option :csharp_namespace, "Google.Protobuf.WellKnownTypes"
+
+
+    ##
+    # Message Fields
+    #
+  end
+
+end
+

--- a/gapic-generator/lib/google/rpc/status.pb.rb
+++ b/gapic-generator/lib/google/rpc/status.pb.rb
@@ -1,0 +1,46 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+
+##
+# Imports
+#
+require 'google/protobuf/any.pb'
+
+module Google
+  module Rpc
+    ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
+
+    ##
+    # Message Classes
+    #
+    class Status < ::Protobuf::Message; end
+
+
+    ##
+    # File Options
+    #
+    set_option :java_package, "com.google.rpc"
+    set_option :java_outer_classname, "StatusProto"
+    set_option :java_multiple_files, true
+    set_option :go_package, "google.golang.org/genproto/googleapis/rpc/status;status"
+    set_option :objc_class_prefix, "RPC"
+
+
+    ##
+    # Message Fields
+    #
+    class Status
+      optional :int32, :code, 1
+      optional :string, :message, 2
+      repeated ::Google::Protobuf::Any, :details, 3
+    end
+
+  end
+
+end
+

--- a/shared/Rakefile
+++ b/shared/Rakefile
@@ -14,15 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-desc "Check that the necessary protobuf files exist."
-task :check_protos do
-  Dir.chdir "../gapic-generator" do
-    Bundler.with_clean_env do
-      sh "bundle exec rake check_protos"
-    end
-  end
-end
-
 desc "Generate the binary input files"
 task :gen do
   Rake::Task["gen:speech"].invoke
@@ -71,11 +62,6 @@ namespace :gen do
     generate_input_file "garbage", garbage_protos
   end
 end
-Rake::Task[:gen].enhance [:check_protos]
-Rake::Task["gen:speech"].enhance [:check_protos]
-Rake::Task["gen:vision"].enhance [:check_protos]
-Rake::Task["gen:showcase"].enhance [:check_protos]
-Rake::Task["gen:garbage"].enhance [:check_protos]
 
 require "rake/testtask"
 desc "Run functional tests for all custom protos"
@@ -90,8 +76,6 @@ namespace :test do
     t.warning = false
   end
 end
-Rake::Task[:test].enhance [:check_protos]
-Rake::Task["test:showcase"].enhance [:check_protos]
 
 desc "Start an interactive shell."
 task :console do
@@ -111,14 +95,12 @@ task :console do
   ARGV.clear
   IRB.start
 end
-Rake::Task[:console].enhance [:check_protos]
 
 desc "Run the CI build"
 task :ci do
   puts "\nshared test\n"
   Rake::Task[:test].invoke
 end
-Rake::Task[:ci].enhance [:check_protos]
 
 task default: :ci
 


### PR DESCRIPTION
This PR adds the ruby files generated by protobuf (not google-protobuf) to the repo. New files can be generated by calling the default generator's `gen:protos` task.

This allows the gem to be referenced from the git repo.

[fixes #44]