### PR TITLE
Use new Gax Protobuf.coerce API

### DIFF
--- a/gapic-generator/templates/default/service/client/method/def/_bidi.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_bidi.erb
@@ -31,7 +31,7 @@ def <%= method.name %> requests, options: nil, &block
   end
 
   requests = requests.lazy.map do |request|
-    Google::Gax.to_proto request, <%= method.request_type %>
+    Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
   end
 
   <%= indent render(partial: "service/client/method/def/options_defaults", locals: { method: method }), 2 %>

--- a/gapic-generator/templates/default/service/client/method/def/_client.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_client.erb
@@ -30,7 +30,7 @@ def <%= method.name %> requests, options: nil, &block
   end
 
   requests = requests.lazy.map do |request|
-    Google::Gax.to_proto request, <%= method.request_type %>
+    Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
   end
 
   <%= indent render(partial: "service/client/method/def/options_defaults", locals: { method: method }), 2 %>

--- a/gapic-generator/templates/default/service/client/method/def/_lro.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_lro.erb
@@ -47,7 +47,7 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   end
 
   request ||= request_fields
-  request = Google::Gax.to_proto request, <%= method.request_type %>
+  request = Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
 
   <%= indent render(partial: "service/client/method/def/options_defaults", locals: { method: method }), 2 %>
 

--- a/gapic-generator/templates/default/service/client/method/def/_normal.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_normal.erb
@@ -47,7 +47,7 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   end
 
   request ||= request_fields
-  request = Google::Gax.to_proto request, <%= method.request_type %>
+  request = Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
 
   <%= indent render(partial: "service/client/method/def/options_defaults", locals: { method: method }), 2 %>
 

--- a/gapic-generator/templates/default/service/client/method/def/_paged.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_paged.erb
@@ -47,7 +47,7 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   end
 
   request ||= request_fields
-  request = Google::Gax.to_proto request, <%= method.request_type %>
+  request = Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
 
   <%= indent render(partial: "service/client/method/def/options_defaults", locals: { method: method }), 2 %>
 

--- a/gapic-generator/templates/default/service/client/method/def/_server.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_server.erb
@@ -50,7 +50,7 @@ def <%= method.name %> request = nil, options: nil, **request_fields, &block
   end
 
   request ||= request_fields
-  request = Google::Gax.to_proto request, <%= method.request_type %>
+  request = Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>
 
   <%= indent render(partial: "service/client/method/def/options_defaults", locals: { method: method }), 2 %>
 

--- a/gapic-generator/templates/default/service/test/method/_bidi.erb
+++ b/gapic-generator/templates/default/service/test/method/_bidi.erb
@@ -10,8 +10,7 @@ describe "<%= method.name %>" do
 
     # Create expected grpc response
     expected_response = {}
-    expected_response = Google::Gax.to_proto expected_response,
-                                             <%= method.return_type %>
+    expected_response = Google::Gax::Protobuf.coerce expected_response, to: <%= method.return_type %>
 
     # Mock Grpc layer
     mock_method = proc do |requests|

--- a/gapic-generator/templates/default/service/test/method/_client.erb
+++ b/gapic-generator/templates/default/service/test/method/_client.erb
@@ -10,8 +10,7 @@ describe "<%= method.name %>" do
 
     # Create expected grpc response
     expected_response = {}
-    expected_response = Google::Gax.to_proto expected_response,
-                                             <%= method.return_type %>
+    expected_response = Google::Gax::Protobuf.coerce expected_response, to: <%= method.return_type %>
 
     # Mock Grpc layer
     mock_method = proc do |requests|

--- a/gapic-generator/templates/default/service/test/method/_lro.erb
+++ b/gapic-generator/templates/default/service/test/method/_lro.erb
@@ -9,8 +9,7 @@ describe "<%= method.name %>" do
 
     # Create expected grpc response
     expected_response = {}
