### PR TITLE
Use Gax Config DSL

### DIFF
--- a/gapic-generator/templates/default/service/client/_client.erb
+++ b/gapic-generator/templates/default/service/client/_client.erb
@@ -55,27 +55,12 @@ class <%= service.client_name %>
   end
 
   ##
-  # @param credentials [Google::Auth::Credentials, String, Hash,
-  #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-  #   Provides the means for authenticating requests made by the client. This
-  #   parameter can be many types.
-  #   A `Google::Auth::Credentials` uses a the properties of its represented
-  #   keyfile for authenticating requests made by this client.
-  #   A `String` will be treated as the path to the keyfile to be used for the
-  #   construction of credentials for this client.
-  #   A `Hash` will be treated as the contents of a keyfile to be used for the
-  #   construction of credentials for this client.
-  #   A `GRPC::Core::Channel` will be used to make calls through.
-  #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-  #   channel credentials should already be composed with a
-  #   `GRPC::Core::CallCredentials` object.
-  #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-  #   transforms the metadata for requests, generally, to give OAuth credentials.
+  # Create a new <%= service.client_name %> client object.
   #
   # @yield [config] Configure the <%= service.client_name %> client.
   # @yieldparam config [<%= service.client_name %>::Configuration]
   #
-  def initialize credentials: nil
+  def initialize
     # These require statements are intentionally placed here to initialize
     # the gRPC module only when it's required.
     # See https://github.com/googleapis/toolkit/issues/446
@@ -89,15 +74,16 @@ class <%= service.client_name %>
     yield @config if block_given?
 
     # Create credentials
+    credentials = @config.credentials
     credentials ||= Credentials.default scope: @config.scope
     if credentials.is_a?(String) || credentials.is_a?(Hash)
       credentials = Credentials.new credentials, scope: @config.scope
     end
 
     <%- if service.lro? -%>
-    <%= service.lro_client_ivar %> = Operations.new(
-      credentials: credentials
-    )
+    <%= service.lro_client_ivar %> = Operations.new do |config|
+      config.credentials = credentials
+    end
     <%- end -%>
 
     @<%= service.stub_name %> = Google::Gax::Grpc::Stub.new(

--- a/gapic-generator/templates/default/service/client/_client.erb
+++ b/gapic-generator/templates/default/service/client/_client.erb
@@ -1,6 +1,8 @@
 <%- assert_locals service -%>
 <% @requires = capture do %>
 require "google/gax"
+require "google/gax/config"
+require "google/gax/config/method"
 
 require "<%= service.gem.version_require %>"
 require "<%= service.service_proto_require %>"
@@ -21,22 +23,36 @@ class <%= service.client_name %>
   # @private
   attr_reader :<%= service.stub_name %>
 
-  # The default address of the service.
-  SERVICE_ADDRESS = "<%= service.client_address %>"
+  ##
+  # Configuration for the <%= service.name %> <%= service.client_name %> API.
+  #
+  # @yield [config] Configure the <%= service.client_name %> client.
+  # @yieldparam config [<%= service.client_name %>::Configuration]
+  #
+  # @return [<%= service.client_name %>::Configuration]
+  #
+  def self.configure
+    @configure ||= <%= service.client_name %>::Configuration.new
+    yield @configure if block_given?
+    @configure
+  end
 
-  # The default port of the service.
-  DEFAULT_SERVICE_PORT = <%= service.client_port %>
-
-  # rubocop:disable Style/MutableConstant
-
-  # The default set of gRPC interceptors.
-  GRPC_INTERCEPTORS = []
-
-  # rubocop:enable Style/MutableConstant
-
-  DEFAULT_TIMEOUT = 30
-
-
+  ##
+  # Configure the <%= service.name %> <%= service.client_name %> instance.
+  #
+  # The configuration is set to the derived mode, meaning that values can be changed,
+  # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+  # should be made on {<%= service.client_name %>.configure}.
+  #
+  # @yield [config] Configure the <%= service.client_name %> client.
+  # @yieldparam config [<%= service.client_name %>::Configuration]
+  #
+  # @return [<%= service.client_name %>::Configuration]
+  #
+  def configure
+    yield @config if block_given?
+    @config
+  end
 
   ##
   # @param credentials [Google::Auth::Credentials, String, Hash,
@@ -55,60 +71,42 @@ class <%= service.client_name %>
   #   `GRPC::Core::CallCredentials` object.
   #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
   #   transforms the metadata for requests, generally, to give OAuth credentials.
-  # @param scope [String, Array<String>]
-  #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-  #   an updater_proc is supplied.
-  # @param timeout [Numeric]
-  #   The default timeout, in seconds, for calls made through this client.
-  # @param metadata [Hash]
-  #   Default metadata to be sent with each request. This can be overridden on a
-  #   per call basis.
   #
-  def initialize \
-      credentials: nil,
-      scope: nil,
-      timeout: DEFAULT_TIMEOUT,
-      metadata: nil,
-      lib_name: nil,
-      lib_version: nil
+  # @yield [config] Configure the <%= service.client_name %> client.
+  # @yieldparam config [<%= service.client_name %>::Configuration]
+  #
+  def initialize credentials: nil
     # These require statements are intentionally placed here to initialize
     # the gRPC module only when it's required.
     # See https://github.com/googleapis/toolkit/issues/446
     require "google/gax/grpc"
     require "<%= service.services_proto_require %>"
 
-    credentials ||= Credentials.default scope: scope
+    # Create the configuration object
+    @config = Configuration.new <%= service.client_name %>.configure
+
+    # Yield the configuration if needed
+    yield @config if block_given?
+
+    # Create credentials
+    credentials ||= Credentials.default scope: @config.scope
     if credentials.is_a?(String) || credentials.is_a?(Hash)
-      credentials = Credentials.new credentials, scope: scope
+      credentials = Credentials.new credentials, scope: @config.scope
     end
 
     <%- if service.lro? -%>
     <%= service.lro_client_ivar %> = Operations.new(
-      credentials: credentials,
-      scope:       scope,
-      timeout:     timeout,
-      metadata:    metadata,
-      lib_name:    lib_name,
-      lib_version: lib_version
+      credentials: credentials
     )
     <%- end -%>
 
     @<%= service.stub_name %> = Google::Gax::Grpc::Stub.new(
       <%= service.services_stub_name_full %>,
-      host:         self.class::SERVICE_ADDRESS,
-      port:         self.class::DEFAULT_SERVICE_PORT,
       credentials:  credentials,
-      interceptors: self.class::GRPC_INTERCEPTORS
+      host:         @config.host,
+      port:         @config.port,
+      interceptors: @config.interceptors
     )
-
-    @timeout = timeout
-    x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-    x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-    x_goog_api_client_header << "gapic/#{<%= service.gem.version_name_full %>}"
-    x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-    x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-    @metadata = metadata.to_h
-    @metadata["x-goog-api-client".freeze] ||= x_goog_api_client_header.join(" ")
   end
 
   # Service calls
@@ -116,6 +114,8 @@ class <%= service.client_name %>
 
   <%= indent_tail render(partial: "service/client/method/def", locals: { method: method }), 2 %>
   <%- end %>
+
+  <%= indent_tail render(partial: "service/client/config", locals: { service: service }), 2 %>
 end
 
 <% @footer = capture do %>

--- a/gapic-generator/templates/default/service/client/_config.erb
+++ b/gapic-generator/templates/default/service/client/_config.erb
@@ -6,7 +6,7 @@ class Configuration
   config_attr :host,         <%= service.client_address.inspect %>, String
   config_attr :port,         <%= service.client_port %>,            Integer
   config_attr :credentials,  nil do |value|
-    allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+    allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
     if defined? ::GRPC
       allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials]
     end

--- a/gapic-generator/templates/default/service/client/_config.erb
+++ b/gapic-generator/templates/default/service/client/_config.erb
@@ -5,6 +5,13 @@ class Configuration
 
   config_attr :host,         <%= service.client_address.inspect %>, String
   config_attr :port,         <%= service.client_port %>,            Integer
+  config_attr :credentials,  nil do |value|
+    allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+    if defined? ::GRPC
+      allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials]
+    end
+    allowed.any? { |klass| klass === value }
+  end
   config_attr :scope,        nil,                                   String, Array, nil
   config_attr :lib_name,     nil,                                   String, nil
   config_attr :lib_version,  nil,                                   String, nil

--- a/gapic-generator/templates/default/service/client/_config.erb
+++ b/gapic-generator/templates/default/service/client/_config.erb
@@ -1,0 +1,45 @@
+<%- assert_locals service -%>
+<%- method_service ||= service  -%>
+class Configuration
+  extend Google::Gax::Config
+
+  config_attr :host,         <%= service.client_address.inspect %>, String
+  config_attr :port,         <%= service.client_port %>,            Integer
+  config_attr :scope,        nil,                                   String, Array, nil
+  config_attr :lib_name,     nil,                                   String, nil
+  config_attr :lib_version,  nil,                                   String, nil
+  config_attr :interceptors, [],                                    Array
+  config_attr :timeout,      nil,                                   Numeric, nil
+  config_attr :metadata,     nil,                                   Hash, nil
+  config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+  def initialize parent_config = nil
+    @parent_config = parent_config unless parent_config.nil?
+
+    yield self if block_given?
+  end
+
+  def rpcs
+    @rpcs ||= begin
+      parent_rpcs = nil
+      parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to?(:rpcs)
+      Rpcs.new parent_rpcs
+    end
+  end
+
+  class Rpcs
+  <%- method_service.methods.each do |method| -%>
+    attr_reader :<%= method.name %>
+  <%- end %>
+
+    def initialize parent_rpcs = nil
+      <%- method_service.methods.each do |method| -%>
+      <%= method.name %>_config = nil
+      <%= method.name %>_config = parent_rpcs&.<%= method.name %> if parent_rpcs&.respond_to? :<%= method.name %>
+      @<%= method.name %> = Google::Gax::Config::Method.new <%= method.name %>_config
+      <%- end %>
+
+      yield self if block_given?
+    end
+  end
+end

--- a/gapic-generator/templates/default/service/client/_operations.erb
+++ b/gapic-generator/templates/default/service/client/_operations.erb
@@ -44,27 +44,12 @@ class Operations
   end
 
   ##
-  # @param credentials [Google::Auth::Credentials, String, Hash,
-  #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-  #   Provides the means for authenticating requests made by the client. This
-  #   parameter can be many types.
-  #   A `Google::Auth::Credentials` uses a the properties of its represented
-  #   keyfile for authenticating requests made by this client.
-  #   A `String` will be treated as the path to the keyfile to be used for the
-  #   construction of credentials for this client.
-  #   A `Hash` will be treated as the contents of a keyfile to be used for the
-  #   construction of credentials for this client.
-  #   A `GRPC::Core::Channel` will be used to make calls through.
-  #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-  #   channel credentials should already be composed with a
-  #   `GRPC::Core::CallCredentials` object.
-  #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-  #   transforms the metadata for requests, generally, to give OAuth credentials.
+  # Create a new Operations client object.
   #
   # @yield [config] Configure the <%= service.client_name %> client.
   # @yieldparam config [Operations::Configuration]
   #
-  def initialize credentials: nil, config: nil
+  def initialize
     # These require statements are intentionally placed here to initialize
     # the gRPC module only when it's required.
     # See https://github.com/googleapis/toolkit/issues/446
@@ -78,6 +63,7 @@ class Operations
     yield @config if block_given?
 
     # Create credentials
+    credentials = @config.credentials
     credentials ||= Credentials.default scope: @config.scope
     if credentials.is_a?(String) || credentials.is_a?(Hash)
       credentials = Credentials.new credentials, scope: @config.scope

--- a/gapic-generator/templates/default/service/client/_operations.erb
+++ b/gapic-generator/templates/default/service/client/_operations.erb
@@ -13,6 +13,37 @@ class Operations
   attr_reader :<%= service.lro_service.stub_name %>
 
   ##
+  # Configuration for the <%= service.name %> Operations API.
+  #
+  # @yield [config] Configure the Operations client.
+  # @yieldparam config [Operations::Configuration]
+  #
+  # @return [Operations::Configuration]
+  #
+  def self.configure
+    @configure ||= Operations::Configuration.new
+    yield @configure if block_given?
+    @configure
+  end
+
+  ##
+  # Configure the <%= service.name %> Operations instance.
+  #
+  # The configuration is set to the derived mode, meaning that values can be changed,
+  # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+  # should be made on {Operations.configure}.
+  #
+  # @yield [config] Configure the Operations client.
+  # @yieldparam config [Operations::Configuration]
+  #
+  # @return [Operations::Configuration]
+  #
+  def configure
+    yield @config if block_given?
+    @config
+  end
+
+  ##
   # @param credentials [Google::Auth::Credentials, String, Hash,
   #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
   #   Provides the means for authenticating requests made by the client. This
@@ -29,49 +60,36 @@ class Operations
   #   `GRPC::Core::CallCredentials` object.
   #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
   #   transforms the metadata for requests, generally, to give OAuth credentials.
-  # @param scope [String, Array<String>]
-  #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-  #   an updater_proc is supplied.
-  # @param timeout [Numeric]
-  #   The default timeout, in seconds, for calls made through this client.
-  # @param metadata [Hash]
-  #   Default metadata to be sent with each request. This can be overridden on a
-  #   per call basis.
   #
-  def initialize \
-      credentials:  nil,
-      scope:        Client::ALL_SCOPES,
-      timeout:      Client::DEFAULT_TIMEOUT,
-      metadata:     nil,
-      lib_name:     nil,
-      lib_version:  nil
+  # @yield [config] Configure the <%= service.client_name %> client.
+  # @yieldparam config [Operations::Configuration]
+  #
+  def initialize credentials: nil, config: nil
     # These require statements are intentionally placed here to initialize
     # the gRPC module only when it's required.
     # See https://github.com/googleapis/toolkit/issues/446
     require "google/gax/grpc"
     require "<%= service.lro_service.services_proto_require %>"
 
-    credentials ||= Credentials.default scope: scope
+    # Create the configuration object
+    @config = Configuration.new Operations.configure
+
+    # Yield the configuration if needed
+    yield @config if block_given?
+
+    # Create credentials
+    credentials ||= Credentials.default scope: @config.scope
     if credentials.is_a?(String) || credentials.is_a?(Hash)
-      credentials = Credentials.new credentials, scope: scope
+      credentials = Credentials.new credentials, scope: @config.scope
     end
 
     @<%= service.lro_service.stub_name %> = Google::Gax::Grpc::Stub.new(
       <%= service.lro_service.services_stub_name_full %>,
-      host:         Client::SERVICE_ADDRESS,
-      port:         Client::DEFAULT_SERVICE_PORT,
       credentials:  credentials,
-      interceptors: Client::GRPC_INTERCEPTORS
+      host:         @config.host,
+      port:         @config.port,
+      interceptors: @config.interceptors
     )
-
-    @timeout = timeout
-    x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-    x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-    x_goog_api_client_header << "gapic/#{<%= service.gem.version_name_full %>}"
-    x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-    x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-    @metadata = metadata.to_h
-    @metadata["x-goog-api-client".freeze] ||= x_goog_api_client_header.join(" ")
   end
 
   # Service calls
@@ -79,4 +97,6 @@ class Operations
 
   <%= indent_tail render(partial: "service/client/method/def", locals: { method: method }), 2 %>
   <%- end %>
+
+  <%= indent_tail render(partial: "service/client/config", locals: { service: service.lro_service }), 2 %>
 end

--- a/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
@@ -3,15 +3,28 @@
 options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
 # Customize the options with defaults
+metadata = @config.rpcs.<%= method.name %>.metadata.to_h
+
+x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+x_goog_api_client_header << "gapic/#{<%= method.service.gem.version_name_full %>}"
+x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join(" ")
 <%- if method.routing_params? -%>
+
 header_params = {
 <%- method.routing_params.each do |rp| -%>
   "<%= rp %>" => request.<%= rp %>,
 <%- end -%>
 }
 request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-metadata = @metadata.merge "x-goog-request-params".freeze => request_params_header
-<%- else -%>
-metadata = @metadata.dup
+metadata[:"x-goog-request-params"] ||= request_params_header
 <%- end -%>
-options.apply_defaults timeout: @timeout, metadata: metadata
+
+options.apply_defaults timeout: @config.rpcs.<%= method.name %>.timeout,
+                       metadata: metadata,
+                       retry_policy: @config.rpcs.<%= method.name %>.retry_policy
+options.apply_defaults timeout: @config.timeout,
+                       metadata: @config.metadata,
+                       retry_policy: @config.retry_policy

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,7 +6,7 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "googleapis/gax-ruby"
+gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/config"
 gem "grpc-tools", "~> 1.18"
 gem "minitest", "~> 5.0"
 gem "minitest-autotest", "~> 1.0"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,7 +6,7 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/config"
+gem "google-gax", github: "googleapis/gax-ruby"
 gem "grpc-tools", "~> 1.18"
 gem "minitest", "~> 5.0"
 gem "minitest-autotest", "~> 1.0"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -486,7 +486,7 @@ module Google
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
             config_attr :credentials,  nil do |value|
-              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
               allowed.any? { |klass| klass === value }
             end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -64,27 +64,12 @@ module Google
           end
 
           ##
-          # @param credentials [Google::Auth::Credentials, String, Hash,
-          #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-          #   Provides the means for authenticating requests made by the client. This
-          #   parameter can be many types.
-          #   A `Google::Auth::Credentials` uses a the properties of its represented
-          #   keyfile for authenticating requests made by this client.
-          #   A `String` will be treated as the path to the keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `Hash` will be treated as the contents of a keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `GRPC::Core::Channel` will be used to make calls through.
-          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-          #   channel credentials should already be composed with a
-          #   `GRPC::Core::CallCredentials` object.
-          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-          #   transforms the metadata for requests, generally, to give OAuth credentials.
+          # Create a new Client client object.
           #
           # @yield [config] Configure the Client client.
           # @yieldparam config [Client::Configuration]
           #
-          def initialize credentials: nil
+          def initialize
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -98,14 +83,15 @@ module Google
             yield @config if block_given?
 
             # Create credentials
+            credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
 
-            @operations_client = Operations.new(
-              credentials: credentials
-            )
+            @operations_client = Operations.new do |config|
+              config.credentials = credentials
+            end
 
             @echo_stub = Google::Gax::Grpc::Stub.new(
               Google::Showcase::V1alpha3::Echo::Stub,
@@ -499,6 +485,11 @@ module Google
 
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
+            config_attr :credentials,  nil do |value|
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+              allowed.any? { |klass| klass === value }
+            end
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -31,6 +31,37 @@ module Google
           attr_reader :operations_stub
 
           ##
+          # Configuration for the Echo Operations API.
+          #
+          # @yield [config] Configure the Operations client.
+          # @yieldparam config [Operations::Configuration]
+          #
+          # @return [Operations::Configuration]
+          #
+          def self.configure
+            @configure ||= Operations::Configuration.new
+            yield @configure if block_given?
+            @configure
+          end
+
+          ##
+          # Configure the Echo Operations instance.
+          #
+          # The configuration is set to the derived mode, meaning that values can be changed,
+          # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+          # should be made on {Operations.configure}.
+          #
+          # @yield [config] Configure the Operations client.
+          # @yieldparam config [Operations::Configuration]
+          #
+          # @return [Operations::Configuration]
+          #
+          def configure
+            yield @config if block_given?
+            @config
+          end
+
+          ##
           # @param credentials [Google::Auth::Credentials, String, Hash,
           #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
           #   Provides the means for authenticating requests made by the client. This
@@ -47,49 +78,36 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scope [String, Array<String>]
-          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-          #   an updater_proc is supplied.
-          # @param timeout [Numeric]
-          #   The default timeout, in seconds, for calls made through this client.
-          # @param metadata [Hash]
-          #   Default metadata to be sent with each request. This can be overridden on a
-          #   per call basis.
           #
-          def initialize \
-              credentials:  nil,
-              scope:        Client::ALL_SCOPES,
-              timeout:      Client::DEFAULT_TIMEOUT,
-              metadata:     nil,
-              lib_name:     nil,
-              lib_version:  nil
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Operations::Configuration]
+          #
+          def initialize credentials: nil, config: nil
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/longrunning/operations_services_pb"
 
-            credentials ||= Credentials.default scope: scope
+            # Create the configuration object
+            @config = Configuration.new Operations.configure
+
+            # Yield the configuration if needed
+            yield @config if block_given?
+
+            # Create credentials
+            credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
-              credentials = Credentials.new credentials, scope: scope
+              credentials = Credentials.new credentials, scope: @config.scope
             end
 
             @operations_stub = Google::Gax::Grpc::Stub.new(
               Google::Longrunning::Operations::Stub,
-              host:         Client::SERVICE_ADDRESS,
-              port:         Client::DEFAULT_SERVICE_PORT,
               credentials:  credentials,
-              interceptors: Client::GRPC_INTERCEPTORS
+              host:         @config.host,
+              port:         @config.port,
+              interceptors: @config.interceptors
             )
-
-            @timeout = timeout
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            @metadata = metadata.to_h
-            @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
           end
 
           # Service calls
@@ -145,12 +163,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.list_operations.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_operations.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
 
@@ -201,12 +234,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.get_operation.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.get_operation.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
 
@@ -258,12 +306,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_operation.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_operation.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
 
@@ -325,16 +388,83 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.cancel_operation.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.cancel_operation.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
 
             @cancel_operation.call request, options: options, operation_callback: block
+          end
+
+          class Configuration
+            extend Google::Gax::Config
+
+            config_attr :host,         "localhost", String
+            config_attr :port,         443, Integer
+            config_attr :scope,        nil,                                   String, Array, nil
+            config_attr :lib_name,     nil,                                   String, nil
+            config_attr :lib_version,  nil,                                   String, nil
+            config_attr :interceptors, [],                                    Array
+            config_attr :timeout,      nil,                                   Numeric, nil
+            config_attr :metadata,     nil,                                   Hash, nil
+            config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+            def initialize parent_config = nil
+              @parent_config = parent_config unless parent_config.nil?
+
+              yield self if block_given?
+            end
+
+            def rpcs
+              @rpcs ||= begin
+                parent_rpcs = nil
+                parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                Rpcs.new parent_rpcs
+              end
+            end
+
+            class Rpcs
+              attr_reader :list_operations
+              attr_reader :get_operation
+              attr_reader :delete_operation
+              attr_reader :cancel_operation
+
+              def initialize parent_rpcs = nil
+                list_operations_config = nil
+                list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
+                @list_operations = Google::Gax::Config::Method.new list_operations_config
+                get_operation_config = nil
+                get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
+                @get_operation = Google::Gax::Config::Method.new get_operation_config
+                delete_operation_config = nil
+                delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
+                @delete_operation = Google::Gax::Config::Method.new delete_operation_config
+                cancel_operation_config = nil
+                cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
+                @cancel_operation = Google::Gax::Config::Method.new cancel_operation_config
+
+                yield self if block_given?
+              end
+            end
           end
         end
       end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -62,27 +62,12 @@ module Google
           end
 
           ##
