### PR TITLE
Add Pagination support

### DIFF
--- a/gapic-generator/templates/default/client/method/def/_paged.erb
+++ b/gapic-generator/templates/default/client/method/def/_paged.erb
@@ -1,0 +1,59 @@
+<%- assert_locals method -%>
+##
+<%- if method.doc_description -%>
+<%= indent method.doc_description, "# " %>
+#
+<%- end -%>
+# @overload <%= method.name %>(request, options: nil)
+#   @param request [<%= method.request_type %> | Hash]
+<%- if method.doc_description -%>
+<%= indent method.doc_description, "#     " %>
+<%- end -%>
+#   @param options [Google::Gax::ApiCall::Options, Hash]
+#     Overrides the default settings for this call, e.g, timeout, retries, etc.
+#
+<%- arg_list = method.arguments.map { |arg| "#{arg.name}: nil"}.join ", " -%>
+# @overload <%= method.name %>(<%= arg_list %>, options: nil)
+<%- method.arguments.each do |arg| -%>
+#   @param <%= arg.name %> [<%= arg.doc_types %>]
+<%- if arg.doc_description -%>
+<%= indent arg.doc_description, "#     " %>
+<%- end -%>
+<%- end -%>
+#   @param options [Google::Gax::ApiCall::Options, Hash]
+#     Overrides the default settings for this call, e.g, timeout, retries, etc.
+<%- if method.arguments.find { |arg| arg.name == "options" } -%>
+#
+#     If you want to provide a {<%= method.request_type %>#options}
+#     value you will need to pass all attributes in a Hash instead of using
+#     named arguments.
+<%- end -%>
+#
+# @yield [response, operation] Access the result along with the RPC operation
+# @yieldparam response [Google::Gax::PagedEnumerable<<%= method.paged_response_type %>>]
+# @yieldparam operation [GRPC::ActiveCall::Operation]
+#
+# @return [Google::Gax::PagedEnumerable<<%= method.paged_response_type %>>]
+# @raise [Google::Gax::GaxError] if the RPC is aborted.
+# @example
+<%= indent method.code_example, "#   " %>
+#
+def <%= method.name %> request = nil, options: nil, **request_fields, &block
+  if request.nil? && request_fields.empty?
+    raise ArgumentError, "request must be provided"
+  end
+  if !request.nil? && !request_fields.empty?
+    raise ArgumentError, "cannot pass both request object and named arguments"
+  end
+
+  request ||= request_fields
+  request = Google::Gax.to_proto request, <%= method.request_type %>
+
+  <%= indent render(partial: "client/method/def/options_defaults", locals: { method: method }), 2 %>
+
+  <%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>
+
+  wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new(<%= method.ivar %>, request, response, options) }
+
+  <%= method.ivar %>.call(request, options: options, operation_callback: block, format_response: wrap_paged_enum)
+end

