### PR TITLE
Fix unintentionally singularizing names

### DIFF
--- a/gapic-generator/lib/google/gapic/gem_builder.rb
+++ b/gapic-generator/lib/google/gapic/gem_builder.rb
@@ -65,7 +65,7 @@ module Google
       end
 
       def gem_class_prefix
-        ActiveSupport::Inflector.classify @name
+        ActiveSupport::Inflector.camelize @name
       end
 
       def controller

--- a/gapic-generator/templates/default/helpers/namespace_helper.rb
+++ b/gapic-generator/templates/default/helpers/namespace_helper.rb
@@ -42,6 +42,6 @@ module NamespaceHelper
   # Ruby double-semicolon separators.
   def ruby_namespace namespaces
     namespaces = namespaces.split "." if namespaces.is_a? String
-    namespaces.reject(&:empty?).map(&:classify).join "::"
+    namespaces.reject(&:empty?).map(&:camelize).join "::"
   end
 end

--- a/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
@@ -95,7 +95,7 @@ class FieldPresenter
 
   def message_ruby_type message
     message.address.map do |namespace_node|
-      ActiveSupport::Inflector.classify namespace_node
+      ActiveSupport::Inflector.camelize namespace_node
     end.join "::"
   end
 end

--- a/gapic-generator/templates/default/helpers/presenters/gem_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/gem_presenter.rb
@@ -45,7 +45,7 @@ class GemPresenter
   end
 
   def namespaces
-    name.split("-").map(&:classify)
+    name.split("-").map(&:camelize)
   end
 
   def name
@@ -55,7 +55,7 @@ class GemPresenter
 
   def title
     gem_config(:title) ||
-      name.split("-").map(&:classify).join(" ")
+      name.split("-").map(&:camelize).join(" ")
   end
 
   def version
@@ -72,7 +72,7 @@ class GemPresenter
   end
 
   def version_name_full
-    name.split("-").map(&:classify).join("::") + "::VERSION"
+    name.split("-").map(&:camelize).join("::") + "::VERSION"
   end
 
   def authors

--- a/gapic-generator/templates/default/helpers/presenters/message_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/message_presenter.rb
@@ -67,7 +67,7 @@ class MessagePresenter
 
   def message_ruby_type message
     message.address.map do |namespace_node|
-      ActiveSupport::Inflector.classify namespace_node
+      ActiveSupport::Inflector.camelize namespace_node
     end.join "::"
   end
 end

--- a/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
@@ -161,7 +161,7 @@ class MethodPresenter
 
   def message_ruby_type message
     message.address.map do |namespace_node|
-      ActiveSupport::Inflector.classify namespace_node
+      ActiveSupport::Inflector.camelize namespace_node
     end.join "::"
   end
 

--- a/gapic-generator/templates/default/helpers/presenters/service_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/service_presenter.rb
@@ -47,7 +47,7 @@ class ServicePresenter
   end
 
   def version
-    ActiveSupport::Inflector.classify @service.address[-2]
+    ActiveSupport::Inflector.camelize @service.address[-2]
   end
 
   def name

--- a/gapic-generator/templates/default/layouts/_ruby.erb
+++ b/gapic-generator/templates/default/layouts/_ruby.erb
@@ -6,7 +6,7 @@
 <%= @requires %>
 <% end %>
 <%- namespaces.each_with_index do |n, i| -%>
-<%= indent "module #{n.classify}", i*2 %>
+<%= indent "module #{n.camelize}", i*2 %>
 <%- end -%>
 <%= indent yield, namespaces.count*2 %>
 <%- namespaces.count.times do |i| -%>

--- a/shared/output/cloud/showcase/proto_docs/google/protobuf/descriptor.rb
+++ b/shared/output/cloud/showcase/proto_docs/google/protobuf/descriptor.rb
@@ -50,7 +50,7 @@ module Google
     # @!attribute [rw] extension
     #   @return [Google::Protobuf::FieldDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::FileOption]