-          # @param credentials [Google::Auth::Credentials, String, Hash,
-          #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-          #   Provides the means for authenticating requests made by the client. This
-          #   parameter can be many types.
-          #   A `Google::Auth::Credentials` uses a the properties of its represented
-          #   keyfile for authenticating requests made by this client.
-          #   A `String` will be treated as the path to the keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `Hash` will be treated as the contents of a keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `GRPC::Core::Channel` will be used to make calls through.
-          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-          #   channel credentials should already be composed with a
-          #   `GRPC::Core::CallCredentials` object.
-          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-          #   transforms the metadata for requests, generally, to give OAuth credentials.
+          # Create a new Operations client object.
           #
           # @yield [config] Configure the Client client.
           # @yieldparam config [Operations::Configuration]
           #
-          def initialize credentials: nil, config: nil
+          def initialize
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -96,6 +81,7 @@ module Google
             yield @config if block_given?
 
             # Create credentials
+            credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
@@ -420,6 +406,11 @@ module Google
 
             config_attr :host,         "localhost", String
             config_attr :port,         443, Integer
+            config_attr :credentials,  nil do |value|
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+              allowed.any? { |klass| klass === value }
+            end
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -407,7 +407,7 @@ module Google
             config_attr :host,         "localhost", String
             config_attr :port,         443, Integer
             config_attr :credentials,  nil do |value|
-              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
               allowed.any? { |klass| klass === value }
             end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -66,27 +66,12 @@ module Google
           end
 
           ##
-          # @param credentials [Google::Auth::Credentials, String, Hash,
-          #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-          #   Provides the means for authenticating requests made by the client. This
-          #   parameter can be many types.
-          #   A `Google::Auth::Credentials` uses a the properties of its represented
-          #   keyfile for authenticating requests made by this client.
-          #   A `String` will be treated as the path to the keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `Hash` will be treated as the contents of a keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `GRPC::Core::Channel` will be used to make calls through.
-          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-          #   channel credentials should already be composed with a
-          #   `GRPC::Core::CallCredentials` object.
-          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-          #   transforms the metadata for requests, generally, to give OAuth credentials.
+          # Create a new Client client object.
           #
           # @yield [config] Configure the Client client.
           # @yieldparam config [Client::Configuration]
           #
-          def initialize credentials: nil
+          def initialize
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -100,6 +85,7 @@ module Google
             yield @config if block_given?
 
             # Create credentials
+            credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
@@ -440,6 +426,11 @@ module Google
 
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
+            config_attr :credentials,  nil do |value|
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+              allowed.any? { |klass| klass === value }
+            end
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 require "google/gax"
+require "google/gax/config"
+require "google/gax/config/method"
 
 require "google/showcase/version"
 require "google/showcase/v1alpha3/identity_pb"
@@ -32,22 +34,36 @@ module Google
           # @private
           attr_reader :identity_stub
 
-          # The default address of the service.
-          SERVICE_ADDRESS = "localhost"
+          ##
+          # Configuration for the Identity Client API.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def self.configure
+            @configure ||= Client::Configuration.new
+            yield @configure if block_given?
+            @configure
+          end
 
-          # The default port of the service.
-          DEFAULT_SERVICE_PORT = 7469
-
-          # rubocop:disable Style/MutableConstant
-
-          # The default set of gRPC interceptors.
-          GRPC_INTERCEPTORS = []
-
-          # rubocop:enable Style/MutableConstant
-
-          DEFAULT_TIMEOUT = 30
-
-
+          ##
+          # Configure the Identity Client instance.
+          #
+          # The configuration is set to the derived mode, meaning that values can be changed,
+          # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+          # should be made on {Client.configure}.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def configure
+            yield @config if block_given?
+            @config
+          end
 
           ##
           # @param credentials [Google::Auth::Credentials, String, Hash,
@@ -66,50 +82,37 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scope [String, Array<String>]
-          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-          #   an updater_proc is supplied.
-          # @param timeout [Numeric]
-          #   The default timeout, in seconds, for calls made through this client.
-          # @param metadata [Hash]
-          #   Default metadata to be sent with each request. This can be overridden on a
-          #   per call basis.
           #
-          def initialize \
-              credentials: nil,
-              scope: nil,
-              timeout: DEFAULT_TIMEOUT,
-              metadata: nil,
-              lib_name: nil,
-              lib_version: nil
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          def initialize credentials: nil
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/identity_services_pb"
 
-            credentials ||= Credentials.default scope: scope
+            # Create the configuration object
+            @config = Configuration.new Client.configure
+
+            # Yield the configuration if needed
+            yield @config if block_given?
+
+            # Create credentials
+            credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
-              credentials = Credentials.new credentials, scope: scope
+              credentials = Credentials.new credentials, scope: @config.scope
             end
 
 
             @identity_stub = Google::Gax::Grpc::Stub.new(
               Google::Showcase::V1alpha3::Identity::Stub,
-              host:         self.class::SERVICE_ADDRESS,
-              port:         self.class::DEFAULT_SERVICE_PORT,
               credentials:  credentials,
-              interceptors: self.class::GRPC_INTERCEPTORS
+              host:         @config.host,
+              port:         @config.port,
+              interceptors: @config.interceptors
             )
-
-            @timeout = timeout
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            @metadata = metadata.to_h
-            @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
           end
 
           # Service calls
@@ -151,8 +154,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.create_user.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.create_user.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.create_user.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @create_user ||= Google::Gax::ApiCall.new @identity_stub.method :create_user
 
@@ -196,12 +212,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.get_user.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.get_user.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.get_user.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @get_user ||= Google::Gax::ApiCall.new @identity_stub.method :get_user
 
@@ -248,12 +279,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.update_user.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "user.name" => request.user.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.update_user.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.update_user.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @update_user ||= Google::Gax::ApiCall.new @identity_stub.method :update_user
 
@@ -297,12 +343,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_user.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_user.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_user.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_user ||= Google::Gax::ApiCall.new @identity_stub.method :delete_user
 
@@ -351,14 +412,83 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.list_users.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.list_users.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_users.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_users ||= Google::Gax::ApiCall.new @identity_stub.method :list_users
 
             wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_users, request, response, options }
 
             @list_users.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+          end
+
+          class Configuration
+            extend Google::Gax::Config
+
+            config_attr :host,         "localhost", String
+            config_attr :port,         7469, Integer
+            config_attr :scope,        nil,                                   String, Array, nil
+            config_attr :lib_name,     nil,                                   String, nil
+            config_attr :lib_version,  nil,                                   String, nil
+            config_attr :interceptors, [],                                    Array
+            config_attr :timeout,      nil,                                   Numeric, nil
+            config_attr :metadata,     nil,                                   Hash, nil
+            config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+            def initialize parent_config = nil
+              @parent_config = parent_config unless parent_config.nil?
+
+              yield self if block_given?
+            end
+
+            def rpcs
+              @rpcs ||= begin
+                parent_rpcs = nil
+                parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                Rpcs.new parent_rpcs
+              end
+            end
+
+            class Rpcs
+              attr_reader :create_user
+              attr_reader :get_user
+              attr_reader :update_user
+              attr_reader :delete_user
+              attr_reader :list_users
+
+              def initialize parent_rpcs = nil
+                create_user_config = nil
+                create_user_config = parent_rpcs&.create_user if parent_rpcs&.respond_to? :create_user
+                @create_user = Google::Gax::Config::Method.new create_user_config
+                get_user_config = nil
+                get_user_config = parent_rpcs&.get_user if parent_rpcs&.respond_to? :get_user
+                @get_user = Google::Gax::Config::Method.new get_user_config
+                update_user_config = nil
+                update_user_config = parent_rpcs&.update_user if parent_rpcs&.respond_to? :update_user
+                @update_user = Google::Gax::Config::Method.new update_user_config
+                delete_user_config = nil
+                delete_user_config = parent_rpcs&.delete_user if parent_rpcs&.respond_to? :delete_user
+                @delete_user = Google::Gax::Config::Method.new delete_user_config
+                list_users_config = nil
+                list_users_config = parent_rpcs&.list_users if parent_rpcs&.respond_to? :list_users
+                @list_users = Google::Gax::Config::Method.new list_users_config
+
+                yield self if block_given?
+              end
+            end
           end
         end
       end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -427,7 +427,7 @@ module Google
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
             config_attr :credentials,  nil do |value|
-              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
               allowed.any? { |klass| klass === value }
             end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 require "google/gax"
+require "google/gax/config"
+require "google/gax/config/method"
 
 require "google/showcase/version"
 require "google/showcase/v1alpha3/messaging_pb"
@@ -33,22 +35,36 @@ module Google
           # @private
           attr_reader :messaging_stub
 
-          # The default address of the service.
-          SERVICE_ADDRESS = "localhost"
+          ##
+          # Configuration for the Messaging Client API.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def self.configure
+            @configure ||= Client::Configuration.new
+            yield @configure if block_given?
+            @configure
+          end
 
-          # The default port of the service.
-          DEFAULT_SERVICE_PORT = 7469
-
-          # rubocop:disable Style/MutableConstant
-
-          # The default set of gRPC interceptors.
-          GRPC_INTERCEPTORS = []
-
-          # rubocop:enable Style/MutableConstant
-
-          DEFAULT_TIMEOUT = 30
-
-
+          ##
+          # Configure the Messaging Client instance.
+          #
+          # The configuration is set to the derived mode, meaning that values can be changed,
+          # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+          # should be made on {Client.configure}.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def configure
+            yield @config if block_given?
+            @config
+          end
 
           ##
           # @param credentials [Google::Auth::Credentials, String, Hash,
@@ -67,58 +83,40 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scope [String, Array<String>]
-          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-          #   an updater_proc is supplied.
-          # @param timeout [Numeric]
-          #   The default timeout, in seconds, for calls made through this client.
-          # @param metadata [Hash]
-          #   Default metadata to be sent with each request. This can be overridden on a
-          #   per call basis.
           #
-          def initialize \
-              credentials: nil,
-              scope: nil,
-              timeout: DEFAULT_TIMEOUT,
-              metadata: nil,
-              lib_name: nil,
-              lib_version: nil
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          def initialize credentials: nil
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/messaging_services_pb"
 
-            credentials ||= Credentials.default scope: scope
+            # Create the configuration object
+            @config = Configuration.new Client.configure
+
+            # Yield the configuration if needed
+            yield @config if block_given?
+
+            # Create credentials
+            credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
-              credentials = Credentials.new credentials, scope: scope
+              credentials = Credentials.new credentials, scope: @config.scope
             end
 
             @operations_client = Operations.new(
-              credentials: credentials,
-              scope:       scope,
-              timeout:     timeout,
-              metadata:    metadata,
-              lib_name:    lib_name,
-              lib_version: lib_version
+              credentials: credentials
             )
 
             @messaging_stub = Google::Gax::Grpc::Stub.new(
               Google::Showcase::V1alpha3::Messaging::Stub,
-              host:         self.class::SERVICE_ADDRESS,
-              port:         self.class::DEFAULT_SERVICE_PORT,
               credentials:  credentials,
-              interceptors: self.class::GRPC_INTERCEPTORS
+              host:         @config.host,
+              port:         @config.port,
+              interceptors: @config.interceptors
             )
-
-            @timeout = timeout
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            @metadata = metadata.to_h
-            @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
           end
 
           # Service calls
@@ -160,8 +158,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.create_room.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.create_room.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.create_room.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @create_room ||= Google::Gax::ApiCall.new @messaging_stub.method :create_room
 
@@ -205,12 +216,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.get_room.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.get_room.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.get_room.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @get_room ||= Google::Gax::ApiCall.new @messaging_stub.method :get_room
 
@@ -257,12 +283,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.update_room.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "room.name" => request.room.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.update_room.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.update_room.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @update_room ||= Google::Gax::ApiCall.new @messaging_stub.method :update_room
 
@@ -306,12 +347,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_room.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_room.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_room.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_room ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_room
 
@@ -360,8 +416,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.list_rooms.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.list_rooms.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_rooms.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_rooms ||= Google::Gax::ApiCall.new @messaging_stub.method :list_rooms
 
@@ -414,12 +483,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.create_blurb.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "parent" => request.parent
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.create_blurb.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.create_blurb.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @create_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :create_blurb
 
@@ -463,12 +547,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.get_blurb.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.get_blurb.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.get_blurb.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @get_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :get_blurb
 
@@ -515,12 +614,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.update_blurb.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "blurb.name" => request.blurb.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.update_blurb.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.update_blurb.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @update_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :update_blurb
 
@@ -564,12 +678,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_blurb.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_blurb.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_blurb.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_blurb
 
@@ -623,12 +752,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.list_blurbs.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "parent" => request.parent
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.list_blurbs.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_blurbs.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :list_blurbs
 
@@ -691,12 +835,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.search_blurbs.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "parent" => request.parent
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.search_blurbs.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.search_blurbs.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @search_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :search_blurbs
 
@@ -749,12 +908,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.stream_blurbs.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.stream_blurbs.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.stream_blurbs.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @stream_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :stream_blurbs
             @stream_blurbs.call request, options: options, stream_callback: block
@@ -797,12 +971,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.send_blurbs.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "parent" => request.parent
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.send_blurbs.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.send_blurbs.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @send_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :send_blurbs
             @send_blurbs.call requests, options: options, operation_callback: block
@@ -848,11 +1037,116 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.connect.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.connect.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.connect.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @connect ||= Google::Gax::ApiCall.new @messaging_stub.method :connect
             @connect.call requests, options: options, stream_callback: block
+          end
+
+          class Configuration
+            extend Google::Gax::Config
+
+            config_attr :host,         "localhost", String
+            config_attr :port,         7469, Integer
+            config_attr :scope,        nil,                                   String, Array, nil
+            config_attr :lib_name,     nil,                                   String, nil
+            config_attr :lib_version,  nil,                                   String, nil
+            config_attr :interceptors, [],                                    Array
+            config_attr :timeout,      nil,                                   Numeric, nil
+            config_attr :metadata,     nil,                                   Hash, nil
+            config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+            def initialize parent_config = nil
+              @parent_config = parent_config unless parent_config.nil?
+
+              yield self if block_given?
+            end
+
+            def rpcs
+              @rpcs ||= begin
+                parent_rpcs = nil
+                parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                Rpcs.new parent_rpcs
+              end
+            end
+
+            class Rpcs
+              attr_reader :create_room
+              attr_reader :get_room
+              attr_reader :update_room
+              attr_reader :delete_room
+              attr_reader :list_rooms
+              attr_reader :create_blurb
+              attr_reader :get_blurb
+              attr_reader :update_blurb
+              attr_reader :delete_blurb
+              attr_reader :list_blurbs
+              attr_reader :search_blurbs
+              attr_reader :stream_blurbs
+              attr_reader :send_blurbs
+              attr_reader :connect
+
+              def initialize parent_rpcs = nil
+                create_room_config = nil
+                create_room_config = parent_rpcs&.create_room if parent_rpcs&.respond_to? :create_room
+                @create_room = Google::Gax::Config::Method.new create_room_config
+                get_room_config = nil
+                get_room_config = parent_rpcs&.get_room if parent_rpcs&.respond_to? :get_room
+                @get_room = Google::Gax::Config::Method.new get_room_config
+                update_room_config = nil
+                update_room_config = parent_rpcs&.update_room if parent_rpcs&.respond_to? :update_room
+                @update_room = Google::Gax::Config::Method.new update_room_config
+                delete_room_config = nil
+                delete_room_config = parent_rpcs&.delete_room if parent_rpcs&.respond_to? :delete_room
+                @delete_room = Google::Gax::Config::Method.new delete_room_config
+                list_rooms_config = nil
+                list_rooms_config = parent_rpcs&.list_rooms if parent_rpcs&.respond_to? :list_rooms
+                @list_rooms = Google::Gax::Config::Method.new list_rooms_config
+                create_blurb_config = nil
+                create_blurb_config = parent_rpcs&.create_blurb if parent_rpcs&.respond_to? :create_blurb
+                @create_blurb = Google::Gax::Config::Method.new create_blurb_config
+                get_blurb_config = nil
+                get_blurb_config = parent_rpcs&.get_blurb if parent_rpcs&.respond_to? :get_blurb
+                @get_blurb = Google::Gax::Config::Method.new get_blurb_config
+                update_blurb_config = nil
+                update_blurb_config = parent_rpcs&.update_blurb if parent_rpcs&.respond_to? :update_blurb
+                @update_blurb = Google::Gax::Config::Method.new update_blurb_config
+                delete_blurb_config = nil
+                delete_blurb_config = parent_rpcs&.delete_blurb if parent_rpcs&.respond_to? :delete_blurb
+                @delete_blurb = Google::Gax::Config::Method.new delete_blurb_config
+                list_blurbs_config = nil
+                list_blurbs_config = parent_rpcs&.list_blurbs if parent_rpcs&.respond_to? :list_blurbs
+                @list_blurbs = Google::Gax::Config::Method.new list_blurbs_config
+                search_blurbs_config = nil
+                search_blurbs_config = parent_rpcs&.search_blurbs if parent_rpcs&.respond_to? :search_blurbs
+                @search_blurbs = Google::Gax::Config::Method.new search_blurbs_config
+                stream_blurbs_config = nil
+                stream_blurbs_config = parent_rpcs&.stream_blurbs if parent_rpcs&.respond_to? :stream_blurbs
+                @stream_blurbs = Google::Gax::Config::Method.new stream_blurbs_config
+                send_blurbs_config = nil
+                send_blurbs_config = parent_rpcs&.send_blurbs if parent_rpcs&.respond_to? :send_blurbs
+                @send_blurbs = Google::Gax::Config::Method.new send_blurbs_config
+                connect_config = nil
+                connect_config = parent_rpcs&.connect if parent_rpcs&.respond_to? :connect
+                @connect = Google::Gax::Config::Method.new connect_config
+
+                yield self if block_given?
+              end
+            end
           end
         end
       end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -1049,7 +1049,7 @@ module Google
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
             config_attr :credentials,  nil do |value|
-              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
               allowed.any? { |klass| klass === value }
             end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -67,27 +67,12 @@ module Google
           end
 
           ##
-          # @param credentials [Google::Auth::Credentials, String, Hash,
-          #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-          #   Provides the means for authenticating requests made by the client. This
-          #   parameter can be many types.
-          #   A `Google::Auth::Credentials` uses a the properties of its represented
-          #   keyfile for authenticating requests made by this client.
-          #   A `String` will be treated as the path to the keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `Hash` will be treated as the contents of a keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `GRPC::Core::Channel` will be used to make calls through.
-          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-          #   channel credentials should already be composed with a
-          #   `GRPC::Core::CallCredentials` object.
-          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-          #   transforms the metadata for requests, generally, to give OAuth credentials.
+          # Create a new Client client object.
           #
           # @yield [config] Configure the Client client.
           # @yieldparam config [Client::Configuration]
           #
-          def initialize credentials: nil
+          def initialize
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -101,14 +86,15 @@ module Google
             yield @config if block_given?
 
             # Create credentials
+            credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
 
-            @operations_client = Operations.new(
-              credentials: credentials
-            )
+            @operations_client = Operations.new do |config|
+              config.credentials = credentials
+            end
 
             @messaging_stub = Google::Gax::Grpc::Stub.new(
               Google::Showcase::V1alpha3::Messaging::Stub,
@@ -1062,6 +1048,11 @@ module Google
 
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
+            config_attr :credentials,  nil do |value|
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+              allowed.any? { |klass| klass === value }
+            end
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -31,6 +31,37 @@ module Google
           attr_reader :operations_stub
 
           ##
+          # Configuration for the Messaging Operations API.
+          #
+          # @yield [config] Configure the Operations client.
+          # @yieldparam config [Operations::Configuration]
+          #
+          # @return [Operations::Configuration]
+          #
+          def self.configure
+            @configure ||= Operations::Configuration.new
+            yield @configure if block_given?
+            @configure
+          end
+
+          ##
+          # Configure the Messaging Operations instance.
+          #
+          # The configuration is set to the derived mode, meaning that values can be changed,
+          # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+          # should be made on {Operations.configure}.
+          #
+          # @yield [config] Configure the Operations client.
+          # @yieldparam config [Operations::Configuration]
+          #
+          # @return [Operations::Configuration]
+          #
+          def configure
+            yield @config if block_given?
+            @config
+          end
+
+          ##
           # @param credentials [Google::Auth::Credentials, String, Hash,
           #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
           #   Provides the means for authenticating requests made by the client. This
@@ -47,49 +78,36 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scope [String, Array<String>]
-          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-          #   an updater_proc is supplied.
-          # @param timeout [Numeric]
-          #   The default timeout, in seconds, for calls made through this client.
-          # @param metadata [Hash]
-          #   Default metadata to be sent with each request. This can be overridden on a
-          #   per call basis.
           #
-          def initialize \
-              credentials:  nil,
-              scope:        Client::ALL_SCOPES,
-              timeout:      Client::DEFAULT_TIMEOUT,
-              metadata:     nil,
-              lib_name:     nil,
-              lib_version:  nil
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Operations::Configuration]
+          #
+          def initialize credentials: nil, config: nil
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/longrunning/operations_services_pb"
 
-            credentials ||= Credentials.default scope: scope
+            # Create the configuration object
+            @config = Configuration.new Operations.configure
+
+            # Yield the configuration if needed
+            yield @config if block_given?
+
+            # Create credentials
+            credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
-              credentials = Credentials.new credentials, scope: scope
+              credentials = Credentials.new credentials, scope: @config.scope
             end
 
             @operations_stub = Google::Gax::Grpc::Stub.new(
               Google::Longrunning::Operations::Stub,
-              host:         Client::SERVICE_ADDRESS,
-              port:         Client::DEFAULT_SERVICE_PORT,
               credentials:  credentials,
-              interceptors: Client::GRPC_INTERCEPTORS
+              host:         @config.host,
+              port:         @config.port,
+              interceptors: @config.interceptors
             )
-
-            @timeout = timeout
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            @metadata = metadata.to_h
-            @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
           end
 
           # Service calls
@@ -145,12 +163,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.list_operations.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_operations.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
 
@@ -201,12 +234,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.get_operation.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.get_operation.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
 
@@ -258,12 +306,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_operation.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_operation.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
 
@@ -325,16 +388,83 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.cancel_operation.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.cancel_operation.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
 
             @cancel_operation.call request, options: options, operation_callback: block
+          end
+
+          class Configuration
+            extend Google::Gax::Config
+
+            config_attr :host,         "localhost", String
+            config_attr :port,         443, Integer
+            config_attr :scope,        nil,                                   String, Array, nil
+            config_attr :lib_name,     nil,                                   String, nil
+            config_attr :lib_version,  nil,                                   String, nil
+            config_attr :interceptors, [],                                    Array
+            config_attr :timeout,      nil,                                   Numeric, nil
+            config_attr :metadata,     nil,                                   Hash, nil
+            config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+            def initialize parent_config = nil
+              @parent_config = parent_config unless parent_config.nil?
+
+              yield self if block_given?
+            end
+
+            def rpcs
+              @rpcs ||= begin
+                parent_rpcs = nil
+                parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                Rpcs.new parent_rpcs
+              end
+            end
+
+            class Rpcs
+              attr_reader :list_operations
+              attr_reader :get_operation
+              attr_reader :delete_operation
+              attr_reader :cancel_operation
+
+              def initialize parent_rpcs = nil
+                list_operations_config = nil
+                list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
+                @list_operations = Google::Gax::Config::Method.new list_operations_config
+                get_operation_config = nil
+                get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
+                @get_operation = Google::Gax::Config::Method.new get_operation_config
+                delete_operation_config = nil
+                delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
+                @delete_operation = Google::Gax::Config::Method.new delete_operation_config
+                cancel_operation_config = nil
+                cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
+                @cancel_operation = Google::Gax::Config::Method.new cancel_operation_config
+
+                yield self if block_given?
+              end
+            end
           end
         end
       end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -62,27 +62,12 @@ module Google
           end
 
           ##
