### PR TITLE
 Use the Gax gRPC stub object

### DIFF
--- a/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
@@ -49,10 +49,6 @@ class MethodPresenter
     end
   end
 
-  def ivar
-    "@#{name}"
-  end
-
   def doc_description
     return nil if @method.docs.leading_comments.empty?
 

--- a/gapic-generator/templates/default/service/client/method/def/_response.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_response.erb
@@ -1,21 +1,19 @@
 <%- assert_locals method -%>
-<%= method.ivar %> ||= Google::Gax::ApiCall.new @<%= method.service.stub_name %>.method :<%= method.name %>
-
 <%- if method.lro? -%>
 wrap_gax_operation = ->(response) { Google::Gax::Operation.new(response, <%= method.service.lro_client_ivar %>) }
 <%- end -%>
 <%- if method.paged? -%>
 <%- if method.lro? -%>
-wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new(<%= method.ivar %>, request, response, options, format_resource: wrap_gax_operation) }
+wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new(@<%= method.service.stub_name %>, :<%= method.name %>, request, response, options, format_resource: wrap_gax_operation) }
 <%- else -%>
-wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new(<%= method.ivar %>, request, response, options) }
+wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new(@<%= method.service.stub_name %>, :<%= method.name %>, request, response, options) }
 <%- end -%>
 <%- end -%>
 
 <%- if method.paged? -%>
-<%= method.ivar %>.call(request, options: options, operation_callback: block, format_response: wrap_paged_enum)
+@<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options, operation_callback: block, format_response: wrap_paged_enum
 <%- elsif method.lro? -%>
-<%= method.ivar %>.call(request, options: options, operation_callback: block, format_response: wrap_gax_operation)
+@<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options, operation_callback: block, format_response: wrap_gax_operation
 <%- else -%>
-<%= method.ivar %>.call(request, options: options, operation_callback: block)
+@<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options, operation_callback: block
 <%- end -%>

--- a/gapic-generator/test/google/gapic/presenters/method_test.rb
+++ b/gapic-generator/test/google/gapic/presenters/method_test.rb
@@ -34,7 +34,6 @@ class MethodPresenterTest < PresenterTest
 
     assert_equal "get_simple_garbage", presenter.name
     assert_equal :normal, presenter.kind
-    assert_equal "@get_simple_garbage", presenter.ivar
     assert_nil presenter.doc_description
   end
 
@@ -43,7 +42,6 @@ class MethodPresenterTest < PresenterTest
 
     assert_equal "get_specific_garbage", presenter.name
     assert_equal :normal, presenter.kind
-    assert_equal "@get_specific_garbage", presenter.ivar
     assert_nil presenter.doc_description
   end
 
@@ -52,7 +50,6 @@ class MethodPresenterTest < PresenterTest
 
     assert_equal "get_nested_garbage", presenter.name
     assert_equal :normal, presenter.kind
-    assert_equal "@get_nested_garbage", presenter.ivar
     assert_nil presenter.doc_description
   end
 
@@ -62,7 +59,6 @@ class MethodPresenterTest < PresenterTest
     assert_equal "get_repeated_garbage", presenter.name
     assert_equal :normal, presenter.kind
     refute presenter.lro?
-    assert_equal "@get_repeated_garbage", presenter.ivar
     assert_nil presenter.doc_description
   end
 
@@ -72,7 +68,6 @@ class MethodPresenterTest < PresenterTest
     assert_equal "long_running_garbage", presenter.name
     assert_equal :normal, presenter.kind
     assert presenter.lro?
-    assert_equal "@long_running_garbage", presenter.ivar
     assert_nil presenter.doc_description
   end
 
@@ -81,7 +76,6 @@ class MethodPresenterTest < PresenterTest
 
     assert_equal "client_garbage", presenter.name
     assert_equal :client, presenter.kind
-    assert_equal "@client_garbage", presenter.ivar
     assert_nil presenter.doc_description
   end
 
@@ -90,7 +84,6 @@ class MethodPresenterTest < PresenterTest
 
     assert_equal "server_garbage", presenter.name
     assert_equal :server, presenter.kind
-    assert_equal "@server_garbage", presenter.ivar
     assert_nil presenter.doc_description
   end
 
@@ -99,7 +92,6 @@ class MethodPresenterTest < PresenterTest
 
     assert_equal "bidi_garbage", presenter.name
     assert_equal :bidi, presenter.kind
-    assert_equal "@bidi_garbage", presenter.ivar
     assert_nil presenter.doc_description
   end
 end

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,7 +6,7 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/grpc-stub-class"
+gem "google-gax", github: "googleapis/gax-ruby"
 gem "grpc-tools", "~> 1.18"
 gem "minitest", "~> 5.0"
 gem "minitest-autotest", "~> 1.0"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,7 +6,7 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "googleapis/gax-ruby"
+gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/grpc-stub-class"
 gem "grpc-tools", "~> 1.18"
 gem "minitest", "~> 5.0"
 gem "minitest-autotest", "~> 1.0"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -156,10 +156,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @echo ||= Google::Gax::ApiCall.new @echo_stub.method :echo
-
-
-            @echo.call request, options: options, operation_callback: block
+            @echo_stub.call_rpc :echo, request, options: options, operation_callback: block
           end
 
           ##
@@ -215,10 +212,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @expand ||= Google::Gax::ApiCall.new @echo_stub.method :expand
-
-
-            @expand.call request, options: options, operation_callback: block
+            @echo_stub.call_rpc :expand, request, options: options, operation_callback: block
           end
 
           ##
@@ -275,10 +269,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @collect ||= Google::Gax::ApiCall.new @echo_stub.method :collect
-
-
-            @collect.call request, options: options, operation_callback: block
+            @echo_stub.call_rpc :collect, request, options: options, operation_callback: block
           end
 
           ##
@@ -335,10 +326,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @chat ||= Google::Gax::ApiCall.new @echo_stub.method :chat
-
-
-            @chat.call request, options: options, operation_callback: block
+            @echo_stub.call_rpc :chat, request, options: options, operation_callback: block
           end
 
           ##
@@ -396,11 +384,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @paged_expand ||= Google::Gax::ApiCall.new @echo_stub.method :paged_expand
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @echo_stub, :paged_expand, request, response, options }
 
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @paged_expand, request, response, options }
-
-            @paged_expand.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @echo_stub.call_rpc :paged_expand, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -461,11 +447,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @wait ||= Google::Gax::ApiCall.new @echo_stub.method :wait
-
             wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-            @wait.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @echo_stub.call_rpc :wait, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 
           class Configuration

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -168,12 +168,10 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
-
             wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_operations, request, response, options, format_resource: wrap_gax_operation }
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
 
-            @list_operations.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -235,11 +233,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
-
             wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-            @get_operation.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 
           ##
@@ -303,10 +299,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
-
-
-            @delete_operation.call request, options: options, operation_callback: block
+            @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
           end
 
           ##
@@ -382,10 +375,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
-
-
-            @cancel_operation.call request, options: options, operation_callback: block
+            @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
           end
 
           class Configuration

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -153,10 +153,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @create_user ||= Google::Gax::ApiCall.new @identity_stub.method :create_user
-
-
-            @create_user.call request, options: options, operation_callback: block
+            @identity_stub.call_rpc :create_user, request, options: options, operation_callback: block
           end
 
           ##
@@ -214,10 +211,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @get_user ||= Google::Gax::ApiCall.new @identity_stub.method :get_user
-
-
-            @get_user.call request, options: options, operation_callback: block
+            @identity_stub.call_rpc :get_user, request, options: options, operation_callback: block
           end
 
           ##
@@ -278,10 +272,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @update_user ||= Google::Gax::ApiCall.new @identity_stub.method :update_user
-
-
-            @update_user.call request, options: options, operation_callback: block
+            @identity_stub.call_rpc :update_user, request, options: options, operation_callback: block
           end
 
           ##
@@ -339,10 +330,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_user ||= Google::Gax::ApiCall.new @identity_stub.method :delete_user
-
-
-            @delete_user.call request, options: options, operation_callback: block
+            @identity_stub.call_rpc :delete_user, request, options: options, operation_callback: block
           end
 
           ##
@@ -399,11 +387,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_users ||= Google::Gax::ApiCall.new @identity_stub.method :list_users
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @identity_stub, :list_users, request, response, options }
 
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_users, request, response, options }
-
-            @list_users.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @identity_stub.call_rpc :list_users, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           class Configuration

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -157,10 +157,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @create_room ||= Google::Gax::ApiCall.new @messaging_stub.method :create_room
-
-
-            @create_room.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :create_room, request, options: options, operation_callback: block
           end
 
           ##
@@ -218,10 +215,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @get_room ||= Google::Gax::ApiCall.new @messaging_stub.method :get_room
-
-
-            @get_room.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :get_room, request, options: options, operation_callback: block
           end
 
           ##
@@ -282,10 +276,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @update_room ||= Google::Gax::ApiCall.new @messaging_stub.method :update_room
-
-
-            @update_room.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :update_room, request, options: options, operation_callback: block
           end
 
           ##
@@ -343,10 +334,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_room ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_room
-
-
-            @delete_room.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :delete_room, request, options: options, operation_callback: block
           end
 
           ##
