### PR TITLE
Add Dockerfile and gapic.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:2.6-stretch
+
+# Add protoc and our common protos.
+COPY --from=gcr.io/gapic-images/api-common-protos:beta /usr/local/bin/protoc /usr/local/bin/protoc
+COPY --from=gcr.io/gapic-images/api-common-protos:beta /protos/ /protos/
+
+# Add our code to the Docker image.
+ADD . /usr/src/gapic-generator-ruby/
+
+WORKDIR /usr/src/gapic-generator-ruby/gapic-generator
+RUN gem install bundler
+RUN bundle install
+
+# Install the executable within the image.
+RUN bundle exec rake install
+RUN chmod -R 777 /usr/local/bundle
+RUN mkdir /.cache
+RUN chmod -R 777 /.cache
+
+# Define the generator as an entry point.
+ENTRYPOINT ["/usr/src/gapic-generator-ruby/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GAPIC_SERVICE_CONFIG=
+
+# enable extended globbing for flag pattern matching
+shopt -s extglob
+
+# Parse out options.
+while true; do
+  case "$1" in
+    --gapic-service-config ) GAPIC_SERVICE_CONFIG="configuration=$2"; shift 2;;
+    --ruby-gapic* ) echo "Skipping unrecognized ruby-gapic flag: $1" >&2; shift ;;
+    --* | +([[:word:][:punct:]]) ) shift ;;
+    * ) break ;;
+  esac
+done
+
+if [ -z "$GAPIC_SERVICE_CONFIG" ]; then
+  echo "Required argument --gapic-service-config missing."
+  exit 64
+fi
+
+
+protoc --proto_path=/protos/ --proto_path=/in/ \
+       --ruby_gapic_out=/out/ \
+       --ruby_gapic_opt="$GAPIC_SERVICE_CONFIG" \
+       `find /in/ -name *.proto`

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,7 +26,7 @@ while true; do
 done
 
 
-protoc --proto_path=/protos/ --proto_path=/in/ \
-       --ruby_gapic_out=/out/ \
-       --ruby_gapic_opt="configuration=/config.yml" \
-       `find /in/ -name *.proto`
+exec protoc --proto_path=/protos/ --proto_path=/in/ \
+            --ruby_gapic_out=/out/ \
+            --ruby_gapic_opt="configuration=/config.yml" \
+            `find /in/ -name *.proto`

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,28 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GAPIC_SERVICE_CONFIG=
-
 # enable extended globbing for flag pattern matching
 shopt -s extglob
 
 # Parse out options.
 while true; do
   case "$1" in
-    --gapic-service-config ) GAPIC_SERVICE_CONFIG="configuration=$2"; shift 2;;
     --ruby-gapic* ) echo "Skipping unrecognized ruby-gapic flag: $1" >&2; shift ;;
     --* | +([[:word:][:punct:]]) ) shift ;;
     * ) break ;;
   esac
 done
 
-if [ -z "$GAPIC_SERVICE_CONFIG" ]; then
-  echo "Required argument --gapic-service-config missing."
-  exit 64
-fi
-
 
 protoc --proto_path=/protos/ --proto_path=/in/ \
        --ruby_gapic_out=/out/ \
-       --ruby_gapic_opt="$GAPIC_SERVICE_CONFIG" \
+       --ruby_gapic_opt="configuration=/config.yml" \
        `find /in/ -name *.proto`

--- a/gapic.sh
+++ b/gapic.sh
@@ -23,6 +23,7 @@ IN=
 OUT=
 PLUGIN_OPTIONS=
 PROTO_PATH=`pwd`
+GAPIC_SERVICE_CONFIG=
 
 # Print help and exit.
 function show_help {
@@ -35,6 +36,7 @@ Required arguments:
   -i, --in        A directory containing the protos describing the API
                     to be generated.
   -o, --out       Destination directory for the completed client library.
+      --config    Location of the GAPIC service configuration .yml file.
 
 Optional arguments:
   -p, --path      The base import path for the protos. Assumed to be the
@@ -53,6 +55,7 @@ while true; do
     -i | --in ) IN="$2"; shift 2 ;;
     -o | --out ) OUT="$2"; shift 2 ;;
     -p | --path ) PROTO_PATH=$2; shift 2 ;;
+    --config ) GAPIC_SERVICE_CONFIG=$2; shift 2 ;;
     --* ) PLUGIN_OPTIONS="$PLUGIN_OPTIONS $1 $2"; shift 2 ;;
     -- ) shift; break; ;;
     * ) break ;;
@@ -95,6 +98,7 @@ fi
 # Generate the client library.
 docker run \
   --mount type=bind,source=${PROTO_PATH}/${IN},destination=/in/${IN},readonly \