-          # @param credentials [Google::Auth::Credentials, String, Hash,
-          #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-          #   Provides the means for authenticating requests made by the client. This
-          #   parameter can be many types.
-          #   A `Google::Auth::Credentials` uses a the properties of its represented
-          #   keyfile for authenticating requests made by this client.
-          #   A `String` will be treated as the path to the keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `Hash` will be treated as the contents of a keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `GRPC::Core::Channel` will be used to make calls through.
-          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-          #   channel credentials should already be composed with a
-          #   `GRPC::Core::CallCredentials` object.
-          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-          #   transforms the metadata for requests, generally, to give OAuth credentials.
+          # Create a new Operations client object.
           #
           # @yield [config] Configure the Client client.
           # @yieldparam config [Operations::Configuration]
           #
-          def initialize credentials: nil, config: nil
+          def initialize
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -96,6 +81,7 @@ module Google
             yield @config if block_given?
 
             # Create credentials
+            credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
@@ -420,6 +406,11 @@ module Google
 
             config_attr :host,         "localhost", String
             config_attr :port,         443, Integer
+            config_attr :credentials,  nil do |value|
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+              allowed.any? { |klass| klass === value }
+            end
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -407,7 +407,7 @@ module Google
             config_attr :host,         "localhost", String
             config_attr :port,         443, Integer
             config_attr :credentials,  nil do |value|
-              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
               allowed.any? { |klass| klass === value }
             end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -645,7 +645,7 @@ module Google
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
             config_attr :credentials,  nil do |value|
-              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
               allowed.any? { |klass| klass === value }
             end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 require "google/gax"
+require "google/gax/config"
+require "google/gax/config/method"
 
 require "google/showcase/version"
 require "google/showcase/v1alpha3/testing_pb"
@@ -32,22 +34,36 @@ module Google
           # @private
           attr_reader :testing_stub
 
-          # The default address of the service.
-          SERVICE_ADDRESS = "localhost"
+          ##
+          # Configuration for the Testing Client API.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def self.configure
+            @configure ||= Client::Configuration.new
+            yield @configure if block_given?
+            @configure
+          end
 
-          # The default port of the service.
-          DEFAULT_SERVICE_PORT = 7469
-
-          # rubocop:disable Style/MutableConstant
-
-          # The default set of gRPC interceptors.
-          GRPC_INTERCEPTORS = []
-
-          # rubocop:enable Style/MutableConstant
-
-          DEFAULT_TIMEOUT = 30
-
-
+          ##
+          # Configure the Testing Client instance.
+          #
+          # The configuration is set to the derived mode, meaning that values can be changed,
+          # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+          # should be made on {Client.configure}.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def configure
+            yield @config if block_given?
+            @config
+          end
 
           ##
           # @param credentials [Google::Auth::Credentials, String, Hash,
@@ -66,50 +82,37 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scope [String, Array<String>]
-          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-          #   an updater_proc is supplied.
-          # @param timeout [Numeric]
-          #   The default timeout, in seconds, for calls made through this client.
-          # @param metadata [Hash]
-          #   Default metadata to be sent with each request. This can be overridden on a
-          #   per call basis.
           #
-          def initialize \
-              credentials: nil,
-              scope: nil,
-              timeout: DEFAULT_TIMEOUT,
-              metadata: nil,
-              lib_name: nil,
-              lib_version: nil
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          def initialize credentials: nil
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/testing_services_pb"
 
-            credentials ||= Credentials.default scope: scope
+            # Create the configuration object
+            @config = Configuration.new Client.configure
+
+            # Yield the configuration if needed
+            yield @config if block_given?
+
+            # Create credentials
+            credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
-              credentials = Credentials.new credentials, scope: scope
+              credentials = Credentials.new credentials, scope: @config.scope
             end
 
 
             @testing_stub = Google::Gax::Grpc::Stub.new(
               Google::Showcase::V1alpha3::Testing::Stub,
-              host:         self.class::SERVICE_ADDRESS,
-              port:         self.class::DEFAULT_SERVICE_PORT,
               credentials:  credentials,
-              interceptors: self.class::GRPC_INTERCEPTORS
+              host:         @config.host,
+              port:         @config.port,
+              interceptors: @config.interceptors
             )
-
-            @timeout = timeout
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            @metadata = metadata.to_h
-            @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
           end
 
           # Service calls
@@ -153,8 +156,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.create_session.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.create_session.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.create_session.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @create_session ||= Google::Gax::ApiCall.new @testing_stub.method :create_session
 
@@ -198,12 +214,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.get_session.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.get_session.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.get_session.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @get_session ||= Google::Gax::ApiCall.new @testing_stub.method :get_session
 
@@ -249,8 +280,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.list_sessions.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.list_sessions.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_sessions.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_sessions ||= Google::Gax::ApiCall.new @testing_stub.method :list_sessions
 
@@ -296,12 +340,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_session.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_session.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_session.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_session ||= Google::Gax::ApiCall.new @testing_stub.method :delete_session
 
@@ -349,12 +408,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.report_session.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.report_session.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.report_session.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @report_session ||= Google::Gax::ApiCall.new @testing_stub.method :report_session
 
@@ -402,12 +476,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.list_tests.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.list_tests.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_tests.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_tests ||= Google::Gax::ApiCall.new @testing_stub.method :list_tests
 
@@ -463,12 +552,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_test.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_test.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_test.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_test ||= Google::Gax::ApiCall.new @testing_stub.method :delete_test
 
@@ -522,16 +626,99 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.verify_test.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.verify_test.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.verify_test.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @verify_test ||= Google::Gax::ApiCall.new @testing_stub.method :verify_test
 
             @verify_test.call request, options: options, operation_callback: block
+          end
+
+          class Configuration
+            extend Google::Gax::Config
+
+            config_attr :host,         "localhost", String
+            config_attr :port,         7469, Integer
+            config_attr :scope,        nil,                                   String, Array, nil
+            config_attr :lib_name,     nil,                                   String, nil
+            config_attr :lib_version,  nil,                                   String, nil
+            config_attr :interceptors, [],                                    Array
+            config_attr :timeout,      nil,                                   Numeric, nil
+            config_attr :metadata,     nil,                                   Hash, nil
+            config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+            def initialize parent_config = nil
+              @parent_config = parent_config unless parent_config.nil?
+
+              yield self if block_given?
+            end
+
+            def rpcs
+              @rpcs ||= begin
+                parent_rpcs = nil
+                parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                Rpcs.new parent_rpcs
+              end
+            end
+
+            class Rpcs
+              attr_reader :create_session
+              attr_reader :get_session
+              attr_reader :list_sessions
+              attr_reader :delete_session
+              attr_reader :report_session
+              attr_reader :list_tests
+              attr_reader :delete_test
+              attr_reader :verify_test
+
+              def initialize parent_rpcs = nil
+                create_session_config = nil
+                create_session_config = parent_rpcs&.create_session if parent_rpcs&.respond_to? :create_session
+                @create_session = Google::Gax::Config::Method.new create_session_config
+                get_session_config = nil
+                get_session_config = parent_rpcs&.get_session if parent_rpcs&.respond_to? :get_session
+                @get_session = Google::Gax::Config::Method.new get_session_config
+                list_sessions_config = nil
+                list_sessions_config = parent_rpcs&.list_sessions if parent_rpcs&.respond_to? :list_sessions
+                @list_sessions = Google::Gax::Config::Method.new list_sessions_config
+                delete_session_config = nil
+                delete_session_config = parent_rpcs&.delete_session if parent_rpcs&.respond_to? :delete_session
+                @delete_session = Google::Gax::Config::Method.new delete_session_config
+                report_session_config = nil
+                report_session_config = parent_rpcs&.report_session if parent_rpcs&.respond_to? :report_session
+                @report_session = Google::Gax::Config::Method.new report_session_config
+                list_tests_config = nil
+                list_tests_config = parent_rpcs&.list_tests if parent_rpcs&.respond_to? :list_tests
+                @list_tests = Google::Gax::Config::Method.new list_tests_config
+                delete_test_config = nil
+                delete_test_config = parent_rpcs&.delete_test if parent_rpcs&.respond_to? :delete_test
+                @delete_test = Google::Gax::Config::Method.new delete_test_config
+                verify_test_config = nil
+                verify_test_config = parent_rpcs&.verify_test if parent_rpcs&.respond_to? :verify_test
+                @verify_test = Google::Gax::Config::Method.new verify_test_config
+
+                yield self if block_given?
+              end
+            end
           end
         end
       end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -66,27 +66,12 @@ module Google
           end
 
           ##
-          # @param credentials [Google::Auth::Credentials, String, Hash,
-          #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-          #   Provides the means for authenticating requests made by the client. This
-          #   parameter can be many types.
-          #   A `Google::Auth::Credentials` uses a the properties of its represented
-          #   keyfile for authenticating requests made by this client.
-          #   A `String` will be treated as the path to the keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `Hash` will be treated as the contents of a keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `GRPC::Core::Channel` will be used to make calls through.
-          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-          #   channel credentials should already be composed with a
-          #   `GRPC::Core::CallCredentials` object.
-          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-          #   transforms the metadata for requests, generally, to give OAuth credentials.
+          # Create a new Client client object.
           #
           # @yield [config] Configure the Client client.
           # @yieldparam config [Client::Configuration]
           #
-          def initialize credentials: nil
+          def initialize
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -100,6 +85,7 @@ module Google
             yield @config if block_given?
 
             # Create credentials
+            credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
@@ -658,6 +644,11 @@ module Google
 
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
+            config_attr :credentials,  nil do |value|
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+              allowed.any? { |klass| klass === value }
+            end
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -301,7 +301,7 @@ module Google
               config_attr :host,         "speech.googleapis.com", String
               config_attr :port,         443, Integer
               config_attr :credentials,  nil do |value|
-                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
                 allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
                 allowed.any? { |klass| klass === value }
               end

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 require "google/gax"
+require "google/gax/config"
+require "google/gax/config/method"
 
 require "google/cloud/speech/version"
 require "google/cloud/speech/v1/cloud_speech_pb"
@@ -31,22 +33,36 @@ module Google
             # @private
             attr_reader :speech_stub
 
-            # The default address of the service.
-            SERVICE_ADDRESS = "speech.googleapis.com"
+            ##
+            # Configuration for the Speech Client API.
+            #
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Client::Configuration]
+            #
+            # @return [Client::Configuration]
+            #
+            def self.configure
+              @configure ||= Client::Configuration.new
+              yield @configure if block_given?
+              @configure
+            end
 
-            # The default port of the service.
-            DEFAULT_SERVICE_PORT = 443
-
-            # rubocop:disable Style/MutableConstant
-
-            # The default set of gRPC interceptors.
-            GRPC_INTERCEPTORS = []
-
-            # rubocop:enable Style/MutableConstant
-
-            DEFAULT_TIMEOUT = 30
-
-
+            ##
+            # Configure the Speech Client instance.
+            #
+            # The configuration is set to the derived mode, meaning that values can be changed,
+            # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+            # should be made on {Client.configure}.
+            #
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Client::Configuration]
+            #
+            # @return [Client::Configuration]
+            #
+            def configure
+              yield @config if block_given?
+              @config
+            end
 
             ##
             # @param credentials [Google::Auth::Credentials, String, Hash,
@@ -65,58 +81,40 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scope [String, Array<String>]
-            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-            #   an updater_proc is supplied.
-            # @param timeout [Numeric]
-            #   The default timeout, in seconds, for calls made through this client.
-            # @param metadata [Hash]
-            #   Default metadata to be sent with each request. This can be overridden on a
-            #   per call basis.
             #
-            def initialize \
-                credentials: nil,
-                scope: nil,
-                timeout: DEFAULT_TIMEOUT,
-                metadata: nil,
-                lib_name: nil,
-                lib_version: nil
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Client::Configuration]
+            #
+            def initialize credentials: nil
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
               require "google/gax/grpc"
               require "google/cloud/speech/v1/cloud_speech_services_pb"
 
-              credentials ||= Credentials.default scope: scope
+              # Create the configuration object
+              @config = Configuration.new Client.configure
+
+              # Yield the configuration if needed
+              yield @config if block_given?
+
+              # Create credentials
+              credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
-                credentials = Credentials.new credentials, scope: scope
+                credentials = Credentials.new credentials, scope: @config.scope
               end
 
               @operations_client = Operations.new(
-                credentials: credentials,
-                scope:       scope,
-                timeout:     timeout,
-                metadata:    metadata,
-                lib_name:    lib_name,
-                lib_version: lib_version
+                credentials: credentials
               )
 
               @speech_stub = Google::Gax::Grpc::Stub.new(
                 Google::Cloud::Speech::V1::Speech::Stub,
-                host:         self.class::SERVICE_ADDRESS,
-                port:         self.class::DEFAULT_SERVICE_PORT,
                 credentials:  credentials,
-                interceptors: self.class::GRPC_INTERCEPTORS
+                host:         @config.host,
+                port:         @config.port,
+                interceptors: @config.interceptors
               )
-
-              @timeout = timeout
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              @metadata = metadata.to_h
-              @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
             end
 
             # Service calls
@@ -163,8 +161,21 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
-              metadata = @metadata.dup
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata = @config.rpcs.recognize.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+              options.apply_defaults timeout:      @config.rpcs.recognize.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.recognize.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @recognize ||= Google::Gax::ApiCall.new @speech_stub.method :recognize
 
@@ -217,8 +228,21 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
-              metadata = @metadata.dup
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata = @config.rpcs.long_running_recognize.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+              options.apply_defaults timeout:      @config.rpcs.long_running_recognize.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.long_running_recognize.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @long_running_recognize ||= Google::Gax::ApiCall.new @speech_stub.method :long_running_recognize
 
@@ -265,11 +289,72 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
-              metadata = @metadata.dup
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata = @config.rpcs.streaming_recognize.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+              options.apply_defaults timeout:      @config.rpcs.streaming_recognize.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.streaming_recognize.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @streaming_recognize ||= Google::Gax::ApiCall.new @speech_stub.method :streaming_recognize
               @streaming_recognize.call requests, options: options, stream_callback: block
+            end
+
+            class Configuration
+              extend Google::Gax::Config
+
+              config_attr :host,         "speech.googleapis.com", String
+              config_attr :port,         443, Integer
+              config_attr :scope,        nil,                                   String, Array, nil
+              config_attr :lib_name,     nil,                                   String, nil
+              config_attr :lib_version,  nil,                                   String, nil
+              config_attr :interceptors, [],                                    Array
+              config_attr :timeout,      nil,                                   Numeric, nil
+              config_attr :metadata,     nil,                                   Hash, nil
+              config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+              def initialize parent_config = nil
+                @parent_config = parent_config unless parent_config.nil?
+
+                yield self if block_given?
+              end
+
+              def rpcs
+                @rpcs ||= begin
+                  parent_rpcs = nil
+                  parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                  Rpcs.new parent_rpcs
+                end
+              end
+
+              class Rpcs
+                attr_reader :recognize
+                attr_reader :long_running_recognize
+                attr_reader :streaming_recognize
+
+                def initialize parent_rpcs = nil
+                  recognize_config = nil
+                  recognize_config = parent_rpcs&.recognize if parent_rpcs&.respond_to? :recognize
+                  @recognize = Google::Gax::Config::Method.new recognize_config
+                  long_running_recognize_config = nil
+                  long_running_recognize_config = parent_rpcs&.long_running_recognize if parent_rpcs&.respond_to? :long_running_recognize
+                  @long_running_recognize = Google::Gax::Config::Method.new long_running_recognize_config
+                  streaming_recognize_config = nil
+                  streaming_recognize_config = parent_rpcs&.streaming_recognize if parent_rpcs&.respond_to? :streaming_recognize
+                  @streaming_recognize = Google::Gax::Config::Method.new streaming_recognize_config
+
+                  yield self if block_given?
+                end
+              end
             end
           end
         end

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -65,27 +65,12 @@ module Google
             end
 
             ##
-            # @param credentials [Google::Auth::Credentials, String, Hash,
-            #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-            #   Provides the means for authenticating requests made by the client. This
-            #   parameter can be many types.
-            #   A `Google::Auth::Credentials` uses a the properties of its represented
-            #   keyfile for authenticating requests made by this client.
-            #   A `String` will be treated as the path to the keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `Hash` will be treated as the contents of a keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `GRPC::Core::Channel` will be used to make calls through.
-            #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-            #   channel credentials should already be composed with a
-            #   `GRPC::Core::CallCredentials` object.
-            #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-            #   transforms the metadata for requests, generally, to give OAuth credentials.
+            # Create a new Client client object.
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Client::Configuration]
             #
-            def initialize credentials: nil
+            def initialize
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
@@ -99,14 +84,15 @@ module Google
               yield @config if block_given?
 
               # Create credentials
+              credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
 
-              @operations_client = Operations.new(
-                credentials: credentials
-              )
+              @operations_client = Operations.new do |config|
+                config.credentials = credentials
+              end
 
               @speech_stub = Google::Gax::Grpc::Stub.new(
                 Google::Cloud::Speech::V1::Speech::Stub,
@@ -314,6 +300,11 @@ module Google
 
               config_attr :host,         "speech.googleapis.com", String
               config_attr :port,         443, Integer
+              config_attr :credentials,  nil do |value|
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+                allowed.any? { |klass| klass === value }
+              end
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -408,7 +408,7 @@ module Google
               config_attr :host,         "speech.googleapis.com", String
               config_attr :port,         443, Integer
               config_attr :credentials,  nil do |value|
-                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
                 allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
                 allowed.any? { |klass| klass === value }
               end

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -32,6 +32,37 @@ module Google
             attr_reader :operations_stub
 
             ##
+            # Configuration for the Speech Operations API.
+            #
+            # @yield [config] Configure the Operations client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            # @return [Operations::Configuration]
+            #
+            def self.configure
+              @configure ||= Operations::Configuration.new
+              yield @configure if block_given?
+              @configure
+            end
+
+            ##
+            # Configure the Speech Operations instance.
+            #
+            # The configuration is set to the derived mode, meaning that values can be changed,
+            # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+            # should be made on {Operations.configure}.
+            #
+            # @yield [config] Configure the Operations client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            # @return [Operations::Configuration]
+            #
+            def configure
+              yield @config if block_given?
+              @config
+            end
+
+            ##
             # @param credentials [Google::Auth::Credentials, String, Hash,
             #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
             #   Provides the means for authenticating requests made by the client. This
@@ -48,49 +79,36 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scope [String, Array<String>]
-            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-            #   an updater_proc is supplied.
-            # @param timeout [Numeric]
-            #   The default timeout, in seconds, for calls made through this client.
-            # @param metadata [Hash]
-            #   Default metadata to be sent with each request. This can be overridden on a
-            #   per call basis.
             #
-            def initialize \
-                credentials:  nil,
-                scope:        Client::ALL_SCOPES,
-                timeout:      Client::DEFAULT_TIMEOUT,
-                metadata:     nil,
-                lib_name:     nil,
-                lib_version:  nil
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            def initialize credentials: nil, config: nil
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
               require "google/gax/grpc"
               require "google/longrunning/operations_services_pb"
 
-              credentials ||= Credentials.default scope: scope
+              # Create the configuration object
+              @config = Configuration.new Operations.configure
+
+              # Yield the configuration if needed
+              yield @config if block_given?
+
+              # Create credentials
+              credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
-                credentials = Credentials.new credentials, scope: scope
+                credentials = Credentials.new credentials, scope: @config.scope
               end
 
               @operations_stub = Google::Gax::Grpc::Stub.new(
                 Google::Longrunning::Operations::Stub,
-                host:         Client::SERVICE_ADDRESS,
-                port:         Client::DEFAULT_SERVICE_PORT,
                 credentials:  credentials,
-                interceptors: Client::GRPC_INTERCEPTORS
+                host:         @config.host,
+                port:         @config.port,
+                interceptors: @config.interceptors
               )
-
-              @timeout = timeout
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              @metadata = metadata.to_h
-              @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
             end
 
             # Service calls
@@ -146,12 +164,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.list_operations.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.list_operations.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
 
@@ -202,12 +235,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.get_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.get_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
 
@@ -259,12 +307,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.delete_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.delete_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
 
@@ -326,16 +389,83 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.cancel_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.cancel_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
 
               @cancel_operation.call request, options: options, operation_callback: block
+            end
+
+            class Configuration
+              extend Google::Gax::Config
+
+              config_attr :host,         "speech.googleapis.com", String
+              config_attr :port,         443, Integer
+              config_attr :scope,        nil,                                   String, Array, nil
+              config_attr :lib_name,     nil,                                   String, nil
+              config_attr :lib_version,  nil,                                   String, nil
+              config_attr :interceptors, [],                                    Array
+              config_attr :timeout,      nil,                                   Numeric, nil
+              config_attr :metadata,     nil,                                   Hash, nil
+              config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+              def initialize parent_config = nil
+                @parent_config = parent_config unless parent_config.nil?
+
+                yield self if block_given?
+              end
+
+              def rpcs
+                @rpcs ||= begin
+                  parent_rpcs = nil
+                  parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                  Rpcs.new parent_rpcs
+                end
+              end
+
+              class Rpcs
+                attr_reader :list_operations
+                attr_reader :get_operation
+                attr_reader :delete_operation
+                attr_reader :cancel_operation
+
+                def initialize parent_rpcs = nil
+                  list_operations_config = nil
+                  list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
+                  @list_operations = Google::Gax::Config::Method.new list_operations_config
+                  get_operation_config = nil
+                  get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
+                  @get_operation = Google::Gax::Config::Method.new get_operation_config
+                  delete_operation_config = nil
+                  delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
+                  @delete_operation = Google::Gax::Config::Method.new delete_operation_config
+                  cancel_operation_config = nil
+                  cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
+                  @cancel_operation = Google::Gax::Config::Method.new cancel_operation_config
+
+                  yield self if block_given?
+                end
+              end
             end
           end
         end

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -63,27 +63,12 @@ module Google
             end
 
             ##
-            # @param credentials [Google::Auth::Credentials, String, Hash,
-            #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-            #   Provides the means for authenticating requests made by the client. This
-            #   parameter can be many types.
-            #   A `Google::Auth::Credentials` uses a the properties of its represented
-            #   keyfile for authenticating requests made by this client.
-            #   A `String` will be treated as the path to the keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `Hash` will be treated as the contents of a keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `GRPC::Core::Channel` will be used to make calls through.
-            #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-            #   channel credentials should already be composed with a
-            #   `GRPC::Core::CallCredentials` object.
-            #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-            #   transforms the metadata for requests, generally, to give OAuth credentials.
+            # Create a new Operations client object.
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Operations::Configuration]
             #
-            def initialize credentials: nil, config: nil
+            def initialize
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
@@ -97,6 +82,7 @@ module Google
               yield @config if block_given?
 
               # Create credentials
+              credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
@@ -421,6 +407,11 @@ module Google
 
               config_attr :host,         "speech.googleapis.com", String
               config_attr :port,         443, Integer