+    #   @return [Google::Protobuf::FileOptions]
     # @!attribute [rw] source_code_info
     #   @return [Google::Protobuf::SourceCodeInfo]
     #     This field contains optional information about the original source code.
@@ -82,7 +82,7 @@ module Google
     # @!attribute [rw] oneof_decl
     #   @return [Google::Protobuf::OneofDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::MessageOption]
+    #   @return [Google::Protobuf::MessageOptions]
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::DescriptorProto::ReservedRange]
     # @!attribute [rw] reserved_name
@@ -98,7 +98,7 @@ module Google
       # @!attribute [rw] end
       #   @return [Integer]
       # @!attribute [rw] options
-      #   @return [Google::Protobuf::ExtensionRangeOption]
+      #   @return [Google::Protobuf::ExtensionRangeOptions]
       class ExtensionRange
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
@@ -165,7 +165,7 @@ module Google
     #     will be used. Otherwise, it's deduced from the field's name by converting
     #     it to camelCase.
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::FieldOption]
+    #   @return [Google::Protobuf::FieldOptions]
     class FieldDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -233,7 +233,7 @@ module Google
     # @!attribute [rw] name
     #   @return [String]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::OneofOption]
+    #   @return [Google::Protobuf::OneofOptions]
     class OneofDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -245,7 +245,7 @@ module Google
     # @!attribute [rw] value
     #   @return [Google::Protobuf::EnumValueDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::EnumOption]
+    #   @return [Google::Protobuf::EnumOptions]
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::EnumDescriptorProto::EnumReservedRange]
     #     Range of reserved numeric values. Reserved numeric values may not be used
@@ -281,7 +281,7 @@ module Google
     # @!attribute [rw] number
     #   @return [Integer]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::EnumValueOption]
+    #   @return [Google::Protobuf::EnumValueOptions]
     class EnumValueDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -293,7 +293,7 @@ module Google
     # @!attribute [rw] method
     #   @return [Google::Protobuf::MethodDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::ServiceOption]
+    #   @return [Google::Protobuf::ServiceOptions]
     class ServiceDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -309,7 +309,7 @@ module Google
     # @!attribute [rw] output_type
     #   @return [String]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::MethodOption]
+    #   @return [Google::Protobuf::MethodOptions]
     # @!attribute [rw] client_streaming
     #   @return [Boolean]
     #     Identifies if client streams multiple client messages

--- a/shared/output/cloud/speech/proto_docs/google/protobuf/descriptor.rb
+++ b/shared/output/cloud/speech/proto_docs/google/protobuf/descriptor.rb
@@ -50,7 +50,7 @@ module Google
     # @!attribute [rw] extension
     #   @return [Google::Protobuf::FieldDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::FileOption]
+    #   @return [Google::Protobuf::FileOptions]
     # @!attribute [rw] source_code_info
     #   @return [Google::Protobuf::SourceCodeInfo]
     #     This field contains optional information about the original source code.
@@ -82,7 +82,7 @@ module Google
     # @!attribute [rw] oneof_decl
     #   @return [Google::Protobuf::OneofDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::MessageOption]
+    #   @return [Google::Protobuf::MessageOptions]
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::DescriptorProto::ReservedRange]
     # @!attribute [rw] reserved_name
@@ -98,7 +98,7 @@ module Google
       # @!attribute [rw] end
       #   @return [Integer]
       # @!attribute [rw] options
-      #   @return [Google::Protobuf::ExtensionRangeOption]
+      #   @return [Google::Protobuf::ExtensionRangeOptions]
       class ExtensionRange
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
@@ -165,7 +165,7 @@ module Google
     #     will be used. Otherwise, it's deduced from the field's name by converting
     #     it to camelCase.
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::FieldOption]
+    #   @return [Google::Protobuf::FieldOptions]
     class FieldDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -233,7 +233,7 @@ module Google
     # @!attribute [rw] name
     #   @return [String]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::OneofOption]