--- a/gapic-generator/templates/default/client_test/_paged.erb
+++ b/gapic-generator/templates/default/client_test/_paged.erb
@@ -1,0 +1,78 @@
+<%- assert_locals method -%>
+describe "<%= method.name %>" do
+  let :custom_error do
+    CustomTestErrorV1.new "Custom test error for <%= method.service.client_name_full %>#<%= method.name %>."
+  end
+
+  it "invokes <%= method.name %> without error" do
+<%= indent render(partial: "client_test/fields", locals: { method: method }), 4 %>
+
+    # Create expected grpc response
+    expected_response = {}
+    expected_response = Google::Gax.to_proto expected_response,
+                                             <%= method.return_type %>
+
+    # Mock Grpc layer
+    mock_method = proc do |request|
+      assert_instance_of <%= method.request_type %>, request
+<%- method.fields.each do |field| -%>
+      assert_equal Google::Gax.to_proto(<%= field.name %>, <%= field.type_name_full %>), request.<%= field.name %>
+<%- end -%>
+      OpenStruct.new execute: expected_response
+    end
+    mock_stub = MockGrpcClientStubV1.new :<%= method.name %>, mock_method
+
+    # Mock auth layer
+    mock_credentials = MockSpeechCredentialsV1.new "<%= method.name %>"
+
+    <%= method.service.services_stub_name_full %>.stub :new, mock_stub do
+      <%= method.service.credentials_class_full %>.stub :default, mock_credentials do
+        client = <%= method.service.client_name_full %>.new
+
+        # Call method
+        response = client.<%= method.name %> <%= method.fields.map(&:name).join ", " %>
+
+        # Verify the response
+        assert_equal expected_response, response
+
+        # Call method with block
+        client.<%= method.name %> <%= method.fields.map(&:name).join ", " %> do |resp, operation|
+          # Verify the response
+          assert_equal expected_response, resp
+          refute_nil operation
+        end
+      end
+    end
+  end
+
+  it "invokes <%= method.name %> with error" do
+<%= indent render(partial: "client_test/fields", locals: { method: method }), 4 %>
+
+    # Mock Grpc layer
+    mock_method = proc do |request|
+      assert_instance_of <%= method.request_type %>, request
+<%- method.fields.each do |field| -%>
+      assert_equal Google::Gax.to_proto(<%= field.name %>, <%= field.type_name_full %>), request.<%= field.name %>
+<%- end -%>
+      raise custom_error
+    end
+    mock_stub = MockGrpcClientStubV1.new :<%= method.name %>, mock_method
+
+    # Mock auth layer
+    mock_credentials = MockSpeechCredentialsV1.new "<%= method.name %>"
+
+    <%= method.service.services_stub_name_full %>.stub :new, mock_stub do
+      <%= method.service.credentials_class_full %>.stub :default, mock_credentials do
+        client = <%= method.service.client_name_full %>.new
+
+        # Call method
+        err = assert_raises Google::Gax::GaxError do
+          client.<%= method.name %> <%= method.fields.map(&:name).join ", " %>
+        end
+
+        # Verify the GaxError wrapped the custom error that was raised.
+        assert_match custom_error.message, err.message
+      end
+    end
+  end
+end

--- a/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
@@ -249,7 +249,7 @@ class MethodPresenter
     return false if repeated_field.nil?
 
     # We want to make sure the first repeated field is also has the lowest field number,
-    # but the google-protobuf gem sorts firlds by number, so we lose the original order.
+    # but the google-protobuf gem sorts fields by number, so we lose the original order.
 
     true
   end

--- a/gapic-generator/test/google/gapic/presenters/method/paged_test.rb
+++ b/gapic-generator/test/google/gapic/presenters/method/paged_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require_relative "../../../../../templates/default/helpers/filepath_helper"
+require_relative "../../../../../templates/default/helpers/namespace_helper"
+require_relative "../../../../../templates/default/helpers/presenters/method_presenter"
+
+class MethodPresenterPagedTest < PresenterTest
+  def method_presenter api_name, service_name, method_name
+    api_obj = api api_name
+    service = api_obj.services.find { |s| s.name == service_name }
+    refute_nil service
+    method = service.methods.find { |s| s.name == method_name }
+    refute_nil method
+    MethodPresenter.new method
+  end
+
+  def test_showcase_Expand
+    presenter = method_presenter :showcase, "Echo", "Expand"
+
+    assert_equal "Google::Showcase::V1alpha3::ExpandRequest", presenter.request_type
+    assert_equal "Google::Showcase::V1alpha3::EchoResponse", presenter.return_type
+
+    refute presenter.paged?
+    assert_nil presenter.paged_response_type
+  end
+
+  def test_showcase_PagedExpand
+    presenter = method_presenter :showcase, "Echo", "PagedExpand"
+
+    assert_equal "Google::Showcase::V1alpha3::PagedExpandRequest", presenter.request_type
+    assert_equal "Google::Showcase::V1alpha3::PagedExpandResponse", presenter.return_type
+
+    assert presenter.paged?
+    assert_equal "Google::Showcase::V1alpha3::EchoResponse", presenter.paged_response_type
+  end
+end

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,7 +6,7 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/fix-paged_enumerable-api_call-call"
+gem "google-gax", github: "googleapis/gax-ruby"
 gem "grpc-tools", "~> 1.18"
 gem "minitest", "~> 5.0"
 gem "minitest-autotest", "~> 1.0"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,6 +6,6 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "googleapis/gax-ruby"
+gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/fix-paged_enumerable-api_call-call"
 gem "grpc-tools", "~> 1.18"
 gem "rake", "~> 10.0"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -8,4 +8,7 @@ gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
 gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/fix-paged_enumerable-api_call-call"
 gem "grpc-tools", "~> 1.18"
+gem "minitest", "~> 5.0"
+gem "minitest-autotest", "~> 1.0"
+gem "minitest-focus", "~> 1.0"
 gem "rake", "~> 10.0"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -339,10 +339,10 @@ module Google
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
-          # @yieldparam response [Google::Showcase::V1alpha3::PagedExpandResponse]
+          # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::EchoResponse>]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
-          # @return [Google::Showcase::V1alpha3::PagedExpandResponse]
+          # @return [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::EchoResponse>]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
@@ -365,7 +365,10 @@ module Google
             options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @paged_expand ||= Google::Gax::ApiCall.new @echo_stub.method :paged_expand
-            @paged_expand.call request, options: options, operation_callback: block
+
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @paged_expand, request, response, options }
+
+            @paged_expand.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -344,10 +344,10 @@ module Google
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
-          # @yieldparam response [Google::Showcase::V1alpha3::ListUsersResponse]
+          # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::User>]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
-          # @return [Google::Showcase::V1alpha3::ListUsersResponse]
+          # @return [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::User>]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
@@ -370,7 +370,10 @@ module Google
             options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_users ||= Google::Gax::ApiCall.new @identity_stub.method :list_users
-            @list_users.call request, options: options, operation_callback: block
+
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_users, request, response, options }
+
+            @list_users.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           protected

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -344,10 +344,10 @@ module Google
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
-          # @yieldparam response [Google::Showcase::V1alpha3::ListRoomsResponse]
+          # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Room>]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
-          # @return [Google::Showcase::V1alpha3::ListRoomsResponse]
+          # @return [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Room>]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
@@ -370,7 +370,10 @@ module Google
             options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_rooms ||= Google::Gax::ApiCall.new @messaging_stub.method :list_rooms
-            @list_rooms.call request, options: options, operation_callback: block
+
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_rooms, request, response, options }
+
+            @list_rooms.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -605,10 +608,10 @@ module Google
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
-          # @yieldparam response [Google::Showcase::V1alpha3::ListBlurbsResponse]
+          # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Blurb>]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
-          # @return [Google::Showcase::V1alpha3::ListBlurbsResponse]
+          # @return [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Blurb>]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
@@ -635,7 +638,10 @@ module Google
             options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :list_blurbs
-            @list_blurbs.call request, options: options, operation_callback: block
+
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_blurbs, request, response, options }
+
+            @list_blurbs.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -242,10 +242,10 @@ module Google
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
-          # @yieldparam response [Google::Showcase::V1alpha3::ListSessionsResponse]
+          # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Session>]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
-          # @return [Google::Showcase::V1alpha3::ListSessionsResponse]
+          # @return [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Session>]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
@@ -268,7 +268,10 @@ module Google
             options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_sessions ||= Google::Gax::ApiCall.new @testing_stub.method :list_sessions
-            @list_sessions.call request, options: options, operation_callback: block
+
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_sessions, request, response, options }
+
+            @list_sessions.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -393,10 +396,10 @@ module Google
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
-          # @yieldparam response [Google::Showcase::V1alpha3::ListTestsResponse]
+          # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Test>]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
-          # @return [Google::Showcase::V1alpha3::ListTestsResponse]
+          # @return [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Test>]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
@@ -423,7 +426,10 @@ module Google
             options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_tests ||= Google::Gax::ApiCall.new @testing_stub.method :list_tests
-            @list_tests.call request, options: options, operation_callback: block
+
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_tests, request, response, options }
+
+            @list_tests.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -226,10 +226,10 @@ module Google
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
-            # @yieldparam response [Google::Cloud::Vision::V1::ListProductSetsResponse]
+            # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ProductSet>]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
-            # @return [Google::Cloud::Vision::V1::ListProductSetsResponse]
+            # @return [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ProductSet>]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   TODO
@@ -256,7 +256,10 @@ module Google
               options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @list_product_sets ||= Google::Gax::ApiCall.new @product_search_stub.method :list_product_sets