+              config_attr :credentials,  nil do |value|
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+                allowed.any? { |klass| klass === value }
+              end
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -65,27 +65,12 @@ module Google
             end
 
             ##
-            # @param credentials [Google::Auth::Credentials, String, Hash,
-            #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-            #   Provides the means for authenticating requests made by the client. This
-            #   parameter can be many types.
-            #   A `Google::Auth::Credentials` uses a the properties of its represented
-            #   keyfile for authenticating requests made by this client.
-            #   A `String` will be treated as the path to the keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `Hash` will be treated as the contents of a keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `GRPC::Core::Channel` will be used to make calls through.
-            #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-            #   channel credentials should already be composed with a
-            #   `GRPC::Core::CallCredentials` object.
-            #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-            #   transforms the metadata for requests, generally, to give OAuth credentials.
+            # Create a new Client client object.
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Client::Configuration]
             #
-            def initialize credentials: nil
+            def initialize
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
@@ -99,14 +84,15 @@ module Google
               yield @config if block_given?
 
               # Create credentials
+              credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
 
-              @operations_client = Operations.new(
-                credentials: credentials
-              )
+              @operations_client = Operations.new do |config|
+                config.credentials = credentials
+              end
 
               @image_annotator_stub = Google::Gax::Grpc::Stub.new(
                 Google::Cloud::Vision::V1::ImageAnnotator::Stub,
@@ -252,6 +238,11 @@ module Google
 
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
+              config_attr :credentials,  nil do |value|
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+                allowed.any? { |klass| klass === value }
+              end
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -239,7 +239,7 @@ module Google
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
               config_attr :credentials,  nil do |value|
-                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
                 allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
                 allowed.any? { |klass| klass === value }
               end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 require "google/gax"
+require "google/gax/config"
+require "google/gax/config/method"
 
 require "google/cloud/vision/version"
 require "google/cloud/vision/v1/image_annotator_pb"
@@ -31,22 +33,36 @@ module Google
             # @private
             attr_reader :image_annotator_stub
 
-            # The default address of the service.
-            SERVICE_ADDRESS = "vision.googleapis.com"
+            ##
+            # Configuration for the ImageAnnotator Client API.
+            #
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Client::Configuration]
+            #
+            # @return [Client::Configuration]
+            #
+            def self.configure
+              @configure ||= Client::Configuration.new
+              yield @configure if block_given?
+              @configure
+            end
 
-            # The default port of the service.
-            DEFAULT_SERVICE_PORT = 443
-
-            # rubocop:disable Style/MutableConstant
-
-            # The default set of gRPC interceptors.
-            GRPC_INTERCEPTORS = []
-
-            # rubocop:enable Style/MutableConstant
-
-            DEFAULT_TIMEOUT = 30
-
-
+            ##
+            # Configure the ImageAnnotator Client instance.
+            #
+            # The configuration is set to the derived mode, meaning that values can be changed,
+            # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+            # should be made on {Client.configure}.
+            #
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Client::Configuration]
+            #
+            # @return [Client::Configuration]
+            #
+            def configure
+              yield @config if block_given?
+              @config
+            end
 
             ##
             # @param credentials [Google::Auth::Credentials, String, Hash,
@@ -65,58 +81,40 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scope [String, Array<String>]
-            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-            #   an updater_proc is supplied.
-            # @param timeout [Numeric]
-            #   The default timeout, in seconds, for calls made through this client.
-            # @param metadata [Hash]
-            #   Default metadata to be sent with each request. This can be overridden on a
-            #   per call basis.
             #
-            def initialize \
-                credentials: nil,
-                scope: nil,
-                timeout: DEFAULT_TIMEOUT,
-                metadata: nil,
-                lib_name: nil,
-                lib_version: nil
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Client::Configuration]
+            #
+            def initialize credentials: nil
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
               require "google/gax/grpc"
               require "google/cloud/vision/v1/image_annotator_services_pb"
 
-              credentials ||= Credentials.default scope: scope
+              # Create the configuration object
+              @config = Configuration.new Client.configure
+
+              # Yield the configuration if needed
+              yield @config if block_given?
+
+              # Create credentials
+              credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
-                credentials = Credentials.new credentials, scope: scope
+                credentials = Credentials.new credentials, scope: @config.scope
               end
 
               @operations_client = Operations.new(
-                credentials: credentials,
-                scope:       scope,
-                timeout:     timeout,
-                metadata:    metadata,
-                lib_name:    lib_name,
-                lib_version: lib_version
+                credentials: credentials
               )
 
               @image_annotator_stub = Google::Gax::Grpc::Stub.new(
                 Google::Cloud::Vision::V1::ImageAnnotator::Stub,
-                host:         self.class::SERVICE_ADDRESS,
-                port:         self.class::DEFAULT_SERVICE_PORT,
                 credentials:  credentials,
-                interceptors: self.class::GRPC_INTERCEPTORS
+                host:         @config.host,
+                port:         @config.port,
+                interceptors: @config.interceptors
               )
-
-              @timeout = timeout
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              @metadata = metadata.to_h
-              @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
             end
 
             # Service calls
@@ -158,8 +156,21 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
-              metadata = @metadata.dup
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata = @config.rpcs.batch_annotate_images.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+              options.apply_defaults timeout:      @config.rpcs.batch_annotate_images.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.batch_annotate_images.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @batch_annotate_images ||= Google::Gax::ApiCall.new @image_annotator_stub.method :batch_annotate_images
 
@@ -213,14 +224,71 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
-              metadata = @metadata.dup
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata = @config.rpcs.async_batch_annotate_files.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+              options.apply_defaults timeout:      @config.rpcs.async_batch_annotate_files.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.async_batch_annotate_files.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @async_batch_annotate_files ||= Google::Gax::ApiCall.new @image_annotator_stub.method :async_batch_annotate_files
 
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
               @async_batch_annotate_files.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            end
+
+            class Configuration
+              extend Google::Gax::Config
+
+              config_attr :host,         "vision.googleapis.com", String
+              config_attr :port,         443, Integer
+              config_attr :scope,        nil,                                   String, Array, nil
+              config_attr :lib_name,     nil,                                   String, nil
+              config_attr :lib_version,  nil,                                   String, nil
+              config_attr :interceptors, [],                                    Array
+              config_attr :timeout,      nil,                                   Numeric, nil
+              config_attr :metadata,     nil,                                   Hash, nil
+              config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+              def initialize parent_config = nil
+                @parent_config = parent_config unless parent_config.nil?
+
+                yield self if block_given?
+              end
+
+              def rpcs
+                @rpcs ||= begin
+                  parent_rpcs = nil
+                  parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                  Rpcs.new parent_rpcs
+                end
+              end
+
+              class Rpcs
+                attr_reader :batch_annotate_images
+                attr_reader :async_batch_annotate_files
+
+                def initialize parent_rpcs = nil
+                  batch_annotate_images_config = nil
+                  batch_annotate_images_config = parent_rpcs&.batch_annotate_images if parent_rpcs&.respond_to? :batch_annotate_images
+                  @batch_annotate_images = Google::Gax::Config::Method.new batch_annotate_images_config
+                  async_batch_annotate_files_config = nil
+                  async_batch_annotate_files_config = parent_rpcs&.async_batch_annotate_files if parent_rpcs&.respond_to? :async_batch_annotate_files
+                  @async_batch_annotate_files = Google::Gax::Config::Method.new async_batch_annotate_files_config
+
+                  yield self if block_given?
+                end
+              end
             end
           end
         end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -63,27 +63,12 @@ module Google
             end
 
             ##
-            # @param credentials [Google::Auth::Credentials, String, Hash,
-            #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-            #   Provides the means for authenticating requests made by the client. This
-            #   parameter can be many types.
-            #   A `Google::Auth::Credentials` uses a the properties of its represented
-            #   keyfile for authenticating requests made by this client.
-            #   A `String` will be treated as the path to the keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `Hash` will be treated as the contents of a keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `GRPC::Core::Channel` will be used to make calls through.
-            #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-            #   channel credentials should already be composed with a
-            #   `GRPC::Core::CallCredentials` object.
-            #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-            #   transforms the metadata for requests, generally, to give OAuth credentials.
+            # Create a new Operations client object.
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Operations::Configuration]
             #
-            def initialize credentials: nil, config: nil
+            def initialize
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
@@ -97,6 +82,7 @@ module Google
               yield @config if block_given?
 
               # Create credentials
+              credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
@@ -421,6 +407,11 @@ module Google
 
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
+              config_attr :credentials,  nil do |value|
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+                allowed.any? { |klass| klass === value }
+              end
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -408,7 +408,7 @@ module Google
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
               config_attr :credentials,  nil do |value|
-                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
                 allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
                 allowed.any? { |klass| klass === value }
               end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -32,6 +32,37 @@ module Google
             attr_reader :operations_stub
 
             ##
+            # Configuration for the ImageAnnotator Operations API.
+            #
+            # @yield [config] Configure the Operations client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            # @return [Operations::Configuration]
+            #
+            def self.configure
+              @configure ||= Operations::Configuration.new
+              yield @configure if block_given?
+              @configure
+            end
+
+            ##
+            # Configure the ImageAnnotator Operations instance.
+            #
+            # The configuration is set to the derived mode, meaning that values can be changed,
+            # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+            # should be made on {Operations.configure}.
+            #
+            # @yield [config] Configure the Operations client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            # @return [Operations::Configuration]
+            #
+            def configure
+              yield @config if block_given?
+              @config
+            end
+
+            ##
             # @param credentials [Google::Auth::Credentials, String, Hash,
             #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
             #   Provides the means for authenticating requests made by the client. This
@@ -48,49 +79,36 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scope [String, Array<String>]
-            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-            #   an updater_proc is supplied.
-            # @param timeout [Numeric]
-            #   The default timeout, in seconds, for calls made through this client.
-            # @param metadata [Hash]
-            #   Default metadata to be sent with each request. This can be overridden on a
-            #   per call basis.
             #
-            def initialize \
-                credentials:  nil,
-                scope:        Client::ALL_SCOPES,
-                timeout:      Client::DEFAULT_TIMEOUT,
-                metadata:     nil,
-                lib_name:     nil,
-                lib_version:  nil
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            def initialize credentials: nil, config: nil
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
               require "google/gax/grpc"
               require "google/longrunning/operations_services_pb"
 
-              credentials ||= Credentials.default scope: scope
+              # Create the configuration object
+              @config = Configuration.new Operations.configure
+
+              # Yield the configuration if needed
+              yield @config if block_given?
+
+              # Create credentials
+              credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
-                credentials = Credentials.new credentials, scope: scope
+                credentials = Credentials.new credentials, scope: @config.scope
               end
 
               @operations_stub = Google::Gax::Grpc::Stub.new(
                 Google::Longrunning::Operations::Stub,
-                host:         Client::SERVICE_ADDRESS,
-                port:         Client::DEFAULT_SERVICE_PORT,
                 credentials:  credentials,
-                interceptors: Client::GRPC_INTERCEPTORS
+                host:         @config.host,
+                port:         @config.port,
+                interceptors: @config.interceptors
               )
-
-              @timeout = timeout
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              @metadata = metadata.to_h
-              @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
             end
 
             # Service calls
@@ -146,12 +164,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.list_operations.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.list_operations.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
 
@@ -202,12 +235,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.get_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.get_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
 
@@ -259,12 +307,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.delete_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.delete_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
 
@@ -326,16 +389,83 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.cancel_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.cancel_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
 
               @cancel_operation.call request, options: options, operation_callback: block
+            end
+
+            class Configuration
+              extend Google::Gax::Config
+
+              config_attr :host,         "vision.googleapis.com", String
+              config_attr :port,         443, Integer
+              config_attr :scope,        nil,                                   String, Array, nil
+              config_attr :lib_name,     nil,                                   String, nil
+              config_attr :lib_version,  nil,                                   String, nil
+              config_attr :interceptors, [],                                    Array
+              config_attr :timeout,      nil,                                   Numeric, nil
+              config_attr :metadata,     nil,                                   Hash, nil
+              config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+              def initialize parent_config = nil
+                @parent_config = parent_config unless parent_config.nil?
+
+                yield self if block_given?
+              end
+
+              def rpcs
+                @rpcs ||= begin
+                  parent_rpcs = nil
+                  parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                  Rpcs.new parent_rpcs
+                end
+              end
+
+              class Rpcs
+                attr_reader :list_operations
+                attr_reader :get_operation
+                attr_reader :delete_operation
+                attr_reader :cancel_operation
+
+                def initialize parent_rpcs = nil
+                  list_operations_config = nil
+                  list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
+                  @list_operations = Google::Gax::Config::Method.new list_operations_config
+                  get_operation_config = nil
+                  get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
+                  @get_operation = Google::Gax::Config::Method.new get_operation_config
+                  delete_operation_config = nil
+                  delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
+                  @delete_operation = Google::Gax::Config::Method.new delete_operation_config
+                  cancel_operation_config = nil
+                  cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
+                  @cancel_operation = Google::Gax::Config::Method.new cancel_operation_config
+
+                  yield self if block_given?
+                end
+              end
             end
           end
         end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 require "google/gax"
+require "google/gax/config"
+require "google/gax/config/method"
 
 require "google/cloud/vision/version"
 require "google/cloud/vision/v1/product_search_service_pb"
@@ -31,22 +33,36 @@ module Google
             # @private
             attr_reader :product_search_stub
 
-            # The default address of the service.
-            SERVICE_ADDRESS = "vision.googleapis.com"
+            ##
+            # Configuration for the ProductSearch Client API.
+            #
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Client::Configuration]
+            #
+            # @return [Client::Configuration]
+            #
+            def self.configure
+              @configure ||= Client::Configuration.new
+              yield @configure if block_given?
+              @configure
+            end
 
-            # The default port of the service.
-            DEFAULT_SERVICE_PORT = 443
-
-            # rubocop:disable Style/MutableConstant
-
-            # The default set of gRPC interceptors.
-            GRPC_INTERCEPTORS = []
-
-            # rubocop:enable Style/MutableConstant
-
-            DEFAULT_TIMEOUT = 30
-
-
+            ##
+            # Configure the ProductSearch Client instance.
+            #
+            # The configuration is set to the derived mode, meaning that values can be changed,
+            # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+            # should be made on {Client.configure}.
+            #
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Client::Configuration]
+            #
+            # @return [Client::Configuration]
+            #
+            def configure
+              yield @config if block_given?
+              @config
+            end
 
             ##
             # @param credentials [Google::Auth::Credentials, String, Hash,
@@ -65,58 +81,40 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scope [String, Array<String>]
-            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-            #   an updater_proc is supplied.
-            # @param timeout [Numeric]
-            #   The default timeout, in seconds, for calls made through this client.
-            # @param metadata [Hash]
-            #   Default metadata to be sent with each request. This can be overridden on a
-            #   per call basis.
             #
-            def initialize \
-                credentials: nil,
-                scope: nil,
-                timeout: DEFAULT_TIMEOUT,
-                metadata: nil,
-                lib_name: nil,
-                lib_version: nil
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Client::Configuration]
+            #
+            def initialize credentials: nil
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
               require "google/gax/grpc"
               require "google/cloud/vision/v1/product_search_service_services_pb"
 
-              credentials ||= Credentials.default scope: scope
+              # Create the configuration object
+              @config = Configuration.new Client.configure
+
+              # Yield the configuration if needed
+              yield @config if block_given?
+
+              # Create credentials
+              credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
-                credentials = Credentials.new credentials, scope: scope
+                credentials = Credentials.new credentials, scope: @config.scope
               end
 
               @operations_client = Operations.new(
-                credentials: credentials,
-                scope:       scope,
-                timeout:     timeout,
-                metadata:    metadata,
-                lib_name:    lib_name,
-                lib_version: lib_version
+                credentials: credentials
               )
 
               @product_search_stub = Google::Gax::Grpc::Stub.new(
                 Google::Cloud::Vision::V1::ProductSearch::Stub,
-                host:         self.class::SERVICE_ADDRESS,
-                port:         self.class::DEFAULT_SERVICE_PORT,
                 credentials:  credentials,
-                interceptors: self.class::GRPC_INTERCEPTORS
+                host:         @config.host,
+                port:         @config.port,
+                interceptors: @config.interceptors
               )
-
-              @timeout = timeout
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              @metadata = metadata.to_h
-              @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
             end
 
             # Service calls
@@ -177,12 +175,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.create_product_set.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "parent" => request.parent
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.create_product_set.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.create_product_set.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @create_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :create_product_set
 
@@ -242,12 +255,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.list_product_sets.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "parent" => request.parent
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.list_product_sets.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.list_product_sets.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @list_product_sets ||= Google::Gax::ApiCall.new @product_search_stub.method :list_product_sets
 
@@ -304,12 +332,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.get_product_set.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.get_product_set.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.get_product_set.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @get_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :get_product_set
 
@@ -372,12 +415,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.update_product_set.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "product_set.name" => request.product_set.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.update_product_set.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.update_product_set.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @update_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :update_product_set
 
@@ -438,12 +496,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.delete_product_set.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.delete_product_set.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.delete_product_set.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @delete_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_product_set
 
@@ -511,12 +584,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.create_product.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "parent" => request.parent
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.create_product.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.create_product.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @create_product ||= Google::Gax::ApiCall.new @product_search_stub.method :create_product
 
@@ -575,12 +663,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.list_products.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "parent" => request.parent
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.list_products.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.list_products.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @list_products ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products
 
@@ -637,12 +740,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.get_product.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.get_product.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.get_product.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @get_product ||= Google::Gax::ApiCall.new @product_search_stub.method :get_product
 
@@ -721,12 +839,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.update_product.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "product.name" => request.product.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.update_product.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.update_product.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @update_product ||= Google::Gax::ApiCall.new @product_search_stub.method :update_product
 
@@ -789,12 +922,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.delete_product.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.delete_product.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.delete_product.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @delete_product ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_product
 
@@ -885,12 +1033,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.create_reference_image.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "parent" => request.parent
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.create_reference_image.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.create_reference_image.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @create_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :create_reference_image
 
@@ -958,12 +1121,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.delete_reference_image.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.delete_reference_image.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.delete_reference_image.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @delete_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_reference_image
 
@@ -1029,12 +1207,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.list_reference_images.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "parent" => request.parent
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.list_reference_images.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.list_reference_images.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @list_reference_images ||= Google::Gax::ApiCall.new @product_search_stub.method :list_reference_images
 
@@ -1092,12 +1285,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.get_reference_image.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.get_reference_image.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.get_reference_image.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @get_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :get_reference_image
 
@@ -1163,12 +1371,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.add_product_to_product_set.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.add_product_to_product_set.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.add_product_to_product_set.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @add_product_to_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :add_product_to_product_set
 
@@ -1228,12 +1451,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.remove_product_from_product_set.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.remove_product_from_product_set.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.remove_product_from_product_set.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @remove_product_from_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :remove_product_from_product_set
 
@@ -1296,12 +1534,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.list_products_in_product_set.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.list_products_in_product_set.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.list_products_in_product_set.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @list_products_in_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products_in_product_set
 
@@ -1371,18 +1624,141 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.import_product_sets.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "parent" => request.parent
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.import_product_sets.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.import_product_sets.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @import_product_sets ||= Google::Gax::ApiCall.new @product_search_stub.method :import_product_sets
 
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
               @import_product_sets.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            end
+
+            class Configuration
+              extend Google::Gax::Config
+
+              config_attr :host,         "vision.googleapis.com", String
+              config_attr :port,         443, Integer
+              config_attr :scope,        nil,                                   String, Array, nil
+              config_attr :lib_name,     nil,                                   String, nil
+              config_attr :lib_version,  nil,                                   String, nil
+              config_attr :interceptors, [],                                    Array
+              config_attr :timeout,      nil,                                   Numeric, nil
+              config_attr :metadata,     nil,                                   Hash, nil
+              config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+              def initialize parent_config = nil
+                @parent_config = parent_config unless parent_config.nil?
+
+                yield self if block_given?
+              end
+
+              def rpcs
+                @rpcs ||= begin
+                  parent_rpcs = nil
+                  parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                  Rpcs.new parent_rpcs
+                end
+              end
+
+              class Rpcs
+                attr_reader :create_product_set
+                attr_reader :list_product_sets
+                attr_reader :get_product_set
+                attr_reader :update_product_set
+                attr_reader :delete_product_set
+                attr_reader :create_product
+                attr_reader :list_products
+                attr_reader :get_product
+                attr_reader :update_product
+                attr_reader :delete_product
+                attr_reader :create_reference_image
+                attr_reader :delete_reference_image
+                attr_reader :list_reference_images
+                attr_reader :get_reference_image
+                attr_reader :add_product_to_product_set
+                attr_reader :remove_product_from_product_set
+                attr_reader :list_products_in_product_set
+                attr_reader :import_product_sets
+
+                def initialize parent_rpcs = nil
+                  create_product_set_config = nil
+                  create_product_set_config = parent_rpcs&.create_product_set if parent_rpcs&.respond_to? :create_product_set
+                  @create_product_set = Google::Gax::Config::Method.new create_product_set_config
+                  list_product_sets_config = nil
+                  list_product_sets_config = parent_rpcs&.list_product_sets if parent_rpcs&.respond_to? :list_product_sets
+                  @list_product_sets = Google::Gax::Config::Method.new list_product_sets_config
+                  get_product_set_config = nil
+                  get_product_set_config = parent_rpcs&.get_product_set if parent_rpcs&.respond_to? :get_product_set
+                  @get_product_set = Google::Gax::Config::Method.new get_product_set_config
+                  update_product_set_config = nil
+                  update_product_set_config = parent_rpcs&.update_product_set if parent_rpcs&.respond_to? :update_product_set
+                  @update_product_set = Google::Gax::Config::Method.new update_product_set_config
+                  delete_product_set_config = nil
+                  delete_product_set_config = parent_rpcs&.delete_product_set if parent_rpcs&.respond_to? :delete_product_set
+                  @delete_product_set = Google::Gax::Config::Method.new delete_product_set_config
+                  create_product_config = nil
+                  create_product_config = parent_rpcs&.create_product if parent_rpcs&.respond_to? :create_product
+                  @create_product = Google::Gax::Config::Method.new create_product_config
+                  list_products_config = nil
+                  list_products_config = parent_rpcs&.list_products if parent_rpcs&.respond_to? :list_products
+                  @list_products = Google::Gax::Config::Method.new list_products_config
+                  get_product_config = nil
+                  get_product_config = parent_rpcs&.get_product if parent_rpcs&.respond_to? :get_product
+                  @get_product = Google::Gax::Config::Method.new get_product_config
+                  update_product_config = nil
+                  update_product_config = parent_rpcs&.update_product if parent_rpcs&.respond_to? :update_product
+                  @update_product = Google::Gax::Config::Method.new update_product_config
+                  delete_product_config = nil
+                  delete_product_config = parent_rpcs&.delete_product if parent_rpcs&.respond_to? :delete_product
+                  @delete_product = Google::Gax::Config::Method.new delete_product_config
+                  create_reference_image_config = nil
+                  create_reference_image_config = parent_rpcs&.create_reference_image if parent_rpcs&.respond_to? :create_reference_image
+                  @create_reference_image = Google::Gax::Config::Method.new create_reference_image_config
+                  delete_reference_image_config = nil
+                  delete_reference_image_config = parent_rpcs&.delete_reference_image if parent_rpcs&.respond_to? :delete_reference_image
+                  @delete_reference_image = Google::Gax::Config::Method.new delete_reference_image_config
+                  list_reference_images_config = nil
+                  list_reference_images_config = parent_rpcs&.list_reference_images if parent_rpcs&.respond_to? :list_reference_images
+                  @list_reference_images = Google::Gax::Config::Method.new list_reference_images_config
+                  get_reference_image_config = nil
+                  get_reference_image_config = parent_rpcs&.get_reference_image if parent_rpcs&.respond_to? :get_reference_image
+                  @get_reference_image = Google::Gax::Config::Method.new get_reference_image_config
+                  add_product_to_product_set_config = nil
+                  add_product_to_product_set_config = parent_rpcs&.add_product_to_product_set if parent_rpcs&.respond_to? :add_product_to_product_set
+                  @add_product_to_product_set = Google::Gax::Config::Method.new add_product_to_product_set_config
+                  remove_product_from_product_set_config = nil
+                  remove_product_from_product_set_config = parent_rpcs&.remove_product_from_product_set if parent_rpcs&.respond_to? :remove_product_from_product_set
+                  @remove_product_from_product_set = Google::Gax::Config::Method.new remove_product_from_product_set_config
+                  list_products_in_product_set_config = nil
+                  list_products_in_product_set_config = parent_rpcs&.list_products_in_product_set if parent_rpcs&.respond_to? :list_products_in_product_set
+                  @list_products_in_product_set = Google::Gax::Config::Method.new list_products_in_product_set_config
+                  import_product_sets_config = nil
+                  import_product_sets_config = parent_rpcs&.import_product_sets if parent_rpcs&.respond_to? :import_product_sets
+                  @import_product_sets = Google::Gax::Config::Method.new import_product_sets_config
+
+                  yield self if block_given?
+                end
+              end
             end
           end
         end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -1645,7 +1645,7 @@ module Google
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
               config_attr :credentials,  nil do |value|
