### PR TITLE
Gax stub channel args

### DIFF
--- a/gapic-generator/templates/default/service/client/_client.erb
+++ b/gapic-generator/templates/default/service/client/_client.erb
@@ -91,6 +91,7 @@ class <%= service.client_name %>
       credentials:  credentials,
       host:         @config.host,
       port:         @config.port,
+      channel_args: @config.channel_args,
       interceptors: @config.interceptors
     )
   end

--- a/gapic-generator/templates/default/service/client/_config.erb
+++ b/gapic-generator/templates/default/service/client/_config.erb
@@ -15,7 +15,8 @@ class Configuration
   config_attr :scope,        nil,                                   String, Array, nil
   config_attr :lib_name,     nil,                                   String, nil
   config_attr :lib_version,  nil,                                   String, nil
-  config_attr :interceptors, [],                                    Array
+  config_attr :channel_args, nil,                                   Hash, nil
+  config_attr :interceptors, nil,                                   Array, nil
   config_attr :timeout,      nil,                                   Numeric, nil
   config_attr :metadata,     nil,                                   Hash, nil
   config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/gapic-generator/templates/default/service/client/_operations.erb
+++ b/gapic-generator/templates/default/service/client/_operations.erb
@@ -74,6 +74,7 @@ class Operations
       credentials:  credentials,
       host:         @config.host,
       port:         @config.port,
+      channel_args: @config.channel_args,
       interceptors: @config.interceptors
     )
   end

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,7 +6,7 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/channel_args"
+gem "google-gax", github: "googleapis/gax-ruby"
 gem "grpc-tools", "~> 1.18"
 gem "minitest", "~> 5.0"
 gem "minitest-autotest", "~> 1.0"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,7 +6,7 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "googleapis/gax-ruby"
+gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/channel_args"
 gem "grpc-tools", "~> 1.18"
 gem "minitest", "~> 5.0"
 gem "minitest-autotest", "~> 1.0"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -98,6 +98,7 @@ module Google
               credentials:  credentials,
               host:         @config.host,
               port:         @config.port,
+              channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
           end
@@ -504,7 +505,8 @@ module Google
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil
-            config_attr :interceptors, [],                                    Array
+            config_attr :channel_args, nil,                                   Hash, nil
+            config_attr :interceptors, nil,                                   Array, nil
             config_attr :timeout,      nil,                                   Numeric, nil
             config_attr :metadata,     nil,                                   Hash, nil
             config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -92,6 +92,7 @@ module Google
               credentials:  credentials,
               host:         @config.host,
               port:         @config.port,
+              channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
           end
@@ -424,7 +425,8 @@ module Google
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil
-            config_attr :interceptors, [],                                    Array
+            config_attr :channel_args, nil,                                   Hash, nil
+            config_attr :interceptors, nil,                                   Array, nil
             config_attr :timeout,      nil,                                   Numeric, nil
             config_attr :metadata,     nil,                                   Hash, nil
             config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -97,6 +97,7 @@ module Google
               credentials:  credentials,
               host:         @config.host,
               port:         @config.port,
+              channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
           end
@@ -448,7 +449,8 @@ module Google
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil
-            config_attr :interceptors, [],                                    Array
+            config_attr :channel_args, nil,                                   Hash, nil
+            config_attr :interceptors, nil,                                   Array, nil
             config_attr :timeout,      nil,                                   Numeric, nil
             config_attr :metadata,     nil,                                   Hash, nil
             config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -101,6 +101,7 @@ module Google
               credentials:  credentials,
               host:         @config.host,
               port:         @config.port,
+              channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
           end
@@ -1090,7 +1091,8 @@ module Google
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil
-            config_attr :interceptors, [],                                    Array
+            config_attr :channel_args, nil,                                   Hash, nil
+            config_attr :interceptors, nil,                                   Array, nil
             config_attr :timeout,      nil,                                   Numeric, nil
             config_attr :metadata,     nil,                                   Hash, nil
             config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -92,6 +92,7 @@ module Google
               credentials:  credentials,
               host:         @config.host,
               port:         @config.port,
+              channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
           end
@@ -424,7 +425,8 @@ module Google
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil
-            config_attr :interceptors, [],                                    Array
+            config_attr :channel_args, nil,                                   Hash, nil
+            config_attr :interceptors, nil,                                   Array, nil
             config_attr :timeout,      nil,                                   Numeric, nil
             config_attr :metadata,     nil,                                   Hash, nil
             config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -97,6 +97,7 @@ module Google
               credentials:  credentials,
               host:         @config.host,
               port:         @config.port,
+              channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
           end
@@ -674,7 +675,8 @@ module Google
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil
-            config_attr :interceptors, [],                                    Array
+            config_attr :channel_args, nil,                                   Hash, nil
+            config_attr :interceptors, nil,                                   Array, nil
             config_attr :timeout,      nil,                                   Numeric, nil
             config_attr :metadata,     nil,                                   Hash, nil
             config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -99,6 +99,7 @@ module Google
                 credentials:  credentials,
                 host:         @config.host,
                 port:         @config.port,
