### PR TITLE
Use Google::Gax::Grpc::Stub.new

### DIFF
--- a/gapic-generator/templates/default/client/_class.erb
+++ b/gapic-generator/templates/default/client/_class.erb
@@ -57,36 +57,6 @@ class <%= service.client_class_name %>
 
   protected
 
-  def create_stub credentials, scopes
-    if credentials.is_a?(String) || credentials.is_a?(Hash)
-      updater_proc = Credentials.new(credentials).updater_proc
-    elsif credentials.is_a? GRPC::Core::Channel
-      channel = credentials
-    elsif credentials.is_a? GRPC::Core::ChannelCredentials
-      chan_creds = credentials
-    elsif credentials.is_a? Proc
-      updater_proc = credentials
-    elsif credentials.is_a? Google::Auth::Credentials
-      updater_proc = credentials.updater_proc
-    end
-
-    # Allow overriding the service path/port in subclasses.
-    service_path = self.class::SERVICE_ADDRESS
-    port = self.class::DEFAULT_SERVICE_PORT
-    interceptors = self.class::GRPC_INTERCEPTORS
-    stub_new = <%= service.services_stub_name_full %>.method :new
-    Google::Gax::Grpc.create_stub(
-      service_path,
-      port,
-      chan_creds: chan_creds,
-      channel: channel,
-      updater_proc: updater_proc,
-      scopes: scopes,
-      interceptors: interceptors,
-      &stub_new
-    )
-  end
-
   def x_goog_api_client_header lib_name, lib_version
     x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
     x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name

--- a/gapic-generator/templates/default/client/_init.erb
+++ b/gapic-generator/templates/default/client/_init.erb
@@ -15,9 +15,9 @@
 #   `GRPC::Core::CallCredentials` object.
 #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
 #   transforms the metadata for requests, generally, to give OAuth credentials.
-# @param scopes [Array<String>]
-#   The OAuth scopes for this service. This parameter is ignored if an
-#   updater_proc is supplied.
+# @param scope [String, Array<String>]
+#   The OAuth scope (or scopes) for this service. This parameter is ignored if
+#   an updater_proc is supplied.
 # @param timeout [Numeric]
 #   The default timeout, in seconds, for calls made through this client.
 # @param metadata [Hash]
@@ -26,7 +26,7 @@
 #
 def initialize \
     credentials: nil,
-    scopes: ALL_SCOPES,
+    scope: ALL_SCOPES,
     timeout: DEFAULT_TIMEOUT,
     metadata: nil,
     lib_name: nil,
@@ -37,12 +37,21 @@ def initialize \
   require "google/gax/grpc"
   require "<%= service.services_proto_require %>"
 
-  credentials ||= Credentials.default scope: scopes
+  credentials ||= Credentials.default scope: scope
+  if credentials.is_a?(String) || credentials.is_a?(Hash)
+    credentials = Credentials.new credentials, scope: scope
+  end
 
 <%- if service.client_lro? -%>
 <%= indent render(partial: "client/lro/init", locals: { service: service }), "  " %>
 <%- end -%>
-  @<%= service.stub_name %> = create_stub credentials, scopes
+  @<%= service.stub_name %> = Google::Gax::Grpc::Stub.new(
+    <%= service.services_stub_name_full %>,
+    host:         self.class::SERVICE_ADDRESS,
+    port:         self.class::DEFAULT_SERVICE_PORT,
+    credentials:  credentials,
+    interceptors: self.class::GRPC_INTERCEPTORS
+  )
 
   @timeout = timeout
   @metadata = metadata.to_h