-                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
                 allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
                 allowed.any? { |klass| klass === value }
               end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -65,27 +65,12 @@ module Google
             end
 
             ##
-            # @param credentials [Google::Auth::Credentials, String, Hash,
-            #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-            #   Provides the means for authenticating requests made by the client. This
-            #   parameter can be many types.
-            #   A `Google::Auth::Credentials` uses a the properties of its represented
-            #   keyfile for authenticating requests made by this client.
-            #   A `String` will be treated as the path to the keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `Hash` will be treated as the contents of a keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `GRPC::Core::Channel` will be used to make calls through.
-            #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-            #   channel credentials should already be composed with a
-            #   `GRPC::Core::CallCredentials` object.
-            #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-            #   transforms the metadata for requests, generally, to give OAuth credentials.
+            # Create a new Client client object.
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Client::Configuration]
             #
-            def initialize credentials: nil
+            def initialize
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
@@ -99,14 +84,15 @@ module Google
               yield @config if block_given?
 
               # Create credentials
+              credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
 
-              @operations_client = Operations.new(
-                credentials: credentials
-              )
+              @operations_client = Operations.new do |config|
+                config.credentials = credentials
+              end
 
               @product_search_stub = Google::Gax::Grpc::Stub.new(
                 Google::Cloud::Vision::V1::ProductSearch::Stub,
@@ -1658,6 +1644,11 @@ module Google
 
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
+              config_attr :credentials,  nil do |value|
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+                allowed.any? { |klass| klass === value }
+              end
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -63,27 +63,12 @@ module Google
             end
 
             ##
-            # @param credentials [Google::Auth::Credentials, String, Hash,
-            #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-            #   Provides the means for authenticating requests made by the client. This
-            #   parameter can be many types.
-            #   A `Google::Auth::Credentials` uses a the properties of its represented
-            #   keyfile for authenticating requests made by this client.
-            #   A `String` will be treated as the path to the keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `Hash` will be treated as the contents of a keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `GRPC::Core::Channel` will be used to make calls through.
-            #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-            #   channel credentials should already be composed with a
-            #   `GRPC::Core::CallCredentials` object.
-            #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-            #   transforms the metadata for requests, generally, to give OAuth credentials.
+            # Create a new Operations client object.
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Operations::Configuration]
             #
-            def initialize credentials: nil, config: nil
+            def initialize
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
@@ -97,6 +82,7 @@ module Google
               yield @config if block_given?
 
               # Create credentials
+              credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
@@ -421,6 +407,11 @@ module Google
 
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
+              config_attr :credentials,  nil do |value|
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+                allowed.any? { |klass| klass === value }
+              end
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -32,6 +32,37 @@ module Google
             attr_reader :operations_stub
 
             ##
+            # Configuration for the ProductSearch Operations API.
+            #
+            # @yield [config] Configure the Operations client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            # @return [Operations::Configuration]
+            #
+            def self.configure
+              @configure ||= Operations::Configuration.new
+              yield @configure if block_given?
+              @configure
+            end
+
+            ##
+            # Configure the ProductSearch Operations instance.
+            #
+            # The configuration is set to the derived mode, meaning that values can be changed,
+            # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+            # should be made on {Operations.configure}.
+            #
+            # @yield [config] Configure the Operations client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            # @return [Operations::Configuration]
+            #
+            def configure
+              yield @config if block_given?
+              @config
+            end
+
+            ##
             # @param credentials [Google::Auth::Credentials, String, Hash,
             #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
             #   Provides the means for authenticating requests made by the client. This
@@ -48,49 +79,36 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scope [String, Array<String>]
-            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-            #   an updater_proc is supplied.
-            # @param timeout [Numeric]
-            #   The default timeout, in seconds, for calls made through this client.
-            # @param metadata [Hash]
-            #   Default metadata to be sent with each request. This can be overridden on a
-            #   per call basis.
             #
-            def initialize \
-                credentials:  nil,
-                scope:        Client::ALL_SCOPES,
-                timeout:      Client::DEFAULT_TIMEOUT,
-                metadata:     nil,
-                lib_name:     nil,
-                lib_version:  nil
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            def initialize credentials: nil, config: nil
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
               require "google/gax/grpc"
               require "google/longrunning/operations_services_pb"
 
-              credentials ||= Credentials.default scope: scope
+              # Create the configuration object
+              @config = Configuration.new Operations.configure
+
+              # Yield the configuration if needed
+              yield @config if block_given?
+
+              # Create credentials
+              credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
-                credentials = Credentials.new credentials, scope: scope
+                credentials = Credentials.new credentials, scope: @config.scope
               end
 
               @operations_stub = Google::Gax::Grpc::Stub.new(
                 Google::Longrunning::Operations::Stub,
-                host:         Client::SERVICE_ADDRESS,
-                port:         Client::DEFAULT_SERVICE_PORT,
                 credentials:  credentials,
-                interceptors: Client::GRPC_INTERCEPTORS
+                host:         @config.host,
+                port:         @config.port,
+                interceptors: @config.interceptors
               )
-
-              @timeout = timeout
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              @metadata = metadata.to_h
-              @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
             end
 
             # Service calls
@@ -146,12 +164,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.list_operations.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.list_operations.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
 
@@ -202,12 +235,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.get_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.get_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
 
@@ -259,12 +307,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.delete_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.delete_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
 
@@ -326,16 +389,83 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.cancel_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.cancel_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
 
               @cancel_operation.call request, options: options, operation_callback: block
+            end
+
+            class Configuration
+              extend Google::Gax::Config
+
+              config_attr :host,         "vision.googleapis.com", String
+              config_attr :port,         443, Integer
+              config_attr :scope,        nil,                                   String, Array, nil
+              config_attr :lib_name,     nil,                                   String, nil
+              config_attr :lib_version,  nil,                                   String, nil
+              config_attr :interceptors, [],                                    Array
+              config_attr :timeout,      nil,                                   Numeric, nil
+              config_attr :metadata,     nil,                                   Hash, nil
+              config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+              def initialize parent_config = nil
+                @parent_config = parent_config unless parent_config.nil?
+
+                yield self if block_given?
+              end
+
+              def rpcs
+                @rpcs ||= begin
+                  parent_rpcs = nil
+                  parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                  Rpcs.new parent_rpcs
+                end
+              end
+
+              class Rpcs
+                attr_reader :list_operations
+                attr_reader :get_operation
+                attr_reader :delete_operation
+                attr_reader :cancel_operation
+
+                def initialize parent_rpcs = nil
+                  list_operations_config = nil
+                  list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
+                  @list_operations = Google::Gax::Config::Method.new list_operations_config
+                  get_operation_config = nil
+                  get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
+                  @get_operation = Google::Gax::Config::Method.new get_operation_config
+                  delete_operation_config = nil
+                  delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
+                  @delete_operation = Google::Gax::Config::Method.new delete_operation_config
+                  cancel_operation_config = nil
+                  cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
+                  @cancel_operation = Google::Gax::Config::Method.new cancel_operation_config
+
+                  yield self if block_given?
+                end
+              end
             end
           end
         end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -408,7 +408,7 @@ module Google
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
               config_attr :credentials,  nil do |value|
-                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
                 allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
                 allowed.any? { |klass| klass === value }
               end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -494,7 +494,7 @@ module Google
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
             config_attr :credentials,  nil do |value|
-              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
               allowed.any? { |klass| klass === value }
             end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -72,27 +72,12 @@ module Google
           end
 
           ##
-          # @param credentials [Google::Auth::Credentials, String, Hash,
-          #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-          #   Provides the means for authenticating requests made by the client. This
-          #   parameter can be many types.
-          #   A `Google::Auth::Credentials` uses a the properties of its represented
-          #   keyfile for authenticating requests made by this client.
-          #   A `String` will be treated as the path to the keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `Hash` will be treated as the contents of a keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `GRPC::Core::Channel` will be used to make calls through.
-          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-          #   channel credentials should already be composed with a
-          #   `GRPC::Core::CallCredentials` object.
-          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-          #   transforms the metadata for requests, generally, to give OAuth credentials.
+          # Create a new Client client object.
           #
           # @yield [config] Configure the Client client.
           # @yieldparam config [Client::Configuration]
           #
-          def initialize credentials: nil
+          def initialize
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -106,14 +91,15 @@ module Google
             yield @config if block_given?
 
             # Create credentials
+            credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
 
-            @operations_client = Operations.new(
-              credentials: credentials
-            )
+            @operations_client = Operations.new do |config|
+              config.credentials = credentials
+            end
 
             @echo_stub = Google::Gax::Grpc::Stub.new(
               Google::Showcase::V1alpha3::Echo::Stub,
@@ -507,6 +493,11 @@ module Google
 
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
+            config_attr :credentials,  nil do |value|
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+              allowed.any? { |klass| klass === value }
+            end
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -23,6 +23,8 @@
 # THE SOFTWARE.
 
 require "google/gax"
+require "google/gax/config"
+require "google/gax/config/method"
 
 require "google/showcase/version"
 require "google/showcase/v1alpha3/echo_pb"
@@ -38,22 +40,36 @@ module Google
           # @private
           attr_reader :echo_stub
 
-          # The default address of the service.
-          SERVICE_ADDRESS = "localhost"
+          ##
+          # Configuration for the Echo Client API.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def self.configure
+            @configure ||= Client::Configuration.new
+            yield @configure if block_given?
+            @configure
+          end
 
-          # The default port of the service.
-          DEFAULT_SERVICE_PORT = 7469
-
-          # rubocop:disable Style/MutableConstant
-
-          # The default set of gRPC interceptors.
-          GRPC_INTERCEPTORS = []
-
-          # rubocop:enable Style/MutableConstant
-
-          DEFAULT_TIMEOUT = 30
-
-
+          ##
+          # Configure the Echo Client instance.
+          #
+          # The configuration is set to the derived mode, meaning that values can be changed,
+          # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+          # should be made on {Client.configure}.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def configure
+            yield @config if block_given?
+            @config
+          end
 
           ##
           # @param credentials [Google::Auth::Credentials, String, Hash,
@@ -72,58 +88,40 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scope [String, Array<String>]
-          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-          #   an updater_proc is supplied.
-          # @param timeout [Numeric]
-          #   The default timeout, in seconds, for calls made through this client.
-          # @param metadata [Hash]
-          #   Default metadata to be sent with each request. This can be overridden on a
-          #   per call basis.
           #
-          def initialize \
-              credentials: nil,
-              scope: nil,
-              timeout: DEFAULT_TIMEOUT,
-              metadata: nil,
-              lib_name: nil,
-              lib_version: nil
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          def initialize credentials: nil
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/echo_services_pb"
 
-            credentials ||= Credentials.default scope: scope
+            # Create the configuration object
+            @config = Configuration.new Client.configure
+
+            # Yield the configuration if needed
+            yield @config if block_given?
+
+            # Create credentials
+            credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
-              credentials = Credentials.new credentials, scope: scope
+              credentials = Credentials.new credentials, scope: @config.scope
             end
 
             @operations_client = Operations.new(
-              credentials: credentials,
-              scope:       scope,
-              timeout:     timeout,
-              metadata:    metadata,
-              lib_name:    lib_name,
-              lib_version: lib_version
+              credentials: credentials
             )
 
             @echo_stub = Google::Gax::Grpc::Stub.new(
               Google::Showcase::V1alpha3::Echo::Stub,
-              host:         self.class::SERVICE_ADDRESS,
-              port:         self.class::DEFAULT_SERVICE_PORT,
               credentials:  credentials,
-              interceptors: self.class::GRPC_INTERCEPTORS
+              host:         @config.host,
+              port:         @config.port,
+              interceptors: @config.interceptors
             )
-
-            @timeout = timeout
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            @metadata = metadata.to_h
-            @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
           end
 
           # Service calls
@@ -167,8 +165,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.echo.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.echo.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.echo.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @echo ||= Google::Gax::ApiCall.new @echo_stub.method :echo
 
@@ -219,8 +230,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.expand.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.expand.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.expand.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @expand ||= Google::Gax::ApiCall.new @echo_stub.method :expand
             @expand.call request, options: options, stream_callback: block
@@ -264,8 +288,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.collect.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.collect.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.collect.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @collect ||= Google::Gax::ApiCall.new @echo_stub.method :collect
             @collect.call requests, options: options, operation_callback: block
@@ -310,8 +347,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.chat.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.chat.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.chat.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @chat ||= Google::Gax::ApiCall.new @echo_stub.method :chat
             @chat.call requests, options: options, stream_callback: block
@@ -360,8 +410,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.paged_expand.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.paged_expand.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.paged_expand.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @paged_expand ||= Google::Gax::ApiCall.new @echo_stub.method :paged_expand
 
@@ -416,14 +479,87 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.wait.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.wait.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.wait.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @wait ||= Google::Gax::ApiCall.new @echo_stub.method :wait
 
             wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
             @wait.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+          end
+
+          class Configuration
+            extend Google::Gax::Config
+
+            config_attr :host,         "localhost", String
+            config_attr :port,         7469, Integer
+            config_attr :scope,        nil,                                   String, Array, nil
+            config_attr :lib_name,     nil,                                   String, nil
+            config_attr :lib_version,  nil,                                   String, nil
+            config_attr :interceptors, [],                                    Array
+            config_attr :timeout,      nil,                                   Numeric, nil
+            config_attr :metadata,     nil,                                   Hash, nil
+            config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+            def initialize parent_config = nil
+              @parent_config = parent_config unless parent_config.nil?
+
+              yield self if block_given?
+            end
+
+            def rpcs
+              @rpcs ||= begin
+                parent_rpcs = nil
+                parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                Rpcs.new parent_rpcs
+              end
+            end
+
+            class Rpcs
+              attr_reader :echo
+              attr_reader :expand
+              attr_reader :collect
+              attr_reader :chat
+              attr_reader :paged_expand
+              attr_reader :wait
+
+              def initialize parent_rpcs = nil
+                echo_config = nil
+                echo_config = parent_rpcs&.echo if parent_rpcs&.respond_to? :echo
+                @echo = Google::Gax::Config::Method.new echo_config
+                expand_config = nil
+                expand_config = parent_rpcs&.expand if parent_rpcs&.respond_to? :expand
+                @expand = Google::Gax::Config::Method.new expand_config
+                collect_config = nil
+                collect_config = parent_rpcs&.collect if parent_rpcs&.respond_to? :collect
+                @collect = Google::Gax::Config::Method.new collect_config
+                chat_config = nil
+                chat_config = parent_rpcs&.chat if parent_rpcs&.respond_to? :chat
+                @chat = Google::Gax::Config::Method.new chat_config
+                paged_expand_config = nil
+                paged_expand_config = parent_rpcs&.paged_expand if parent_rpcs&.respond_to? :paged_expand
+                @paged_expand = Google::Gax::Config::Method.new paged_expand_config
+                wait_config = nil
+                wait_config = parent_rpcs&.wait if parent_rpcs&.respond_to? :wait
+                @wait = Google::Gax::Config::Method.new wait_config
+
+                yield self if block_given?
+              end
+            end
           end
         end
       end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -39,6 +39,37 @@ module Google
           attr_reader :operations_stub
 
           ##
+          # Configuration for the Echo Operations API.
+          #
+          # @yield [config] Configure the Operations client.
+          # @yieldparam config [Operations::Configuration]
+          #
+          # @return [Operations::Configuration]
+          #
+          def self.configure
+            @configure ||= Operations::Configuration.new
+            yield @configure if block_given?
+            @configure
+          end
+
+          ##
+          # Configure the Echo Operations instance.
+          #
+          # The configuration is set to the derived mode, meaning that values can be changed,
+          # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+          # should be made on {Operations.configure}.
+          #
+          # @yield [config] Configure the Operations client.
+          # @yieldparam config [Operations::Configuration]
+          #
+          # @return [Operations::Configuration]
+          #
+          def configure
+            yield @config if block_given?
+            @config
+          end
+
+          ##
           # @param credentials [Google::Auth::Credentials, String, Hash,
           #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
           #   Provides the means for authenticating requests made by the client. This
@@ -55,49 +86,36 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scope [String, Array<String>]
-          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-          #   an updater_proc is supplied.
-          # @param timeout [Numeric]
-          #   The default timeout, in seconds, for calls made through this client.
-          # @param metadata [Hash]
-          #   Default metadata to be sent with each request. This can be overridden on a
-          #   per call basis.
           #
-          def initialize \
-              credentials:  nil,
-              scope:        Client::ALL_SCOPES,
-              timeout:      Client::DEFAULT_TIMEOUT,
-              metadata:     nil,
-              lib_name:     nil,
-              lib_version:  nil
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Operations::Configuration]
+          #
+          def initialize credentials: nil, config: nil
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/longrunning/operations_services_pb"
 
-            credentials ||= Credentials.default scope: scope
+            # Create the configuration object
+            @config = Configuration.new Operations.configure
+
+            # Yield the configuration if needed
+            yield @config if block_given?
+
+            # Create credentials
+            credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
-              credentials = Credentials.new credentials, scope: scope
+              credentials = Credentials.new credentials, scope: @config.scope
             end
 
             @operations_stub = Google::Gax::Grpc::Stub.new(
               Google::Longrunning::Operations::Stub,
-              host:         Client::SERVICE_ADDRESS,
-              port:         Client::DEFAULT_SERVICE_PORT,
               credentials:  credentials,
-              interceptors: Client::GRPC_INTERCEPTORS
+              host:         @config.host,
+              port:         @config.port,
+              interceptors: @config.interceptors
             )
-
-            @timeout = timeout
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            @metadata = metadata.to_h
-            @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
           end
 
           # Service calls
@@ -153,12 +171,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.list_operations.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_operations.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
 
@@ -209,12 +242,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.get_operation.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.get_operation.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
 
@@ -266,12 +314,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_operation.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_operation.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
 
@@ -333,16 +396,83 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.cancel_operation.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.cancel_operation.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
 
             @cancel_operation.call request, options: options, operation_callback: block
+          end
+
+          class Configuration
+            extend Google::Gax::Config
+
+            config_attr :host,         "localhost", String
+            config_attr :port,         443, Integer
+            config_attr :scope,        nil,                                   String, Array, nil
+            config_attr :lib_name,     nil,                                   String, nil
+            config_attr :lib_version,  nil,                                   String, nil
+            config_attr :interceptors, [],                                    Array
+            config_attr :timeout,      nil,                                   Numeric, nil
+            config_attr :metadata,     nil,                                   Hash, nil
+            config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+            def initialize parent_config = nil
+              @parent_config = parent_config unless parent_config.nil?
+
+              yield self if block_given?
+            end
+
+            def rpcs
+              @rpcs ||= begin
+                parent_rpcs = nil
+                parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                Rpcs.new parent_rpcs
+              end
+            end
+
+            class Rpcs
+              attr_reader :list_operations
+              attr_reader :get_operation
+              attr_reader :delete_operation
+              attr_reader :cancel_operation
+
+              def initialize parent_rpcs = nil
+                list_operations_config = nil
+                list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
+                @list_operations = Google::Gax::Config::Method.new list_operations_config
+                get_operation_config = nil
+                get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
+                @get_operation = Google::Gax::Config::Method.new get_operation_config
+                delete_operation_config = nil
+                delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
+                @delete_operation = Google::Gax::Config::Method.new delete_operation_config
+                cancel_operation_config = nil
+                cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
+                @cancel_operation = Google::Gax::Config::Method.new cancel_operation_config
+
+                yield self if block_given?
+              end
+            end
           end
         end
       end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -70,27 +70,12 @@ module Google
           end
 
           ##
-          # @param credentials [Google::Auth::Credentials, String, Hash,
-          #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-          #   Provides the means for authenticating requests made by the client. This
-          #   parameter can be many types.
-          #   A `Google::Auth::Credentials` uses a the properties of its represented
-          #   keyfile for authenticating requests made by this client.
-          #   A `String` will be treated as the path to the keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `Hash` will be treated as the contents of a keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `GRPC::Core::Channel` will be used to make calls through.
-          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-          #   channel credentials should already be composed with a
-          #   `GRPC::Core::CallCredentials` object.
-          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-          #   transforms the metadata for requests, generally, to give OAuth credentials.
+          # Create a new Operations client object.
           #
           # @yield [config] Configure the Client client.
           # @yieldparam config [Operations::Configuration]
           #
-          def initialize credentials: nil, config: nil
+          def initialize
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -104,6 +89,7 @@ module Google
             yield @config if block_given?
 
             # Create credentials
+            credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
@@ -428,6 +414,11 @@ module Google
 
             config_attr :host,         "localhost", String
             config_attr :port,         443, Integer
+            config_attr :credentials,  nil do |value|
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+              allowed.any? { |klass| klass === value }
+            end
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -415,7 +415,7 @@ module Google
             config_attr :host,         "localhost", String
             config_attr :port,         443, Integer
             config_attr :credentials,  nil do |value|
-              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
               allowed.any? { |klass| klass === value }
             end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -435,7 +435,7 @@ module Google
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
             config_attr :credentials,  nil do |value|
-              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
               allowed.any? { |klass| klass === value }
             end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -74,27 +74,12 @@ module Google
           end
 
           ##