+    #   @return [Google::Protobuf::OneofOptions]
     class OneofDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -245,7 +245,7 @@ module Google
     # @!attribute [rw] value
     #   @return [Google::Protobuf::EnumValueDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::EnumOption]
+    #   @return [Google::Protobuf::EnumOptions]
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::EnumDescriptorProto::EnumReservedRange]
     #     Range of reserved numeric values. Reserved numeric values may not be used
@@ -281,7 +281,7 @@ module Google
     # @!attribute [rw] number
     #   @return [Integer]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::EnumValueOption]
+    #   @return [Google::Protobuf::EnumValueOptions]
     class EnumValueDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -293,7 +293,7 @@ module Google
     # @!attribute [rw] method
     #   @return [Google::Protobuf::MethodDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::ServiceOption]
+    #   @return [Google::Protobuf::ServiceOptions]
     class ServiceDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -309,7 +309,7 @@ module Google
     # @!attribute [rw] output_type
     #   @return [String]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::MethodOption]
+    #   @return [Google::Protobuf::MethodOptions]
     # @!attribute [rw] client_streaming
     #   @return [Boolean]
     #     Identifies if client streams multiple client messages

--- a/shared/output/cloud/vision/proto_docs/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/cloud/vision/proto_docs/google/cloud/vision/v1/image_annotator.rb
@@ -562,13 +562,13 @@ module Google
         #     error if one or more of the specified languages is not one of the
         #     [supported languages](/vision/docs/languages).
         # @!attribute [rw] crop_hints_params
-        #   @return [Google::Cloud::Vision::V1::CropHintsParam]
+        #   @return [Google::Cloud::Vision::V1::CropHintsParams]
         #     Parameters for crop hints annotation request.
         # @!attribute [rw] product_search_params
-        #   @return [Google::Cloud::Vision::V1::ProductSearchParam]
+        #   @return [Google::Cloud::Vision::V1::ProductSearchParams]
         #     Parameters for product search.
         # @!attribute [rw] web_detection_params
-        #   @return [Google::Cloud::Vision::V1::WebDetectionParam]
+        #   @return [Google::Cloud::Vision::V1::WebDetectionParams]
         #     Parameters for web detection.
         class ImageContext
           include Google::Protobuf::MessageExts
@@ -635,7 +635,7 @@ module Google
         #   @return [Google::Cloud::Vision::V1::SafeSearchAnnotation]
         #     If present, safe-search annotation has completed successfully.
         # @!attribute [rw] image_properties_annotation
-        #   @return [Google::Cloud::Vision::V1::ImageProperty]
+        #   @return [Google::Cloud::Vision::V1::ImageProperties]
         #     If present, image properties were extracted successfully.
         # @!attribute [rw] crop_hints_annotation
         #   @return [Google::Cloud::Vision::V1::CropHintsAnnotation]
@@ -644,7 +644,7 @@ module Google
         #   @return [Google::Cloud::Vision::V1::WebDetection]
         #     If present, web detection has completed successfully.
         # @!attribute [rw] product_search_results
-        #   @return [Google::Cloud::Vision::V1::ProductSearchResult]
+        #   @return [Google::Cloud::Vision::V1::ProductSearchResults]
         #     If present, product search has completed successfully.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]

--- a/shared/output/cloud/vision/proto_docs/google/cloud/vision/v1/product_search.rb
+++ b/shared/output/cloud/vision/proto_docs/google/cloud/vision/v1/product_search.rb
@@ -54,10 +54,10 @@ module Google
         #     Timestamp of the index which provided these results. Changes made after
         #     this time are not reflected in the current results.
         # @!attribute [rw] results
-        #   @return [Google::Cloud::Vision::V1::ProductSearchResult::Result]
+        #   @return [Google::Cloud::Vision::V1::ProductSearchResults::Result]
         #     List of results, one for each product match.
         # @!attribute [rw] product_grouped_results