--- a/gapic-generator/templates/default/client/lro/_init.erb
+++ b/gapic-generator/templates/default/client/lro/_init.erb
@@ -1,6 +1,6 @@
 @operations_client = OperationsClient.new(
   credentials: credentials,
-  scopes: scopes,
+  scope: scope,
   timeout: timeout,
   lib_name: lib_name,
   lib_version: lib_version

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,6 +6,6 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/update-grpc-stub"
+gem "google-gax", github: "googleapis/gax-ruby"
 gem "grpc-tools", "~> 1.18"
 gem "rake", "~> 10.0"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,6 +6,6 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "googleapis/gax-ruby"
+gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/update-grpc-stub"
 gem "grpc-tools", "~> 1.18"
 gem "rake", "~> 10.0"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -76,9 +76,9 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scopes [Array<String>]
-          #   The OAuth scopes for this service. This parameter is ignored if an
-          #   updater_proc is supplied.
+          # @param scope [String, Array<String>]
+          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
@@ -87,7 +87,7 @@ module Google
           #
           def initialize \
               credentials: nil,
-              scopes: ALL_SCOPES,
+              scope: ALL_SCOPES,
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
               lib_name: nil,
@@ -98,16 +98,25 @@ module Google
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/echo_services_pb"
 
-            credentials ||= Credentials.default scope: scopes
+            credentials ||= Credentials.default scope: scope
+            if credentials.is_a?(String) || credentials.is_a?(Hash)
+              credentials = Credentials.new credentials, scope: scope
+            end
 
             @operations_client = OperationsClient.new(
               credentials: credentials,
-              scopes:      scopes,
+              scope:       scope,
               timeout:     timeout,
               lib_name:    lib_name,
               lib_version: lib_version
             )
-            @echo_stub = create_stub credentials, scopes
+            @echo_stub = Google::Gax::Grpc::Stub.new(
+              Google::Showcase::V1alpha3::Echo::Stub,
+              host:         self.class::SERVICE_ADDRESS,
+              port:         self.class::DEFAULT_SERVICE_PORT,
+              credentials:  credentials,
+              interceptors: self.class::GRPC_INTERCEPTORS
+            )
 
             @timeout = timeout
             @metadata = metadata.to_h
@@ -420,36 +429,6 @@ module Google
           end
 
           protected
-
-          def create_stub credentials, scopes
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
-              updater_proc = Credentials.new(credentials).updater_proc
-            elsif credentials.is_a? GRPC::Core::Channel
-              channel = credentials
-            elsif credentials.is_a? GRPC::Core::ChannelCredentials
-              chan_creds = credentials
-            elsif credentials.is_a? Proc
-              updater_proc = credentials
-            elsif credentials.is_a? Google::Auth::Credentials
-              updater_proc = credentials.updater_proc
-            end
-
-            # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
-            interceptors = self.class::GRPC_INTERCEPTORS
-            stub_new = Google::Showcase::V1alpha3::Echo::Stub.method :new
-            Google::Gax::Grpc.create_stub(
-              service_path,
-              port,
-              chan_creds:   chan_creds,
-              channel:      channel,
-              updater_proc: updater_proc,
-              scopes:       scopes,
-              interceptors: interceptors,
-              &stub_new
-            )
-          end
 
           def x_goog_api_client_header lib_name, lib_version
             x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -79,9 +79,9 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scopes [Array<String>]
-          #   The OAuth scopes for this service. This parameter is ignored if an
-          #   updater_proc is supplied.
+          # @param scope [String, Array<String>]
+          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
@@ -90,7 +90,7 @@ module Google
           #
           def initialize \
               credentials: nil,
-              scopes: ALL_SCOPES,
+              scope: ALL_SCOPES,
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
               lib_name: nil,
@@ -101,16 +101,25 @@ module Google
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/identity_services_pb"
 
-            credentials ||= Credentials.default scope: scopes
+            credentials ||= Credentials.default scope: scope
+            if credentials.is_a?(String) || credentials.is_a?(Hash)
+              credentials = Credentials.new credentials, scope: scope
+            end
 
             @operations_client = OperationsClient.new(
               credentials: credentials,
-              scopes:      scopes,
+              scope:       scope,
               timeout:     timeout,
               lib_name:    lib_name,
               lib_version: lib_version
             )
-            @identity_stub = create_stub credentials, scopes
+            @identity_stub = Google::Gax::Grpc::Stub.new(
+              Google::Showcase::V1alpha3::Identity::Stub,
+              host:         self.class::SERVICE_ADDRESS,
+              port:         self.class::DEFAULT_SERVICE_PORT,
+              credentials:  credentials,
+              interceptors: self.class::GRPC_INTERCEPTORS
+            )
 
             @timeout = timeout
             @metadata = metadata.to_h
@@ -363,36 +372,6 @@ module Google
           end
 
           protected
-
-          def create_stub credentials, scopes
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
-              updater_proc = Credentials.new(credentials).updater_proc
-            elsif credentials.is_a? GRPC::Core::Channel
-              channel = credentials
-            elsif credentials.is_a? GRPC::Core::ChannelCredentials
-              chan_creds = credentials
-            elsif credentials.is_a? Proc
-              updater_proc = credentials
-            elsif credentials.is_a? Google::Auth::Credentials
-              updater_proc = credentials.updater_proc
-            end
-
-            # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
-            interceptors = self.class::GRPC_INTERCEPTORS
-            stub_new = Google::Showcase::V1alpha3::Identity::Stub.method :new
-            Google::Gax::Grpc.create_stub(
-              service_path,
-              port,
-              chan_creds:   chan_creds,
-              channel:      channel,
-              updater_proc: updater_proc,
-              scopes:       scopes,
-              interceptors: interceptors,
-              &stub_new
-            )
-          end
 
           def x_goog_api_client_header lib_name, lib_version
             x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -79,9 +79,9 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scopes [Array<String>]
-          #   The OAuth scopes for this service. This parameter is ignored if an
-          #   updater_proc is supplied.
+          # @param scope [String, Array<String>]
+          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
@@ -90,7 +90,7 @@ module Google
           #
           def initialize \
               credentials: nil,
-              scopes: ALL_SCOPES,
+              scope: ALL_SCOPES,
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
               lib_name: nil,
@@ -101,16 +101,25 @@ module Google
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/messaging_services_pb"
 
-            credentials ||= Credentials.default scope: scopes
+            credentials ||= Credentials.default scope: scope
+            if credentials.is_a?(String) || credentials.is_a?(Hash)
+              credentials = Credentials.new credentials, scope: scope
+            end
 
             @operations_client = OperationsClient.new(
               credentials: credentials,
-              scopes:      scopes,
+              scope:       scope,
               timeout:     timeout,
               lib_name:    lib_name,
               lib_version: lib_version
             )
-            @messaging_stub = create_stub credentials, scopes
+            @messaging_stub = Google::Gax::Grpc::Stub.new(
+              Google::Showcase::V1alpha3::Messaging::Stub,
+              host:         self.class::SERVICE_ADDRESS,
+              port:         self.class::DEFAULT_SERVICE_PORT,
+              credentials:  credentials,
+              interceptors: self.class::GRPC_INTERCEPTORS
+            )
 
             @timeout = timeout
             @metadata = metadata.to_h
@@ -827,36 +836,6 @@ module Google
           end
 
           protected
-
-          def create_stub credentials, scopes
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
-              updater_proc = Credentials.new(credentials).updater_proc
-            elsif credentials.is_a? GRPC::Core::Channel
-              channel = credentials
-            elsif credentials.is_a? GRPC::Core::ChannelCredentials
-              chan_creds = credentials
-            elsif credentials.is_a? Proc
-              updater_proc = credentials
-            elsif credentials.is_a? Google::Auth::Credentials
-              updater_proc = credentials.updater_proc
-            end
-
-            # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
-            interceptors = self.class::GRPC_INTERCEPTORS
-            stub_new = Google::Showcase::V1alpha3::Messaging::Stub.method :new
-            Google::Gax::Grpc.create_stub(
-              service_path,
-              port,
-              chan_creds:   chan_creds,
-              channel:      channel,
-              updater_proc: updater_proc,
-              scopes:       scopes,
-              interceptors: interceptors,
-              &stub_new
-            )
-          end
 
           def x_goog_api_client_header lib_name, lib_version
             x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -79,9 +79,9 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scopes [Array<String>]
-          #   The OAuth scopes for this service. This parameter is ignored if an
-          #   updater_proc is supplied.
+          # @param scope [String, Array<String>]
+          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
@@ -90,7 +90,7 @@ module Google
           #
           def initialize \
               credentials: nil,
-              scopes: ALL_SCOPES,
+              scope: ALL_SCOPES,
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
               lib_name: nil,
@@ -101,16 +101,25 @@ module Google
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/testing_services_pb"
 
-            credentials ||= Credentials.default scope: scopes
+            credentials ||= Credentials.default scope: scope
+            if credentials.is_a?(String) || credentials.is_a?(Hash)
+              credentials = Credentials.new credentials, scope: scope
+            end
 
             @operations_client = OperationsClient.new(
               credentials: credentials,
-              scopes:      scopes,
+              scope:       scope,
               timeout:     timeout,
               lib_name:    lib_name,
               lib_version: lib_version
             )
-            @testing_stub = create_stub credentials, scopes
+            @testing_stub = Google::Gax::Grpc::Stub.new(
+              Google::Showcase::V1alpha3::Testing::Stub,
+              host:         self.class::SERVICE_ADDRESS,
+              port:         self.class::DEFAULT_SERVICE_PORT,
+              credentials:  credentials,
+              interceptors: self.class::GRPC_INTERCEPTORS
+            )
 
             @timeout = timeout
             @metadata = metadata.to_h
@@ -528,36 +537,6 @@ module Google
           end
 
           protected
-
-          def create_stub credentials, scopes
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
-              updater_proc = Credentials.new(credentials).updater_proc
-            elsif credentials.is_a? GRPC::Core::Channel
-              channel = credentials
-            elsif credentials.is_a? GRPC::Core::ChannelCredentials
-              chan_creds = credentials
-            elsif credentials.is_a? Proc
-              updater_proc = credentials
-            elsif credentials.is_a? Google::Auth::Credentials
-              updater_proc = credentials.updater_proc
-            end
-
-            # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
-            interceptors = self.class::GRPC_INTERCEPTORS
-            stub_new = Google::Showcase::V1alpha3::Testing::Stub.method :new
-            Google::Gax::Grpc.create_stub(
-              service_path,
-              port,
-              chan_creds:   chan_creds,
-              channel:      channel,
-              updater_proc: updater_proc,
-              scopes:       scopes,
-              interceptors: interceptors,
-              &stub_new
-            )
-          end
 
           def x_goog_api_client_header lib_name, lib_version
             x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -77,9 +77,9 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scopes [Array<String>]
-            #   The OAuth scopes for this service. This parameter is ignored if an
-            #   updater_proc is supplied.
+            # @param scope [String, Array<String>]
+            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+            #   an updater_proc is supplied.
             # @param timeout [Numeric]
             #   The default timeout, in seconds, for calls made through this client.
             # @param metadata [Hash]
@@ -88,7 +88,7 @@ module Google
             #
             def initialize \
                 credentials: nil,
-                scopes: ALL_SCOPES,
+                scope: ALL_SCOPES,
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
                 lib_name: nil,
@@ -99,16 +99,25 @@ module Google
               require "google/gax/grpc"
               require "google/cloud/speech/v1/cloud_speech_services_pb"
 
-              credentials ||= Credentials.default scope: scopes
+              credentials ||= Credentials.default scope: scope
+              if credentials.is_a?(String) || credentials.is_a?(Hash)
+                credentials = Credentials.new credentials, scope: scope
+              end
 
               @operations_client = OperationsClient.new(
                 credentials: credentials,
-                scopes:      scopes,
+                scope:       scope,
                 timeout:     timeout,
                 lib_name:    lib_name,
                 lib_version: lib_version
               )
-              @speech_stub = create_stub credentials, scopes
+              @speech_stub = Google::Gax::Grpc::Stub.new(
+                Google::Cloud::Speech::V1::Speech::Stub,
+                host:         self.class::SERVICE_ADDRESS,
+                port:         self.class::DEFAULT_SERVICE_PORT,
+                credentials:  credentials,
+                interceptors: self.class::GRPC_INTERCEPTORS
+              )
 
               @timeout = timeout
               @metadata = metadata.to_h
@@ -272,36 +281,6 @@ module Google
             end
 
             protected
-
-            def create_stub credentials, scopes
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
-                updater_proc = Credentials.new(credentials).updater_proc
-              elsif credentials.is_a? GRPC::Core::Channel
-                channel = credentials
-              elsif credentials.is_a? GRPC::Core::ChannelCredentials
-                chan_creds = credentials
-              elsif credentials.is_a? Proc
-                updater_proc = credentials
-              elsif credentials.is_a? Google::Auth::Credentials
-                updater_proc = credentials.updater_proc
-              end
-
-              # Allow overriding the service path/port in subclasses.
-              service_path = self.class::SERVICE_ADDRESS
-              port = self.class::DEFAULT_SERVICE_PORT
-              interceptors = self.class::GRPC_INTERCEPTORS
-              stub_new = Google::Cloud::Speech::V1::Speech::Stub.method :new
-              Google::Gax::Grpc.create_stub(
-                service_path,
-                port,
-                chan_creds:   chan_creds,
-                channel:      channel,
-                updater_proc: updater_proc,
-                scopes:       scopes,
-                interceptors: interceptors,
-                &stub_new
-              )
-            end
 
             def x_goog_api_client_header lib_name, lib_version
               x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -77,9 +77,9 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scopes [Array<String>]
-            #   The OAuth scopes for this service. This parameter is ignored if an
-            #   updater_proc is supplied.
+            # @param scope [String, Array<String>]
+            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+            #   an updater_proc is supplied.
             # @param timeout [Numeric]
             #   The default timeout, in seconds, for calls made through this client.
             # @param metadata [Hash]
@@ -88,7 +88,7 @@ module Google
             #
             def initialize \
                 credentials: nil,
-                scopes: ALL_SCOPES,
+                scope: ALL_SCOPES,
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
                 lib_name: nil,
@@ -99,16 +99,25 @@ module Google
               require "google/gax/grpc"
               require "google/cloud/vision/v1/image_annotator_services_pb"
 
-              credentials ||= Credentials.default scope: scopes
+              credentials ||= Credentials.default scope: scope
+              if credentials.is_a?(String) || credentials.is_a?(Hash)
+                credentials = Credentials.new credentials, scope: scope
+              end
 
               @operations_client = OperationsClient.new(
                 credentials: credentials,
-                scopes:      scopes,
+                scope:       scope,
                 timeout:     timeout,
                 lib_name:    lib_name,
                 lib_version: lib_version
               )
-              @image_annotator_stub = create_stub credentials, scopes
+              @image_annotator_stub = Google::Gax::Grpc::Stub.new(
+                Google::Cloud::Vision::V1::ImageAnnotator::Stub,
+                host:         self.class::SERVICE_ADDRESS,
+                port:         self.class::DEFAULT_SERVICE_PORT,
+                credentials:  credentials,
+                interceptors: self.class::GRPC_INTERCEPTORS
+              )
 
               @timeout = timeout
               @metadata = metadata.to_h
@@ -222,36 +231,6 @@ module Google
             end
 
             protected
-
-            def create_stub credentials, scopes
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
-                updater_proc = Credentials.new(credentials).updater_proc
-              elsif credentials.is_a? GRPC::Core::Channel
-                channel = credentials
-              elsif credentials.is_a? GRPC::Core::ChannelCredentials
-                chan_creds = credentials
-              elsif credentials.is_a? Proc
-                updater_proc = credentials
-              elsif credentials.is_a? Google::Auth::Credentials
-                updater_proc = credentials.updater_proc
-              end
-
-              # Allow overriding the service path/port in subclasses.
-              service_path = self.class::SERVICE_ADDRESS
-              port = self.class::DEFAULT_SERVICE_PORT
-              interceptors = self.class::GRPC_INTERCEPTORS
-              stub_new = Google::Cloud::Vision::V1::ImageAnnotator::Stub.method :new
-              Google::Gax::Grpc.create_stub(
-                service_path,
-                port,
-                chan_creds:   chan_creds,
-                channel:      channel,
-                updater_proc: updater_proc,
-                scopes:       scopes,
-                interceptors: interceptors,
-                &stub_new
-              )
-            end
 
             def x_goog_api_client_header lib_name, lib_version
               x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -77,9 +77,9 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scopes [Array<String>]
-            #   The OAuth scopes for this service. This parameter is ignored if an
-            #   updater_proc is supplied.
+            # @param scope [String, Array<String>]
+            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+            #   an updater_proc is supplied.
             # @param timeout [Numeric]
             #   The default timeout, in seconds, for calls made through this client.
             # @param metadata [Hash]
@@ -88,7 +88,7 @@ module Google
             #
             def initialize \
                 credentials: nil,
-                scopes: ALL_SCOPES,
+                scope: ALL_SCOPES,
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
                 lib_name: nil,
@@ -99,16 +99,25 @@ module Google
               require "google/gax/grpc"
               require "google/cloud/vision/v1/product_search_service_services_pb"
 
-              credentials ||= Credentials.default scope: scopes
+              credentials ||= Credentials.default scope: scope
+              if credentials.is_a?(String) || credentials.is_a?(Hash)
+                credentials = Credentials.new credentials, scope: scope
+              end
 
               @operations_client = OperationsClient.new(
                 credentials: credentials,
-                scopes:      scopes,
+                scope:       scope,
                 timeout:     timeout,
                 lib_name:    lib_name,
                 lib_version: lib_version
               )
-              @product_search_stub = create_stub credentials, scopes
+              @product_search_stub = Google::Gax::Grpc::Stub.new(
+                Google::Cloud::Vision::V1::ProductSearch::Stub,
+                host:         self.class::SERVICE_ADDRESS,
+                port:         self.class::DEFAULT_SERVICE_PORT,
+                credentials:  credentials,
+                interceptors: self.class::GRPC_INTERCEPTORS
+              )
 
               @timeout = timeout
               @metadata = metadata.to_h
@@ -1336,36 +1345,6 @@ module Google
             end
 
             protected
-
-            def create_stub credentials, scopes
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
-                updater_proc = Credentials.new(credentials).updater_proc
-              elsif credentials.is_a? GRPC::Core::Channel
-                channel = credentials
-              elsif credentials.is_a? GRPC::Core::ChannelCredentials
-                chan_creds = credentials
-              elsif credentials.is_a? Proc
-                updater_proc = credentials
-              elsif credentials.is_a? Google::Auth::Credentials
-                updater_proc = credentials.updater_proc
-              end
-
-              # Allow overriding the service path/port in subclasses.
-              service_path = self.class::SERVICE_ADDRESS
-              port = self.class::DEFAULT_SERVICE_PORT
-              interceptors = self.class::GRPC_INTERCEPTORS
-              stub_new = Google::Cloud::Vision::V1::ProductSearch::Stub.method :new
-              Google::Gax::Grpc.create_stub(
-                service_path,
-                port,
-                chan_creds:   chan_creds,
-                channel:      channel,
-                updater_proc: updater_proc,
-                scopes:       scopes,
-                interceptors: interceptors,
-                &stub_new
-              )
-            end
 
             def x_goog_api_client_header lib_name, lib_version
               x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -84,9 +84,9 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scopes [Array<String>]
-          #   The OAuth scopes for this service. This parameter is ignored if an
-          #   updater_proc is supplied.
+          # @param scope [String, Array<String>]
+          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
@@ -95,7 +95,7 @@ module Google
           #
           def initialize \
               credentials: nil,
-              scopes: ALL_SCOPES,
+              scope: ALL_SCOPES,
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
               lib_name: nil,
@@ -106,16 +106,25 @@ module Google
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/echo_services_pb"
 
-            credentials ||= Credentials.default scope: scopes
+            credentials ||= Credentials.default scope: scope
+            if credentials.is_a?(String) || credentials.is_a?(Hash)
+              credentials = Credentials.new credentials, scope: scope
+            end
 
             @operations_client = OperationsClient.new(
               credentials: credentials,
-              scopes:      scopes,
+              scope:       scope,
               timeout:     timeout,
               lib_name:    lib_name,
               lib_version: lib_version
             )
-            @echo_stub = create_stub credentials, scopes
+            @echo_stub = Google::Gax::Grpc::Stub.new(
+              Google::Showcase::V1alpha3::Echo::Stub,
+              host:         self.class::SERVICE_ADDRESS,
+              port:         self.class::DEFAULT_SERVICE_PORT,
+              credentials:  credentials,
+              interceptors: self.class::GRPC_INTERCEPTORS
+            )
 
             @timeout = timeout
             @metadata = metadata.to_h
@@ -428,36 +437,6 @@ module Google
           end
 
           protected
-
-          def create_stub credentials, scopes
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
-              updater_proc = Credentials.new(credentials).updater_proc
-            elsif credentials.is_a? GRPC::Core::Channel
-              channel = credentials
-            elsif credentials.is_a? GRPC::Core::ChannelCredentials
-              chan_creds = credentials
-            elsif credentials.is_a? Proc
-              updater_proc = credentials
-            elsif credentials.is_a? Google::Auth::Credentials
-              updater_proc = credentials.updater_proc
-            end
-
-            # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
-            interceptors = self.class::GRPC_INTERCEPTORS
-            stub_new = Google::Showcase::V1alpha3::Echo::Stub.method :new
-            Google::Gax::Grpc.create_stub(
-              service_path,
-              port,
-              chan_creds:   chan_creds,
-              channel:      channel,
-              updater_proc: updater_proc,
-              scopes:       scopes,
-              interceptors: interceptors,
-              &stub_new
-            )
-          end
 
           def x_goog_api_client_header lib_name, lib_version
             x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -87,9 +87,9 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scopes [Array<String>]
-          #   The OAuth scopes for this service. This parameter is ignored if an
-          #   updater_proc is supplied.
+          # @param scope [String, Array<String>]
+          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
@@ -98,7 +98,7 @@ module Google
           #
           def initialize \
               credentials: nil,
-              scopes: ALL_SCOPES,
+              scope: ALL_SCOPES,
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
               lib_name: nil,
@@ -109,16 +109,25 @@ module Google
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/identity_services_pb"
 
-            credentials ||= Credentials.default scope: scopes
+            credentials ||= Credentials.default scope: scope
+            if credentials.is_a?(String) || credentials.is_a?(Hash)
+              credentials = Credentials.new credentials, scope: scope
+            end
 
             @operations_client = OperationsClient.new(
               credentials: credentials,
-              scopes:      scopes,
+              scope:       scope,
               timeout:     timeout,
               lib_name:    lib_name,
               lib_version: lib_version
             )
-            @identity_stub = create_stub credentials, scopes
+            @identity_stub = Google::Gax::Grpc::Stub.new(
+              Google::Showcase::V1alpha3::Identity::Stub,
+              host:         self.class::SERVICE_ADDRESS,
+              port:         self.class::DEFAULT_SERVICE_PORT,
+              credentials:  credentials,
+              interceptors: self.class::GRPC_INTERCEPTORS
+            )
 
             @timeout = timeout
             @metadata = metadata.to_h
@@ -371,36 +380,6 @@ module Google
           end
 
           protected
-
-          def create_stub credentials, scopes
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
-              updater_proc = Credentials.new(credentials).updater_proc
-            elsif credentials.is_a? GRPC::Core::Channel
-              channel = credentials
-            elsif credentials.is_a? GRPC::Core::ChannelCredentials
-              chan_creds = credentials
-            elsif credentials.is_a? Proc
-              updater_proc = credentials
-            elsif credentials.is_a? Google::Auth::Credentials
-              updater_proc = credentials.updater_proc
-            end
-
-            # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
-            interceptors = self.class::GRPC_INTERCEPTORS
-            stub_new = Google::Showcase::V1alpha3::Identity::Stub.method :new
-            Google::Gax::Grpc.create_stub(
-              service_path,
-              port,
-              chan_creds:   chan_creds,
-              channel:      channel,
-              updater_proc: updater_proc,
-              scopes:       scopes,
-              interceptors: interceptors,
-              &stub_new
-            )
-          end
 
           def x_goog_api_client_header lib_name, lib_version
             x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -87,9 +87,9 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scopes [Array<String>]
-          #   The OAuth scopes for this service. This parameter is ignored if an
-          #   updater_proc is supplied.
+          # @param scope [String, Array<String>]
+          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
@@ -98,7 +98,7 @@ module Google
           #
           def initialize \
               credentials: nil,
-              scopes: ALL_SCOPES,
+              scope: ALL_SCOPES,
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
               lib_name: nil,
@@ -109,16 +109,25 @@ module Google
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/messaging_services_pb"
 
-            credentials ||= Credentials.default scope: scopes
+            credentials ||= Credentials.default scope: scope
+            if credentials.is_a?(String) || credentials.is_a?(Hash)
+              credentials = Credentials.new credentials, scope: scope
+            end
 
             @operations_client = OperationsClient.new(
               credentials: credentials,
-              scopes:      scopes,
+              scope:       scope,
               timeout:     timeout,
               lib_name:    lib_name,
               lib_version: lib_version
             )
-            @messaging_stub = create_stub credentials, scopes
+            @messaging_stub = Google::Gax::Grpc::Stub.new(
+              Google::Showcase::V1alpha3::Messaging::Stub,
+              host:         self.class::SERVICE_ADDRESS,
+              port:         self.class::DEFAULT_SERVICE_PORT,
+              credentials:  credentials,
+              interceptors: self.class::GRPC_INTERCEPTORS
+            )
 
             @timeout = timeout
             @metadata = metadata.to_h
@@ -835,36 +844,6 @@ module Google
           end
 
           protected
-
-          def create_stub credentials, scopes
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
-              updater_proc = Credentials.new(credentials).updater_proc
-            elsif credentials.is_a? GRPC::Core::Channel
-              channel = credentials
-            elsif credentials.is_a? GRPC::Core::ChannelCredentials
-              chan_creds = credentials
-            elsif credentials.is_a? Proc
-              updater_proc = credentials
-            elsif credentials.is_a? Google::Auth::Credentials
-              updater_proc = credentials.updater_proc
-            end
-
-            # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
-            interceptors = self.class::GRPC_INTERCEPTORS
-            stub_new = Google::Showcase::V1alpha3::Messaging::Stub.method :new
-            Google::Gax::Grpc.create_stub(
-              service_path,
-              port,
-              chan_creds:   chan_creds,
-              channel:      channel,
-              updater_proc: updater_proc,
-              scopes:       scopes,
-              interceptors: interceptors,
-              &stub_new
-            )
-          end
 
           def x_goog_api_client_header lib_name, lib_version
             x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -87,9 +87,9 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scopes [Array<String>]
-          #   The OAuth scopes for this service. This parameter is ignored if an
-          #   updater_proc is supplied.
+          # @param scope [String, Array<String>]
+          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+          #   an updater_proc is supplied.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param metadata [Hash]
@@ -98,7 +98,7 @@ module Google
           #
           def initialize \
               credentials: nil,
-              scopes: ALL_SCOPES,
+              scope: ALL_SCOPES,
               timeout: DEFAULT_TIMEOUT,
               metadata: nil,
               lib_name: nil,
@@ -109,16 +109,25 @@ module Google
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/testing_services_pb"
 
-            credentials ||= Credentials.default scope: scopes
+            credentials ||= Credentials.default scope: scope
+            if credentials.is_a?(String) || credentials.is_a?(Hash)
+              credentials = Credentials.new credentials, scope: scope
+            end
 
             @operations_client = OperationsClient.new(
               credentials: credentials,
-              scopes:      scopes,
+              scope:       scope,
               timeout:     timeout,
               lib_name:    lib_name,
               lib_version: lib_version
             )
-            @testing_stub = create_stub credentials, scopes
+            @testing_stub = Google::Gax::Grpc::Stub.new(
+              Google::Showcase::V1alpha3::Testing::Stub,
+              host:         self.class::SERVICE_ADDRESS,
+              port:         self.class::DEFAULT_SERVICE_PORT,
+              credentials:  credentials,
+              interceptors: self.class::GRPC_INTERCEPTORS
+            )
 
             @timeout = timeout
             @metadata = metadata.to_h
@@ -536,36 +545,6 @@ module Google
           end
 
           protected
-
-          def create_stub credentials, scopes
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
-              updater_proc = Credentials.new(credentials).updater_proc
-            elsif credentials.is_a? GRPC::Core::Channel
-              channel = credentials
-            elsif credentials.is_a? GRPC::Core::ChannelCredentials
-              chan_creds = credentials
-            elsif credentials.is_a? Proc
-              updater_proc = credentials
-            elsif credentials.is_a? Google::Auth::Credentials
-              updater_proc = credentials.updater_proc
-            end
-
-            # Allow overriding the service path/port in subclasses.
-            service_path = self.class::SERVICE_ADDRESS
-            port = self.class::DEFAULT_SERVICE_PORT
-            interceptors = self.class::GRPC_INTERCEPTORS
-            stub_new = Google::Showcase::V1alpha3::Testing::Stub.method :new
-            Google::Gax::Grpc.create_stub(
-              service_path,
-              port,
-              chan_creds:   chan_creds,
-              channel:      channel,
-              updater_proc: updater_proc,
-              scopes:       scopes,
-              interceptors: interceptors,
-              &stub_new
-            )
-          end
 
           def x_goog_api_client_header lib_name, lib_version
             x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -85,9 +85,9 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scopes [Array<String>]
-            #   The OAuth scopes for this service. This parameter is ignored if an
-            #   updater_proc is supplied.
+            # @param scope [String, Array<String>]
+            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+            #   an updater_proc is supplied.
             # @param timeout [Numeric]
             #   The default timeout, in seconds, for calls made through this client.
             # @param metadata [Hash]
@@ -96,7 +96,7 @@ module Google
             #
             def initialize \
                 credentials: nil,
-                scopes: ALL_SCOPES,
+                scope: ALL_SCOPES,
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
                 lib_name: nil,
@@ -107,16 +107,25 @@ module Google
               require "google/gax/grpc"
               require "google/cloud/speech/v1/cloud_speech_services_pb"
 
-              credentials ||= Credentials.default scope: scopes
+              credentials ||= Credentials.default scope: scope
+              if credentials.is_a?(String) || credentials.is_a?(Hash)
+                credentials = Credentials.new credentials, scope: scope
+              end
 
               @operations_client = OperationsClient.new(
                 credentials: credentials,
-                scopes:      scopes,
+                scope:       scope,
                 timeout:     timeout,
                 lib_name:    lib_name,
                 lib_version: lib_version
               )
-              @speech_stub = create_stub credentials, scopes
+              @speech_stub = Google::Gax::Grpc::Stub.new(
+                Google::Cloud::Speech::V1::Speech::Stub,
+                host:         self.class::SERVICE_ADDRESS,
+                port:         self.class::DEFAULT_SERVICE_PORT,
+                credentials:  credentials,
+                interceptors: self.class::GRPC_INTERCEPTORS
+              )
 
               @timeout = timeout
               @metadata = metadata.to_h
@@ -280,36 +289,6 @@ module Google
             end
 
             protected
-
-            def create_stub credentials, scopes
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
-                updater_proc = Credentials.new(credentials).updater_proc
-              elsif credentials.is_a? GRPC::Core::Channel
-                channel = credentials
-              elsif credentials.is_a? GRPC::Core::ChannelCredentials
-                chan_creds = credentials
-              elsif credentials.is_a? Proc
-                updater_proc = credentials
-              elsif credentials.is_a? Google::Auth::Credentials
-                updater_proc = credentials.updater_proc
-              end
-
-              # Allow overriding the service path/port in subclasses.
-              service_path = self.class::SERVICE_ADDRESS
-              port = self.class::DEFAULT_SERVICE_PORT
-              interceptors = self.class::GRPC_INTERCEPTORS
-              stub_new = Google::Cloud::Speech::V1::Speech::Stub.method :new
-              Google::Gax::Grpc.create_stub(
-                service_path,
-                port,
-                chan_creds:   chan_creds,
-                channel:      channel,
-                updater_proc: updater_proc,
-                scopes:       scopes,
-                interceptors: interceptors,
-                &stub_new
-              )
-            end
 
             def x_goog_api_client_header lib_name, lib_version
               x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -85,9 +85,9 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scopes [Array<String>]
-            #   The OAuth scopes for this service. This parameter is ignored if an
-            #   updater_proc is supplied.
+            # @param scope [String, Array<String>]
+            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+            #   an updater_proc is supplied.
             # @param timeout [Numeric]
             #   The default timeout, in seconds, for calls made through this client.
             # @param metadata [Hash]
@@ -96,7 +96,7 @@ module Google
             #
             def initialize \
                 credentials: nil,
-                scopes: ALL_SCOPES,
+                scope: ALL_SCOPES,
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
                 lib_name: nil,
@@ -107,16 +107,25 @@ module Google
               require "google/gax/grpc"
               require "google/cloud/vision/v1/image_annotator_services_pb"
 
-              credentials ||= Credentials.default scope: scopes
+              credentials ||= Credentials.default scope: scope
+              if credentials.is_a?(String) || credentials.is_a?(Hash)
+                credentials = Credentials.new credentials, scope: scope
+              end
 
               @operations_client = OperationsClient.new(
                 credentials: credentials,
-                scopes:      scopes,
+                scope:       scope,
                 timeout:     timeout,
                 lib_name:    lib_name,
                 lib_version: lib_version
               )
-              @image_annotator_stub = create_stub credentials, scopes
+              @image_annotator_stub = Google::Gax::Grpc::Stub.new(
+                Google::Cloud::Vision::V1::ImageAnnotator::Stub,
+                host:         self.class::SERVICE_ADDRESS,
+                port:         self.class::DEFAULT_SERVICE_PORT,
+                credentials:  credentials,
+                interceptors: self.class::GRPC_INTERCEPTORS
+              )
 
               @timeout = timeout
               @metadata = metadata.to_h
@@ -230,36 +239,6 @@ module Google
             end
 
             protected
-
-            def create_stub credentials, scopes
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
-                updater_proc = Credentials.new(credentials).updater_proc
-              elsif credentials.is_a? GRPC::Core::Channel
-                channel = credentials
-              elsif credentials.is_a? GRPC::Core::ChannelCredentials
-                chan_creds = credentials
-              elsif credentials.is_a? Proc
-                updater_proc = credentials
-              elsif credentials.is_a? Google::Auth::Credentials
-                updater_proc = credentials.updater_proc
-              end
-
-              # Allow overriding the service path/port in subclasses.
-              service_path = self.class::SERVICE_ADDRESS
-              port = self.class::DEFAULT_SERVICE_PORT
-              interceptors = self.class::GRPC_INTERCEPTORS
-              stub_new = Google::Cloud::Vision::V1::ImageAnnotator::Stub.method :new
-              Google::Gax::Grpc.create_stub(
-                service_path,
-                port,
-                chan_creds:   chan_creds,
-                channel:      channel,
-                updater_proc: updater_proc,
-                scopes:       scopes,
-                interceptors: interceptors,
-                &stub_new
-              )
-            end
 
             def x_goog_api_client_header lib_name, lib_version
               x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -85,9 +85,9 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scopes [Array<String>]
-            #   The OAuth scopes for this service. This parameter is ignored if an
-            #   updater_proc is supplied.
+            # @param scope [String, Array<String>]
+            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
+            #   an updater_proc is supplied.
             # @param timeout [Numeric]
             #   The default timeout, in seconds, for calls made through this client.
             # @param metadata [Hash]
@@ -96,7 +96,7 @@ module Google
             #
             def initialize \
                 credentials: nil,
-                scopes: ALL_SCOPES,
+                scope: ALL_SCOPES,
                 timeout: DEFAULT_TIMEOUT,
                 metadata: nil,
                 lib_name: nil,
@@ -107,16 +107,25 @@ module Google
               require "google/gax/grpc"
               require "google/cloud/vision/v1/product_search_service_services_pb"
 
-              credentials ||= Credentials.default scope: scopes
+              credentials ||= Credentials.default scope: scope
+              if credentials.is_a?(String) || credentials.is_a?(Hash)
+                credentials = Credentials.new credentials, scope: scope
+              end
 
               @operations_client = OperationsClient.new(
                 credentials: credentials,
-                scopes:      scopes,
+                scope:       scope,
                 timeout:     timeout,
                 lib_name:    lib_name,
                 lib_version: lib_version
               )
-              @product_search_stub = create_stub credentials, scopes
+              @product_search_stub = Google::Gax::Grpc::Stub.new(
+                Google::Cloud::Vision::V1::ProductSearch::Stub,
+                host:         self.class::SERVICE_ADDRESS,
+                port:         self.class::DEFAULT_SERVICE_PORT,
+                credentials:  credentials,
+                interceptors: self.class::GRPC_INTERCEPTORS
+              )
 
               @timeout = timeout
               @metadata = metadata.to_h
@@ -1344,36 +1353,6 @@ module Google
             end
 
             protected
-
-            def create_stub credentials, scopes
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
-                updater_proc = Credentials.new(credentials).updater_proc
-              elsif credentials.is_a? GRPC::Core::Channel
-                channel = credentials
-              elsif credentials.is_a? GRPC::Core::ChannelCredentials
-                chan_creds = credentials
-              elsif credentials.is_a? Proc
-                updater_proc = credentials
-              elsif credentials.is_a? Google::Auth::Credentials
-                updater_proc = credentials.updater_proc
-              end
-
-              # Allow overriding the service path/port in subclasses.
-              service_path = self.class::SERVICE_ADDRESS
-              port = self.class::DEFAULT_SERVICE_PORT
-              interceptors = self.class::GRPC_INTERCEPTORS
-              stub_new = Google::Cloud::Vision::V1::ProductSearch::Stub.method :new
-              Google::Gax::Grpc.create_stub(
-                service_path,
-                port,
-                chan_creds:   chan_creds,
-                channel:      channel,
-                updater_proc: updater_proc,
-                scopes:       scopes,
-                interceptors: interceptors,
-                &stub_new
-              )
-            end
 
             def x_goog_api_client_header lib_name, lib_version
               x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]


### PR DESCRIPTION
Use a more familiar convention for creating a Gax Stub object.

The GAX side of this change is: googleapis/gax-ruby#180