@@ -403,11 +391,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_rooms ||= Google::Gax::ApiCall.new @messaging_stub.method :list_rooms
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, options }
 
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_rooms, request, response, options }
-
-            @list_rooms.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @messaging_stub.call_rpc :list_rooms, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -472,10 +458,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @create_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :create_blurb
-
-
-            @create_blurb.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :create_blurb, request, options: options, operation_callback: block
           end
 
           ##
@@ -533,10 +516,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @get_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :get_blurb
-
-
-            @get_blurb.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :get_blurb, request, options: options, operation_callback: block
           end
 
           ##
@@ -597,10 +577,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @update_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :update_blurb
-
-
-            @update_blurb.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :update_blurb, request, options: options, operation_callback: block
           end
 
           ##
@@ -658,10 +635,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_blurb
-
-
-            @delete_blurb.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :delete_blurb, request, options: options, operation_callback: block
           end
 
           ##
@@ -729,11 +703,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :list_blurbs
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, options }
 
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_blurbs, request, response, options }
-
-            @list_blurbs.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @messaging_stub.call_rpc :list_blurbs, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -808,11 +780,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @search_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :search_blurbs
-
             wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-            @search_blurbs.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @messaging_stub.call_rpc :search_blurbs, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 
           ##
@@ -874,10 +844,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @stream_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :stream_blurbs
-
-
-            @stream_blurbs.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :stream_blurbs, request, options: options, operation_callback: block
           end
 
           ##
@@ -939,10 +906,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @send_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :send_blurbs
-
-
-            @send_blurbs.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :send_blurbs, request, options: options, operation_callback: block
           end
 
           ##
@@ -1000,10 +964,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @connect ||= Google::Gax::ApiCall.new @messaging_stub.method :connect
-
-
-            @connect.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :connect, request, options: options, operation_callback: block
           end
 
           class Configuration

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -168,12 +168,10 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
-
             wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_operations, request, response, options, format_resource: wrap_gax_operation }
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
 
-            @list_operations.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -235,11 +233,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
-
             wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-            @get_operation.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 
           ##
@@ -303,10 +299,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
-
-
-            @delete_operation.call request, options: options, operation_callback: block
+            @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
           end
 
           ##
@@ -382,10 +375,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
-
-
-            @cancel_operation.call request, options: options, operation_callback: block
+            @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
           end
 
           class Configuration

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -155,10 +155,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @create_session ||= Google::Gax::ApiCall.new @testing_stub.method :create_session
-
-
-            @create_session.call request, options: options, operation_callback: block
+            @testing_stub.call_rpc :create_session, request, options: options, operation_callback: block
           end
 
           ##
@@ -216,10 +213,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @get_session ||= Google::Gax::ApiCall.new @testing_stub.method :get_session
-
-
-            @get_session.call request, options: options, operation_callback: block
+            @testing_stub.call_rpc :get_session, request, options: options, operation_callback: block
           end
 
           ##
@@ -273,11 +267,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_sessions ||= Google::Gax::ApiCall.new @testing_stub.method :list_sessions
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @testing_stub, :list_sessions, request, response, options }
 
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_sessions, request, response, options }
-
-            @list_sessions.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @testing_stub.call_rpc :list_sessions, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -335,10 +327,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_session ||= Google::Gax::ApiCall.new @testing_stub.method :delete_session
-
-
-            @delete_session.call request, options: options, operation_callback: block
+            @testing_stub.call_rpc :delete_session, request, options: options, operation_callback: block
           end
 
           ##
@@ -400,10 +389,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @report_session ||= Google::Gax::ApiCall.new @testing_stub.method :report_session
-
-
-            @report_session.call request, options: options, operation_callback: block
+            @testing_stub.call_rpc :report_session, request, options: options, operation_callback: block
           end
 
           ##
@@ -465,11 +451,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_tests ||= Google::Gax::ApiCall.new @testing_stub.method :list_tests
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @testing_stub, :list_tests, request, response, options }
 
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_tests, request, response, options }
-
-            @list_tests.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @testing_stub.call_rpc :list_tests, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -537,10 +521,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_test ||= Google::Gax::ApiCall.new @testing_stub.method :delete_test
-
-
-            @delete_test.call request, options: options, operation_callback: block
+            @testing_stub.call_rpc :delete_test, request, options: options, operation_callback: block
           end
 
           ##
@@ -608,10 +589,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @verify_test ||= Google::Gax::ApiCall.new @testing_stub.method :verify_test
-
-
-            @verify_test.call request, options: options, operation_callback: block
+            @testing_stub.call_rpc :verify_test, request, options: options, operation_callback: block
           end
 
           class Configuration

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -160,10 +160,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @recognize ||= Google::Gax::ApiCall.new @speech_stub.method :recognize
-
-
-              @recognize.call request, options: options, operation_callback: block
+              @speech_stub.call_rpc :recognize, request, options: options, operation_callback: block
             end
 
             ##