-          # @param credentials [Google::Auth::Credentials, String, Hash,
-          #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-          #   Provides the means for authenticating requests made by the client. This
-          #   parameter can be many types.
-          #   A `Google::Auth::Credentials` uses a the properties of its represented
-          #   keyfile for authenticating requests made by this client.
-          #   A `String` will be treated as the path to the keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `Hash` will be treated as the contents of a keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `GRPC::Core::Channel` will be used to make calls through.
-          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-          #   channel credentials should already be composed with a
-          #   `GRPC::Core::CallCredentials` object.
-          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-          #   transforms the metadata for requests, generally, to give OAuth credentials.
+          # Create a new Client client object.
           #
           # @yield [config] Configure the Client client.
           # @yieldparam config [Client::Configuration]
           #
-          def initialize credentials: nil
+          def initialize
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -108,6 +93,7 @@ module Google
             yield @config if block_given?
 
             # Create credentials
+            credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
@@ -448,6 +434,11 @@ module Google
 
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
+            config_attr :credentials,  nil do |value|
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+              allowed.any? { |klass| klass === value }
+            end
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -23,6 +23,8 @@
 # THE SOFTWARE.
 
 require "google/gax"
+require "google/gax/config"
+require "google/gax/config/method"
 
 require "google/showcase/version"
 require "google/showcase/v1alpha3/identity_pb"
@@ -40,22 +42,36 @@ module Google
           # @private
           attr_reader :identity_stub
 
-          # The default address of the service.
-          SERVICE_ADDRESS = "localhost"
+          ##
+          # Configuration for the Identity Client API.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def self.configure
+            @configure ||= Client::Configuration.new
+            yield @configure if block_given?
+            @configure
+          end
 
-          # The default port of the service.
-          DEFAULT_SERVICE_PORT = 7469
-
-          # rubocop:disable Style/MutableConstant
-
-          # The default set of gRPC interceptors.
-          GRPC_INTERCEPTORS = []
-
-          # rubocop:enable Style/MutableConstant
-
-          DEFAULT_TIMEOUT = 30
-
-
+          ##
+          # Configure the Identity Client instance.
+          #
+          # The configuration is set to the derived mode, meaning that values can be changed,
+          # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+          # should be made on {Client.configure}.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def configure
+            yield @config if block_given?
+            @config
+          end
 
           ##
           # @param credentials [Google::Auth::Credentials, String, Hash,
@@ -74,50 +90,37 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scope [String, Array<String>]
-          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-          #   an updater_proc is supplied.
-          # @param timeout [Numeric]
-          #   The default timeout, in seconds, for calls made through this client.
-          # @param metadata [Hash]
-          #   Default metadata to be sent with each request. This can be overridden on a
-          #   per call basis.
           #
-          def initialize \
-              credentials: nil,
-              scope: nil,
-              timeout: DEFAULT_TIMEOUT,
-              metadata: nil,
-              lib_name: nil,
-              lib_version: nil
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          def initialize credentials: nil
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/identity_services_pb"
 
-            credentials ||= Credentials.default scope: scope
+            # Create the configuration object
+            @config = Configuration.new Client.configure
+
+            # Yield the configuration if needed
+            yield @config if block_given?
+
+            # Create credentials
+            credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
-              credentials = Credentials.new credentials, scope: scope
+              credentials = Credentials.new credentials, scope: @config.scope
             end
 
 
             @identity_stub = Google::Gax::Grpc::Stub.new(
               Google::Showcase::V1alpha3::Identity::Stub,
-              host:         self.class::SERVICE_ADDRESS,
-              port:         self.class::DEFAULT_SERVICE_PORT,
               credentials:  credentials,
-              interceptors: self.class::GRPC_INTERCEPTORS
+              host:         @config.host,
+              port:         @config.port,
+              interceptors: @config.interceptors
             )
-
-            @timeout = timeout
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            @metadata = metadata.to_h
-            @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
           end
 
           # Service calls
@@ -159,8 +162,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.create_user.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.create_user.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.create_user.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @create_user ||= Google::Gax::ApiCall.new @identity_stub.method :create_user
 
@@ -204,12 +220,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.get_user.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.get_user.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.get_user.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @get_user ||= Google::Gax::ApiCall.new @identity_stub.method :get_user
 
@@ -256,12 +287,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.update_user.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "user.name" => request.user.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.update_user.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.update_user.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @update_user ||= Google::Gax::ApiCall.new @identity_stub.method :update_user
 
@@ -305,12 +351,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_user.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_user.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_user.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_user ||= Google::Gax::ApiCall.new @identity_stub.method :delete_user
 
@@ -359,14 +420,83 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.list_users.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.list_users.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_users.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_users ||= Google::Gax::ApiCall.new @identity_stub.method :list_users
 
             wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_users, request, response, options }
 
             @list_users.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+          end
+
+          class Configuration
+            extend Google::Gax::Config
+
+            config_attr :host,         "localhost", String
+            config_attr :port,         7469, Integer
+            config_attr :scope,        nil,                                   String, Array, nil
+            config_attr :lib_name,     nil,                                   String, nil
+            config_attr :lib_version,  nil,                                   String, nil
+            config_attr :interceptors, [],                                    Array
+            config_attr :timeout,      nil,                                   Numeric, nil
+            config_attr :metadata,     nil,                                   Hash, nil
+            config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+            def initialize parent_config = nil
+              @parent_config = parent_config unless parent_config.nil?
+
+              yield self if block_given?
+            end
+
+            def rpcs
+              @rpcs ||= begin
+                parent_rpcs = nil
+                parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                Rpcs.new parent_rpcs
+              end
+            end
+
+            class Rpcs
+              attr_reader :create_user
+              attr_reader :get_user
+              attr_reader :update_user
+              attr_reader :delete_user
+              attr_reader :list_users
+
+              def initialize parent_rpcs = nil
+                create_user_config = nil
+                create_user_config = parent_rpcs&.create_user if parent_rpcs&.respond_to? :create_user
+                @create_user = Google::Gax::Config::Method.new create_user_config
+                get_user_config = nil
+                get_user_config = parent_rpcs&.get_user if parent_rpcs&.respond_to? :get_user
+                @get_user = Google::Gax::Config::Method.new get_user_config
+                update_user_config = nil
+                update_user_config = parent_rpcs&.update_user if parent_rpcs&.respond_to? :update_user
+                @update_user = Google::Gax::Config::Method.new update_user_config
+                delete_user_config = nil
+                delete_user_config = parent_rpcs&.delete_user if parent_rpcs&.respond_to? :delete_user
+                @delete_user = Google::Gax::Config::Method.new delete_user_config
+                list_users_config = nil
+                list_users_config = parent_rpcs&.list_users if parent_rpcs&.respond_to? :list_users
+                @list_users = Google::Gax::Config::Method.new list_users_config
+
+                yield self if block_given?
+              end
+            end
           end
         end
       end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -1057,7 +1057,7 @@ module Google
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
             config_attr :credentials,  nil do |value|
-              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
               allowed.any? { |klass| klass === value }
             end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -23,6 +23,8 @@
 # THE SOFTWARE.
 
 require "google/gax"
+require "google/gax/config"
+require "google/gax/config/method"
 
 require "google/showcase/version"
 require "google/showcase/v1alpha3/messaging_pb"
@@ -41,22 +43,36 @@ module Google
           # @private
           attr_reader :messaging_stub
 
-          # The default address of the service.
-          SERVICE_ADDRESS = "localhost"
+          ##
+          # Configuration for the Messaging Client API.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def self.configure
+            @configure ||= Client::Configuration.new
+            yield @configure if block_given?
+            @configure
+          end
 
-          # The default port of the service.
-          DEFAULT_SERVICE_PORT = 7469
-
-          # rubocop:disable Style/MutableConstant
-
-          # The default set of gRPC interceptors.
-          GRPC_INTERCEPTORS = []
-
-          # rubocop:enable Style/MutableConstant
-
-          DEFAULT_TIMEOUT = 30
-
-
+          ##
+          # Configure the Messaging Client instance.
+          #
+          # The configuration is set to the derived mode, meaning that values can be changed,
+          # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+          # should be made on {Client.configure}.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def configure
+            yield @config if block_given?
+            @config
+          end
 
           ##
           # @param credentials [Google::Auth::Credentials, String, Hash,
@@ -75,58 +91,40 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scope [String, Array<String>]
-          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-          #   an updater_proc is supplied.
-          # @param timeout [Numeric]
-          #   The default timeout, in seconds, for calls made through this client.
-          # @param metadata [Hash]
-          #   Default metadata to be sent with each request. This can be overridden on a
-          #   per call basis.
           #
-          def initialize \
-              credentials: nil,
-              scope: nil,
-              timeout: DEFAULT_TIMEOUT,
-              metadata: nil,
-              lib_name: nil,
-              lib_version: nil
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          def initialize credentials: nil
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/messaging_services_pb"
 
-            credentials ||= Credentials.default scope: scope
+            # Create the configuration object
+            @config = Configuration.new Client.configure
+
+            # Yield the configuration if needed
+            yield @config if block_given?
+
+            # Create credentials
+            credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
-              credentials = Credentials.new credentials, scope: scope
+              credentials = Credentials.new credentials, scope: @config.scope
             end
 
             @operations_client = Operations.new(
-              credentials: credentials,
-              scope:       scope,
-              timeout:     timeout,
-              metadata:    metadata,
-              lib_name:    lib_name,
-              lib_version: lib_version
+              credentials: credentials
             )
 
             @messaging_stub = Google::Gax::Grpc::Stub.new(
               Google::Showcase::V1alpha3::Messaging::Stub,
-              host:         self.class::SERVICE_ADDRESS,
-              port:         self.class::DEFAULT_SERVICE_PORT,
               credentials:  credentials,
-              interceptors: self.class::GRPC_INTERCEPTORS
+              host:         @config.host,
+              port:         @config.port,
+              interceptors: @config.interceptors
             )
-
-            @timeout = timeout
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            @metadata = metadata.to_h
-            @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
           end
 
           # Service calls
@@ -168,8 +166,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.create_room.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.create_room.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.create_room.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @create_room ||= Google::Gax::ApiCall.new @messaging_stub.method :create_room
 
@@ -213,12 +224,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.get_room.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.get_room.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.get_room.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @get_room ||= Google::Gax::ApiCall.new @messaging_stub.method :get_room
 
@@ -265,12 +291,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.update_room.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "room.name" => request.room.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.update_room.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.update_room.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @update_room ||= Google::Gax::ApiCall.new @messaging_stub.method :update_room
 
@@ -314,12 +355,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_room.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_room.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_room.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_room ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_room
 
@@ -368,8 +424,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.list_rooms.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.list_rooms.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_rooms.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_rooms ||= Google::Gax::ApiCall.new @messaging_stub.method :list_rooms
 
@@ -422,12 +491,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.create_blurb.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "parent" => request.parent
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.create_blurb.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.create_blurb.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @create_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :create_blurb
 
@@ -471,12 +555,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.get_blurb.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.get_blurb.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.get_blurb.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @get_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :get_blurb
 
@@ -523,12 +622,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.update_blurb.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "blurb.name" => request.blurb.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.update_blurb.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.update_blurb.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @update_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :update_blurb
 
@@ -572,12 +686,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_blurb.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_blurb.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_blurb.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_blurb
 
@@ -631,12 +760,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.list_blurbs.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "parent" => request.parent
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.list_blurbs.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_blurbs.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :list_blurbs
 
@@ -699,12 +843,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.search_blurbs.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "parent" => request.parent
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.search_blurbs.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.search_blurbs.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @search_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :search_blurbs
 
@@ -757,12 +916,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.stream_blurbs.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.stream_blurbs.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.stream_blurbs.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @stream_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :stream_blurbs
             @stream_blurbs.call request, options: options, stream_callback: block
@@ -805,12 +979,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.send_blurbs.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "parent" => request.parent
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.send_blurbs.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.send_blurbs.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @send_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :send_blurbs
             @send_blurbs.call requests, options: options, operation_callback: block
@@ -856,11 +1045,116 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.connect.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.connect.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.connect.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @connect ||= Google::Gax::ApiCall.new @messaging_stub.method :connect
             @connect.call requests, options: options, stream_callback: block
+          end
+
+          class Configuration
+            extend Google::Gax::Config
+
+            config_attr :host,         "localhost", String
+            config_attr :port,         7469, Integer
+            config_attr :scope,        nil,                                   String, Array, nil
+            config_attr :lib_name,     nil,                                   String, nil
+            config_attr :lib_version,  nil,                                   String, nil
+            config_attr :interceptors, [],                                    Array
+            config_attr :timeout,      nil,                                   Numeric, nil
+            config_attr :metadata,     nil,                                   Hash, nil
+            config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+            def initialize parent_config = nil
+              @parent_config = parent_config unless parent_config.nil?
+
+              yield self if block_given?
+            end
+
+            def rpcs
+              @rpcs ||= begin
+                parent_rpcs = nil
+                parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                Rpcs.new parent_rpcs
+              end
+            end
+
+            class Rpcs
+              attr_reader :create_room
+              attr_reader :get_room
+              attr_reader :update_room
+              attr_reader :delete_room
+              attr_reader :list_rooms
+              attr_reader :create_blurb
+              attr_reader :get_blurb
+              attr_reader :update_blurb
+              attr_reader :delete_blurb
+              attr_reader :list_blurbs
+              attr_reader :search_blurbs
+              attr_reader :stream_blurbs
+              attr_reader :send_blurbs
+              attr_reader :connect
+
+              def initialize parent_rpcs = nil
+                create_room_config = nil
+                create_room_config = parent_rpcs&.create_room if parent_rpcs&.respond_to? :create_room
+                @create_room = Google::Gax::Config::Method.new create_room_config
+                get_room_config = nil
+                get_room_config = parent_rpcs&.get_room if parent_rpcs&.respond_to? :get_room
+                @get_room = Google::Gax::Config::Method.new get_room_config
+                update_room_config = nil
+                update_room_config = parent_rpcs&.update_room if parent_rpcs&.respond_to? :update_room
+                @update_room = Google::Gax::Config::Method.new update_room_config
+                delete_room_config = nil
+                delete_room_config = parent_rpcs&.delete_room if parent_rpcs&.respond_to? :delete_room
+                @delete_room = Google::Gax::Config::Method.new delete_room_config
+                list_rooms_config = nil
+                list_rooms_config = parent_rpcs&.list_rooms if parent_rpcs&.respond_to? :list_rooms
+                @list_rooms = Google::Gax::Config::Method.new list_rooms_config
+                create_blurb_config = nil
+                create_blurb_config = parent_rpcs&.create_blurb if parent_rpcs&.respond_to? :create_blurb
+                @create_blurb = Google::Gax::Config::Method.new create_blurb_config
+                get_blurb_config = nil
+                get_blurb_config = parent_rpcs&.get_blurb if parent_rpcs&.respond_to? :get_blurb
+                @get_blurb = Google::Gax::Config::Method.new get_blurb_config
+                update_blurb_config = nil
+                update_blurb_config = parent_rpcs&.update_blurb if parent_rpcs&.respond_to? :update_blurb
+                @update_blurb = Google::Gax::Config::Method.new update_blurb_config
+                delete_blurb_config = nil
+                delete_blurb_config = parent_rpcs&.delete_blurb if parent_rpcs&.respond_to? :delete_blurb
+                @delete_blurb = Google::Gax::Config::Method.new delete_blurb_config
+                list_blurbs_config = nil
+                list_blurbs_config = parent_rpcs&.list_blurbs if parent_rpcs&.respond_to? :list_blurbs
+                @list_blurbs = Google::Gax::Config::Method.new list_blurbs_config
+                search_blurbs_config = nil
+                search_blurbs_config = parent_rpcs&.search_blurbs if parent_rpcs&.respond_to? :search_blurbs
+                @search_blurbs = Google::Gax::Config::Method.new search_blurbs_config
+                stream_blurbs_config = nil
+                stream_blurbs_config = parent_rpcs&.stream_blurbs if parent_rpcs&.respond_to? :stream_blurbs
+                @stream_blurbs = Google::Gax::Config::Method.new stream_blurbs_config
+                send_blurbs_config = nil
+                send_blurbs_config = parent_rpcs&.send_blurbs if parent_rpcs&.respond_to? :send_blurbs
+                @send_blurbs = Google::Gax::Config::Method.new send_blurbs_config
+                connect_config = nil
+                connect_config = parent_rpcs&.connect if parent_rpcs&.respond_to? :connect
+                @connect = Google::Gax::Config::Method.new connect_config
+
+                yield self if block_given?
+              end
+            end
           end
         end
       end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -75,27 +75,12 @@ module Google
           end
 
           ##
-          # @param credentials [Google::Auth::Credentials, String, Hash,
-          #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-          #   Provides the means for authenticating requests made by the client. This
-          #   parameter can be many types.
-          #   A `Google::Auth::Credentials` uses a the properties of its represented
-          #   keyfile for authenticating requests made by this client.
-          #   A `String` will be treated as the path to the keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `Hash` will be treated as the contents of a keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `GRPC::Core::Channel` will be used to make calls through.
-          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-          #   channel credentials should already be composed with a
-          #   `GRPC::Core::CallCredentials` object.
-          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-          #   transforms the metadata for requests, generally, to give OAuth credentials.
+          # Create a new Client client object.
           #
           # @yield [config] Configure the Client client.
           # @yieldparam config [Client::Configuration]
           #
-          def initialize credentials: nil
+          def initialize
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -109,14 +94,15 @@ module Google
             yield @config if block_given?
 
             # Create credentials
+            credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
 
-            @operations_client = Operations.new(
-              credentials: credentials
-            )
+            @operations_client = Operations.new do |config|
+              config.credentials = credentials
+            end
 
             @messaging_stub = Google::Gax::Grpc::Stub.new(
               Google::Showcase::V1alpha3::Messaging::Stub,
@@ -1070,6 +1056,11 @@ module Google
 
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
+            config_attr :credentials,  nil do |value|
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+              allowed.any? { |klass| klass === value }
+            end
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -39,6 +39,37 @@ module Google
           attr_reader :operations_stub
 
           ##
+          # Configuration for the Messaging Operations API.
+          #
+          # @yield [config] Configure the Operations client.
+          # @yieldparam config [Operations::Configuration]
+          #
+          # @return [Operations::Configuration]
+          #
+          def self.configure
+            @configure ||= Operations::Configuration.new
+            yield @configure if block_given?
+            @configure
+          end
+
+          ##
+          # Configure the Messaging Operations instance.
+          #
+          # The configuration is set to the derived mode, meaning that values can be changed,
+          # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+          # should be made on {Operations.configure}.
+          #
+          # @yield [config] Configure the Operations client.
+          # @yieldparam config [Operations::Configuration]
+          #
+          # @return [Operations::Configuration]
+          #
+          def configure
+            yield @config if block_given?
+            @config
+          end
+
+          ##
           # @param credentials [Google::Auth::Credentials, String, Hash,
           #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
           #   Provides the means for authenticating requests made by the client. This
@@ -55,49 +86,36 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scope [String, Array<String>]
-          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-          #   an updater_proc is supplied.
-          # @param timeout [Numeric]
-          #   The default timeout, in seconds, for calls made through this client.
-          # @param metadata [Hash]
-          #   Default metadata to be sent with each request. This can be overridden on a
-          #   per call basis.
           #
-          def initialize \
-              credentials:  nil,
-              scope:        Client::ALL_SCOPES,
-              timeout:      Client::DEFAULT_TIMEOUT,
-              metadata:     nil,
-              lib_name:     nil,
-              lib_version:  nil
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Operations::Configuration]
+          #
+          def initialize credentials: nil, config: nil
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/longrunning/operations_services_pb"
 
-            credentials ||= Credentials.default scope: scope
+            # Create the configuration object
+            @config = Configuration.new Operations.configure
+
+            # Yield the configuration if needed
+            yield @config if block_given?
+
+            # Create credentials
+            credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
-              credentials = Credentials.new credentials, scope: scope
+              credentials = Credentials.new credentials, scope: @config.scope
             end
 
             @operations_stub = Google::Gax::Grpc::Stub.new(
               Google::Longrunning::Operations::Stub,
-              host:         Client::SERVICE_ADDRESS,
-              port:         Client::DEFAULT_SERVICE_PORT,
               credentials:  credentials,
-              interceptors: Client::GRPC_INTERCEPTORS
+              host:         @config.host,
+              port:         @config.port,
+              interceptors: @config.interceptors
             )
-
-            @timeout = timeout
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            @metadata = metadata.to_h
-            @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
           end
 
           # Service calls
@@ -153,12 +171,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.list_operations.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_operations.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
 
@@ -209,12 +242,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.get_operation.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.get_operation.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
 
@@ -266,12 +314,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_operation.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_operation.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
 
@@ -333,16 +396,83 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.cancel_operation.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.cancel_operation.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
 
             @cancel_operation.call request, options: options, operation_callback: block
+          end
+
+          class Configuration
+            extend Google::Gax::Config
+
+            config_attr :host,         "localhost", String
+            config_attr :port,         443, Integer
+            config_attr :scope,        nil,                                   String, Array, nil
+            config_attr :lib_name,     nil,                                   String, nil
+            config_attr :lib_version,  nil,                                   String, nil
+            config_attr :interceptors, [],                                    Array
+            config_attr :timeout,      nil,                                   Numeric, nil
+            config_attr :metadata,     nil,                                   Hash, nil
+            config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+            def initialize parent_config = nil
+              @parent_config = parent_config unless parent_config.nil?
+
+              yield self if block_given?
+            end
+
+            def rpcs
+              @rpcs ||= begin
+                parent_rpcs = nil
+                parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                Rpcs.new parent_rpcs
+              end
+            end
+
+            class Rpcs
+              attr_reader :list_operations
+              attr_reader :get_operation
+              attr_reader :delete_operation
+              attr_reader :cancel_operation
+
+              def initialize parent_rpcs = nil
+                list_operations_config = nil
+                list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
+                @list_operations = Google::Gax::Config::Method.new list_operations_config
+                get_operation_config = nil
+                get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
+                @get_operation = Google::Gax::Config::Method.new get_operation_config
+                delete_operation_config = nil
+                delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
+                @delete_operation = Google::Gax::Config::Method.new delete_operation_config
+                cancel_operation_config = nil
+                cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
+                @cancel_operation = Google::Gax::Config::Method.new cancel_operation_config
+
+                yield self if block_given?
+              end
+            end
           end
         end
       end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -70,27 +70,12 @@ module Google
           end
 
           ##
-          # @param credentials [Google::Auth::Credentials, String, Hash,
-          #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-          #   Provides the means for authenticating requests made by the client. This
-          #   parameter can be many types.
-          #   A `Google::Auth::Credentials` uses a the properties of its represented
-          #   keyfile for authenticating requests made by this client.
-          #   A `String` will be treated as the path to the keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `Hash` will be treated as the contents of a keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `GRPC::Core::Channel` will be used to make calls through.
-          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-          #   channel credentials should already be composed with a
-          #   `GRPC::Core::CallCredentials` object.
-          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-          #   transforms the metadata for requests, generally, to give OAuth credentials.
+          # Create a new Operations client object.
           #
           # @yield [config] Configure the Client client.
           # @yieldparam config [Operations::Configuration]
           #
-          def initialize credentials: nil, config: nil
+          def initialize
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -104,6 +89,7 @@ module Google
             yield @config if block_given?
 
             # Create credentials
+            credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
@@ -428,6 +414,11 @@ module Google
 
             config_attr :host,         "localhost", String
             config_attr :port,         443, Integer