-        #   @return [Google::Cloud::Vision::V1::ProductSearchResult::GroupedResult]
+        #   @return [Google::Cloud::Vision::V1::ProductSearchResults::GroupedResult]
         #     List of results grouped by products detected in the query image. Each entry
         #     corresponds to one bounding polygon in the query image, and contains the
         #     matching products specific to that region. There may be duplicate product
@@ -89,7 +89,7 @@ module Google
           #   @return [Google::Cloud::Vision::V1::BoundingPoly]
           #     The bounding polygon around the product detected in the query image.
           # @!attribute [rw] results
-          #   @return [Google::Cloud::Vision::V1::ProductSearchResult::Result]
+          #   @return [Google::Cloud::Vision::V1::ProductSearchResults::Result]
           #     List of results, one for each product match.
           class GroupedResult
             include Google::Protobuf::MessageExts

--- a/shared/output/cloud/vision/proto_docs/google/protobuf/descriptor.rb
+++ b/shared/output/cloud/vision/proto_docs/google/protobuf/descriptor.rb
@@ -50,7 +50,7 @@ module Google
     # @!attribute [rw] extension
     #   @return [Google::Protobuf::FieldDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::FileOption]
+    #   @return [Google::Protobuf::FileOptions]
     # @!attribute [rw] source_code_info
     #   @return [Google::Protobuf::SourceCodeInfo]
     #     This field contains optional information about the original source code.
@@ -82,7 +82,7 @@ module Google
     # @!attribute [rw] oneof_decl
     #   @return [Google::Protobuf::OneofDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::MessageOption]
+    #   @return [Google::Protobuf::MessageOptions]
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::DescriptorProto::ReservedRange]
     # @!attribute [rw] reserved_name
@@ -98,7 +98,7 @@ module Google
       # @!attribute [rw] end
       #   @return [Integer]
       # @!attribute [rw] options
-      #   @return [Google::Protobuf::ExtensionRangeOption]
+      #   @return [Google::Protobuf::ExtensionRangeOptions]
       class ExtensionRange
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
@@ -165,7 +165,7 @@ module Google
     #     will be used. Otherwise, it's deduced from the field's name by converting
     #     it to camelCase.
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::FieldOption]
+    #   @return [Google::Protobuf::FieldOptions]
     class FieldDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -233,7 +233,7 @@ module Google
     # @!attribute [rw] name
     #   @return [String]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::OneofOption]
+    #   @return [Google::Protobuf::OneofOptions]
     class OneofDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -245,7 +245,7 @@ module Google
     # @!attribute [rw] value
     #   @return [Google::Protobuf::EnumValueDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::EnumOption]
+    #   @return [Google::Protobuf::EnumOptions]
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::EnumDescriptorProto::EnumReservedRange]
     #     Range of reserved numeric values. Reserved numeric values may not be used
@@ -281,7 +281,7 @@ module Google
     # @!attribute [rw] number
     #   @return [Integer]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::EnumValueOption]
+    #   @return [Google::Protobuf::EnumValueOptions]
     class EnumValueDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -293,7 +293,7 @@ module Google
     # @!attribute [rw] method
     #   @return [Google::Protobuf::MethodDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::ServiceOption]
+    #   @return [Google::Protobuf::ServiceOptions]
     class ServiceDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -309,7 +309,7 @@ module Google
     # @!attribute [rw] output_type
     #   @return [String]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::MethodOption]
+    #   @return [Google::Protobuf::MethodOptions]
     # @!attribute [rw] client_streaming
     #   @return [Boolean]
     #     Identifies if client streams multiple client messages

--- a/shared/output/gapic/templates/showcase/proto_docs/google/protobuf/descriptor.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/protobuf/descriptor.rb
@@ -58,7 +58,7 @@ module Google
     # @!attribute [rw] extension
     #   @return [Google::Protobuf::FieldDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::FileOption]