@@ -224,11 +221,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @long_running_recognize ||= Google::Gax::ApiCall.new @speech_stub.method :long_running_recognize
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-              @long_running_recognize.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @speech_stub.call_rpc :long_running_recognize, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
             ##
@@ -284,10 +279,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @streaming_recognize ||= Google::Gax::ApiCall.new @speech_stub.method :streaming_recognize
-
-
-              @streaming_recognize.call request, options: options, operation_callback: block
+              @speech_stub.call_rpc :streaming_recognize, request, options: options, operation_callback: block
             end
 
             class Configuration

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -169,12 +169,10 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_operations, request, response, options, format_resource: wrap_gax_operation }
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
 
-              @list_operations.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -236,11 +234,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-              @get_operation.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
             ##
@@ -304,10 +300,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
-
-
-              @delete_operation.call request, options: options, operation_callback: block
+              @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
             end
 
             ##
@@ -383,10 +376,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
-
-
-              @cancel_operation.call request, options: options, operation_callback: block
+              @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
             end
 
             class Configuration

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -155,10 +155,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @batch_annotate_images ||= Google::Gax::ApiCall.new @image_annotator_stub.method :batch_annotate_images
-
-
-              @batch_annotate_images.call request, options: options, operation_callback: block
+              @image_annotator_stub.call_rpc :batch_annotate_images, request, options: options, operation_callback: block
             end
 
             ##
@@ -220,11 +217,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @async_batch_annotate_files ||= Google::Gax::ApiCall.new @image_annotator_stub.method :async_batch_annotate_files
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-              @async_batch_annotate_files.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @image_annotator_stub.call_rpc :async_batch_annotate_files, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
             class Configuration

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -169,12 +169,10 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_operations, request, response, options, format_resource: wrap_gax_operation }
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
 
-              @list_operations.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -236,11 +234,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-              @get_operation.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
             ##
@@ -304,10 +300,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
-
-
-              @delete_operation.call request, options: options, operation_callback: block
+              @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
             end
 
             ##
@@ -383,10 +376,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
-
-
-              @cancel_operation.call request, options: options, operation_callback: block
+              @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
             end
 
             class Configuration

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -180,10 +180,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @create_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :create_product_set
-
-
-              @create_product_set.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :create_product_set, request, options: options, operation_callback: block
             end
 
             ##
@@ -257,11 +254,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_product_sets ||= Google::Gax::ApiCall.new @product_search_stub.method :list_product_sets
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, options }
 
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_product_sets, request, response, options }
-
-              @list_product_sets.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @product_search_stub.call_rpc :list_product_sets, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -330,10 +325,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @get_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :get_product_set
-
-
-              @get_product_set.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :get_product_set, request, options: options, operation_callback: block
             end
 
             ##
@@ -410,10 +402,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @update_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :update_product_set
-
-
-              @update_product_set.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :update_product_set, request, options: options, operation_callback: block
             end
 
             ##
@@ -488,10 +477,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @delete_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_product_set
-
-
-              @delete_product_set.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :delete_product_set, request, options: options, operation_callback: block
             end
 
             ##
@@ -573,10 +559,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @create_product ||= Google::Gax::ApiCall.new @product_search_stub.method :create_product
-
-
-              @create_product.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :create_product, request, options: options, operation_callback: block
             end
 
             ##
@@ -649,11 +632,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_products ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @product_search_stub, :list_products, request, response, options }
 
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_products, request, response, options }
-
-              @list_products.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @product_search_stub.call_rpc :list_products, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -722,10 +703,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @get_product ||= Google::Gax::ApiCall.new @product_search_stub.method :get_product
-
-
-              @get_product.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :get_product, request, options: options, operation_callback: block
             end
 
             ##
@@ -818,10 +796,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @update_product ||= Google::Gax::ApiCall.new @product_search_stub.method :update_product
-
-
-              @update_product.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :update_product, request, options: options, operation_callback: block
             end
 
             ##
@@ -898,10 +873,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @delete_product ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_product
-
-
-              @delete_product.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :delete_product, request, options: options, operation_callback: block
             end
 
             ##
@@ -1006,10 +978,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @create_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :create_reference_image
-
-
-              @create_reference_image.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :create_reference_image, request, options: options, operation_callback: block
             end
 
             ##
@@ -1091,10 +1060,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @delete_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_reference_image
-
-
-              @delete_reference_image.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :delete_reference_image, request, options: options, operation_callback: block
             end
 
             ##