+            config_attr :credentials,  nil do |value|
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+              allowed.any? { |klass| klass === value }
+            end
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -415,7 +415,7 @@ module Google
             config_attr :host,         "localhost", String
             config_attr :port,         443, Integer
             config_attr :credentials,  nil do |value|
-              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
               allowed.any? { |klass| klass === value }
             end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -23,6 +23,8 @@
 # THE SOFTWARE.
 
 require "google/gax"
+require "google/gax/config"
+require "google/gax/config/method"
 
 require "google/showcase/version"
 require "google/showcase/v1alpha3/testing_pb"
@@ -40,22 +42,36 @@ module Google
           # @private
           attr_reader :testing_stub
 
-          # The default address of the service.
-          SERVICE_ADDRESS = "localhost"
+          ##
+          # Configuration for the Testing Client API.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def self.configure
+            @configure ||= Client::Configuration.new
+            yield @configure if block_given?
+            @configure
+          end
 
-          # The default port of the service.
-          DEFAULT_SERVICE_PORT = 7469
-
-          # rubocop:disable Style/MutableConstant
-
-          # The default set of gRPC interceptors.
-          GRPC_INTERCEPTORS = []
-
-          # rubocop:enable Style/MutableConstant
-
-          DEFAULT_TIMEOUT = 30
-
-
+          ##
+          # Configure the Testing Client instance.
+          #
+          # The configuration is set to the derived mode, meaning that values can be changed,
+          # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+          # should be made on {Client.configure}.
+          #
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          # @return [Client::Configuration]
+          #
+          def configure
+            yield @config if block_given?
+            @config
+          end
 
           ##
           # @param credentials [Google::Auth::Credentials, String, Hash,
@@ -74,50 +90,37 @@ module Google
           #   `GRPC::Core::CallCredentials` object.
           #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
           #   transforms the metadata for requests, generally, to give OAuth credentials.
-          # @param scope [String, Array<String>]
-          #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-          #   an updater_proc is supplied.
-          # @param timeout [Numeric]
-          #   The default timeout, in seconds, for calls made through this client.
-          # @param metadata [Hash]
-          #   Default metadata to be sent with each request. This can be overridden on a
-          #   per call basis.
           #
-          def initialize \
-              credentials: nil,
-              scope: nil,
-              timeout: DEFAULT_TIMEOUT,
-              metadata: nil,
-              lib_name: nil,
-              lib_version: nil
+          # @yield [config] Configure the Client client.
+          # @yieldparam config [Client::Configuration]
+          #
+          def initialize credentials: nil
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
             require "google/gax/grpc"
             require "google/showcase/v1alpha3/testing_services_pb"
 
-            credentials ||= Credentials.default scope: scope
+            # Create the configuration object
+            @config = Configuration.new Client.configure
+
+            # Yield the configuration if needed
+            yield @config if block_given?
+
+            # Create credentials
+            credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
-              credentials = Credentials.new credentials, scope: scope
+              credentials = Credentials.new credentials, scope: @config.scope
             end
 
 
             @testing_stub = Google::Gax::Grpc::Stub.new(
               Google::Showcase::V1alpha3::Testing::Stub,
-              host:         self.class::SERVICE_ADDRESS,
-              port:         self.class::DEFAULT_SERVICE_PORT,
               credentials:  credentials,
-              interceptors: self.class::GRPC_INTERCEPTORS
+              host:         @config.host,
+              port:         @config.port,
+              interceptors: @config.interceptors
             )
-
-            @timeout = timeout
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            @metadata = metadata.to_h
-            @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
           end
 
           # Service calls
@@ -161,8 +164,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.create_session.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.create_session.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.create_session.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @create_session ||= Google::Gax::ApiCall.new @testing_stub.method :create_session
 
@@ -206,12 +222,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.get_session.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.get_session.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.get_session.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @get_session ||= Google::Gax::ApiCall.new @testing_stub.method :get_session
 
@@ -257,8 +288,21 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
-            metadata = @metadata.dup
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata = @config.rpcs.list_sessions.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+            options.apply_defaults timeout:      @config.rpcs.list_sessions.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_sessions.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_sessions ||= Google::Gax::ApiCall.new @testing_stub.method :list_sessions
 
@@ -304,12 +348,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_session.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_session.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_session.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_session ||= Google::Gax::ApiCall.new @testing_stub.method :delete_session
 
@@ -357,12 +416,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.report_session.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.report_session.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.report_session.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @report_session ||= Google::Gax::ApiCall.new @testing_stub.method :report_session
 
@@ -410,12 +484,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.list_tests.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.list_tests.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.list_tests.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @list_tests ||= Google::Gax::ApiCall.new @testing_stub.method :list_tests
 
@@ -471,12 +560,27 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.delete_test.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.delete_test.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.delete_test.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @delete_test ||= Google::Gax::ApiCall.new @testing_stub.method :delete_test
 
@@ -530,16 +634,99 @@ module Google
             options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
             # Customize the options with defaults
+            metadata = @config.rpcs.verify_test.metadata.to_h
+
+            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
+            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
             header_params = {
               "name" => request.name
             }
             request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-            metadata = @metadata.merge "x-goog-request-params" => request_params_header
-            options.apply_defaults timeout: @timeout, metadata: metadata
+            metadata[:"x-goog-request-params"] ||= request_params_header
+
+            options.apply_defaults timeout:      @config.rpcs.verify_test.timeout,
+                                   metadata:     metadata,
+                                   retry_policy: @config.rpcs.verify_test.retry_policy
+            options.apply_defaults timeout:      @config.timeout,
+                                   metadata:     @config.metadata,
+                                   retry_policy: @config.retry_policy
 
             @verify_test ||= Google::Gax::ApiCall.new @testing_stub.method :verify_test
 
             @verify_test.call request, options: options, operation_callback: block
+          end
+
+          class Configuration
+            extend Google::Gax::Config
+
+            config_attr :host,         "localhost", String
+            config_attr :port,         7469, Integer
+            config_attr :scope,        nil,                                   String, Array, nil
+            config_attr :lib_name,     nil,                                   String, nil
+            config_attr :lib_version,  nil,                                   String, nil
+            config_attr :interceptors, [],                                    Array
+            config_attr :timeout,      nil,                                   Numeric, nil
+            config_attr :metadata,     nil,                                   Hash, nil
+            config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+            def initialize parent_config = nil
+              @parent_config = parent_config unless parent_config.nil?
+
+              yield self if block_given?
+            end
+
+            def rpcs
+              @rpcs ||= begin
+                parent_rpcs = nil
+                parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                Rpcs.new parent_rpcs
+              end
+            end
+
+            class Rpcs
+              attr_reader :create_session
+              attr_reader :get_session
+              attr_reader :list_sessions
+              attr_reader :delete_session
+              attr_reader :report_session
+              attr_reader :list_tests
+              attr_reader :delete_test
+              attr_reader :verify_test
+
+              def initialize parent_rpcs = nil
+                create_session_config = nil
+                create_session_config = parent_rpcs&.create_session if parent_rpcs&.respond_to? :create_session
+                @create_session = Google::Gax::Config::Method.new create_session_config
+                get_session_config = nil
+                get_session_config = parent_rpcs&.get_session if parent_rpcs&.respond_to? :get_session
+                @get_session = Google::Gax::Config::Method.new get_session_config
+                list_sessions_config = nil
+                list_sessions_config = parent_rpcs&.list_sessions if parent_rpcs&.respond_to? :list_sessions
+                @list_sessions = Google::Gax::Config::Method.new list_sessions_config
+                delete_session_config = nil
+                delete_session_config = parent_rpcs&.delete_session if parent_rpcs&.respond_to? :delete_session
+                @delete_session = Google::Gax::Config::Method.new delete_session_config
+                report_session_config = nil
+                report_session_config = parent_rpcs&.report_session if parent_rpcs&.respond_to? :report_session
+                @report_session = Google::Gax::Config::Method.new report_session_config
+                list_tests_config = nil
+                list_tests_config = parent_rpcs&.list_tests if parent_rpcs&.respond_to? :list_tests
+                @list_tests = Google::Gax::Config::Method.new list_tests_config
+                delete_test_config = nil
+                delete_test_config = parent_rpcs&.delete_test if parent_rpcs&.respond_to? :delete_test
+                @delete_test = Google::Gax::Config::Method.new delete_test_config
+                verify_test_config = nil
+                verify_test_config = parent_rpcs&.verify_test if parent_rpcs&.respond_to? :verify_test
+                @verify_test = Google::Gax::Config::Method.new verify_test_config
+
+                yield self if block_given?
+              end
+            end
           end
         end
       end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -653,7 +653,7 @@ module Google
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
             config_attr :credentials,  nil do |value|
-              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
               allowed.any? { |klass| klass === value }
             end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -74,27 +74,12 @@ module Google
           end
 
           ##
-          # @param credentials [Google::Auth::Credentials, String, Hash,
-          #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-          #   Provides the means for authenticating requests made by the client. This
-          #   parameter can be many types.
-          #   A `Google::Auth::Credentials` uses a the properties of its represented
-          #   keyfile for authenticating requests made by this client.
-          #   A `String` will be treated as the path to the keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `Hash` will be treated as the contents of a keyfile to be used for the
-          #   construction of credentials for this client.
-          #   A `GRPC::Core::Channel` will be used to make calls through.
-          #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-          #   channel credentials should already be composed with a
-          #   `GRPC::Core::CallCredentials` object.
-          #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-          #   transforms the metadata for requests, generally, to give OAuth credentials.
+          # Create a new Client client object.
           #
           # @yield [config] Configure the Client client.
           # @yieldparam config [Client::Configuration]
           #
-          def initialize credentials: nil
+          def initialize
             # These require statements are intentionally placed here to initialize
             # the gRPC module only when it's required.
             # See https://github.com/googleapis/toolkit/issues/446
@@ -108,6 +93,7 @@ module Google
             yield @config if block_given?
 
             # Create credentials
+            credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
@@ -666,6 +652,11 @@ module Google
 
             config_attr :host,         "localhost", String
             config_attr :port,         7469, Integer
+            config_attr :credentials,  nil do |value|
+              allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+              allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+              allowed.any? { |klass| klass === value }
+            end
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -73,27 +73,12 @@ module Google
             end
 
             ##
-            # @param credentials [Google::Auth::Credentials, String, Hash,
-            #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-            #   Provides the means for authenticating requests made by the client. This
-            #   parameter can be many types.
-            #   A `Google::Auth::Credentials` uses a the properties of its represented
-            #   keyfile for authenticating requests made by this client.
-            #   A `String` will be treated as the path to the keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `Hash` will be treated as the contents of a keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `GRPC::Core::Channel` will be used to make calls through.
-            #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-            #   channel credentials should already be composed with a
-            #   `GRPC::Core::CallCredentials` object.
-            #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-            #   transforms the metadata for requests, generally, to give OAuth credentials.
+            # Create a new Client client object.
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Client::Configuration]
             #
-            def initialize credentials: nil
+            def initialize
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
@@ -107,14 +92,15 @@ module Google
               yield @config if block_given?
 
               # Create credentials
+              credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
 
-              @operations_client = Operations.new(
-                credentials: credentials
-              )
+              @operations_client = Operations.new do |config|
+                config.credentials = credentials
+              end
 
               @speech_stub = Google::Gax::Grpc::Stub.new(
                 Google::Cloud::Speech::V1::Speech::Stub,
@@ -322,6 +308,11 @@ module Google
 
               config_attr :host,         "speech.googleapis.com", String
               config_attr :port,         443, Integer
+              config_attr :credentials,  nil do |value|
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+                allowed.any? { |klass| klass === value }
+              end
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -309,7 +309,7 @@ module Google
               config_attr :host,         "speech.googleapis.com", String
               config_attr :port,         443, Integer
               config_attr :credentials,  nil do |value|
-                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
                 allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
                 allowed.any? { |klass| klass === value }
               end

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -23,6 +23,8 @@
 # THE SOFTWARE.
 
 require "google/gax"
+require "google/gax/config"
+require "google/gax/config/method"
 
 require "google/cloud/speech/version"
 require "google/cloud/speech/v1/cloud_speech_pb"
@@ -39,22 +41,36 @@ module Google
             # @private
             attr_reader :speech_stub
 
-            # The default address of the service.
-            SERVICE_ADDRESS = "speech.googleapis.com"
+            ##
+            # Configuration for the Speech Client API.
+            #
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Client::Configuration]
+            #
+            # @return [Client::Configuration]
+            #
+            def self.configure
+              @configure ||= Client::Configuration.new
+              yield @configure if block_given?
+              @configure
+            end
 
-            # The default port of the service.
-            DEFAULT_SERVICE_PORT = 443
-
-            # rubocop:disable Style/MutableConstant
-
-            # The default set of gRPC interceptors.
-            GRPC_INTERCEPTORS = []
-
-            # rubocop:enable Style/MutableConstant
-
-            DEFAULT_TIMEOUT = 30
-
-
+            ##
+            # Configure the Speech Client instance.
+            #
+            # The configuration is set to the derived mode, meaning that values can be changed,
+            # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+            # should be made on {Client.configure}.
+            #
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Client::Configuration]
+            #
+            # @return [Client::Configuration]
+            #
+            def configure
+              yield @config if block_given?
+              @config
+            end
 
             ##
             # @param credentials [Google::Auth::Credentials, String, Hash,
@@ -73,58 +89,40 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scope [String, Array<String>]
-            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-            #   an updater_proc is supplied.
-            # @param timeout [Numeric]
-            #   The default timeout, in seconds, for calls made through this client.
-            # @param metadata [Hash]
-            #   Default metadata to be sent with each request. This can be overridden on a
-            #   per call basis.
             #
-            def initialize \
-                credentials: nil,
-                scope: nil,
-                timeout: DEFAULT_TIMEOUT,
-                metadata: nil,
-                lib_name: nil,
-                lib_version: nil
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Client::Configuration]
+            #
+            def initialize credentials: nil
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
               require "google/gax/grpc"
               require "google/cloud/speech/v1/cloud_speech_services_pb"
 
-              credentials ||= Credentials.default scope: scope
+              # Create the configuration object
+              @config = Configuration.new Client.configure
+
+              # Yield the configuration if needed
+              yield @config if block_given?
+
+              # Create credentials
+              credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
-                credentials = Credentials.new credentials, scope: scope
+                credentials = Credentials.new credentials, scope: @config.scope
               end
 
               @operations_client = Operations.new(
-                credentials: credentials,
-                scope:       scope,
-                timeout:     timeout,
-                metadata:    metadata,
-                lib_name:    lib_name,
-                lib_version: lib_version
+                credentials: credentials
               )
 
               @speech_stub = Google::Gax::Grpc::Stub.new(
                 Google::Cloud::Speech::V1::Speech::Stub,
-                host:         self.class::SERVICE_ADDRESS,
-                port:         self.class::DEFAULT_SERVICE_PORT,
                 credentials:  credentials,
-                interceptors: self.class::GRPC_INTERCEPTORS
+                host:         @config.host,
+                port:         @config.port,
+                interceptors: @config.interceptors
               )
-
-              @timeout = timeout
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              @metadata = metadata.to_h
-              @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
             end
 
             # Service calls
@@ -171,8 +169,21 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
-              metadata = @metadata.dup
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata = @config.rpcs.recognize.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+              options.apply_defaults timeout:      @config.rpcs.recognize.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.recognize.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @recognize ||= Google::Gax::ApiCall.new @speech_stub.method :recognize
 
@@ -225,8 +236,21 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
-              metadata = @metadata.dup
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata = @config.rpcs.long_running_recognize.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+              options.apply_defaults timeout:      @config.rpcs.long_running_recognize.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.long_running_recognize.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @long_running_recognize ||= Google::Gax::ApiCall.new @speech_stub.method :long_running_recognize
 
@@ -273,11 +297,72 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
-              metadata = @metadata.dup
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata = @config.rpcs.streaming_recognize.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
+              options.apply_defaults timeout:      @config.rpcs.streaming_recognize.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.streaming_recognize.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @streaming_recognize ||= Google::Gax::ApiCall.new @speech_stub.method :streaming_recognize
               @streaming_recognize.call requests, options: options, stream_callback: block
+            end
+
+            class Configuration
+              extend Google::Gax::Config
+
+              config_attr :host,         "speech.googleapis.com", String
+              config_attr :port,         443, Integer
+              config_attr :scope,        nil,                                   String, Array, nil
+              config_attr :lib_name,     nil,                                   String, nil
+              config_attr :lib_version,  nil,                                   String, nil
+              config_attr :interceptors, [],                                    Array
+              config_attr :timeout,      nil,                                   Numeric, nil
+              config_attr :metadata,     nil,                                   Hash, nil
+              config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+              def initialize parent_config = nil
+                @parent_config = parent_config unless parent_config.nil?
+
+                yield self if block_given?
+              end
+
+              def rpcs
+                @rpcs ||= begin
+                  parent_rpcs = nil
+                  parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                  Rpcs.new parent_rpcs
+                end
+              end
+
+              class Rpcs
+                attr_reader :recognize
+                attr_reader :long_running_recognize
+                attr_reader :streaming_recognize
+
+                def initialize parent_rpcs = nil
+                  recognize_config = nil
+                  recognize_config = parent_rpcs&.recognize if parent_rpcs&.respond_to? :recognize
+                  @recognize = Google::Gax::Config::Method.new recognize_config
+                  long_running_recognize_config = nil
+                  long_running_recognize_config = parent_rpcs&.long_running_recognize if parent_rpcs&.respond_to? :long_running_recognize
+                  @long_running_recognize = Google::Gax::Config::Method.new long_running_recognize_config
+                  streaming_recognize_config = nil
+                  streaming_recognize_config = parent_rpcs&.streaming_recognize if parent_rpcs&.respond_to? :streaming_recognize
+                  @streaming_recognize = Google::Gax::Config::Method.new streaming_recognize_config
+
+                  yield self if block_given?
+                end
+              end
             end
           end
         end

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -71,27 +71,12 @@ module Google
             end
 
             ##
-            # @param credentials [Google::Auth::Credentials, String, Hash,
-            #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-            #   Provides the means for authenticating requests made by the client. This
-            #   parameter can be many types.
-            #   A `Google::Auth::Credentials` uses a the properties of its represented
-            #   keyfile for authenticating requests made by this client.
-            #   A `String` will be treated as the path to the keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `Hash` will be treated as the contents of a keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `GRPC::Core::Channel` will be used to make calls through.
-            #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-            #   channel credentials should already be composed with a
-            #   `GRPC::Core::CallCredentials` object.
-            #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-            #   transforms the metadata for requests, generally, to give OAuth credentials.
+            # Create a new Operations client object.
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Operations::Configuration]
             #
-            def initialize credentials: nil, config: nil
+            def initialize
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
@@ -105,6 +90,7 @@ module Google
               yield @config if block_given?
 
               # Create credentials
+              credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
@@ -429,6 +415,11 @@ module Google
 
               config_attr :host,         "speech.googleapis.com", String
               config_attr :port,         443, Integer
+              config_attr :credentials,  nil do |value|
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+                allowed.any? { |klass| klass === value }
+              end
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -416,7 +416,7 @@ module Google
               config_attr :host,         "speech.googleapis.com", String
               config_attr :port,         443, Integer
               config_attr :credentials,  nil do |value|
-                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
                 allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
                 allowed.any? { |klass| klass === value }
               end

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -40,6 +40,37 @@ module Google
             attr_reader :operations_stub
 
             ##
+            # Configuration for the Speech Operations API.
+            #
+            # @yield [config] Configure the Operations client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            # @return [Operations::Configuration]
+            #
+            def self.configure
+              @configure ||= Operations::Configuration.new
+              yield @configure if block_given?
+              @configure
+            end
+
+            ##
+            # Configure the Speech Operations instance.
+            #
+            # The configuration is set to the derived mode, meaning that values can be changed,
+            # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+            # should be made on {Operations.configure}.
+            #
+            # @yield [config] Configure the Operations client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            # @return [Operations::Configuration]
+            #
+            def configure
+              yield @config if block_given?
+              @config
+            end
+
+            ##
             # @param credentials [Google::Auth::Credentials, String, Hash,
             #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
             #   Provides the means for authenticating requests made by the client. This
@@ -56,49 +87,36 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scope [String, Array<String>]
-            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-            #   an updater_proc is supplied.
-            # @param timeout [Numeric]
-            #   The default timeout, in seconds, for calls made through this client.
-            # @param metadata [Hash]
-            #   Default metadata to be sent with each request. This can be overridden on a
-            #   per call basis.
             #
-            def initialize \
-                credentials:  nil,
-                scope:        Client::ALL_SCOPES,
-                timeout:      Client::DEFAULT_TIMEOUT,
-                metadata:     nil,
-                lib_name:     nil,
-                lib_version:  nil
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            def initialize credentials: nil, config: nil
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
               require "google/gax/grpc"
               require "google/longrunning/operations_services_pb"
 
-              credentials ||= Credentials.default scope: scope
+              # Create the configuration object
+              @config = Configuration.new Operations.configure
+
+              # Yield the configuration if needed
+              yield @config if block_given?
+
+              # Create credentials
+              credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
-                credentials = Credentials.new credentials, scope: scope
+                credentials = Credentials.new credentials, scope: @config.scope
               end
 
               @operations_stub = Google::Gax::Grpc::Stub.new(
                 Google::Longrunning::Operations::Stub,
-                host:         Client::SERVICE_ADDRESS,
-                port:         Client::DEFAULT_SERVICE_PORT,
                 credentials:  credentials,
-                interceptors: Client::GRPC_INTERCEPTORS
+                host:         @config.host,
+                port:         @config.port,
+                interceptors: @config.interceptors
               )
-
-              @timeout = timeout
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              @metadata = metadata.to_h
-              @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
             end
 
             # Service calls
@@ -154,12 +172,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.list_operations.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.list_operations.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
 
@@ -210,12 +243,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.get_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.get_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
 
@@ -267,12 +315,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.delete_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.delete_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
 
@@ -334,16 +397,83 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.cancel_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.cancel_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
 
               @cancel_operation.call request, options: options, operation_callback: block
+            end
+
+            class Configuration
+              extend Google::Gax::Config
+
+              config_attr :host,         "speech.googleapis.com", String
+              config_attr :port,         443, Integer
+              config_attr :scope,        nil,                                   String, Array, nil
+              config_attr :lib_name,     nil,                                   String, nil
+              config_attr :lib_version,  nil,                                   String, nil
+              config_attr :interceptors, [],                                    Array
+              config_attr :timeout,      nil,                                   Numeric, nil
+              config_attr :metadata,     nil,                                   Hash, nil
+              config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+              def initialize parent_config = nil
+                @parent_config = parent_config unless parent_config.nil?
+
+                yield self if block_given?
+              end
+
+              def rpcs
+                @rpcs ||= begin
+                  parent_rpcs = nil
+                  parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                  Rpcs.new parent_rpcs
+                end
+              end
+
+              class Rpcs
+                attr_reader :list_operations
+                attr_reader :get_operation
+                attr_reader :delete_operation
+                attr_reader :cancel_operation
+
+                def initialize parent_rpcs = nil
+                  list_operations_config = nil
+                  list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
+                  @list_operations = Google::Gax::Config::Method.new list_operations_config
+                  get_operation_config = nil
+                  get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
+                  @get_operation = Google::Gax::Config::Method.new get_operation_config
+                  delete_operation_config = nil
+                  delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
+                  @delete_operation = Google::Gax::Config::Method.new delete_operation_config
+                  cancel_operation_config = nil
+                  cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
+                  @cancel_operation = Google::Gax::Config::Method.new cancel_operation_config
+
+                  yield self if block_given?
+                end
+              end
             end
           end
         end

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -247,7 +247,7 @@ module Google
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
               config_attr :credentials,  nil do |value|