+    #   @return [Google::Protobuf::FileOptions]
     # @!attribute [rw] source_code_info
     #   @return [Google::Protobuf::SourceCodeInfo]
     #     This field contains optional information about the original source code.
@@ -90,7 +90,7 @@ module Google
     # @!attribute [rw] oneof_decl
     #   @return [Google::Protobuf::OneofDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::MessageOption]
+    #   @return [Google::Protobuf::MessageOptions]
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::DescriptorProto::ReservedRange]
     # @!attribute [rw] reserved_name
@@ -106,7 +106,7 @@ module Google
       # @!attribute [rw] end
       #   @return [Integer]
       # @!attribute [rw] options
-      #   @return [Google::Protobuf::ExtensionRangeOption]
+      #   @return [Google::Protobuf::ExtensionRangeOptions]
       class ExtensionRange
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
@@ -173,7 +173,7 @@ module Google
     #     will be used. Otherwise, it's deduced from the field's name by converting
     #     it to camelCase.
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::FieldOption]
+    #   @return [Google::Protobuf::FieldOptions]
     class FieldDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -241,7 +241,7 @@ module Google
     # @!attribute [rw] name
     #   @return [String]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::OneofOption]
+    #   @return [Google::Protobuf::OneofOptions]
     class OneofDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -253,7 +253,7 @@ module Google
     # @!attribute [rw] value
     #   @return [Google::Protobuf::EnumValueDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::EnumOption]
+    #   @return [Google::Protobuf::EnumOptions]
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::EnumDescriptorProto::EnumReservedRange]
     #     Range of reserved numeric values. Reserved numeric values may not be used
@@ -289,7 +289,7 @@ module Google
     # @!attribute [rw] number
     #   @return [Integer]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::EnumValueOption]
+    #   @return [Google::Protobuf::EnumValueOptions]
     class EnumValueDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -301,7 +301,7 @@ module Google
     # @!attribute [rw] method
     #   @return [Google::Protobuf::MethodDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::ServiceOption]
+    #   @return [Google::Protobuf::ServiceOptions]
     class ServiceDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -317,7 +317,7 @@ module Google
     # @!attribute [rw] output_type
     #   @return [String]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::MethodOption]
+    #   @return [Google::Protobuf::MethodOptions]
     # @!attribute [rw] client_streaming
     #   @return [Boolean]
     #     Identifies if client streams multiple client messages

--- a/shared/output/gapic/templates/speech/proto_docs/google/protobuf/descriptor.rb
+++ b/shared/output/gapic/templates/speech/proto_docs/google/protobuf/descriptor.rb
@@ -58,7 +58,7 @@ module Google
     # @!attribute [rw] extension
     #   @return [Google::Protobuf::FieldDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::FileOption]
+    #   @return [Google::Protobuf::FileOptions]
     # @!attribute [rw] source_code_info
     #   @return [Google::Protobuf::SourceCodeInfo]
     #     This field contains optional information about the original source code.
@@ -90,7 +90,7 @@ module Google
     # @!attribute [rw] oneof_decl
     #   @return [Google::Protobuf::OneofDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::MessageOption]
+    #   @return [Google::Protobuf::MessageOptions]
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::DescriptorProto::ReservedRange]
     # @!attribute [rw] reserved_name
@@ -106,7 +106,7 @@ module Google
       # @!attribute [rw] end
       #   @return [Integer]
       # @!attribute [rw] options
-      #   @return [Google::Protobuf::ExtensionRangeOption]
+      #   @return [Google::Protobuf::ExtensionRangeOptions]
       class ExtensionRange
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
@@ -173,7 +173,7 @@ module Google
     #     will be used. Otherwise, it's deduced from the field's name by converting
     #     it to camelCase.
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::FieldOption]
+    #   @return [Google::Protobuf::FieldOptions]
     class FieldDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -241,7 +241,7 @@ module Google
     # @!attribute [rw] name
     #   @return [String]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::OneofOption]