-              @list_product_sets.call request, options: options, operation_callback: block
+
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_product_sets, request, response, options }
+
+              @list_product_sets.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -557,10 +560,10 @@ module Google
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
-            # @yieldparam response [Google::Cloud::Vision::V1::ListProductsResponse]
+            # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
-            # @return [Google::Cloud::Vision::V1::ListProductsResponse]
+            # @return [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   TODO
@@ -587,7 +590,10 @@ module Google
               options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @list_products ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products
-              @list_products.call request, options: options, operation_callback: block
+
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_products, request, response, options }
+
+              @list_products.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -1009,10 +1015,10 @@ module Google
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
-            # @yieldparam response [Google::Cloud::Vision::V1::ListReferenceImagesResponse]
+            # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ReferenceImage>]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
-            # @return [Google::Cloud::Vision::V1::ListReferenceImagesResponse]
+            # @return [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ReferenceImage>]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   TODO
@@ -1039,7 +1045,10 @@ module Google
               options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @list_reference_images ||= Google::Gax::ApiCall.new @product_search_stub.method :list_reference_images
-              @list_reference_images.call request, options: options, operation_callback: block
+
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_reference_images, request, response, options }
+
+              @list_reference_images.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -1274,10 +1283,10 @@ module Google
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
-            # @yieldparam response [Google::Cloud::Vision::V1::ListProductsInProductSetResponse]
+            # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
-            # @return [Google::Cloud::Vision::V1::ListProductsInProductSetResponse]
+            # @return [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   TODO
@@ -1304,7 +1313,10 @@ module Google
               options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @list_products_in_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products_in_product_set
-              @list_products_in_product_set.call request, options: options, operation_callback: block
+
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_products_in_product_set, request, response, options }
+
+              @list_products_in_product_set.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -347,10 +347,10 @@ module Google
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
-          # @yieldparam response [Google::Showcase::V1alpha3::PagedExpandResponse]
+          # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::EchoResponse>]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
-          # @return [Google::Showcase::V1alpha3::PagedExpandResponse]
+          # @return [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::EchoResponse>]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
@@ -373,7 +373,10 @@ module Google
             options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @paged_expand ||= Google::Gax::ApiCall.new @echo_stub.method :paged_expand
-            @paged_expand.call request, options: options, operation_callback: block
+
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @paged_expand, request, response, options }
+
+            @paged_expand.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -352,10 +352,10 @@ module Google
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
-          # @yieldparam response [Google::Showcase::V1alpha3::ListUsersResponse]
+          # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::User>]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
-          # @return [Google::Showcase::V1alpha3::ListUsersResponse]
+          # @return [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::User>]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
@@ -378,7 +378,10 @@ module Google
             options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_users ||= Google::Gax::ApiCall.new @identity_stub.method :list_users
-            @list_users.call request, options: options, operation_callback: block
+
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_users, request, response, options }
+
+            @list_users.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           protected

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -352,10 +352,10 @@ module Google
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
-          # @yieldparam response [Google::Showcase::V1alpha3::ListRoomsResponse]
+          # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Room>]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
-          # @return [Google::Showcase::V1alpha3::ListRoomsResponse]
+          # @return [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Room>]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
@@ -378,7 +378,10 @@ module Google
             options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_rooms ||= Google::Gax::ApiCall.new @messaging_stub.method :list_rooms
-            @list_rooms.call request, options: options, operation_callback: block
+
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_rooms, request, response, options }
+
+            @list_rooms.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -613,10 +616,10 @@ module Google
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
-          # @yieldparam response [Google::Showcase::V1alpha3::ListBlurbsResponse]
+          # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Blurb>]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
-          # @return [Google::Showcase::V1alpha3::ListBlurbsResponse]
+          # @return [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Blurb>]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
@@ -643,7 +646,10 @@ module Google
             options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :list_blurbs
-            @list_blurbs.call request, options: options, operation_callback: block
+
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_blurbs, request, response, options }
+
+            @list_blurbs.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -250,10 +250,10 @@ module Google
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
-          # @yieldparam response [Google::Showcase::V1alpha3::ListSessionsResponse]
+          # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Session>]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
-          # @return [Google::Showcase::V1alpha3::ListSessionsResponse]
+          # @return [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Session>]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
@@ -276,7 +276,10 @@ module Google
             options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_sessions ||= Google::Gax::ApiCall.new @testing_stub.method :list_sessions
