### PR TITLE
Fix Showcase acceptance tests

### DIFF
--- a/shared/test/showcase/echo/chat_test.rb
+++ b/shared/test/showcase/echo/chat_test.rb
@@ -16,6 +16,7 @@
 
 require "test_helper"
 require "google/showcase/v1alpha3/echo"
+require "grpc"
 
 class ChatTest < ShowcaseTest
   def test_closure

--- a/shared/test/showcase/echo/echo_test.rb
+++ b/shared/test/showcase/echo/echo_test.rb
@@ -16,6 +16,7 @@
 
 require "test_helper"
 require "google/showcase/v1alpha3/echo"
+require "grpc"
 
 class EchoTest < ShowcaseTest
   def test_echo

--- a/shared/test/showcase/echo/expand_test.rb
+++ b/shared/test/showcase/echo/expand_test.rb
@@ -16,6 +16,7 @@
 
 require "test_helper"
 require "google/showcase/v1alpha3/echo"
+require "grpc"
 
 class ExpandTest < ShowcaseTest
   def test_expand

--- a/shared/test/showcase/echo/paged_expand_test.rb
+++ b/shared/test/showcase/echo/paged_expand_test.rb
@@ -16,6 +16,7 @@
 
 require "test_helper"
 require "google/showcase/v1alpha3/echo"
+require "grpc"
 
 class PagedExpandTest < ShowcaseTest
   def test_paged_expand

--- a/shared/test/showcase/echo/wait_test.rb
+++ b/shared/test/showcase/echo/wait_test.rb
@@ -16,6 +16,7 @@
 
 require "test_helper"
 require "google/showcase/v1alpha3/echo"
+require "grpc"
 
 class WaitTest < ShowcaseTest
   def test_wait
@@ -23,7 +24,7 @@ class WaitTest < ShowcaseTest
       credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
     )
 
-    operation = client.wait ttl: { nanos: 50000 }, success: { content: "hi there!" }
+    operation = client.wait ttl: { nanos: 500000 }, success: { content: "hi there!" }
 
     refute operation.done?
     operation.wait_until_done!
@@ -38,7 +39,7 @@ class WaitTest < ShowcaseTest
       credentials: GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
     )
 
-    operation = client.wait ttl: { nanos: 50000 }, error: Google::Rpc::Status.new(message: "nope")
+    operation = client.wait ttl: { nanos: 500000 }, error: Google::Rpc::Status.new(message: "nope")
 
     refute operation.done?
     operation.wait_until_done!


### PR DESCRIPTION
The tests use GRPC, but Gax recently fixed loading grpc too early.
Because of this, the tests need to require grpc in order to use it.