-    expected_response = Google::Gax.to_proto expected_response,
-                                             <%= method.return_type %>
+    expected_response = Google::Gax::Protobuf.coerce expected_response, to: <%= method.return_type %>
     result = Google::Protobuf::Any.new
     result.pack expected_response
     operation = Google::Longrunning::Operation.new(
@@ -23,7 +22,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Google::Gax.to_proto(<%= field.name %>, <%= field.type_name_full %>), request.<%= field.name %>
+      assert_equal Google::Gax::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
 <%- end -%>
       OpenStruct.new execute: operation
     end
@@ -62,7 +61,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Google::Gax.to_proto(<%= field.name %>, <%= field.type_name_full %>), request.<%= field.name %>
+      assert_equal Google::Gax::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
 <%- end -%>
       OpenStruct.new execute: operation
     end
@@ -92,7 +91,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Google::Gax.to_proto(<%= field.name %>, <%= field.type_name_full %>), request.<%= field.name %>
+      assert_equal Google::Gax::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
 <%- end -%>
       raise custom_error
     end

--- a/gapic-generator/templates/default/service/test/method/_normal.erb
+++ b/gapic-generator/templates/default/service/test/method/_normal.erb
@@ -9,14 +9,13 @@ describe "<%= method.name %>" do
 
     # Create expected grpc response
     expected_response = {}
-    expected_response = Google::Gax.to_proto expected_response,
-                                             <%= method.return_type %>
+    expected_response = Google::Gax::Protobuf.coerce expected_response, to: <%= method.return_type %>
 
     # Mock Grpc layer
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Google::Gax.to_proto(<%= field.name %>, <%= field.type_name_full %>), request.<%= field.name %>
+      assert_equal Google::Gax::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
 <%- end -%>
       OpenStruct.new execute: expected_response
     end
@@ -52,7 +51,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Google::Gax.to_proto(<%= field.name %>, <%= field.type_name_full %>), request.<%= field.name %>
+      assert_equal Google::Gax::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
 <%- end -%>
       raise custom_error
     end

--- a/gapic-generator/templates/default/service/test/method/_paged.erb
+++ b/gapic-generator/templates/default/service/test/method/_paged.erb
@@ -9,14 +9,13 @@ describe "<%= method.name %>" do
 
     # Create expected grpc response
     expected_response = {}
-    expected_response = Google::Gax.to_proto expected_response,
-                                             <%= method.return_type %>
+    expected_response = Google::Gax::Protobuf.coerce expected_response, to: <%= method.return_type %>
 
     # Mock Grpc layer
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Google::Gax.to_proto(<%= field.name %>, <%= field.type_name_full %>), request.<%= field.name %>
+      assert_equal Google::Gax::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
 <%- end -%>
       OpenStruct.new execute: expected_response
     end
@@ -52,7 +51,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Google::Gax.to_proto(<%= field.name %>, <%= field.type_name_full %>), request.<%= field.name %>
+      assert_equal Google::Gax::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
 <%- end -%>
       raise custom_error
     end

--- a/gapic-generator/templates/default/service/test/method/_server.erb
+++ b/gapic-generator/templates/default/service/test/method/_server.erb
@@ -9,14 +9,13 @@ describe "<%= method.name %>" do
 
     # Create expected grpc response
     expected_response = {}
-    expected_response = Google::Gax.to_proto expected_response,
-                                             <%= method.return_type %>
+    expected_response = Google::Gax::Protobuf.coerce expected_response, to: <%= method.return_type %>
 
     # Mock Grpc layer
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Google::Gax.to_proto(<%= field.name %>, <%= field.type_name_full %>), request.<%= field.name %>
+      assert_equal Google::Gax::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
 <%- end -%>
       OpenStruct.new execute: expected_response
     end
@@ -46,7 +45,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Google::Gax.to_proto(<%= field.name %>, <%= field.type_name_full %>), request.<%= field.name %>
+      assert_equal Google::Gax::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
 <%- end -%>
       raise custom_error
     end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -153,7 +153,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::EchoRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -204,7 +204,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ExpandRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ExpandRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -248,7 +248,7 @@ module Google
             end
 
             requests = requests.lazy.map do |request|
-              Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
+              Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::EchoRequest
             end
 
             # Converts hash and nil to an options object
@@ -294,7 +294,7 @@ module Google
             end
 
             requests = requests.lazy.map do |request|
-              Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
+              Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::EchoRequest
             end
 
             # Converts hash and nil to an options object
@@ -345,7 +345,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::PagedExpandRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::PagedExpandRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -401,7 +401,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::WaitRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::WaitRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -139,7 +139,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::ListOperationsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -194,7 +194,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::GetOperationRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -250,7 +250,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::DeleteOperationRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -316,7 +316,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::CancelOperationRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -145,7 +145,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateUserRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateUserRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -189,7 +189,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetUserRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetUserRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -240,7 +240,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateUserRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateUserRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -288,7 +288,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteUserRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteUserRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -341,7 +341,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListUsersRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListUsersRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -154,7 +154,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateRoomRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateRoomRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -198,7 +198,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetRoomRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetRoomRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -249,7 +249,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateRoomRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateRoomRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -297,7 +297,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteRoomRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteRoomRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -350,7 +350,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListRoomsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListRoomsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -404,7 +404,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateBlurbRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -452,7 +452,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetBlurbRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetBlurbRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -503,7 +503,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateBlurbRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateBlurbRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -551,7 +551,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteBlurbRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteBlurbRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -609,7 +609,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListBlurbsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListBlurbsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -677,7 +677,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::SearchBlurbsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::SearchBlurbsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -734,7 +734,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::StreamBlurbsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::StreamBlurbsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -781,7 +781,7 @@ module Google
             end
 
             requests = requests.lazy.map do |request|
-              Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
+              Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateBlurbRequest
             end
 
             # Converts hash and nil to an options object
@@ -832,7 +832,7 @@ module Google
             end
 
             requests = requests.lazy.map do |request|
-              Google::Gax.to_proto request, Google::Showcase::V1alpha3::ConnectRequest
+              Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ConnectRequest
             end
 
             # Converts hash and nil to an options object

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -139,7 +139,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::ListOperationsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -194,7 +194,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::GetOperationRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -250,7 +250,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::DeleteOperationRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -316,7 +316,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::CancelOperationRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -147,7 +147,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateSessionRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateSessionRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -191,7 +191,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetSessionRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetSessionRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -241,7 +241,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListSessionsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListSessionsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -288,7 +288,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteSessionRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteSessionRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -340,7 +340,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ReportSessionRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ReportSessionRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -392,7 +392,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListTestsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListTestsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -453,7 +453,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteTestRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteTestRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -511,7 +511,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::VerifyTestRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::VerifyTestRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/cloud/showcase/test/google/showcase/v1alpha3/echo_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1alpha3/echo_test.rb
@@ -75,14 +75,13 @@ describe Google::Showcase::V1alpha3::Echo::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::EchoResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::EchoRequest, request
-        assert_equal Google::Gax.to_proto(content), request.content
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(content, to: ), request.content
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :echo, mock_method
@@ -118,8 +117,8 @@ describe Google::Showcase::V1alpha3::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::EchoRequest, request
-        assert_equal Google::Gax.to_proto(content), request.content
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(content, to: ), request.content
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :echo, mock_method
@@ -155,14 +154,13 @@ describe Google::Showcase::V1alpha3::Echo::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::EchoResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ExpandRequest, request
-        assert_equal Google::Gax.to_proto(content), request.content
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(content, to: ), request.content
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :expand, mock_method
@@ -192,8 +190,8 @@ describe Google::Showcase::V1alpha3::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ExpandRequest, request
-        assert_equal Google::Gax.to_proto(content), request.content
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(content, to: ), request.content
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :expand, mock_method
@@ -228,8 +226,7 @@ describe Google::Showcase::V1alpha3::Echo::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::EchoResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -292,8 +289,7 @@ describe Google::Showcase::V1alpha3::Echo::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::EchoResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -359,15 +355,14 @@ describe Google::Showcase::V1alpha3::Echo::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::PagedExpandResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::PagedExpandResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::PagedExpandRequest, request
-        assert_equal Google::Gax.to_proto(content), request.content
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(content, to: ), request.content
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
@@ -404,9 +399,9 @@ describe Google::Showcase::V1alpha3::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::PagedExpandRequest, request
-        assert_equal Google::Gax.to_proto(content), request.content
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(content, to: ), request.content
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
@@ -436,31 +431,30 @@ describe Google::Showcase::V1alpha3::Echo::Client do
     end
 
     it "invokes wait without error" do
-      # Create request parameters
-      end_time = {}
-      ttl = {}
-      error = {}
-      success = {}
+    # Create request parameters
+    end_time = {}
+    ttl = {}
+    error = {}
+    success = {}
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Longrunning::Operation
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name:     "operations/wait_test",
-        done:     true,
+        name: "operations/wait_test",
+        done: true,
         response: result
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::WaitRequest, request
-        assert_equal Google::Gax.to_proto(end_time, Google::Protobuf::Timestamp), request.end_time
-        assert_equal Google::Gax.to_proto(ttl, Google::Protobuf::Duration), request.ttl
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
-        assert_equal Google::Gax.to_proto(success, Google::Showcase::V1alpha3::WaitResponse), request.success
+        assert_equal Google::Gax::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+        assert_equal Google::Gax::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(success, to: Google::Showcase::V1alpha3::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -482,29 +476,29 @@ describe Google::Showcase::V1alpha3::Echo::Client do
     end
 
     it "invokes wait and returns an operation error." do
-      # Create request parameters
-      end_time = {}
-      ttl = {}
-      error = {}
-      success = {}
+    # Create request parameters
+    end_time = {}
+    ttl = {}
+    error = {}
+    success = {}
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
         message: "Operation error for Google::Showcase::V1alpha3::Echo::Client#wait."
       )
       operation = Google::Longrunning::Operation.new(
-        name:  "operations/wait_test",
-        done:  true,
+        name: "operations/wait_test",
+        done: true,
         error: operation_error
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::WaitRequest, request
-        assert_equal Google::Gax.to_proto(end_time, Google::Protobuf::Timestamp), request.end_time
-        assert_equal Google::Gax.to_proto(ttl, Google::Protobuf::Duration), request.ttl
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
-        assert_equal Google::Gax.to_proto(success, Google::Showcase::V1alpha3::WaitResponse), request.success
+        assert_equal Google::Gax::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+        assert_equal Google::Gax::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(success, to: Google::Showcase::V1alpha3::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -527,19 +521,19 @@ describe Google::Showcase::V1alpha3::Echo::Client do
     end
 
     it "invokes wait with error" do
-      # Create request parameters
-      end_time = {}
-      ttl = {}
-      error = {}
-      success = {}
+    # Create request parameters
+    end_time = {}
+    ttl = {}
+    error = {}
+    success = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::WaitRequest, request
-        assert_equal Google::Gax.to_proto(end_time, Google::Protobuf::Timestamp), request.end_time
-        assert_equal Google::Gax.to_proto(ttl, Google::Protobuf::Duration), request.ttl
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
-        assert_equal Google::Gax.to_proto(success, Google::Showcase::V1alpha3::WaitResponse), request.success
+        assert_equal Google::Gax::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+        assert_equal Google::Gax::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(success, to: Google::Showcase::V1alpha3::WaitResponse), request.success
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method

--- a/shared/output/cloud/showcase/test/google/showcase/v1alpha3/identity_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1alpha3/identity_test.rb
@@ -74,13 +74,12 @@ describe Google::Showcase::V1alpha3::Identity::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::User
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::User
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateUserRequest, request
-        assert_equal Google::Gax.to_proto(user, Google::Showcase::V1alpha3::User), request.user
+        assert_equal Google::Gax::Protobuf.coerce(user, to: Google::Showcase::V1alpha3::User), request.user
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
@@ -115,7 +114,7 @@ describe Google::Showcase::V1alpha3::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateUserRequest, request
-        assert_equal Google::Gax.to_proto(user, Google::Showcase::V1alpha3::User), request.user
+        assert_equal Google::Gax::Protobuf.coerce(user, to: Google::Showcase::V1alpha3::User), request.user
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
@@ -150,13 +149,12 @@ describe Google::Showcase::V1alpha3::Identity::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::User
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::User
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetUserRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
@@ -191,7 +189,7 @@ describe Google::Showcase::V1alpha3::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetUserRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
@@ -227,14 +225,13 @@ describe Google::Showcase::V1alpha3::Identity::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::User
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::User
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::UpdateUserRequest, request
-        assert_equal Google::Gax.to_proto(user, Google::Showcase::V1alpha3::User), request.user
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(user, to: Google::Showcase::V1alpha3::User), request.user
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
@@ -270,8 +267,8 @@ describe Google::Showcase::V1alpha3::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::UpdateUserRequest, request
-        assert_equal Google::Gax.to_proto(user, Google::Showcase::V1alpha3::User), request.user
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(user, to: Google::Showcase::V1alpha3::User), request.user
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
@@ -306,13 +303,12 @@ describe Google::Showcase::V1alpha3::Identity::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteUserRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
@@ -347,7 +343,7 @@ describe Google::Showcase::V1alpha3::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteUserRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
@@ -383,14 +379,13 @@ describe Google::Showcase::V1alpha3::Identity::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::ListUsersResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::ListUsersResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListUsersRequest, request
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_users, mock_method
@@ -426,8 +421,8 @@ describe Google::Showcase::V1alpha3::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListUsersRequest, request
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_users, mock_method

--- a/shared/output/cloud/showcase/test/google/showcase/v1alpha3/messaging_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1alpha3/messaging_test.rb
@@ -74,13 +74,12 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Room
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Room
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateRoomRequest, request
-        assert_equal Google::Gax.to_proto(room, Google::Showcase::V1alpha3::Room), request.room
+        assert_equal Google::Gax::Protobuf.coerce(room, to: Google::Showcase::V1alpha3::Room), request.room
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
@@ -115,7 +114,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateRoomRequest, request
-        assert_equal Google::Gax.to_proto(room, Google::Showcase::V1alpha3::Room), request.room
+        assert_equal Google::Gax::Protobuf.coerce(room, to: Google::Showcase::V1alpha3::Room), request.room
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
@@ -150,13 +149,12 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Room
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Room
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetRoomRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
@@ -191,7 +189,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetRoomRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
@@ -227,14 +225,13 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Room
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Room
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::UpdateRoomRequest, request
-        assert_equal Google::Gax.to_proto(room, Google::Showcase::V1alpha3::Room), request.room
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(room, to: Google::Showcase::V1alpha3::Room), request.room
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
@@ -270,8 +267,8 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::UpdateRoomRequest, request
-        assert_equal Google::Gax.to_proto(room, Google::Showcase::V1alpha3::Room), request.room
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(room, to: Google::Showcase::V1alpha3::Room), request.room
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
@@ -306,13 +303,12 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteRoomRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
@@ -347,7 +343,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteRoomRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
@@ -383,14 +379,13 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::ListRoomsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::ListRoomsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListRoomsRequest, request
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
@@ -426,8 +421,8 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListRoomsRequest, request
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
@@ -463,14 +458,13 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Blurb
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Blurb
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateBlurbRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(blurb, Google::Showcase::V1alpha3::Blurb), request.blurb
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(blurb, to: Google::Showcase::V1alpha3::Blurb), request.blurb
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
@@ -506,8 +500,8 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateBlurbRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(blurb, Google::Showcase::V1alpha3::Blurb), request.blurb
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(blurb, to: Google::Showcase::V1alpha3::Blurb), request.blurb
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
@@ -542,13 +536,12 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Blurb
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Blurb
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetBlurbRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
@@ -583,7 +576,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetBlurbRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
@@ -619,14 +612,13 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Blurb
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Blurb
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::UpdateBlurbRequest, request
-        assert_equal Google::Gax.to_proto(blurb, Google::Showcase::V1alpha3::Blurb), request.blurb
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(blurb, to: Google::Showcase::V1alpha3::Blurb), request.blurb
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
@@ -662,8 +654,8 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::UpdateBlurbRequest, request
-        assert_equal Google::Gax.to_proto(blurb, Google::Showcase::V1alpha3::Blurb), request.blurb
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(blurb, to: Google::Showcase::V1alpha3::Blurb), request.blurb
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
@@ -698,13 +690,12 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteBlurbRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
@@ -739,7 +730,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteBlurbRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
@@ -776,15 +767,14 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::ListBlurbsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::ListBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
@@ -821,9 +811,9 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
@@ -853,31 +843,30 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
     end
 
     it "invokes search_blurbs without error" do
-      # Create request parameters
-      query = "hello world"
-      parent = "hello world"
-      page_size = 42
-      page_token = "hello world"
+    # Create request parameters
+    query = "hello world"
+    parent = "hello world"
+    page_size = 42
+    page_token = "hello world"
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Longrunning::Operation
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name:     "operations/search_blurbs_test",
-        done:     true,
+        name: "operations/search_blurbs_test",
+        done: true,
         response: result
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::SearchBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(query), request.query
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(query, to: ), request.query
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -899,29 +888,29 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
     end
 
     it "invokes search_blurbs and returns an operation error." do
-      # Create request parameters
-      query = "hello world"
-      parent = "hello world"
-      page_size = 42
-      page_token = "hello world"
+    # Create request parameters
+    query = "hello world"
+    parent = "hello world"
+    page_size = 42
+    page_token = "hello world"
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
         message: "Operation error for Google::Showcase::V1alpha3::Messaging::Client#search_blurbs."
       )
       operation = Google::Longrunning::Operation.new(
-        name:  "operations/search_blurbs_test",
-        done:  true,
+        name: "operations/search_blurbs_test",
+        done: true,
         error: operation_error
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::SearchBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(query), request.query
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(query, to: ), request.query
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -944,19 +933,19 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
     end
 
     it "invokes search_blurbs with error" do
-      # Create request parameters
-      query = "hello world"
-      parent = "hello world"
-      page_size = 42
-      page_token = "hello world"
+    # Create request parameters
+    query = "hello world"
+    parent = "hello world"
+    page_size = 42
+    page_token = "hello world"
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::SearchBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(query), request.query
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(query, to: ), request.query
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -992,14 +981,13 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::StreamBlurbsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::StreamBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::StreamBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(expire_time, Google::Protobuf::Timestamp), request.expire_time
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :stream_blurbs, mock_method
@@ -1029,8 +1017,8 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::StreamBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(expire_time, Google::Protobuf::Timestamp), request.expire_time
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :stream_blurbs, mock_method
@@ -1065,8 +1053,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::SendBlurbsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::SendBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -1129,8 +1116,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::StreamBlurbsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::StreamBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|

--- a/shared/output/cloud/showcase/test/google/showcase/v1alpha3/testing_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1alpha3/testing_test.rb
@@ -74,13 +74,12 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Session
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Session
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateSessionRequest, request
-        assert_equal Google::Gax.to_proto(session, Google::Showcase::V1alpha3::Session), request.session
+        assert_equal Google::Gax::Protobuf.coerce(session, to: Google::Showcase::V1alpha3::Session), request.session
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
@@ -115,7 +114,7 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateSessionRequest, request
-        assert_equal Google::Gax.to_proto(session, Google::Showcase::V1alpha3::Session), request.session
+        assert_equal Google::Gax::Protobuf.coerce(session, to: Google::Showcase::V1alpha3::Session), request.session
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
@@ -150,13 +149,12 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Session
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Session
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetSessionRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
@@ -191,7 +189,7 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetSessionRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
@@ -227,14 +225,13 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::ListSessionsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::ListSessionsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListSessionsRequest, request
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
@@ -270,8 +267,8 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListSessionsRequest, request
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
@@ -306,13 +303,12 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteSessionRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
@@ -347,7 +343,7 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteSessionRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
@@ -382,13 +378,12 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::ReportSessionResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::ReportSessionResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ReportSessionRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
@@ -423,7 +418,7 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ReportSessionRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
@@ -460,15 +455,14 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::ListTestsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::ListTestsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListTestsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
@@ -505,9 +499,9 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListTestsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
@@ -542,13 +536,12 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteTestRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
@@ -583,7 +576,7 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteTestRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
@@ -620,15 +613,14 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::VerifyTestResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::VerifyTestResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::VerifyTestRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(answer), request.answer
-        assert_equal Google::Gax.to_proto(answers), request.answers
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(answer, to: ), request.answer
+        assert_equal Google::Gax::Protobuf.coerce(answers, to: ), request.answers
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method
@@ -665,9 +657,9 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::VerifyTestRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(answer), request.answer
-        assert_equal Google::Gax.to_proto(answers), request.answers
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(answer, to: ), request.answer
+        assert_equal Google::Gax::Protobuf.coerce(answers, to: ), request.answers
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -157,7 +157,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Speech::V1::RecognizeRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::RecognizeRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -210,7 +210,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Speech::V1::LongRunningRecognizeRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::LongRunningRecognizeRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -256,7 +256,7 @@ module Google
               end
 
               requests = requests.lazy.map do |request|
-                Google::Gax.to_proto request, Google::Cloud::Speech::V1::StreamingRecognizeRequest
+                Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::StreamingRecognizeRequest
               end
 
               # Converts hash and nil to an options object

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -140,7 +140,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::ListOperationsRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -195,7 +195,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::GetOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -251,7 +251,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::DeleteOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -317,7 +317,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::CancelOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
@@ -75,14 +75,13 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Speech::V1::RecognizeResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Speech::V1::RecognizeResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::RecognizeRequest, request
-        assert_equal Google::Gax.to_proto(config, Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Google::Gax.to_proto(audio, Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Google::Gax::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Google::Gax::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
@@ -118,8 +117,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::RecognizeRequest, request
-        assert_equal Google::Gax.to_proto(config, Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Google::Gax.to_proto(audio, Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Google::Gax::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Google::Gax::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
@@ -155,8 +154,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Longrunning::Operation
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -168,8 +166,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-        assert_equal Google::Gax.to_proto(config, Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Google::Gax.to_proto(audio, Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Google::Gax::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Google::Gax::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -208,8 +206,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-        assert_equal Google::Gax.to_proto(config, Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Google::Gax.to_proto(audio, Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Google::Gax::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Google::Gax::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -239,8 +237,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-        assert_equal Google::Gax.to_proto(config, Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Google::Gax.to_proto(audio, Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Google::Gax::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Google::Gax::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -275,8 +273,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Speech::V1::StreamingRecognizeResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Speech::V1::StreamingRecognizeResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -152,7 +152,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -206,7 +206,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -140,7 +140,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::ListOperationsRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -195,7 +195,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::GetOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -251,7 +251,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::DeleteOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -317,7 +317,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::CancelOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -171,7 +171,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -235,7 +235,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductSetsRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductSetsRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -297,7 +297,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -364,7 +364,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::UpdateProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -429,7 +429,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -501,7 +501,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateProductRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -564,7 +564,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductsRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -626,7 +626,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetProductRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -709,7 +709,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::UpdateProductRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -776,7 +776,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteProductRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -871,7 +871,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateReferenceImageRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateReferenceImageRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -943,7 +943,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteReferenceImageRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteReferenceImageRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -1013,7 +1013,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListReferenceImagesRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListReferenceImagesRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -1076,7 +1076,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetReferenceImageRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetReferenceImageRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -1146,7 +1146,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::AddProductToProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AddProductToProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -1210,7 +1210,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -1277,7 +1277,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductsInProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsInProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -1352,7 +1352,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ImportProductSetsRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ImportProductSetsRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -140,7 +140,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::ListOperationsRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -195,7 +195,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::GetOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -251,7 +251,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::DeleteOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -317,7 +317,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::CancelOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -74,13 +74,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::BatchAnnotateImagesResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::BatchAnnotateImagesResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateImagesRequest, request
-        assert_equal Google::Gax.to_proto(requests, Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal Google::Gax::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
@@ -115,7 +114,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateImagesRequest, request
-        assert_equal Google::Gax.to_proto(requests, Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal Google::Gax::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
@@ -150,8 +149,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Longrunning::Operation
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -163,7 +161,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-        assert_equal Google::Gax.to_proto(requests, Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+        assert_equal Google::Gax::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
@@ -201,7 +199,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-        assert_equal Google::Gax.to_proto(requests, Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+        assert_equal Google::Gax::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
@@ -230,7 +228,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-        assert_equal Google::Gax.to_proto(requests, Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+        assert_equal Google::Gax::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
@@ -76,15 +76,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ProductSet
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ProductSet
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductSetRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(product_set, Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Google::Gax.to_proto(product_set_id), request.product_set_id
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal Google::Gax::Protobuf.coerce(product_set_id, to: ), request.product_set_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
@@ -121,9 +120,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductSetRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(product_set, Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Google::Gax.to_proto(product_set_id), request.product_set_id
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal Google::Gax::Protobuf.coerce(product_set_id, to: ), request.product_set_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
@@ -160,15 +159,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ListProductSetsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListProductSetsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductSetsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
@@ -205,9 +203,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductSetsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
@@ -242,13 +240,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ProductSet
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ProductSet
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
@@ -283,7 +280,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
@@ -319,14 +316,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ProductSet
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ProductSet
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductSetRequest, request
-        assert_equal Google::Gax.to_proto(product_set, Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
@@ -362,8 +358,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductSetRequest, request
-        assert_equal Google::Gax.to_proto(product_set, Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
@@ -398,13 +394,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
@@ -439,7 +434,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
@@ -476,15 +471,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::Product
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::Product
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(product, Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Google::Gax.to_proto(product_id), request.product_id
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(product_id, to: ), request.product_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
@@ -521,9 +515,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(product, Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Google::Gax.to_proto(product_id), request.product_id
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(product_id, to: ), request.product_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
@@ -560,15 +554,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ListProductsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListProductsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
@@ -605,9 +598,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
@@ -642,13 +635,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::Product
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::Product
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
@@ -683,7 +675,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
@@ -719,14 +711,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::Product
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::Product
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductRequest, request
-        assert_equal Google::Gax.to_proto(product, Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
@@ -762,8 +753,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductRequest, request
-        assert_equal Google::Gax.to_proto(product, Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
@@ -798,13 +789,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
@@ -839,7 +829,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
@@ -876,15 +866,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ReferenceImage
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ReferenceImage
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateReferenceImageRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(reference_image, Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
-        assert_equal Google::Gax.to_proto(reference_image_id), request.reference_image_id
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
+        assert_equal Google::Gax::Protobuf.coerce(reference_image_id, to: ), request.reference_image_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
@@ -921,9 +910,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateReferenceImageRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(reference_image, Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
-        assert_equal Google::Gax.to_proto(reference_image_id), request.reference_image_id
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
+        assert_equal Google::Gax::Protobuf.coerce(reference_image_id, to: ), request.reference_image_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
@@ -958,13 +947,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteReferenceImageRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
@@ -999,7 +987,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteReferenceImageRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
@@ -1036,15 +1024,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ListReferenceImagesResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListReferenceImagesResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListReferenceImagesRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
@@ -1081,9 +1068,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListReferenceImagesRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
@@ -1118,13 +1105,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ReferenceImage
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ReferenceImage
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetReferenceImageRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
@@ -1159,7 +1145,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetReferenceImageRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
@@ -1195,14 +1181,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AddProductToProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(product, to: ), request.product
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
@@ -1238,8 +1223,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AddProductToProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(product, to: ), request.product
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
@@ -1275,14 +1260,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(product, to: ), request.product
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
@@ -1318,8 +1302,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(product, to: ), request.product
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
@@ -1356,15 +1340,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ListProductsInProductSetResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListProductsInProductSetResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsInProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
@@ -1401,9 +1384,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsInProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
@@ -1433,27 +1416,26 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
     end
 
     it "invokes import_product_sets without error" do
-      # Create request parameters
-      parent = "hello world"
-      input_config = {}
+    # Create request parameters
+    parent = "hello world"
+    input_config = {}
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Longrunning::Operation
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name:     "operations/import_product_sets_test",
-        done:     true,
+        name: "operations/import_product_sets_test",
+        done: true,
         response: result
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(input_config, Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1475,25 +1457,25 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
     end
 
     it "invokes import_product_sets and returns an operation error." do
-      # Create request parameters
-      parent = "hello world"
-      input_config = {}
+    # Create request parameters
+    parent = "hello world"
+    input_config = {}
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
         message: "Operation error for Google::Cloud::Vision::V1::ProductSearch::Client#import_product_sets."
       )
       operation = Google::Longrunning::Operation.new(
-        name:  "operations/import_product_sets_test",
-        done:  true,
+        name: "operations/import_product_sets_test",
+        done: true,
         error: operation_error
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(input_config, Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1516,15 +1498,15 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
     end
 
     it "invokes import_product_sets with error" do
-      # Create request parameters
-      parent = "hello world"
-      input_config = {}
+    # Create request parameters
+    parent = "hello world"
+    input_config = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(input_config, Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -161,7 +161,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::EchoRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -212,7 +212,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ExpandRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ExpandRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -256,7 +256,7 @@ module Google
             end
 
             requests = requests.lazy.map do |request|
-              Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
+              Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::EchoRequest
             end
 
             # Converts hash and nil to an options object
@@ -302,7 +302,7 @@ module Google
             end
 
             requests = requests.lazy.map do |request|
-              Google::Gax.to_proto request, Google::Showcase::V1alpha3::EchoRequest
+              Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::EchoRequest
             end
 
             # Converts hash and nil to an options object
@@ -353,7 +353,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::PagedExpandRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::PagedExpandRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -409,7 +409,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::WaitRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::WaitRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -147,7 +147,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::ListOperationsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -202,7 +202,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::GetOperationRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -258,7 +258,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::DeleteOperationRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -324,7 +324,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::CancelOperationRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -153,7 +153,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateUserRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateUserRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -197,7 +197,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetUserRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetUserRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -248,7 +248,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateUserRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateUserRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -296,7 +296,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteUserRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteUserRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -349,7 +349,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListUsersRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListUsersRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -162,7 +162,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateRoomRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateRoomRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -206,7 +206,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetRoomRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetRoomRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -257,7 +257,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateRoomRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateRoomRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -305,7 +305,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteRoomRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteRoomRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -358,7 +358,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListRoomsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListRoomsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -412,7 +412,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateBlurbRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -460,7 +460,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetBlurbRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetBlurbRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -511,7 +511,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::UpdateBlurbRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateBlurbRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -559,7 +559,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteBlurbRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteBlurbRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -617,7 +617,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListBlurbsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListBlurbsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -685,7 +685,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::SearchBlurbsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::SearchBlurbsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -742,7 +742,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::StreamBlurbsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::StreamBlurbsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -789,7 +789,7 @@ module Google
             end
 
             requests = requests.lazy.map do |request|
-              Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateBlurbRequest
+              Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateBlurbRequest
             end
 
             # Converts hash and nil to an options object
@@ -840,7 +840,7 @@ module Google
             end
 
             requests = requests.lazy.map do |request|
-              Google::Gax.to_proto request, Google::Showcase::V1alpha3::ConnectRequest
+              Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ConnectRequest
             end
 
             # Converts hash and nil to an options object

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -147,7 +147,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::ListOperationsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -202,7 +202,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::GetOperationRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -258,7 +258,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::DeleteOperationRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -324,7 +324,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Longrunning::CancelOperationRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -155,7 +155,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::CreateSessionRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateSessionRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -199,7 +199,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::GetSessionRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetSessionRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -249,7 +249,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListSessionsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListSessionsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -296,7 +296,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteSessionRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteSessionRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -348,7 +348,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ReportSessionRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ReportSessionRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -400,7 +400,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::ListTestsRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListTestsRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -461,7 +461,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::DeleteTestRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteTestRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -519,7 +519,7 @@ module Google
             end
 
             request ||= request_fields
-            request = Google::Gax.to_proto request, Google::Showcase::V1alpha3::VerifyTestRequest
+            request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::VerifyTestRequest
 
             # Converts hash and nil to an options object
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1alpha3/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1alpha3/echo_test.rb
@@ -83,14 +83,13 @@ describe Google::Showcase::V1alpha3::Echo::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::EchoResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::EchoRequest, request
-        assert_equal Google::Gax.to_proto(content), request.content
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(content, to: ), request.content
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :echo, mock_method
@@ -126,8 +125,8 @@ describe Google::Showcase::V1alpha3::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::EchoRequest, request
-        assert_equal Google::Gax.to_proto(content), request.content
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(content, to: ), request.content
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :echo, mock_method
@@ -163,14 +162,13 @@ describe Google::Showcase::V1alpha3::Echo::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::EchoResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ExpandRequest, request
-        assert_equal Google::Gax.to_proto(content), request.content
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(content, to: ), request.content
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :expand, mock_method
@@ -200,8 +198,8 @@ describe Google::Showcase::V1alpha3::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ExpandRequest, request
-        assert_equal Google::Gax.to_proto(content), request.content
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(content, to: ), request.content
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :expand, mock_method
@@ -236,8 +234,7 @@ describe Google::Showcase::V1alpha3::Echo::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::EchoResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -300,8 +297,7 @@ describe Google::Showcase::V1alpha3::Echo::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::EchoResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -367,15 +363,14 @@ describe Google::Showcase::V1alpha3::Echo::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::PagedExpandResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::PagedExpandResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::PagedExpandRequest, request
-        assert_equal Google::Gax.to_proto(content), request.content
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(content, to: ), request.content
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
@@ -412,9 +407,9 @@ describe Google::Showcase::V1alpha3::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::PagedExpandRequest, request
-        assert_equal Google::Gax.to_proto(content), request.content
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(content, to: ), request.content
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
@@ -444,31 +439,30 @@ describe Google::Showcase::V1alpha3::Echo::Client do
     end
 
     it "invokes wait without error" do
-      # Create request parameters
-      end_time = {}
-      ttl = {}
-      error = {}
-      success = {}
+    # Create request parameters
+    end_time = {}
+    ttl = {}
+    error = {}
+    success = {}
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Longrunning::Operation
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name:     "operations/wait_test",
-        done:     true,
+        name: "operations/wait_test",
+        done: true,
         response: result
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::WaitRequest, request
-        assert_equal Google::Gax.to_proto(end_time, Google::Protobuf::Timestamp), request.end_time
-        assert_equal Google::Gax.to_proto(ttl, Google::Protobuf::Duration), request.ttl
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
-        assert_equal Google::Gax.to_proto(success, Google::Showcase::V1alpha3::WaitResponse), request.success
+        assert_equal Google::Gax::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+        assert_equal Google::Gax::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(success, to: Google::Showcase::V1alpha3::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -490,29 +484,29 @@ describe Google::Showcase::V1alpha3::Echo::Client do
     end
 
     it "invokes wait and returns an operation error." do
-      # Create request parameters
-      end_time = {}
-      ttl = {}
-      error = {}
-      success = {}
+    # Create request parameters
+    end_time = {}
+    ttl = {}
+    error = {}
+    success = {}
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
         message: "Operation error for Google::Showcase::V1alpha3::Echo::Client#wait."
       )
       operation = Google::Longrunning::Operation.new(
-        name:  "operations/wait_test",
-        done:  true,
+        name: "operations/wait_test",
+        done: true,
         error: operation_error
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::WaitRequest, request
-        assert_equal Google::Gax.to_proto(end_time, Google::Protobuf::Timestamp), request.end_time
-        assert_equal Google::Gax.to_proto(ttl, Google::Protobuf::Duration), request.ttl
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
-        assert_equal Google::Gax.to_proto(success, Google::Showcase::V1alpha3::WaitResponse), request.success
+        assert_equal Google::Gax::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+        assert_equal Google::Gax::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(success, to: Google::Showcase::V1alpha3::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -535,19 +529,19 @@ describe Google::Showcase::V1alpha3::Echo::Client do
     end
 
     it "invokes wait with error" do
-      # Create request parameters
-      end_time = {}
-      ttl = {}
-      error = {}
-      success = {}
+    # Create request parameters
+    end_time = {}
+    ttl = {}
+    error = {}
+    success = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::WaitRequest, request
-        assert_equal Google::Gax.to_proto(end_time, Google::Protobuf::Timestamp), request.end_time
-        assert_equal Google::Gax.to_proto(ttl, Google::Protobuf::Duration), request.ttl
-        assert_equal Google::Gax.to_proto(error, Google::Rpc::Status), request.error
-        assert_equal Google::Gax.to_proto(success, Google::Showcase::V1alpha3::WaitResponse), request.success
+        assert_equal Google::Gax::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+        assert_equal Google::Gax::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+        assert_equal Google::Gax::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Google::Gax::Protobuf.coerce(success, to: Google::Showcase::V1alpha3::WaitResponse), request.success
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1alpha3/identity_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1alpha3/identity_test.rb
@@ -82,13 +82,12 @@ describe Google::Showcase::V1alpha3::Identity::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::User
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::User
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateUserRequest, request
-        assert_equal Google::Gax.to_proto(user, Google::Showcase::V1alpha3::User), request.user
+        assert_equal Google::Gax::Protobuf.coerce(user, to: Google::Showcase::V1alpha3::User), request.user
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
@@ -123,7 +122,7 @@ describe Google::Showcase::V1alpha3::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateUserRequest, request
-        assert_equal Google::Gax.to_proto(user, Google::Showcase::V1alpha3::User), request.user
+        assert_equal Google::Gax::Protobuf.coerce(user, to: Google::Showcase::V1alpha3::User), request.user
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
@@ -158,13 +157,12 @@ describe Google::Showcase::V1alpha3::Identity::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::User
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::User
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetUserRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
@@ -199,7 +197,7 @@ describe Google::Showcase::V1alpha3::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetUserRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
@@ -235,14 +233,13 @@ describe Google::Showcase::V1alpha3::Identity::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::User
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::User
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::UpdateUserRequest, request
-        assert_equal Google::Gax.to_proto(user, Google::Showcase::V1alpha3::User), request.user
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(user, to: Google::Showcase::V1alpha3::User), request.user
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
@@ -278,8 +275,8 @@ describe Google::Showcase::V1alpha3::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::UpdateUserRequest, request
-        assert_equal Google::Gax.to_proto(user, Google::Showcase::V1alpha3::User), request.user
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(user, to: Google::Showcase::V1alpha3::User), request.user
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
@@ -314,13 +311,12 @@ describe Google::Showcase::V1alpha3::Identity::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteUserRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
@@ -355,7 +351,7 @@ describe Google::Showcase::V1alpha3::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteUserRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
@@ -391,14 +387,13 @@ describe Google::Showcase::V1alpha3::Identity::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::ListUsersResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::ListUsersResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListUsersRequest, request
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_users, mock_method
@@ -434,8 +429,8 @@ describe Google::Showcase::V1alpha3::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListUsersRequest, request
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_users, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1alpha3/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1alpha3/messaging_test.rb
@@ -82,13 +82,12 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Room
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Room
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateRoomRequest, request
-        assert_equal Google::Gax.to_proto(room, Google::Showcase::V1alpha3::Room), request.room
+        assert_equal Google::Gax::Protobuf.coerce(room, to: Google::Showcase::V1alpha3::Room), request.room
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
@@ -123,7 +122,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateRoomRequest, request
-        assert_equal Google::Gax.to_proto(room, Google::Showcase::V1alpha3::Room), request.room
+        assert_equal Google::Gax::Protobuf.coerce(room, to: Google::Showcase::V1alpha3::Room), request.room
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
@@ -158,13 +157,12 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Room
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Room
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetRoomRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
@@ -199,7 +197,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetRoomRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
@@ -235,14 +233,13 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Room
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Room
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::UpdateRoomRequest, request
-        assert_equal Google::Gax.to_proto(room, Google::Showcase::V1alpha3::Room), request.room
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(room, to: Google::Showcase::V1alpha3::Room), request.room
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
@@ -278,8 +275,8 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::UpdateRoomRequest, request
-        assert_equal Google::Gax.to_proto(room, Google::Showcase::V1alpha3::Room), request.room
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(room, to: Google::Showcase::V1alpha3::Room), request.room
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
@@ -314,13 +311,12 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteRoomRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
@@ -355,7 +351,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteRoomRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
@@ -391,14 +387,13 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::ListRoomsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::ListRoomsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListRoomsRequest, request
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
@@ -434,8 +429,8 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListRoomsRequest, request
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
@@ -471,14 +466,13 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Blurb
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Blurb
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateBlurbRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(blurb, Google::Showcase::V1alpha3::Blurb), request.blurb
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(blurb, to: Google::Showcase::V1alpha3::Blurb), request.blurb
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
@@ -514,8 +508,8 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateBlurbRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(blurb, Google::Showcase::V1alpha3::Blurb), request.blurb
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(blurb, to: Google::Showcase::V1alpha3::Blurb), request.blurb
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
@@ -550,13 +544,12 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Blurb
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Blurb
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetBlurbRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
@@ -591,7 +584,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetBlurbRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
@@ -627,14 +620,13 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Blurb
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Blurb
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::UpdateBlurbRequest, request
-        assert_equal Google::Gax.to_proto(blurb, Google::Showcase::V1alpha3::Blurb), request.blurb
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(blurb, to: Google::Showcase::V1alpha3::Blurb), request.blurb
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
@@ -670,8 +662,8 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::UpdateBlurbRequest, request
-        assert_equal Google::Gax.to_proto(blurb, Google::Showcase::V1alpha3::Blurb), request.blurb
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(blurb, to: Google::Showcase::V1alpha3::Blurb), request.blurb
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
@@ -706,13 +698,12 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteBlurbRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
@@ -747,7 +738,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteBlurbRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
@@ -784,15 +775,14 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::ListBlurbsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::ListBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
@@ -829,9 +819,9 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
@@ -861,31 +851,30 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
     end
 
     it "invokes search_blurbs without error" do
-      # Create request parameters
-      query = "hello world"
-      parent = "hello world"
-      page_size = 42
-      page_token = "hello world"
+    # Create request parameters
+    query = "hello world"
+    parent = "hello world"
+    page_size = 42
+    page_token = "hello world"
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Longrunning::Operation
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name:     "operations/search_blurbs_test",
-        done:     true,
+        name: "operations/search_blurbs_test",
+        done: true,
         response: result
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::SearchBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(query), request.query
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(query, to: ), request.query
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -907,29 +896,29 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
     end
 
     it "invokes search_blurbs and returns an operation error." do
-      # Create request parameters
-      query = "hello world"
-      parent = "hello world"
-      page_size = 42
-      page_token = "hello world"
+    # Create request parameters
+    query = "hello world"
+    parent = "hello world"
+    page_size = 42
+    page_token = "hello world"
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
         message: "Operation error for Google::Showcase::V1alpha3::Messaging::Client#search_blurbs."
       )
       operation = Google::Longrunning::Operation.new(
-        name:  "operations/search_blurbs_test",
-        done:  true,
+        name: "operations/search_blurbs_test",
+        done: true,
         error: operation_error
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::SearchBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(query), request.query
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(query, to: ), request.query
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -952,19 +941,19 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
     end
 
     it "invokes search_blurbs with error" do
-      # Create request parameters
-      query = "hello world"
-      parent = "hello world"
-      page_size = 42
-      page_token = "hello world"
+    # Create request parameters
+    query = "hello world"
+    parent = "hello world"
+    page_size = 42
+    page_token = "hello world"
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::SearchBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(query), request.query
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(query, to: ), request.query
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -1000,14 +989,13 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::StreamBlurbsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::StreamBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::StreamBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(expire_time, Google::Protobuf::Timestamp), request.expire_time
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :stream_blurbs, mock_method
@@ -1037,8 +1025,8 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::StreamBlurbsRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(expire_time, Google::Protobuf::Timestamp), request.expire_time
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :stream_blurbs, mock_method
@@ -1073,8 +1061,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::SendBlurbsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::SendBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -1137,8 +1124,7 @@ describe Google::Showcase::V1alpha3::Messaging::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::StreamBlurbsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::StreamBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1alpha3/testing_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1alpha3/testing_test.rb
@@ -82,13 +82,12 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Session
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Session
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateSessionRequest, request
-        assert_equal Google::Gax.to_proto(session, Google::Showcase::V1alpha3::Session), request.session
+        assert_equal Google::Gax::Protobuf.coerce(session, to: Google::Showcase::V1alpha3::Session), request.session
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
@@ -123,7 +122,7 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::CreateSessionRequest, request
-        assert_equal Google::Gax.to_proto(session, Google::Showcase::V1alpha3::Session), request.session
+        assert_equal Google::Gax::Protobuf.coerce(session, to: Google::Showcase::V1alpha3::Session), request.session
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
@@ -158,13 +157,12 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::Session
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::Session
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetSessionRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
@@ -199,7 +197,7 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::GetSessionRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
@@ -235,14 +233,13 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::ListSessionsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::ListSessionsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListSessionsRequest, request
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
@@ -278,8 +275,8 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListSessionsRequest, request
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
@@ -314,13 +311,12 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteSessionRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
@@ -355,7 +351,7 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteSessionRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
@@ -390,13 +386,12 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::ReportSessionResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::ReportSessionResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ReportSessionRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
@@ -431,7 +426,7 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ReportSessionRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
@@ -468,15 +463,14 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::ListTestsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::ListTestsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListTestsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
@@ -513,9 +507,9 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::ListTestsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
@@ -550,13 +544,12 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteTestRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
@@ -591,7 +584,7 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::DeleteTestRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
@@ -628,15 +621,14 @@ describe Google::Showcase::V1alpha3::Testing::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Showcase::V1alpha3::VerifyTestResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Showcase::V1alpha3::VerifyTestResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::VerifyTestRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(answer), request.answer
-        assert_equal Google::Gax.to_proto(answers), request.answers
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(answer, to: ), request.answer
+        assert_equal Google::Gax::Protobuf.coerce(answers, to: ), request.answers
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method
@@ -673,9 +665,9 @@ describe Google::Showcase::V1alpha3::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1alpha3::VerifyTestRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(answer), request.answer
-        assert_equal Google::Gax.to_proto(answers), request.answers
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(answer, to: ), request.answer
+        assert_equal Google::Gax::Protobuf.coerce(answers, to: ), request.answers
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -165,7 +165,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Speech::V1::RecognizeRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::RecognizeRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -218,7 +218,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Speech::V1::LongRunningRecognizeRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::LongRunningRecognizeRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -264,7 +264,7 @@ module Google
               end
 
               requests = requests.lazy.map do |request|
-                Google::Gax.to_proto request, Google::Cloud::Speech::V1::StreamingRecognizeRequest
+                Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::StreamingRecognizeRequest
               end
 
               # Converts hash and nil to an options object

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -148,7 +148,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::ListOperationsRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -203,7 +203,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::GetOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -259,7 +259,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::DeleteOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -325,7 +325,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::CancelOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_test.rb
@@ -83,14 +83,13 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Speech::V1::RecognizeResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Speech::V1::RecognizeResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::RecognizeRequest, request
-        assert_equal Google::Gax.to_proto(config, Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Google::Gax.to_proto(audio, Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Google::Gax::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Google::Gax::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
@@ -126,8 +125,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::RecognizeRequest, request
-        assert_equal Google::Gax.to_proto(config, Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Google::Gax.to_proto(audio, Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Google::Gax::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Google::Gax::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
@@ -163,8 +162,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Longrunning::Operation
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -176,8 +174,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-        assert_equal Google::Gax.to_proto(config, Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Google::Gax.to_proto(audio, Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Google::Gax::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Google::Gax::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -216,8 +214,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-        assert_equal Google::Gax.to_proto(config, Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Google::Gax.to_proto(audio, Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Google::Gax::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Google::Gax::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -247,8 +245,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-        assert_equal Google::Gax.to_proto(config, Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Google::Gax.to_proto(audio, Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Google::Gax::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Google::Gax::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -283,8 +281,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Speech::V1::StreamingRecognizeResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Speech::V1::StreamingRecognizeResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -160,7 +160,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -214,7 +214,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -148,7 +148,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::ListOperationsRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -203,7 +203,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::GetOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -259,7 +259,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::DeleteOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -325,7 +325,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::CancelOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -179,7 +179,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -243,7 +243,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductSetsRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductSetsRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -305,7 +305,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -372,7 +372,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::UpdateProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -437,7 +437,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -509,7 +509,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateProductRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -572,7 +572,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductsRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -634,7 +634,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetProductRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -717,7 +717,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::UpdateProductRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -784,7 +784,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteProductRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -879,7 +879,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::CreateReferenceImageRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateReferenceImageRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -951,7 +951,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::DeleteReferenceImageRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteReferenceImageRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -1021,7 +1021,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListReferenceImagesRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListReferenceImagesRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -1084,7 +1084,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::GetReferenceImageRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetReferenceImageRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -1154,7 +1154,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::AddProductToProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AddProductToProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -1218,7 +1218,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -1285,7 +1285,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ListProductsInProductSetRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsInProductSetRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -1360,7 +1360,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Cloud::Vision::V1::ImportProductSetsRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ImportProductSetsRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -148,7 +148,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::ListOperationsRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -203,7 +203,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::GetOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -259,7 +259,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::DeleteOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
@@ -325,7 +325,7 @@ module Google
               end
 
               request ||= request_fields
-              request = Google::Gax.to_proto request, Google::Longrunning::CancelOperationRequest
+              request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -82,13 +82,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::BatchAnnotateImagesResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::BatchAnnotateImagesResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateImagesRequest, request
-        assert_equal Google::Gax.to_proto(requests, Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal Google::Gax::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
@@ -123,7 +122,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateImagesRequest, request
-        assert_equal Google::Gax.to_proto(requests, Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal Google::Gax::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
@@ -158,8 +157,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Longrunning::Operation
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -171,7 +169,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-        assert_equal Google::Gax.to_proto(requests, Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+        assert_equal Google::Gax::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
@@ -209,7 +207,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-        assert_equal Google::Gax.to_proto(requests, Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+        assert_equal Google::Gax::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
@@ -238,7 +236,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-        assert_equal Google::Gax.to_proto(requests, Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+        assert_equal Google::Gax::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_test.rb
@@ -84,15 +84,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ProductSet
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ProductSet
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductSetRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(product_set, Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Google::Gax.to_proto(product_set_id), request.product_set_id
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal Google::Gax::Protobuf.coerce(product_set_id, to: ), request.product_set_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
@@ -129,9 +128,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductSetRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(product_set, Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Google::Gax.to_proto(product_set_id), request.product_set_id
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal Google::Gax::Protobuf.coerce(product_set_id, to: ), request.product_set_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
@@ -168,15 +167,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ListProductSetsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListProductSetsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductSetsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
@@ -213,9 +211,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductSetsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
@@ -250,13 +248,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ProductSet
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ProductSet
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
@@ -291,7 +288,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
@@ -327,14 +324,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ProductSet
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ProductSet
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductSetRequest, request
-        assert_equal Google::Gax.to_proto(product_set, Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
@@ -370,8 +366,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductSetRequest, request
-        assert_equal Google::Gax.to_proto(product_set, Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
@@ -406,13 +402,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
@@ -447,7 +442,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
@@ -484,15 +479,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::Product
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::Product
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(product, Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Google::Gax.to_proto(product_id), request.product_id
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(product_id, to: ), request.product_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
@@ -529,9 +523,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(product, Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Google::Gax.to_proto(product_id), request.product_id
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(product_id, to: ), request.product_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
@@ -568,15 +562,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ListProductsResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListProductsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
@@ -613,9 +606,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
@@ -650,13 +643,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::Product
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::Product
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
@@ -691,7 +683,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
@@ -727,14 +719,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::Product
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::Product
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductRequest, request
-        assert_equal Google::Gax.to_proto(product, Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
@@ -770,8 +761,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductRequest, request
-        assert_equal Google::Gax.to_proto(product, Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Google::Gax.to_proto(update_mask, Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Google::Gax::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
@@ -806,13 +797,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
@@ -847,7 +837,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
@@ -884,15 +874,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ReferenceImage
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ReferenceImage
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateReferenceImageRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(reference_image, Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
-        assert_equal Google::Gax.to_proto(reference_image_id), request.reference_image_id
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
+        assert_equal Google::Gax::Protobuf.coerce(reference_image_id, to: ), request.reference_image_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
@@ -929,9 +918,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateReferenceImageRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(reference_image, Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
-        assert_equal Google::Gax.to_proto(reference_image_id), request.reference_image_id
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
+        assert_equal Google::Gax::Protobuf.coerce(reference_image_id, to: ), request.reference_image_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
@@ -966,13 +955,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteReferenceImageRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
@@ -1007,7 +995,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteReferenceImageRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
@@ -1044,15 +1032,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ListReferenceImagesResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListReferenceImagesResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListReferenceImagesRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
@@ -1089,9 +1076,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListReferenceImagesRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
@@ -1126,13 +1113,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ReferenceImage
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ReferenceImage
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetReferenceImageRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
@@ -1167,7 +1153,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetReferenceImageRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
@@ -1203,14 +1189,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AddProductToProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(product, to: ), request.product
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
@@ -1246,8 +1231,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AddProductToProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(product, to: ), request.product
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
@@ -1283,14 +1268,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Protobuf::Empty
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(product, to: ), request.product
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
@@ -1326,8 +1310,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(product), request.product
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(product, to: ), request.product
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
@@ -1364,15 +1348,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Cloud::Vision::V1::ListProductsInProductSetResponse
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListProductsInProductSetResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsInProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
@@ -1409,9 +1392,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsInProductSetRequest, request
-        assert_equal Google::Gax.to_proto(name), request.name
-        assert_equal Google::Gax.to_proto(page_size), request.page_size
-        assert_equal Google::Gax.to_proto(page_token), request.page_token
+        assert_equal Google::Gax::Protobuf.coerce(name, to: ), request.name
+        assert_equal Google::Gax::Protobuf.coerce(page_size, to: ), request.page_size
+        assert_equal Google::Gax::Protobuf.coerce(page_token, to: ), request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
@@ -1441,27 +1424,26 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
     end
 
     it "invokes import_product_sets without error" do
-      # Create request parameters
-      parent = "hello world"
-      input_config = {}
+    # Create request parameters
+    parent = "hello world"
+    input_config = {}
 
       # Create expected grpc response
       expected_response = {}
-      expected_response = Google::Gax.to_proto expected_response,
-                                               Google::Longrunning::Operation
+      expected_response = Google::Gax::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name:     "operations/import_product_sets_test",
-        done:     true,
+        name: "operations/import_product_sets_test",
+        done: true,
         response: result
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(input_config, Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1483,25 +1465,25 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
     end
 
     it "invokes import_product_sets and returns an operation error." do
-      # Create request parameters
-      parent = "hello world"
-      input_config = {}
+    # Create request parameters
+    parent = "hello world"
+    input_config = {}
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
         message: "Operation error for Google::Cloud::Vision::V1::ProductSearch::Client#import_product_sets."
       )
       operation = Google::Longrunning::Operation.new(
-        name:  "operations/import_product_sets_test",
-        done:  true,
+        name: "operations/import_product_sets_test",
+        done: true,
         error: operation_error
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(input_config, Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1524,15 +1506,15 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
     end
 
     it "invokes import_product_sets with error" do
-      # Create request parameters
-      parent = "hello world"
-      input_config = {}
+    # Create request parameters
+    parent = "hello world"
+    input_config = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-        assert_equal Google::Gax.to_proto(parent), request.parent
-        assert_equal Google::Gax.to_proto(input_config, Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+        assert_equal Google::Gax::Protobuf.coerce(parent, to: ), request.parent
+        assert_equal Google::Gax::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method


### PR DESCRIPTION
This PR updates the generator to use the new `Protobuf.coerce` method instead of the previous `Gax.to_proto` method.