@@ -1174,11 +1140,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_reference_images ||= Google::Gax::ApiCall.new @product_search_stub.method :list_reference_images
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, options }
 
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_reference_images, request, response, options }
-
-              @list_reference_images.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @product_search_stub.call_rpc :list_reference_images, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -1248,10 +1212,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @get_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :get_reference_image
-
-
-              @get_reference_image.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :get_reference_image, request, options: options, operation_callback: block
             end
 
             ##
@@ -1331,10 +1292,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @add_product_to_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :add_product_to_product_set
-
-
-              @add_product_to_product_set.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :add_product_to_product_set, request, options: options, operation_callback: block
             end
 
             ##
@@ -1408,10 +1366,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @remove_product_from_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :remove_product_from_product_set
-
-
-              @remove_product_from_product_set.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :remove_product_from_product_set, request, options: options, operation_callback: block
             end
 
             ##
@@ -1488,11 +1443,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_products_in_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products_in_product_set
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, options }
 
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_products_in_product_set, request, response, options }
-
-              @list_products_in_product_set.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @product_search_stub.call_rpc :list_products_in_product_set, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -1574,11 +1527,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @import_product_sets ||= Google::Gax::ApiCall.new @product_search_stub.method :import_product_sets
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-              @import_product_sets.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @product_search_stub.call_rpc :import_product_sets, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
             class Configuration

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -169,12 +169,10 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_operations, request, response, options, format_resource: wrap_gax_operation }
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
 
-              @list_operations.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -236,11 +234,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-              @get_operation.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
             ##
@@ -304,10 +300,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
-
-
-              @delete_operation.call request, options: options, operation_callback: block
+              @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
             end
 
             ##
@@ -383,10 +376,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
-
-
-              @cancel_operation.call request, options: options, operation_callback: block
+              @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
             end
 
             class Configuration

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -164,10 +164,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @echo ||= Google::Gax::ApiCall.new @echo_stub.method :echo
-
-
-            @echo.call request, options: options, operation_callback: block
+            @echo_stub.call_rpc :echo, request, options: options, operation_callback: block
           end
 
           ##
@@ -223,10 +220,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @expand ||= Google::Gax::ApiCall.new @echo_stub.method :expand
-
-
-            @expand.call request, options: options, operation_callback: block
+            @echo_stub.call_rpc :expand, request, options: options, operation_callback: block
           end
 
           ##
@@ -283,10 +277,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @collect ||= Google::Gax::ApiCall.new @echo_stub.method :collect
-
-
-            @collect.call request, options: options, operation_callback: block
+            @echo_stub.call_rpc :collect, request, options: options, operation_callback: block
           end
 
           ##
@@ -343,10 +334,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @chat ||= Google::Gax::ApiCall.new @echo_stub.method :chat
-
-
-            @chat.call request, options: options, operation_callback: block
+            @echo_stub.call_rpc :chat, request, options: options, operation_callback: block
           end
 
           ##
@@ -404,11 +392,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @paged_expand ||= Google::Gax::ApiCall.new @echo_stub.method :paged_expand
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @echo_stub, :paged_expand, request, response, options }
 
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @paged_expand, request, response, options }
-
-            @paged_expand.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @echo_stub.call_rpc :paged_expand, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -469,11 +455,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @wait ||= Google::Gax::ApiCall.new @echo_stub.method :wait
-
             wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-            @wait.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @echo_stub.call_rpc :wait, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 
           class Configuration

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -176,12 +176,10 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
-
             wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_operations, request, response, options, format_resource: wrap_gax_operation }
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
 
-            @list_operations.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -243,11 +241,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
-
             wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-            @get_operation.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 
           ##
@@ -311,10 +307,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
-
-
-            @delete_operation.call request, options: options, operation_callback: block
+            @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
           end
 
           ##
@@ -390,10 +383,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
-
-
-            @cancel_operation.call request, options: options, operation_callback: block
+            @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
           end
 
           class Configuration

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -161,10 +161,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @create_user ||= Google::Gax::ApiCall.new @identity_stub.method :create_user
-
-
-            @create_user.call request, options: options, operation_callback: block
+            @identity_stub.call_rpc :create_user, request, options: options, operation_callback: block
           end
 
           ##
@@ -222,10 +219,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @get_user ||= Google::Gax::ApiCall.new @identity_stub.method :get_user
-
-
-            @get_user.call request, options: options, operation_callback: block
+            @identity_stub.call_rpc :get_user, request, options: options, operation_callback: block
           end
 
           ##