+                channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
             end
@@ -314,7 +315,8 @@ module Google
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil
-              config_attr :interceptors, [],                                    Array
+              config_attr :channel_args, nil,                                   Hash, nil
+              config_attr :interceptors, nil,                                   Array, nil
               config_attr :timeout,      nil,                                   Numeric, nil
               config_attr :metadata,     nil,                                   Hash, nil
               config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -93,6 +93,7 @@ module Google
                 credentials:  credentials,
                 host:         @config.host,
                 port:         @config.port,
+                channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
             end
@@ -425,7 +426,8 @@ module Google
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil
-              config_attr :interceptors, [],                                    Array
+              config_attr :channel_args, nil,                                   Hash, nil
+              config_attr :interceptors, nil,                                   Array, nil
               config_attr :timeout,      nil,                                   Numeric, nil
               config_attr :metadata,     nil,                                   Hash, nil
               config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -99,6 +99,7 @@ module Google
                 credentials:  credentials,
                 host:         @config.host,
                 port:         @config.port,
+                channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
             end
@@ -251,7 +252,8 @@ module Google
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil
-              config_attr :interceptors, [],                                    Array
+              config_attr :channel_args, nil,                                   Hash, nil
+              config_attr :interceptors, nil,                                   Array, nil
               config_attr :timeout,      nil,                                   Numeric, nil
               config_attr :metadata,     nil,                                   Hash, nil
               config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -93,6 +93,7 @@ module Google
                 credentials:  credentials,
                 host:         @config.host,
                 port:         @config.port,
+                channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
             end
@@ -425,7 +426,8 @@ module Google
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil
-              config_attr :interceptors, [],                                    Array
+              config_attr :channel_args, nil,                                   Hash, nil
+              config_attr :interceptors, nil,                                   Array, nil
               config_attr :timeout,      nil,                                   Numeric, nil
               config_attr :metadata,     nil,                                   Hash, nil
               config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -99,6 +99,7 @@ module Google
                 credentials:  credentials,
                 host:         @config.host,
                 port:         @config.port,
+                channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
             end
@@ -1701,7 +1702,8 @@ module Google
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil
-              config_attr :interceptors, [],                                    Array
+              config_attr :channel_args, nil,                                   Hash, nil
+              config_attr :interceptors, nil,                                   Array, nil
               config_attr :timeout,      nil,                                   Numeric, nil
               config_attr :metadata,     nil,                                   Hash, nil
               config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -93,6 +93,7 @@ module Google
                 credentials:  credentials,
                 host:         @config.host,
                 port:         @config.port,
+                channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
             end
@@ -425,7 +426,8 @@ module Google
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil
-              config_attr :interceptors, [],                                    Array
+              config_attr :channel_args, nil,                                   Hash, nil
+              config_attr :interceptors, nil,                                   Array, nil
               config_attr :timeout,      nil,                                   Numeric, nil
               config_attr :metadata,     nil,                                   Hash, nil
               config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -106,6 +106,7 @@ module Google
               credentials:  credentials,
               host:         @config.host,
               port:         @config.port,
+              channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
           end
@@ -512,7 +513,8 @@ module Google
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil
-            config_attr :interceptors, [],                                    Array
+            config_attr :channel_args, nil,                                   Hash, nil
+            config_attr :interceptors, nil,                                   Array, nil
             config_attr :timeout,      nil,                                   Numeric, nil
             config_attr :metadata,     nil,                                   Hash, nil
             config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -100,6 +100,7 @@ module Google
               credentials:  credentials,
               host:         @config.host,
               port:         @config.port,
+              channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
           end
@@ -432,7 +433,8 @@ module Google
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil
-            config_attr :interceptors, [],                                    Array
+            config_attr :channel_args, nil,                                   Hash, nil
+            config_attr :interceptors, nil,                                   Array, nil
             config_attr :timeout,      nil,                                   Numeric, nil
             config_attr :metadata,     nil,                                   Hash, nil
             config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -105,6 +105,7 @@ module Google
               credentials:  credentials,
               host:         @config.host,
               port:         @config.port,
+              channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
           end
@@ -456,7 +457,8 @@ module Google
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil
-            config_attr :interceptors, [],                                    Array
+            config_attr :channel_args, nil,                                   Hash, nil
+            config_attr :interceptors, nil,                                   Array, nil
             config_attr :timeout,      nil,                                   Numeric, nil
             config_attr :metadata,     nil,                                   Hash, nil
             config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -109,6 +109,7 @@ module Google
               credentials:  credentials,
               host:         @config.host,
               port:         @config.port,
+              channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
           end
@@ -1098,7 +1099,8 @@ module Google
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil
-            config_attr :interceptors, [],                                    Array
+            config_attr :channel_args, nil,                                   Hash, nil
+            config_attr :interceptors, nil,                                   Array, nil
             config_attr :timeout,      nil,                                   Numeric, nil
             config_attr :metadata,     nil,                                   Hash, nil
             config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -100,6 +100,7 @@ module Google
               credentials:  credentials,
               host:         @config.host,
               port:         @config.port,