-            @list_sessions.call request, options: options, operation_callback: block
+
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_sessions, request, response, options }
+
+            @list_sessions.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -401,10 +404,10 @@ module Google
           #     Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
-          # @yieldparam response [Google::Showcase::V1alpha3::ListTestsResponse]
+          # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Test>]
           # @yieldparam operation [GRPC::ActiveCall::Operation]
           #
-          # @return [Google::Showcase::V1alpha3::ListTestsResponse]
+          # @return [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Test>]
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           # @example
           #   TODO
@@ -431,7 +434,10 @@ module Google
             options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
             @list_tests ||= Google::Gax::ApiCall.new @testing_stub.method :list_tests
-            @list_tests.call request, options: options, operation_callback: block
+
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_tests, request, response, options }
+
+            @list_tests.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -234,10 +234,10 @@ module Google
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
-            # @yieldparam response [Google::Cloud::Vision::V1::ListProductSetsResponse]
+            # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ProductSet>]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
-            # @return [Google::Cloud::Vision::V1::ListProductSetsResponse]
+            # @return [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ProductSet>]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   TODO
@@ -264,7 +264,10 @@ module Google
               options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @list_product_sets ||= Google::Gax::ApiCall.new @product_search_stub.method :list_product_sets
-              @list_product_sets.call request, options: options, operation_callback: block
+
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_product_sets, request, response, options }
+
+              @list_product_sets.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -565,10 +568,10 @@ module Google
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
-            # @yieldparam response [Google::Cloud::Vision::V1::ListProductsResponse]
+            # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
-            # @return [Google::Cloud::Vision::V1::ListProductsResponse]
+            # @return [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   TODO
@@ -595,7 +598,10 @@ module Google
               options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @list_products ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products
-              @list_products.call request, options: options, operation_callback: block
+
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_products, request, response, options }
+
+              @list_products.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -1017,10 +1023,10 @@ module Google
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
-            # @yieldparam response [Google::Cloud::Vision::V1::ListReferenceImagesResponse]
+            # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ReferenceImage>]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
-            # @return [Google::Cloud::Vision::V1::ListReferenceImagesResponse]
+            # @return [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ReferenceImage>]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   TODO
@@ -1047,7 +1053,10 @@ module Google
               options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @list_reference_images ||= Google::Gax::ApiCall.new @product_search_stub.method :list_reference_images
-              @list_reference_images.call request, options: options, operation_callback: block
+
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_reference_images, request, response, options }
+
+              @list_reference_images.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -1282,10 +1291,10 @@ module Google
             #     Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
-            # @yieldparam response [Google::Cloud::Vision::V1::ListProductsInProductSetResponse]
+            # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
             # @yieldparam operation [GRPC::ActiveCall::Operation]
             #
-            # @return [Google::Cloud::Vision::V1::ListProductsInProductSetResponse]
+            # @return [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
             # @raise [Google::Gax::GaxError] if the RPC is aborted.
             # @example
             #   TODO
@@ -1312,7 +1321,10 @@ module Google
               options.apply_defaults timeout: @timeout, metadata: metadata, retry_policy: retry_policy
 
               @list_products_in_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products_in_product_set
-              @list_products_in_product_set.call request, options: options, operation_callback: block
+
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_products_in_product_set, request, response, options }
+
+              @list_products_in_product_set.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##

--- a/shared/test/showcase/echo/chat_test.rb
+++ b/shared/test/showcase/echo/chat_test.rb
@@ -17,18 +17,8 @@
 require "test_helper"
 require "google/showcase/v1alpha3/echo"
 
-class EchoTest < ShowcaseTest
-  def test_echo
-    client = Google::Showcase::V1alpha3::Echo.new(
-      credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    )
-
-    response = client.echo content: 'hi there!'
-
-    assert_equal 'hi there!', response.content
-  end
-
-  def test_chat_closure
+class ChatTest < ShowcaseTest
+  def test_closure
     client = Google::Showcase::V1alpha3::Echo.new(
       credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
     )