+  --mount type=bind,source=$GAPIC_SERVICE_CONFIG,destination=/config.yml,readonly \
   --mount type=bind,source=$OUT,destination=/out \
   --rm \
   --user $UID \

--- a/gapic.sh
+++ b/gapic.sh
@@ -17,7 +17,8 @@ set -e
 CMD="$0"
 
 # Set variables used by this script.
-# All of these are set in options below, and all but $PATH are required.
+# All of these are set in options below, and all but PLUGIN_OPTIONS and
+# PROTO_PATH are required.
 IMAGE=
 IN=
 OUT=
@@ -104,4 +105,3 @@ docker run \
   --user $UID \
   $IMAGE \
   $PLUGIN_OPTIONS
-exit $?

--- a/gapic.sh
+++ b/gapic.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e 
+
+CMD="$0"
+
+# Set variables used by this script.
+# All of these are set in options below, and all but $PATH are required.
+IMAGE=
+IN=
+OUT=
+PLUGIN_OPTIONS=
+PROTO_PATH=`pwd`
+
+# Print help and exit.
+function show_help {
+  cat << EOF
+Usage: $CMD --image IMAGE --in IN_DIR --out OUT_DIR [--path PATH_DIR]
+
+Required arguments:
+      --image     The Docker image to use. The script will attempt to pull
+                    it if it is not present.
+  -i, --in        A directory containing the protos describing the API
+                    to be generated.
+  -o, --out       Destination directory for the completed client library.
+
+Optional arguments:
+  -p, --path      The base import path for the protos. Assumed to be the
+                    current working directory if unspecified.
+  -h, --help      This help information.
+EOF
+ 
+  exit 0
+}
+
+# Parse out options.
+while true; do
+  case "$1" in
+    -h | --help ) show_help ;;
+    --image ) IMAGE="$2"; shift 2 ;;
+    -i | --in ) IN="$2"; shift 2 ;;
+    -o | --out ) OUT="$2"; shift 2 ;;
+    -p | --path ) PROTO_PATH=$2; shift 2 ;;
+    --* ) PLUGIN_OPTIONS="$PLUGIN_OPTIONS $1 $2"; shift 2 ;;
+    -- ) shift; break; ;;
+    * ) break ;;
+  esac
+done
+
+# Ensure that all required options are set.
+if [ -z "$IMAGE" ] || [ -z "$IN" ] || [ -z "$OUT" ]; then
+  cat << EOF
+Required argument missing.
+The --image, --in, and --out arguments are all required.
+Run $CMD --help for more information.
+EOF
+
+  exit 64
+fi
+
+# Ensure that the input directory exists (and is a directory).
+if ! [ -d $IN ]; then
+  cat << EOF
+Directory does not exist: $IN
+EOF
+  exit 2
+fi
+
+# Ensure Docker is running and seems healthy.
+# This is mostly a check to bubble useful errors quickly.
+docker ps > /dev/null
+
+# If the output directory does not exist, create it.
+mkdir -p $OUT
+
+# If the output directory is not empty, warn (but continue).
+if [ "$(ls -A $OUT )" ]; then
+  cat << EOF
+Warning: Output directory is not empty.
+EOF
+fi
+
+# Generate the client library.
+docker run \
+  --mount type=bind,source=${PROTO_PATH}/${IN},destination=/in/${IN},readonly \
+  --mount type=bind,source=$OUT,destination=/out \
+  --rm \
+  --user $UID \
+  $IMAGE \
+  $PLUGIN_OPTIONS
+exit $?


### PR DESCRIPTION
Support language-agnostic build pipeline. This hook is currently implemented in the top-level of the repo, but only targets `gapic-generator`.

#### Existing implementations

The `gapic.sh` file executes `docker run`, then within the Docker image the `docker-entrypoint.sh` file calls `protoc`.

##### Go

[gapic.sh](https://github.com/googleapis/gapic-generator-python/blob/master/gapic.sh)
[docker-entrypoint.sh](https://github.com/googleapis/gapic-generator-python/blob/master/docker-entrypoint.sh)

##### Python

[gapic.sh](https://github.com/googleapis/gapic-generator-go/blob/master/gapic.sh)
[docker-entrypoint.sh](https://github.com/googleapis/gapic-generator-go/blob/master/docker-entrypoint.sh)

#### Usage:

The notable addition to `gapic.sh` in Ruby is the `--config` option.

```sh
gapic-generator-ruby$ docker build -t gapic-generator-ruby .
gapic-generator-ruby$ sh gapic.sh --image gapic-generator-ruby -i shared/protos/google/showcase/v1alpha3 -o /Users/quartzmo/code/google/codez/gapic-generator-ruby/gapic-generator/test-out-1 --config /Users/quartzmo/code/google/codez/gapic-generator-ruby/shared/config/showcase.yml
```