+              channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
           end
@@ -432,7 +433,8 @@ module Google
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil
-            config_attr :interceptors, [],                                    Array
+            config_attr :channel_args, nil,                                   Hash, nil
+            config_attr :interceptors, nil,                                   Array, nil
             config_attr :timeout,      nil,                                   Numeric, nil
             config_attr :metadata,     nil,                                   Hash, nil
             config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -105,6 +105,7 @@ module Google
               credentials:  credentials,
               host:         @config.host,
               port:         @config.port,
+              channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
           end
@@ -682,7 +683,8 @@ module Google
             config_attr :scope,        nil,                                   String, Array, nil
             config_attr :lib_name,     nil,                                   String, nil
             config_attr :lib_version,  nil,                                   String, nil
-            config_attr :interceptors, [],                                    Array
+            config_attr :channel_args, nil,                                   Hash, nil
+            config_attr :interceptors, nil,                                   Array, nil
             config_attr :timeout,      nil,                                   Numeric, nil
             config_attr :metadata,     nil,                                   Hash, nil
             config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -107,6 +107,7 @@ module Google
                 credentials:  credentials,
                 host:         @config.host,
                 port:         @config.port,
+                channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
             end
@@ -322,7 +323,8 @@ module Google
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil
-              config_attr :interceptors, [],                                    Array
+              config_attr :channel_args, nil,                                   Hash, nil
+              config_attr :interceptors, nil,                                   Array, nil
               config_attr :timeout,      nil,                                   Numeric, nil
               config_attr :metadata,     nil,                                   Hash, nil
               config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -101,6 +101,7 @@ module Google
                 credentials:  credentials,
                 host:         @config.host,
                 port:         @config.port,
+                channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
             end
@@ -433,7 +434,8 @@ module Google
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil
-              config_attr :interceptors, [],                                    Array
+              config_attr :channel_args, nil,                                   Hash, nil
+              config_attr :interceptors, nil,                                   Array, nil
               config_attr :timeout,      nil,                                   Numeric, nil
               config_attr :metadata,     nil,                                   Hash, nil
               config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -107,6 +107,7 @@ module Google
                 credentials:  credentials,
                 host:         @config.host,
                 port:         @config.port,
+                channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
             end
@@ -259,7 +260,8 @@ module Google
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil
-              config_attr :interceptors, [],                                    Array
+              config_attr :channel_args, nil,                                   Hash, nil
+              config_attr :interceptors, nil,                                   Array, nil
               config_attr :timeout,      nil,                                   Numeric, nil
               config_attr :metadata,     nil,                                   Hash, nil
               config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -101,6 +101,7 @@ module Google
                 credentials:  credentials,
                 host:         @config.host,
                 port:         @config.port,
+                channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
             end
@@ -433,7 +434,8 @@ module Google
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil
-              config_attr :interceptors, [],                                    Array
+              config_attr :channel_args, nil,                                   Hash, nil
+              config_attr :interceptors, nil,                                   Array, nil
               config_attr :timeout,      nil,                                   Numeric, nil
               config_attr :metadata,     nil,                                   Hash, nil
               config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -107,6 +107,7 @@ module Google
                 credentials:  credentials,
                 host:         @config.host,
                 port:         @config.port,
+                channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
             end
@@ -1709,7 +1710,8 @@ module Google
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil
-              config_attr :interceptors, [],                                    Array
+              config_attr :channel_args, nil,                                   Hash, nil
+              config_attr :interceptors, nil,                                   Array, nil
               config_attr :timeout,      nil,                                   Numeric, nil
               config_attr :metadata,     nil,                                   Hash, nil
               config_attr :retry_policy, nil,                                   Hash, Proc, nil

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -101,6 +101,7 @@ module Google
                 credentials:  credentials,
                 host:         @config.host,
                 port:         @config.port,
+                channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
             end
@@ -433,7 +434,8 @@ module Google
               config_attr :scope,        nil,                                   String, Array, nil
               config_attr :lib_name,     nil,                                   String, nil
               config_attr :lib_version,  nil,                                   String, nil
-              config_attr :interceptors, [],                                    Array
+              config_attr :channel_args, nil,                                   Hash, nil
+              config_attr :interceptors, nil,                                   Array, nil
               config_attr :timeout,      nil,                                   Numeric, nil
               config_attr :metadata,     nil,                                   Hash, nil
               config_attr :retry_policy, nil,                                   Hash, Proc, nil


### PR DESCRIPTION
This PR adds the `channel_args` value to the client's `Configuration` object. This config value allows users to control the behavior of the GRPC client object, including setting the size of the maximum request and response messages. Using the configuration object to set this value seems like the most appropriate and expected mechanism.

This PR is dependent on `channel_args` being added to Gax in googleapis/gax-ruby#201.