@@ -286,10 +280,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @update_user ||= Google::Gax::ApiCall.new @identity_stub.method :update_user
-
-
-            @update_user.call request, options: options, operation_callback: block
+            @identity_stub.call_rpc :update_user, request, options: options, operation_callback: block
           end
 
           ##
@@ -347,10 +338,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_user ||= Google::Gax::ApiCall.new @identity_stub.method :delete_user
-
-
-            @delete_user.call request, options: options, operation_callback: block
+            @identity_stub.call_rpc :delete_user, request, options: options, operation_callback: block
           end
 
           ##
@@ -407,11 +395,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_users ||= Google::Gax::ApiCall.new @identity_stub.method :list_users
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @identity_stub, :list_users, request, response, options }
 
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_users, request, response, options }
-
-            @list_users.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @identity_stub.call_rpc :list_users, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           class Configuration

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -165,10 +165,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @create_room ||= Google::Gax::ApiCall.new @messaging_stub.method :create_room
-
-
-            @create_room.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :create_room, request, options: options, operation_callback: block
           end
 
           ##
@@ -226,10 +223,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @get_room ||= Google::Gax::ApiCall.new @messaging_stub.method :get_room
-
-
-            @get_room.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :get_room, request, options: options, operation_callback: block
           end
 
           ##
@@ -290,10 +284,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @update_room ||= Google::Gax::ApiCall.new @messaging_stub.method :update_room
-
-
-            @update_room.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :update_room, request, options: options, operation_callback: block
           end
 
           ##
@@ -351,10 +342,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_room ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_room
-
-
-            @delete_room.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :delete_room, request, options: options, operation_callback: block
           end
 
           ##
@@ -411,11 +399,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_rooms ||= Google::Gax::ApiCall.new @messaging_stub.method :list_rooms
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, options }
 
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_rooms, request, response, options }
-
-            @list_rooms.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @messaging_stub.call_rpc :list_rooms, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -480,10 +466,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @create_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :create_blurb
-
-
-            @create_blurb.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :create_blurb, request, options: options, operation_callback: block
           end
 
           ##
@@ -541,10 +524,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @get_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :get_blurb
-
-
-            @get_blurb.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :get_blurb, request, options: options, operation_callback: block
           end
 
           ##
@@ -605,10 +585,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @update_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :update_blurb
-
-
-            @update_blurb.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :update_blurb, request, options: options, operation_callback: block
           end
 
           ##
@@ -666,10 +643,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_blurb ||= Google::Gax::ApiCall.new @messaging_stub.method :delete_blurb
-
-
-            @delete_blurb.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :delete_blurb, request, options: options, operation_callback: block
           end
 
           ##
@@ -737,11 +711,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :list_blurbs
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, options }
 
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_blurbs, request, response, options }
-
-            @list_blurbs.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @messaging_stub.call_rpc :list_blurbs, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -816,11 +788,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @search_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :search_blurbs
-
             wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-            @search_blurbs.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @messaging_stub.call_rpc :search_blurbs, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 
           ##
@@ -882,10 +852,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @stream_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :stream_blurbs
-
-
-            @stream_blurbs.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :stream_blurbs, request, options: options, operation_callback: block
           end
 
           ##
@@ -947,10 +914,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @send_blurbs ||= Google::Gax::ApiCall.new @messaging_stub.method :send_blurbs
-
-
-            @send_blurbs.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :send_blurbs, request, options: options, operation_callback: block
           end
 
           ##
@@ -1008,10 +972,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @connect ||= Google::Gax::ApiCall.new @messaging_stub.method :connect
-
-
-            @connect.call request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :connect, request, options: options, operation_callback: block
           end
 
           class Configuration

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -176,12 +176,10 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
-
             wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_operations, request, response, options, format_resource: wrap_gax_operation }
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
 
-            @list_operations.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -243,11 +241,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
-
             wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-            @get_operation.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 
           ##
@@ -311,10 +307,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
-
-
-            @delete_operation.call request, options: options, operation_callback: block
+            @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
           end
 
           ##
@@ -390,10 +383,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
-
-
-            @cancel_operation.call request, options: options, operation_callback: block
+            @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
           end
 
           class Configuration

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -163,10 +163,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @create_session ||= Google::Gax::ApiCall.new @testing_stub.method :create_session
-
-
-            @create_session.call request, options: options, operation_callback: block
+            @testing_stub.call_rpc :create_session, request, options: options, operation_callback: block
           end
 
           ##
@@ -224,10 +221,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @get_session ||= Google::Gax::ApiCall.new @testing_stub.method :get_session
-
-
-            @get_session.call request, options: options, operation_callback: block
+            @testing_stub.call_rpc :get_session, request, options: options, operation_callback: block
           end
 
           ##