+    #   @return [Google::Protobuf::OneofOptions]
     class OneofDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -253,7 +253,7 @@ module Google
     # @!attribute [rw] value
     #   @return [Google::Protobuf::EnumValueDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::EnumOption]
+    #   @return [Google::Protobuf::EnumOptions]
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::EnumDescriptorProto::EnumReservedRange]
     #     Range of reserved numeric values. Reserved numeric values may not be used
@@ -289,7 +289,7 @@ module Google
     # @!attribute [rw] number
     #   @return [Integer]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::EnumValueOption]
+    #   @return [Google::Protobuf::EnumValueOptions]
     class EnumValueDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -301,7 +301,7 @@ module Google
     # @!attribute [rw] method
     #   @return [Google::Protobuf::MethodDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::ServiceOption]
+    #   @return [Google::Protobuf::ServiceOptions]
     class ServiceDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -317,7 +317,7 @@ module Google
     # @!attribute [rw] output_type
     #   @return [String]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::MethodOption]
+    #   @return [Google::Protobuf::MethodOptions]
     # @!attribute [rw] client_streaming
     #   @return [Boolean]
     #     Identifies if client streams multiple client messages

--- a/shared/output/gapic/templates/vision/proto_docs/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/gapic/templates/vision/proto_docs/google/cloud/vision/v1/image_annotator.rb
@@ -570,13 +570,13 @@ module Google
         #     error if one or more of the specified languages is not one of the
         #     [supported languages](/vision/docs/languages).
         # @!attribute [rw] crop_hints_params
-        #   @return [Google::Cloud::Vision::V1::CropHintsParam]
+        #   @return [Google::Cloud::Vision::V1::CropHintsParams]
         #     Parameters for crop hints annotation request.
         # @!attribute [rw] product_search_params
-        #   @return [Google::Cloud::Vision::V1::ProductSearchParam]
+        #   @return [Google::Cloud::Vision::V1::ProductSearchParams]
         #     Parameters for product search.
         # @!attribute [rw] web_detection_params
-        #   @return [Google::Cloud::Vision::V1::WebDetectionParam]
+        #   @return [Google::Cloud::Vision::V1::WebDetectionParams]
         #     Parameters for web detection.
         class ImageContext
           include Google::Protobuf::MessageExts
@@ -643,7 +643,7 @@ module Google
         #   @return [Google::Cloud::Vision::V1::SafeSearchAnnotation]
         #     If present, safe-search annotation has completed successfully.
         # @!attribute [rw] image_properties_annotation
-        #   @return [Google::Cloud::Vision::V1::ImageProperty]
+        #   @return [Google::Cloud::Vision::V1::ImageProperties]
         #     If present, image properties were extracted successfully.
         # @!attribute [rw] crop_hints_annotation
         #   @return [Google::Cloud::Vision::V1::CropHintsAnnotation]
@@ -652,7 +652,7 @@ module Google
         #   @return [Google::Cloud::Vision::V1::WebDetection]
         #     If present, web detection has completed successfully.
         # @!attribute [rw] product_search_results
-        #   @return [Google::Cloud::Vision::V1::ProductSearchResult]
+        #   @return [Google::Cloud::Vision::V1::ProductSearchResults]
         #     If present, product search has completed successfully.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]

--- a/shared/output/gapic/templates/vision/proto_docs/google/cloud/vision/v1/product_search.rb
+++ b/shared/output/gapic/templates/vision/proto_docs/google/cloud/vision/v1/product_search.rb
@@ -62,10 +62,10 @@ module Google
         #     Timestamp of the index which provided these results. Changes made after
         #     this time are not reflected in the current results.
         # @!attribute [rw] results
-        #   @return [Google::Cloud::Vision::V1::ProductSearchResult::Result]
+        #   @return [Google::Cloud::Vision::V1::ProductSearchResults::Result]
         #     List of results, one for each product match.
         # @!attribute [rw] product_grouped_results