@@ -69,7 +59,7 @@ class EchoTest < ShowcaseTest
     assert pull_count >= 20, "should have pulled 20 messages by now"
   end
 
-  def test_chat_enumerator
+  def test_enumerator
     client = Google::Showcase::V1alpha3::Echo.new(
       credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
     )

--- a/shared/test/showcase/echo/echo_test.rb
+++ b/shared/test/showcase/echo/echo_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require "google/showcase/v1alpha3/echo"
+
+class EchoTest < ShowcaseTest
+  def test_echo
+    client = Google::Showcase::V1alpha3::Echo.new(
+      credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
+    )
+
+    response = client.echo content: 'hi there!'
+
+    assert_equal 'hi there!', response.content
+  end
+end

--- a/shared/test/showcase/echo/expand_test.rb
+++ b/shared/test/showcase/echo/expand_test.rb
@@ -26,8 +26,6 @@ class ExpandTest < ShowcaseTest
     request_content = "The quick brown fox jumps over the lazy dog"
     responses = Queue.new
 
-    stream_input = Google::Gax::StreamInput.new
-
     response_thread = client.expand content: request_content do |response|
       responses << response
     end

--- a/shared/test/showcase/echo/expand_test.rb
+++ b/shared/test/showcase/echo/expand_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require "google/showcase/v1alpha3/echo"
+
+class ExpandTest < ShowcaseTest
+  def test_expand
+    client = Google::Showcase::V1alpha3::Echo.new(
+      credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
+    )
+
+    request_content = "The quick brown fox jumps over the lazy dog"
+    responses = Queue.new
+
+    stream_input = Google::Gax::StreamInput.new
+
+    response_thread = client.expand content: request_content do |response|
+      responses << response
+    end
+
+    response_thread.join
+
+    responses_content_array = Array.new(responses.size) { responses.pop.content }
+
+    assert_equal request_content, responses_content_array.join(" ")
+  end
+end

--- a/shared/test/showcase/echo/paged_expand_test.rb
+++ b/shared/test/showcase/echo/paged_expand_test.rb
@@ -44,6 +44,8 @@ class PagedExpandTest < ShowcaseTest
     response_enum = client.paged_expand content: request_content, page_size: 2
 
     assert_kind_of Google::Gax::PagedEnumerable, response_enum
+    assert_kind_of Google::Showcase::V1alpha3::PagedExpandResponse, response_enum.page.response
+    assert_equal ["The", "quick"], response_enum.page.response.responses.map(&:content)
 
     responses_content_array = response_enum.to_a.map(&:content)
 

--- a/shared/test/showcase/echo/paged_expand_test.rb
+++ b/shared/test/showcase/echo/paged_expand_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require "google/showcase/v1alpha3/echo"
+
+class PagedExpandTest < ShowcaseTest
+  def test_paged_expand
+    client = Google::Showcase::V1alpha3::Echo.new(
+      credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
+    )
+
+    request_content = "The quick brown fox jumps over the lazy dog"
+
+    response_enum = client.paged_expand content: request_content
+
+    assert_kind_of Google::Gax::PagedEnumerable, response_enum
+
+    responses_content_array = response_enum.to_a.map(&:content)
+
+    assert_equal request_content, responses_content_array.join(" ")
+  end
+
+  def test_page_size
+    client = Google::Showcase::V1alpha3::Echo.new(
+      credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
+    )
+
+    request_content = "The quick brown fox jumps over the lazy dog"
+
+    response_enum = client.paged_expand content: request_content, page_size: 2
+
+    assert_kind_of Google::Gax::PagedEnumerable, response_enum
+
+    responses_content_array = response_enum.to_a.map(&:content)
+
+    assert_equal request_content, responses_content_array.join(" ")
+  end
+end

--- a/shared/test/test_helper.rb
+++ b/shared/test/test_helper.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 require "minitest/autorun"
+require "minitest/focus"
 require "fileutils"
 require "open3"
 require "tmpdir"


### PR DESCRIPTION
Add paging support in the default generator. Add showcase tests for Expand and PagedExpand.

This change requires googleapis/gax-ruby#182 to be merged first.