@@ -281,11 +275,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_sessions ||= Google::Gax::ApiCall.new @testing_stub.method :list_sessions
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @testing_stub, :list_sessions, request, response, options }
 
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_sessions, request, response, options }
-
-            @list_sessions.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @testing_stub.call_rpc :list_sessions, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -343,10 +335,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_session ||= Google::Gax::ApiCall.new @testing_stub.method :delete_session
-
-
-            @delete_session.call request, options: options, operation_callback: block
+            @testing_stub.call_rpc :delete_session, request, options: options, operation_callback: block
           end
 
           ##
@@ -408,10 +397,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @report_session ||= Google::Gax::ApiCall.new @testing_stub.method :report_session
-
-
-            @report_session.call request, options: options, operation_callback: block
+            @testing_stub.call_rpc :report_session, request, options: options, operation_callback: block
           end
 
           ##
@@ -473,11 +459,9 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @list_tests ||= Google::Gax::ApiCall.new @testing_stub.method :list_tests
+            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @testing_stub, :list_tests, request, response, options }
 
-            wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_tests, request, response, options }
-
-            @list_tests.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            @testing_stub.call_rpc :list_tests, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
 
           ##
@@ -545,10 +529,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @delete_test ||= Google::Gax::ApiCall.new @testing_stub.method :delete_test
-
-
-            @delete_test.call request, options: options, operation_callback: block
+            @testing_stub.call_rpc :delete_test, request, options: options, operation_callback: block
           end
 
           ##
@@ -616,10 +597,7 @@ module Google
                                    metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @verify_test ||= Google::Gax::ApiCall.new @testing_stub.method :verify_test
-
-
-            @verify_test.call request, options: options, operation_callback: block
+            @testing_stub.call_rpc :verify_test, request, options: options, operation_callback: block
           end
 
           class Configuration

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -168,10 +168,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @recognize ||= Google::Gax::ApiCall.new @speech_stub.method :recognize
-
-
-              @recognize.call request, options: options, operation_callback: block
+              @speech_stub.call_rpc :recognize, request, options: options, operation_callback: block
             end
 
             ##
@@ -232,11 +229,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @long_running_recognize ||= Google::Gax::ApiCall.new @speech_stub.method :long_running_recognize
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-              @long_running_recognize.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @speech_stub.call_rpc :long_running_recognize, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
             ##
@@ -292,10 +287,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @streaming_recognize ||= Google::Gax::ApiCall.new @speech_stub.method :streaming_recognize
-
-
-              @streaming_recognize.call request, options: options, operation_callback: block
+              @speech_stub.call_rpc :streaming_recognize, request, options: options, operation_callback: block
             end
 
             class Configuration

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -177,12 +177,10 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_operations, request, response, options, format_resource: wrap_gax_operation }
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
 
-              @list_operations.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -244,11 +242,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-              @get_operation.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
             ##
@@ -312,10 +308,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
-
-
-              @delete_operation.call request, options: options, operation_callback: block
+              @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
             end
 
             ##
@@ -391,10 +384,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
-
-
-              @cancel_operation.call request, options: options, operation_callback: block
+              @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
             end
 
             class Configuration

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -163,10 +163,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @batch_annotate_images ||= Google::Gax::ApiCall.new @image_annotator_stub.method :batch_annotate_images
-
-
-              @batch_annotate_images.call request, options: options, operation_callback: block
+              @image_annotator_stub.call_rpc :batch_annotate_images, request, options: options, operation_callback: block
             end
 
             ##
@@ -228,11 +225,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @async_batch_annotate_files ||= Google::Gax::ApiCall.new @image_annotator_stub.method :async_batch_annotate_files
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-              @async_batch_annotate_files.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @image_annotator_stub.call_rpc :async_batch_annotate_files, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
             class Configuration

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -177,12 +177,10 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_operations, request, response, options, format_resource: wrap_gax_operation }
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
 
-              @list_operations.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -244,11 +242,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-              @get_operation.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
             ##
@@ -312,10 +308,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
-
-
-              @delete_operation.call request, options: options, operation_callback: block
+              @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
             end
 
             ##
@@ -391,10 +384,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
-
-
-              @cancel_operation.call request, options: options, operation_callback: block
+              @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
             end
 
             class Configuration

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -188,10 +188,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @create_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :create_product_set
-
-
-              @create_product_set.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :create_product_set, request, options: options, operation_callback: block
             end
 
             ##
@@ -265,11 +262,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_product_sets ||= Google::Gax::ApiCall.new @product_search_stub.method :list_product_sets
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, options }
 
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_product_sets, request, response, options }
-
-              @list_product_sets.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @product_search_stub.call_rpc :list_product_sets, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -338,10 +333,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @get_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :get_product_set
-
-
-              @get_product_set.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :get_product_set, request, options: options, operation_callback: block
             end
 
             ##