-        #   @return [Google::Cloud::Vision::V1::ProductSearchResult::GroupedResult]
+        #   @return [Google::Cloud::Vision::V1::ProductSearchResults::GroupedResult]
         #     List of results grouped by products detected in the query image. Each entry
         #     corresponds to one bounding polygon in the query image, and contains the
         #     matching products specific to that region. There may be duplicate product
@@ -97,7 +97,7 @@ module Google
           #   @return [Google::Cloud::Vision::V1::BoundingPoly]
           #     The bounding polygon around the product detected in the query image.
           # @!attribute [rw] results
-          #   @return [Google::Cloud::Vision::V1::ProductSearchResult::Result]
+          #   @return [Google::Cloud::Vision::V1::ProductSearchResults::Result]
           #     List of results, one for each product match.
           class GroupedResult
             include Google::Protobuf::MessageExts

--- a/shared/output/gapic/templates/vision/proto_docs/google/protobuf/descriptor.rb
+++ b/shared/output/gapic/templates/vision/proto_docs/google/protobuf/descriptor.rb
@@ -58,7 +58,7 @@ module Google
     # @!attribute [rw] extension
     #   @return [Google::Protobuf::FieldDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::FileOption]
+    #   @return [Google::Protobuf::FileOptions]
     # @!attribute [rw] source_code_info
     #   @return [Google::Protobuf::SourceCodeInfo]
     #     This field contains optional information about the original source code.
@@ -90,7 +90,7 @@ module Google
     # @!attribute [rw] oneof_decl
     #   @return [Google::Protobuf::OneofDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::MessageOption]
+    #   @return [Google::Protobuf::MessageOptions]
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::DescriptorProto::ReservedRange]
     # @!attribute [rw] reserved_name
@@ -106,7 +106,7 @@ module Google
       # @!attribute [rw] end
       #   @return [Integer]
       # @!attribute [rw] options
-      #   @return [Google::Protobuf::ExtensionRangeOption]
+      #   @return [Google::Protobuf::ExtensionRangeOptions]
       class ExtensionRange
         include Google::Protobuf::MessageExts
         extend Google::Protobuf::MessageExts::ClassMethods
@@ -173,7 +173,7 @@ module Google
     #     will be used. Otherwise, it's deduced from the field's name by converting
     #     it to camelCase.
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::FieldOption]
+    #   @return [Google::Protobuf::FieldOptions]
     class FieldDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -241,7 +241,7 @@ module Google
     # @!attribute [rw] name
     #   @return [String]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::OneofOption]
+    #   @return [Google::Protobuf::OneofOptions]
     class OneofDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -253,7 +253,7 @@ module Google
     # @!attribute [rw] value
     #   @return [Google::Protobuf::EnumValueDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::EnumOption]
+    #   @return [Google::Protobuf::EnumOptions]
     # @!attribute [rw] reserved_range
     #   @return [Google::Protobuf::EnumDescriptorProto::EnumReservedRange]
     #     Range of reserved numeric values. Reserved numeric values may not be used
@@ -289,7 +289,7 @@ module Google
     # @!attribute [rw] number
     #   @return [Integer]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::EnumValueOption]
+    #   @return [Google::Protobuf::EnumValueOptions]
     class EnumValueDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -301,7 +301,7 @@ module Google
     # @!attribute [rw] method
     #   @return [Google::Protobuf::MethodDescriptorProto]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::ServiceOption]
+    #   @return [Google::Protobuf::ServiceOptions]
     class ServiceDescriptorProto
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods
@@ -317,7 +317,7 @@ module Google
     # @!attribute [rw] output_type
     #   @return [String]
     # @!attribute [rw] options
-    #   @return [Google::Protobuf::MethodOption]
+    #   @return [Google::Protobuf::MethodOptions]
     # @!attribute [rw] client_streaming
     #   @return [Boolean]
     #     Identifies if client streams multiple client messages


### PR DESCRIPTION
Switch to using `camelize` instead of `classify`, which was singularizing the names.