-                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
                 allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
                 allowed.any? { |klass| klass === value }
               end

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -73,27 +73,12 @@ module Google
             end
 
             ##
-            # @param credentials [Google::Auth::Credentials, String, Hash,
-            #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-            #   Provides the means for authenticating requests made by the client. This
-            #   parameter can be many types.
-            #   A `Google::Auth::Credentials` uses a the properties of its represented
-            #   keyfile for authenticating requests made by this client.
-            #   A `String` will be treated as the path to the keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `Hash` will be treated as the contents of a keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `GRPC::Core::Channel` will be used to make calls through.
-            #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-            #   channel credentials should already be composed with a
-            #   `GRPC::Core::CallCredentials` object.
-            #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-            #   transforms the metadata for requests, generally, to give OAuth credentials.
+            # Create a new Client client object.
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Client::Configuration]
             #
-            def initialize credentials: nil
+            def initialize
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
@@ -107,14 +92,15 @@ module Google
               yield @config if block_given?
 
               # Create credentials
+              credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
 
-              @operations_client = Operations.new(
-                credentials: credentials
-              )
+              @operations_client = Operations.new do |config|
+                config.credentials = credentials
+              end
 
               @image_annotator_stub = Google::Gax::Grpc::Stub.new(
                 Google::Cloud::Vision::V1::ImageAnnotator::Stub,
@@ -260,6 +246,11 @@ module Google
 
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
+              config_attr :credentials,  nil do |value|
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+                allowed.any? { |klass| klass === value }
+              end
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -71,27 +71,12 @@ module Google
             end
 
             ##
-            # @param credentials [Google::Auth::Credentials, String, Hash,
-            #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-            #   Provides the means for authenticating requests made by the client. This
-            #   parameter can be many types.
-            #   A `Google::Auth::Credentials` uses a the properties of its represented
-            #   keyfile for authenticating requests made by this client.
-            #   A `String` will be treated as the path to the keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `Hash` will be treated as the contents of a keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `GRPC::Core::Channel` will be used to make calls through.
-            #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-            #   channel credentials should already be composed with a
-            #   `GRPC::Core::CallCredentials` object.
-            #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-            #   transforms the metadata for requests, generally, to give OAuth credentials.
+            # Create a new Operations client object.
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Operations::Configuration]
             #
-            def initialize credentials: nil, config: nil
+            def initialize
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
@@ -105,6 +90,7 @@ module Google
               yield @config if block_given?
 
               # Create credentials
+              credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
@@ -429,6 +415,11 @@ module Google
 
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
+              config_attr :credentials,  nil do |value|
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+                allowed.any? { |klass| klass === value }
+              end
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -40,6 +40,37 @@ module Google
             attr_reader :operations_stub
 
             ##
+            # Configuration for the ImageAnnotator Operations API.
+            #
+            # @yield [config] Configure the Operations client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            # @return [Operations::Configuration]
+            #
+            def self.configure
+              @configure ||= Operations::Configuration.new
+              yield @configure if block_given?
+              @configure
+            end
+
+            ##
+            # Configure the ImageAnnotator Operations instance.
+            #
+            # The configuration is set to the derived mode, meaning that values can be changed,
+            # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+            # should be made on {Operations.configure}.
+            #
+            # @yield [config] Configure the Operations client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            # @return [Operations::Configuration]
+            #
+            def configure
+              yield @config if block_given?
+              @config
+            end
+
+            ##
             # @param credentials [Google::Auth::Credentials, String, Hash,
             #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
             #   Provides the means for authenticating requests made by the client. This
@@ -56,49 +87,36 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scope [String, Array<String>]
-            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-            #   an updater_proc is supplied.
-            # @param timeout [Numeric]
-            #   The default timeout, in seconds, for calls made through this client.
-            # @param metadata [Hash]
-            #   Default metadata to be sent with each request. This can be overridden on a
-            #   per call basis.
             #
-            def initialize \
-                credentials:  nil,
-                scope:        Client::ALL_SCOPES,
-                timeout:      Client::DEFAULT_TIMEOUT,
-                metadata:     nil,
-                lib_name:     nil,
-                lib_version:  nil
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            def initialize credentials: nil, config: nil
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
               require "google/gax/grpc"
               require "google/longrunning/operations_services_pb"
 
-              credentials ||= Credentials.default scope: scope
+              # Create the configuration object
+              @config = Configuration.new Operations.configure
+
+              # Yield the configuration if needed
+              yield @config if block_given?
+
+              # Create credentials
+              credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
-                credentials = Credentials.new credentials, scope: scope
+                credentials = Credentials.new credentials, scope: @config.scope
               end
 
               @operations_stub = Google::Gax::Grpc::Stub.new(
                 Google::Longrunning::Operations::Stub,
-                host:         Client::SERVICE_ADDRESS,
-                port:         Client::DEFAULT_SERVICE_PORT,
                 credentials:  credentials,
-                interceptors: Client::GRPC_INTERCEPTORS
+                host:         @config.host,
+                port:         @config.port,
+                interceptors: @config.interceptors
               )
-
-              @timeout = timeout
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              @metadata = metadata.to_h
-              @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
             end
 
             # Service calls
@@ -154,12 +172,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.list_operations.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.list_operations.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
 
@@ -210,12 +243,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.get_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.get_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
 
@@ -267,12 +315,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.delete_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.delete_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
 
@@ -334,16 +397,83 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.cancel_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.cancel_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
 
               @cancel_operation.call request, options: options, operation_callback: block
+            end
+
+            class Configuration
+              extend Google::Gax::Config
+
+              config_attr :host,         "vision.googleapis.com", String
+              config_attr :port,         443, Integer
+              config_attr :scope,        nil,                                   String, Array, nil
+              config_attr :lib_name,     nil,                                   String, nil
+              config_attr :lib_version,  nil,                                   String, nil
+              config_attr :interceptors, [],                                    Array
+              config_attr :timeout,      nil,                                   Numeric, nil
+              config_attr :metadata,     nil,                                   Hash, nil
+              config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+              def initialize parent_config = nil
+                @parent_config = parent_config unless parent_config.nil?
+
+                yield self if block_given?
+              end
+
+              def rpcs
+                @rpcs ||= begin
+                  parent_rpcs = nil
+                  parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                  Rpcs.new parent_rpcs
+                end
+              end
+
+              class Rpcs
+                attr_reader :list_operations
+                attr_reader :get_operation
+                attr_reader :delete_operation
+                attr_reader :cancel_operation
+
+                def initialize parent_rpcs = nil
+                  list_operations_config = nil
+                  list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
+                  @list_operations = Google::Gax::Config::Method.new list_operations_config
+                  get_operation_config = nil
+                  get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
+                  @get_operation = Google::Gax::Config::Method.new get_operation_config
+                  delete_operation_config = nil
+                  delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
+                  @delete_operation = Google::Gax::Config::Method.new delete_operation_config
+                  cancel_operation_config = nil
+                  cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
+                  @cancel_operation = Google::Gax::Config::Method.new cancel_operation_config
+
+                  yield self if block_given?
+                end
+              end
             end
           end
         end

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -416,7 +416,7 @@ module Google
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
               config_attr :credentials,  nil do |value|
-                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
                 allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
                 allowed.any? { |klass| klass === value }
               end

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -73,27 +73,12 @@ module Google
             end
 
             ##
-            # @param credentials [Google::Auth::Credentials, String, Hash,
-            #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-            #   Provides the means for authenticating requests made by the client. This
-            #   parameter can be many types.
-            #   A `Google::Auth::Credentials` uses a the properties of its represented
-            #   keyfile for authenticating requests made by this client.
-            #   A `String` will be treated as the path to the keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `Hash` will be treated as the contents of a keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `GRPC::Core::Channel` will be used to make calls through.
-            #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-            #   channel credentials should already be composed with a
-            #   `GRPC::Core::CallCredentials` object.
-            #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-            #   transforms the metadata for requests, generally, to give OAuth credentials.
+            # Create a new Client client object.
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Client::Configuration]
             #
-            def initialize credentials: nil
+            def initialize
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
@@ -107,14 +92,15 @@ module Google
               yield @config if block_given?
 
               # Create credentials
+              credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
 
-              @operations_client = Operations.new(
-                credentials: credentials
-              )
+              @operations_client = Operations.new do |config|
+                config.credentials = credentials
+              end
 
               @product_search_stub = Google::Gax::Grpc::Stub.new(
                 Google::Cloud::Vision::V1::ProductSearch::Stub,
@@ -1666,6 +1652,11 @@ module Google
 
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
+              config_attr :credentials,  nil do |value|
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+                allowed.any? { |klass| klass === value }
+              end
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -1653,7 +1653,7 @@ module Google
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
               config_attr :credentials,  nil do |value|
-                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
                 allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
                 allowed.any? { |klass| klass === value }
               end

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -40,6 +40,37 @@ module Google
             attr_reader :operations_stub
 
             ##
+            # Configuration for the ProductSearch Operations API.
+            #
+            # @yield [config] Configure the Operations client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            # @return [Operations::Configuration]
+            #
+            def self.configure
+              @configure ||= Operations::Configuration.new
+              yield @configure if block_given?
+              @configure
+            end
+
+            ##
+            # Configure the ProductSearch Operations instance.
+            #
+            # The configuration is set to the derived mode, meaning that values can be changed,
+            # but structural changes (adding new fields, etc.) are not allowed. Structural changes
+            # should be made on {Operations.configure}.
+            #
+            # @yield [config] Configure the Operations client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            # @return [Operations::Configuration]
+            #
+            def configure
+              yield @config if block_given?
+              @config
+            end
+
+            ##
             # @param credentials [Google::Auth::Credentials, String, Hash,
             #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
             #   Provides the means for authenticating requests made by the client. This
@@ -56,49 +87,36 @@ module Google
             #   `GRPC::Core::CallCredentials` object.
             #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
             #   transforms the metadata for requests, generally, to give OAuth credentials.
-            # @param scope [String, Array<String>]
-            #   The OAuth scope (or scopes) for this service. This parameter is ignored if
-            #   an updater_proc is supplied.
-            # @param timeout [Numeric]
-            #   The default timeout, in seconds, for calls made through this client.
-            # @param metadata [Hash]
-            #   Default metadata to be sent with each request. This can be overridden on a
-            #   per call basis.
             #
-            def initialize \
-                credentials:  nil,
-                scope:        Client::ALL_SCOPES,
-                timeout:      Client::DEFAULT_TIMEOUT,
-                metadata:     nil,
-                lib_name:     nil,
-                lib_version:  nil
+            # @yield [config] Configure the Client client.
+            # @yieldparam config [Operations::Configuration]
+            #
+            def initialize credentials: nil, config: nil
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
               require "google/gax/grpc"
               require "google/longrunning/operations_services_pb"
 
-              credentials ||= Credentials.default scope: scope
+              # Create the configuration object
+              @config = Configuration.new Operations.configure
+
+              # Yield the configuration if needed
+              yield @config if block_given?
+
+              # Create credentials
+              credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
-                credentials = Credentials.new credentials, scope: scope
+                credentials = Credentials.new credentials, scope: @config.scope
               end
 
               @operations_stub = Google::Gax::Grpc::Stub.new(
                 Google::Longrunning::Operations::Stub,
-                host:         Client::SERVICE_ADDRESS,
-                port:         Client::DEFAULT_SERVICE_PORT,
                 credentials:  credentials,
-                interceptors: Client::GRPC_INTERCEPTORS
+                host:         @config.host,
+                port:         @config.port,
+                interceptors: @config.interceptors
               )
-
-              @timeout = timeout
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{lib_name}/#{lib_version}" if lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              @metadata = metadata.to_h
-              @metadata["x-goog-api-client"] ||= x_goog_api_client_header.join " "
             end
 
             # Service calls
@@ -154,12 +172,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.list_operations.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.list_operations.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
 
@@ -210,12 +243,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.get_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.get_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
 
@@ -267,12 +315,27 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.delete_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.delete_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
 
@@ -334,16 +397,83 @@ module Google
               options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? :to_h
 
               # Customize the options with defaults
+              metadata = @config.rpcs.cancel_operation.metadata.to_h
+
+              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
+              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
+              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
+              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
+              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
+              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+
               header_params = {
                 "name" => request.name
               }
               request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
-              metadata = @metadata.merge "x-goog-request-params" => request_params_header
-              options.apply_defaults timeout: @timeout, metadata: metadata
+              metadata[:"x-goog-request-params"] ||= request_params_header
+
+              options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
+                                     metadata:     metadata,
+                                     retry_policy: @config.rpcs.cancel_operation.retry_policy
+              options.apply_defaults timeout:      @config.timeout,
+                                     metadata:     @config.metadata,
+                                     retry_policy: @config.retry_policy
 
               @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
 
               @cancel_operation.call request, options: options, operation_callback: block
+            end
+
+            class Configuration
+              extend Google::Gax::Config
+
+              config_attr :host,         "vision.googleapis.com", String
+              config_attr :port,         443, Integer
+              config_attr :scope,        nil,                                   String, Array, nil
+              config_attr :lib_name,     nil,                                   String, nil
+              config_attr :lib_version,  nil,                                   String, nil
+              config_attr :interceptors, [],                                    Array
+              config_attr :timeout,      nil,                                   Numeric, nil
+              config_attr :metadata,     nil,                                   Hash, nil
+              config_attr :retry_policy, nil,                                   Hash, Proc, nil
+
+              def initialize parent_config = nil
+                @parent_config = parent_config unless parent_config.nil?
+
+                yield self if block_given?
+              end
+
+              def rpcs
+                @rpcs ||= begin
+                  parent_rpcs = nil
+                  parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
+                  Rpcs.new parent_rpcs
+                end
+              end
+
+              class Rpcs
+                attr_reader :list_operations
+                attr_reader :get_operation
+                attr_reader :delete_operation
+                attr_reader :cancel_operation
+
+                def initialize parent_rpcs = nil
+                  list_operations_config = nil
+                  list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
+                  @list_operations = Google::Gax::Config::Method.new list_operations_config
+                  get_operation_config = nil
+                  get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
+                  @get_operation = Google::Gax::Config::Method.new get_operation_config
+                  delete_operation_config = nil
+                  delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
+                  @delete_operation = Google::Gax::Config::Method.new delete_operation_config
+                  cancel_operation_config = nil
+                  cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
+                  @cancel_operation = Google::Gax::Config::Method.new cancel_operation_config
+
+                  yield self if block_given?
+                end
+              end
             end
           end
         end

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -71,27 +71,12 @@ module Google
             end
 
             ##
-            # @param credentials [Google::Auth::Credentials, String, Hash,
-            #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-            #   Provides the means for authenticating requests made by the client. This
-            #   parameter can be many types.
-            #   A `Google::Auth::Credentials` uses a the properties of its represented
-            #   keyfile for authenticating requests made by this client.
-            #   A `String` will be treated as the path to the keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `Hash` will be treated as the contents of a keyfile to be used for the
-            #   construction of credentials for this client.
-            #   A `GRPC::Core::Channel` will be used to make calls through.
-            #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The
-            #   channel credentials should already be composed with a
-            #   `GRPC::Core::CallCredentials` object.
-            #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc
-            #   transforms the metadata for requests, generally, to give OAuth credentials.
+            # Create a new Operations client object.
             #
             # @yield [config] Configure the Client client.
             # @yieldparam config [Operations::Configuration]
             #
-            def initialize credentials: nil, config: nil
+            def initialize
               # These require statements are intentionally placed here to initialize
               # the gRPC module only when it's required.
               # See https://github.com/googleapis/toolkit/issues/446
@@ -105,6 +90,7 @@ module Google
               yield @config if block_given?
 
               # Create credentials
+              credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
@@ -429,6 +415,11 @@ module Google
 
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
+              config_attr :credentials,  nil do |value|
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
+                allowed.any? { |klass| klass === value }
+              end
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -416,7 +416,7 @@ module Google
               config_attr :host,         "vision.googleapis.com", String
               config_attr :port,         443, Integer
               config_attr :credentials,  nil do |value|
-                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials]
+                allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, nil]
                 allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
                 allowed.any? { |klass| klass === value }
               end

--- a/shared/test/showcase/echo/chat_test.rb
+++ b/shared/test/showcase/echo/chat_test.rb
@@ -20,9 +20,9 @@ require "grpc"
 
 class ChatTest < ShowcaseTest
   def test_closure
-    client = Google::Showcase::V1alpha3::Echo::Client.new(
-      credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    )
+    client = Google::Showcase::V1alpha3::Echo::Client.new do |config|
+      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
+    end
 
     pull_count = 0
 
@@ -61,9 +61,9 @@ class ChatTest < ShowcaseTest
   end
 
   def test_enumerator
-    client = Google::Showcase::V1alpha3::Echo::Client.new(
-      credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    )
+    client = Google::Showcase::V1alpha3::Echo::Client.new do |config|
+      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
+    end
 
     pull_count = 0
 

--- a/shared/test/showcase/echo/chat_test.rb
+++ b/shared/test/showcase/echo/chat_test.rb
@@ -16,6 +16,7 @@
 
 require "test_helper"
 require "google/showcase/v1alpha3/echo"
+require "grpc"
 
 class ChatTest < ShowcaseTest
   def test_closure

--- a/shared/test/showcase/echo/echo_test.rb
+++ b/shared/test/showcase/echo/echo_test.rb
@@ -20,9 +20,9 @@ require "grpc"
 
 class EchoTest < ShowcaseTest
   def test_echo
-    client = Google::Showcase::V1alpha3::Echo::Client.new(
-      credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    )
+    client = Google::Showcase::V1alpha3::Echo::Client.new do |config|
+      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
+    end
 
     response = client.echo content: 'hi there!'
 

--- a/shared/test/showcase/echo/echo_test.rb
+++ b/shared/test/showcase/echo/echo_test.rb
@@ -16,6 +16,7 @@
 
 require "test_helper"
 require "google/showcase/v1alpha3/echo"
+require "grpc"
 
 class EchoTest < ShowcaseTest
   def test_echo

--- a/shared/test/showcase/echo/expand_test.rb
+++ b/shared/test/showcase/echo/expand_test.rb
@@ -16,6 +16,7 @@
 
 require "test_helper"
 require "google/showcase/v1alpha3/echo"
+require "grpc"
 
 class ExpandTest < ShowcaseTest
   def test_expand

--- a/shared/test/showcase/echo/expand_test.rb
+++ b/shared/test/showcase/echo/expand_test.rb
@@ -20,9 +20,9 @@ require "grpc"
 
 class ExpandTest < ShowcaseTest
   def test_expand
-    client = Google::Showcase::V1alpha3::Echo::Client.new(
-      credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    )
+    client = Google::Showcase::V1alpha3::Echo::Client.new do |config|
+      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
+    end
 
     request_content = "The quick brown fox jumps over the lazy dog"
     responses = Queue.new

--- a/shared/test/showcase/echo/paged_expand_test.rb
+++ b/shared/test/showcase/echo/paged_expand_test.rb
@@ -16,6 +16,7 @@
 
 require "test_helper"
 require "google/showcase/v1alpha3/echo"
+require "grpc"
 
 class PagedExpandTest < ShowcaseTest
   def test_paged_expand

--- a/shared/test/showcase/echo/paged_expand_test.rb
+++ b/shared/test/showcase/echo/paged_expand_test.rb
@@ -20,9 +20,9 @@ require "grpc"
 
 class PagedExpandTest < ShowcaseTest
   def test_paged_expand
-    client = Google::Showcase::V1alpha3::Echo::Client.new(
-      credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    )
+    client = Google::Showcase::V1alpha3::Echo::Client.new do |config|
+      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
+    end
 
     request_content = "The quick brown fox jumps over the lazy dog"
 
@@ -36,9 +36,9 @@ class PagedExpandTest < ShowcaseTest
   end
 
   def test_page_size
-    client = Google::Showcase::V1alpha3::Echo::Client.new(
-      credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    )
+    client = Google::Showcase::V1alpha3::Echo::Client.new do |config|
+      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
+    end
 
     request_content = "The quick brown fox jumps over the lazy dog"
 

--- a/shared/test/showcase/echo/wait_test.rb
+++ b/shared/test/showcase/echo/wait_test.rb
@@ -23,7 +23,7 @@ class WaitTest < ShowcaseTest
       credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
     )
 
-    operation = client.wait ttl: { nanos: 50000 }, success: { content: "hi there!" }
+    operation = client.wait ttl: { nanos: 500000 }, success: { content: "hi there!" }
 
     refute operation.done?
     operation.wait_until_done!
@@ -38,7 +38,7 @@ class WaitTest < ShowcaseTest
       credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
     )
 
-    operation = client.wait ttl: { nanos: 50000 }, error: Google::Rpc::Status.new(message: "nope")
+    operation = client.wait ttl: { nanos: 500000 }, error: Google::Rpc::Status.new(message: "nope")
 
     refute operation.done?
     operation.wait_until_done!

--- a/shared/test/showcase/echo/wait_test.rb
+++ b/shared/test/showcase/echo/wait_test.rb
@@ -20,9 +20,9 @@ require "grpc"
 
 class WaitTest < ShowcaseTest
   def test_wait
-    client = Google::Showcase::V1alpha3::Echo::Client.new(
-      credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    )
+    client = Google::Showcase::V1alpha3::Echo::Client.new do |config|
+      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
+    end
 
     operation = client.wait ttl: { nanos: 500000 }, success: { content: "hi there!" }
 
@@ -35,9 +35,9 @@ class WaitTest < ShowcaseTest
   end
 
   def test_wait_error
-    client = Google::Showcase::V1alpha3::Echo::Client.new(
-      credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    )
+    client = Google::Showcase::V1alpha3::Echo::Client.new do |config|
+      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
+    end
 
     operation = client.wait ttl: { nanos: 500000 }, error: Google::Rpc::Status.new(message: "nope")
 

--- a/shared/test/showcase/echo/wait_test.rb
+++ b/shared/test/showcase/echo/wait_test.rb
@@ -16,6 +16,7 @@
 
 require "test_helper"
 require "google/showcase/v1alpha3/echo"
+require "grpc"
 
 class WaitTest < ShowcaseTest
   def test_wait


### PR DESCRIPTION
This PR is an alternate implementation to #142 to add configuration to the generated libraries. It depends on the Gax Config DSL added in googleapis/gax-ruby#196. This PR adds a `configuration` method to each service client class and replaces the use of constants. The client can now be configured globally and per-instance:

```ruby
# Set global defaults
Google::Cloud::Vision::V1::ImageAnnotator::Client.configure do |config|
  config.timeout = 120
  config.retry_policy = { retry_codes: [14] }
  config.rpcs.batch_annotate_images.retry_policy = { retry_codes: [12, 14] }
end

# Set/override the defaults on an individual instance
client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
  config.timeout = 90
  config.retry_policy = { retry_codes: [12, 14] }
  config.rpcs.batch_annotate_images.retry_policy = { retry_codes: [14] }
end
```

[refs #122]