@@ -418,10 +410,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @update_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :update_product_set
-
-
-              @update_product_set.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :update_product_set, request, options: options, operation_callback: block
             end
 
             ##
@@ -496,10 +485,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @delete_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_product_set
-
-
-              @delete_product_set.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :delete_product_set, request, options: options, operation_callback: block
             end
 
             ##
@@ -581,10 +567,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @create_product ||= Google::Gax::ApiCall.new @product_search_stub.method :create_product
-
-
-              @create_product.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :create_product, request, options: options, operation_callback: block
             end
 
             ##
@@ -657,11 +640,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_products ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @product_search_stub, :list_products, request, response, options }
 
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_products, request, response, options }
-
-              @list_products.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @product_search_stub.call_rpc :list_products, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -730,10 +711,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @get_product ||= Google::Gax::ApiCall.new @product_search_stub.method :get_product
-
-
-              @get_product.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :get_product, request, options: options, operation_callback: block
             end
 
             ##
@@ -826,10 +804,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @update_product ||= Google::Gax::ApiCall.new @product_search_stub.method :update_product
-
-
-              @update_product.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :update_product, request, options: options, operation_callback: block
             end
 
             ##
@@ -906,10 +881,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @delete_product ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_product
-
-
-              @delete_product.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :delete_product, request, options: options, operation_callback: block
             end
 
             ##
@@ -1014,10 +986,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @create_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :create_reference_image
-
-
-              @create_reference_image.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :create_reference_image, request, options: options, operation_callback: block
             end
 
             ##
@@ -1099,10 +1068,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @delete_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :delete_reference_image
-
-
-              @delete_reference_image.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :delete_reference_image, request, options: options, operation_callback: block
             end
 
             ##
@@ -1182,11 +1148,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_reference_images ||= Google::Gax::ApiCall.new @product_search_stub.method :list_reference_images
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, options }
 
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_reference_images, request, response, options }
-
-              @list_reference_images.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @product_search_stub.call_rpc :list_reference_images, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -1256,10 +1220,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @get_reference_image ||= Google::Gax::ApiCall.new @product_search_stub.method :get_reference_image
-
-
-              @get_reference_image.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :get_reference_image, request, options: options, operation_callback: block
             end
 
             ##
@@ -1339,10 +1300,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @add_product_to_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :add_product_to_product_set
-
-
-              @add_product_to_product_set.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :add_product_to_product_set, request, options: options, operation_callback: block
             end
 
             ##
@@ -1416,10 +1374,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @remove_product_from_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :remove_product_from_product_set
-
-
-              @remove_product_from_product_set.call request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :remove_product_from_product_set, request, options: options, operation_callback: block
             end
 
             ##
@@ -1496,11 +1451,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_products_in_product_set ||= Google::Gax::ApiCall.new @product_search_stub.method :list_products_in_product_set
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, options }
 
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_products_in_product_set, request, response, options }
-
-              @list_products_in_product_set.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @product_search_stub.call_rpc :list_products_in_product_set, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -1582,11 +1535,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @import_product_sets ||= Google::Gax::ApiCall.new @product_search_stub.method :import_product_sets
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-              @import_product_sets.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @product_search_stub.call_rpc :import_product_sets, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
             class Configuration

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -177,12 +177,10 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @list_operations ||= Google::Gax::ApiCall.new @operations_stub.method :list_operations
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @list_operations, request, response, options, format_resource: wrap_gax_operation }
+              wrap_paged_enum = ->(response) { Google::Gax::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
 
-              @list_operations.call request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
 
             ##
@@ -244,11 +242,9 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @get_operation ||= Google::Gax::ApiCall.new @operations_stub.method :get_operation
-
               wrap_gax_operation = ->(response) { Google::Gax::Operation.new response, @operations_client }
 
-              @get_operation.call request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
             ##
@@ -312,10 +308,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @delete_operation ||= Google::Gax::ApiCall.new @operations_stub.method :delete_operation
-
-
-              @delete_operation.call request, options: options, operation_callback: block
+              @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
             end
 
             ##
@@ -391,10 +384,7 @@ module Google
                                      metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @cancel_operation ||= Google::Gax::ApiCall.new @operations_stub.method :cancel_operation
-
-
-              @cancel_operation.call request, options: options, operation_callback: block
+              @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
             end
 
             class Configuration


### PR DESCRIPTION
Implement calling the RPC by calling a method on the Stub object instead of creating an ApiCall object. This reduces the number of instance variables on the client object.

Dependent on googleapis/gax-ruby#206.