### PR TITLE
Switch Client to positional args

### DIFF
--- a/gapic-generator/templates/default/service/client/method/_def.erb
+++ b/gapic-generator/templates/default/service/client/method/_def.erb
@@ -13,7 +13,7 @@
 # @example
 <%= indent method.code_example, "#   " %>
 #
-<%= render partial: "service/client/method/def/signature", locals: { method: method } -%>
+def <%= method.name %> request, options = nil, &block
 <%= indent render(partial: "service/client/method/def/request", locals: { method: method }), 2 %>
 
 <%= indent render(partial: "service/client/method/def/options_defaults", locals: { method: method }), 2 %>

--- a/gapic-generator/templates/default/service/client/method/def/_request_normal.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_request_normal.erb
@@ -1,10 +1,4 @@
 <%- assert_locals method -%>
-if request.nil? && request_fields.empty?
-  raise ArgumentError, "request must be provided"
-end
-if !request.nil? && !request_fields.empty?
-  raise ArgumentError, "cannot pass both request object and named arguments"
-end
+raise ArgumentError, "request must be provided" if request.nil?
 
-request ||= request_fields
 request = Google::Gax::Protobuf.coerce request, to: <%= method.request_type %>

--- a/gapic-generator/templates/default/service/client/method/def/_signature.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_signature.erb
@@ -1,6 +1,0 @@
-<%- assert_locals method -%>
-<%- if method.client_streaming? -%>
-def <%= method.name %> request, options: nil, &block
-<%- else -%>
-def <%= method.name %> request = nil, options: nil, **request_fields, &block
-<%- end -%>

--- a/gapic-generator/templates/default/service/client/method/docs/_request_normal.erb
+++ b/gapic-generator/templates/default/service/client/method/docs/_request_normal.erb
@@ -3,5 +3,12 @@
 <%- if method.doc_description -%>
 <%= indent method.doc_description, "#   " %>
 <%- end -%>
-# @param options [Google::Gax::ApiCall::Options, Hash]
+#
+#   When using a hash, the following fields are supported:
+#
+<%- method.arguments.each do |arg| -%>
+#   * `<%= arg.name %>` (`<%= arg.doc_types %>`)<%- if arg.doc_description -%>:
+<%= indent arg.doc_description, "#     " %>
+<%- end -%>
+<%- end -%># @param options [Google::Gax::ApiCall::Options, Hash]
 #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/gapic-generator/templates/default/service/client/method/docs/_request_normal.erb
+++ b/gapic-generator/templates/default/service/client/method/docs/_request_normal.erb
@@ -1,25 +1,7 @@
 <%- assert_locals method -%>
-# @overload <%= method.name %>(request, options: nil)
-#   @param request [<%= method.request_type %> | Hash]
+# @param request [<%= method.request_type %> | Hash]
 <%- if method.doc_description -%>
-<%= indent method.doc_description, "#     " %>
+<%= indent method.doc_description, "#   " %>
 <%- end -%>
-#   @param options [Google::Gax::ApiCall::Options, Hash]
-#     Overrides the default settings for this call, e.g, timeout, retries, etc.
-#
-<%- arg_list = method.arguments.map { |arg| "#{arg.name}: nil"}.join ", " -%>
-# @overload <%= method.name %>(<%= arg_list %>, options: nil)
-<%- method.arguments.each do |arg| -%>
-#   @param <%= arg.name %> [<%= arg.doc_types %>]
-<%- if arg.doc_description -%>
-<%= indent arg.doc_description, "#     " %>
-<%- end -%>
-<%- end -%>
-#   @param options [Google::Gax::ApiCall::Options, Hash]
-#     Overrides the default settings for this call, e.g, timeout, retries, etc.
-<%- if method.arguments.find { |arg| arg.name == "options" } -%>
-#
-#     If you want to provide a {<%= method.request_type %>#options}
-#     value you will need to pass all attributes in a Hash instead of using
-#     named arguments.
-<%- end -%>
+# @param options [Google::Gax::ApiCall::Options, Hash]
+#   Overrides the default settings for this call, e.g, timeout, retries, etc.

--- a/gapic-generator/templates/default/service/client/method/docs/_request_normal.erb
+++ b/gapic-generator/templates/default/service/client/method/docs/_request_normal.erb
@@ -4,4 +4,4 @@
 <%= indent method.doc_description, "#   " %>
 <%- end -%>
 # @param options [Google::Gax::ApiCall::Options, Hash]
-#   Overrides the default settings for this call, e.g, timeout, retries, etc.
+#   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/gapic-generator/templates/default/service/client/method/docs/_request_streaming.erb
+++ b/gapic-generator/templates/default/service/client/method/docs/_request_streaming.erb
@@ -2,4 +2,4 @@
 # @param request [Google::Gax::StreamInput, Enumerable<<%= method.request_type %> | Hash>]
 #   An enumerable of {<%= method.request_type %>} instances.
 # @param options [Google::Gax::ApiCall::Options, Hash]
-#   Overrides the default settings for this call, e.g, timeout, retries, etc.
+#   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,7 +6,7 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/client-methods-positional"
+gem "google-gax", github: "googleapis/gax-ruby"
 gem "grpc-tools", "~> 1.18"
 gem "minitest", "~> 5.0"
 gem "minitest-autotest", "~> 1.0"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,7 +6,7 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "googleapis/gax-ruby"
+gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/client-methods-positional"
 gem "grpc-tools", "~> 1.18"
 gem "minitest", "~> 5.0"
 gem "minitest-autotest", "~> 1.0"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -110,6 +110,13 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
           #   This method simply echos the request. This method is showcases unary rpcs.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `content` (`String`):
+          #     The content to be echoed by the server.
+          #   * `error` (`Google::Rpc::Status | Hash`):
+          #     The error to be thrown by the server.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -162,6 +169,13 @@ module Google
           # @param request [Google::Showcase::V1alpha3::ExpandRequest | Hash]
           #   This method split the given content into words and will pass each word back
           #   through the stream. This method showcases server-side streaming rpcs.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `content` (`String`):
+          #     The content that will be split into words and returned on the stream.
+          #   * `error` (`Google::Rpc::Status | Hash`):
+          #     The error that is thrown after all words are sent on the stream.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -334,6 +348,15 @@ module Google
           # @param request [Google::Showcase::V1alpha3::PagedExpandRequest | Hash]
           #   This is similar to the Expand method but instead of returning a stream of
           #   expanded words, this method returns a paged list of expanded words.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `content` (`String`):
+          #     The string to expand.
+          #   * `page_size` (`Integer`):
+          #     The amount of words to returned in each page.
+          #   * `page_token` (`String`):
+          #     The position of the page to be returned.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -387,6 +410,18 @@ module Google
           # @param request [Google::Showcase::V1alpha3::WaitRequest | Hash]
           #   This method will wait the requested amount of and then return.
           #   This method showcases how a client handles a request timing out.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `end_time` (`Google::Protobuf::Timestamp | Hash`):
+          #     The time that this operation will complete.
+          #   * `ttl` (`Google::Protobuf::Duration | Hash`):
+          #     The duration of this operation.
+          #   * `error` (`Google::Rpc::Status | Hash`):
+          #     The error that will be returned by the server. If this code is specified
+          #     to be the OK rpc code, an empty response will be returned.
+          #   * `success` (`Google::Showcase::V1alpha3::WaitResponse | Hash`):
+          #     The response to be returned on operation completion.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -111,7 +111,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
           #   This method simply echos the request. This method is showcases unary rpcs.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
@@ -163,7 +163,7 @@ module Google
           #   This method split the given content into words and will pass each word back
           #   through the stream. This method showcases server-side streaming rpcs.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -215,7 +215,7 @@ module Google
           # @param request [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
@@ -275,7 +275,7 @@ module Google
           # @param request [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -335,7 +335,7 @@ module Google
           #   This is similar to the Expand method but instead of returning a stream of
           #   expanded words, this method returns a paged list of expanded words.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -388,7 +388,7 @@ module Google
           #   This method will wait the requested amount of and then return.
           #   This method showcases how a client handles a request timing out.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -108,19 +108,10 @@ module Google
           ##
           # This method simply echos the request. This method is showcases unary rpcs.
           #
-          # @overload echo(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
-          #     This method simply echos the request. This method is showcases unary rpcs.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload echo(content: nil, error: nil, options: nil)
-          #   @param content [String]
-          #     The content to be echoed by the server.
-          #   @param error [Google::Rpc::Status | Hash]
-          #     The error to be thrown by the server.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
+          #   This method simply echos the request. This method is showcases unary rpcs.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
@@ -133,13 +124,9 @@ module Google
           # @example
           #   TODO
           #
-          def echo request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def echo request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::EchoRequest
 
             # Converts hash and nil to an options object
@@ -172,20 +159,11 @@ module Google
           # This method split the given content into words and will pass each word back
           # through the stream. This method showcases server-side streaming rpcs.
           #
-          # @overload expand(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ExpandRequest | Hash]
-          #     This method split the given content into words and will pass each word back
-          #     through the stream. This method showcases server-side streaming rpcs.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload expand(content: nil, error: nil, options: nil)
-          #   @param content [String]
-          #     The content that will be split into words and returned on the stream.
-          #   @param error [Google::Rpc::Status | Hash]
-          #     The error that is thrown after all words are sent on the stream.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ExpandRequest | Hash]
+          #   This method split the given content into words and will pass each word back
+          #   through the stream. This method showcases server-side streaming rpcs.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -198,13 +176,9 @@ module Google
           # @example
           #   TODO
           #
-          def expand request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def expand request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ExpandRequest
 
             # Converts hash and nil to an options object
@@ -254,7 +228,7 @@ module Google
           # @example
           #   TODO
           #
-          def collect request, options: nil, &block
+          def collect request, options = nil, &block
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -314,7 +288,7 @@ module Google
           # @example
           #   TODO
           #
-          def chat request, options: nil, &block
+          def chat request, options = nil, &block
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -357,22 +331,11 @@ module Google
           # This is similar to the Expand method but instead of returning a stream of
           # expanded words, this method returns a paged list of expanded words.
           #
-          # @overload paged_expand(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::PagedExpandRequest | Hash]
-          #     This is similar to the Expand method but instead of returning a stream of
-          #     expanded words, this method returns a paged list of expanded words.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload paged_expand(content: nil, page_size: nil, page_token: nil, options: nil)
-          #   @param content [String]
-          #     The string to expand.
-          #   @param page_size [Integer]
-          #     The amount of words to returned in each page.
-          #   @param page_token [String]
-          #     The position of the page to be returned.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::PagedExpandRequest | Hash]
+          #   This is similar to the Expand method but instead of returning a stream of
+          #   expanded words, this method returns a paged list of expanded words.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -385,13 +348,9 @@ module Google
           # @example
           #   TODO
           #
-          def paged_expand request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def paged_expand request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::PagedExpandRequest
 
             # Converts hash and nil to an options object
@@ -425,25 +384,11 @@ module Google
           # This method will wait the requested amount of and then return.
           # This method showcases how a client handles a request timing out.
           #
-          # @overload wait(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::WaitRequest | Hash]
-          #     This method will wait the requested amount of and then return.
-          #     This method showcases how a client handles a request timing out.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload wait(end_time: nil, ttl: nil, error: nil, success: nil, options: nil)
-          #   @param end_time [Google::Protobuf::Timestamp | Hash]
-          #     The time that this operation will complete.
-          #   @param ttl [Google::Protobuf::Duration | Hash]
-          #     The duration of this operation.
-          #   @param error [Google::Rpc::Status | Hash]
-          #     The error that will be returned by the server. If this code is specified
-          #     to be the OK rpc code, an empty response will be returned.
-          #   @param success [Google::Showcase::V1alpha3::WaitResponse | Hash]
-          #     The response to be returned on operation completion.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::WaitRequest | Hash]
+          #   This method will wait the requested amount of and then return.
+          #   This method showcases how a client handles a request timing out.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -456,13 +401,9 @@ module Google
           # @example
           #   TODO
           #
-          def wait request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def wait request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::WaitRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -112,6 +112,17 @@ module Google
           #
           #   NOTE: the `name` binding below allows API services to override the binding
           #   to use different resource name schemes, such as `users/*/operations`.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation collection.
+          #   * `filter` (`String`):
+          #     The standard list filter.
+          #   * `page_size` (`Integer`):
+          #     The standard list page size.
+          #   * `page_token` (`String`):
+          #     The standard list page token.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -174,6 +185,11 @@ module Google
           #   Gets the latest state of a long-running operation.  Clients can use this
           #   method to poll the operation result at intervals as recommended by the API
           #   service.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation resource.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -237,6 +253,11 @@ module Google
           #   no longer interested in the operation result. It does not cancel the
           #   operation. If the server doesn't support this method, it returns
           #   `google.rpc.Code.UNIMPLEMENTED`.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation resource to be deleted.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -311,6 +332,11 @@ module Google
           #   the operation is not deleted; instead, it becomes an operation with
           #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           #   corresponding to `Code.CANCELLED`.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation resource to be cancelled.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -113,7 +113,7 @@ module Google
           #   NOTE: the `name` binding below allows API services to override the binding
           #   to use different resource name schemes, such as `users/*/operations`.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -175,7 +175,7 @@ module Google
           #   method to poll the operation result at intervals as recommended by the API
           #   service.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -238,7 +238,7 @@ module Google
           #   operation. If the server doesn't support this method, it returns
           #   `google.rpc.Code.UNIMPLEMENTED`.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -312,7 +312,7 @@ module Google
           #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           #   corresponding to `Code.CANCELLED`.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -106,27 +106,14 @@ module Google
           # NOTE: the `name` binding below allows API services to override the binding
           # to use different resource name schemes, such as `users/*/operations`.
           #
-          # @overload list_operations(request, options: nil)
-          #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-          #     Lists operations that match the specified filter in the request. If the
-          #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+          # @param request [Google::Longrunning::ListOperationsRequest | Hash]
+          #   Lists operations that match the specified filter in the request. If the
+          #   server doesn't support this method, it returns `UNIMPLEMENTED`.
           #
-          #     NOTE: the `name` binding below allows API services to override the binding
-          #     to use different resource name schemes, such as `users/*/operations`.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation collection.
-          #   @param filter [String]
-          #     The standard list filter.
-          #   @param page_size [Integer]
-          #     The standard list page size.
-          #   @param page_token [String]
-          #     The standard list page token.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   NOTE: the `name` binding below allows API services to override the binding
+          #   to use different resource name schemes, such as `users/*/operations`.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -139,13 +126,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_operations request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_operations request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
             # Converts hash and nil to an options object
@@ -187,19 +170,12 @@ module Google
           # method to poll the operation result at intervals as recommended by the API
           # service.
           #
-          # @overload get_operation(request, options: nil)
-          #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-          #     Gets the latest state of a long-running operation.  Clients can use this
-          #     method to poll the operation result at intervals as recommended by the API
-          #     service.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload get_operation(name: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation resource.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Longrunning::GetOperationRequest | Hash]
+          #   Gets the latest state of a long-running operation.  Clients can use this
+          #   method to poll the operation result at intervals as recommended by the API
+          #   service.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -212,13 +188,9 @@ module Google
           # @example
           #   TODO
           #
-          def get_operation request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def get_operation request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
             # Converts hash and nil to an options object
@@ -260,20 +232,13 @@ module Google
           # operation. If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.
           #
-          # @overload delete_operation(request, options: nil)
-          #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-          #     Deletes a long-running operation. This method indicates that the client is
-          #     no longer interested in the operation result. It does not cancel the
-          #     operation. If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_operation(name: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation resource to be deleted.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+          #   Deletes a long-running operation. This method indicates that the client is
+          #   no longer interested in the operation result. It does not cancel the
+          #   operation. If the server doesn't support this method, it returns
+          #   `google.rpc.Code.UNIMPLEMENTED`.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -286,13 +251,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_operation request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_operation request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
             # Converts hash and nil to an options object
@@ -339,26 +300,19 @@ module Google
           # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           # corresponding to `Code.CANCELLED`.
           #
-          # @overload cancel_operation(request, options: nil)
-          #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-          #     Starts asynchronous cancellation on a long-running operation.  The server
-          #     makes a best effort to cancel the operation, but success is not
-          #     guaranteed.  If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-          #     other methods to check whether the cancellation succeeded or whether the
-          #     operation completed despite cancellation. On successful cancellation,
-          #     the operation is not deleted; instead, it becomes an operation with
-          #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-          #     corresponding to `Code.CANCELLED`.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload cancel_operation(name: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation resource to be cancelled.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Longrunning::CancelOperationRequest | Hash]
+          #   Starts asynchronous cancellation on a long-running operation.  The server
+          #   makes a best effort to cancel the operation, but success is not
+          #   guaranteed.  If the server doesn't support this method, it returns
+          #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+          #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          #   other methods to check whether the cancellation succeeded or whether the
+          #   operation completed despite cancellation. On successful cancellation,
+          #   the operation is not deleted; instead, it becomes an operation with
+          #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          #   corresponding to `Code.CANCELLED`.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -371,13 +325,9 @@ module Google
           # @example
           #   TODO
           #
-          def cancel_operation request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def cancel_operation request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -109,6 +109,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
           #   Creates a user.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `user` (`Google::Showcase::V1alpha3::User | Hash`):
+          #     The user to create.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -159,6 +164,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
           #   Retrieves the User with the given uri.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of the requested user.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -215,6 +225,14 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
           #   Updates a user.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `user` (`Google::Showcase::V1alpha3::User | Hash`):
+          #     The user to update.
+          #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+          #     The field mask to determine wich fields are to be updated. If empty, the
+          #     server will assume all fields are to be updated.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -271,6 +289,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
           #   Deletes a user, their profile, and all of their authored messages.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of the user to delete.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -327,6 +350,16 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
           #   Lists all users.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `page_size` (`Integer`):
+          #     The maximum number of users to return. Server may return fewer users
+          #     than requested. If unspecified, server will pick an appropriate default.
+          #   * `page_token` (`String`):
+          #     The value of google.showcase.v1alpha3.ListUsersResponse.next_page_token
+          #     returned from the previous call to
+          #     `google.showcase.v1alpha3.Identity\ListUsers` method.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -107,17 +107,10 @@ module Google
           ##
           # Creates a user.
           #
-          # @overload create_user(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
-          #     Creates a user.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload create_user(user: nil, options: nil)
-          #   @param user [Google::Showcase::V1alpha3::User | Hash]
-          #     The user to create.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
+          #   Creates a user.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -130,13 +123,9 @@ module Google
           # @example
           #   TODO
           #
-          def create_user request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def create_user request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateUserRequest
 
             # Converts hash and nil to an options object
@@ -168,17 +157,10 @@ module Google
           ##
           # Retrieves the User with the given uri.
           #
-          # @overload get_user(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
-          #     Retrieves the User with the given uri.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload get_user(name: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of the requested user.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
+          #   Retrieves the User with the given uri.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -191,13 +173,9 @@ module Google
           # @example
           #   TODO
           #
-          def get_user request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def get_user request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetUserRequest
 
             # Converts hash and nil to an options object
@@ -235,20 +213,10 @@ module Google
           ##
           # Updates a user.
           #
-          # @overload update_user(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
-          #     Updates a user.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload update_user(user: nil, update_mask: nil, options: nil)
-          #   @param user [Google::Showcase::V1alpha3::User | Hash]
-          #     The user to update.
-          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
-          #     The field mask to determine wich fields are to be updated. If empty, the
-          #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
+          #   Updates a user.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -261,13 +229,9 @@ module Google
           # @example
           #   TODO
           #
-          def update_user request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def update_user request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateUserRequest
 
             # Converts hash and nil to an options object
@@ -305,17 +269,10 @@ module Google
           ##
           # Deletes a user, their profile, and all of their authored messages.
           #
-          # @overload delete_user(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
-          #     Deletes a user, their profile, and all of their authored messages.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_user(name: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of the user to delete.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
+          #   Deletes a user, their profile, and all of their authored messages.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -328,13 +285,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_user request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_user request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteUserRequest
 
             # Converts hash and nil to an options object
@@ -372,22 +325,10 @@ module Google
           ##
           # Lists all users.
           #
-          # @overload list_users(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
-          #     Lists all users.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_users(page_size: nil, page_token: nil, options: nil)
-          #   @param page_size [Integer]
-          #     The maximum number of users to return. Server may return fewer users
-          #     than requested. If unspecified, server will pick an appropriate default.
-          #   @param page_token [String]
-          #     The value of google.showcase.v1alpha3.ListUsersResponse.next_page_token
-          #     returned from the previous call to
-          #     `google.showcase.v1alpha3.Identity\ListUsers` method.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
+          #   Lists all users.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::User>]
@@ -400,13 +341,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_users request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_users request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListUsersRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -110,7 +110,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
           #   Creates a user.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -160,7 +160,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
           #   Retrieves the User with the given uri.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -216,7 +216,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
           #   Updates a user.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -272,7 +272,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
           #   Deletes a user, their profile, and all of their authored messages.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -328,7 +328,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
           #   Lists all users.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::User>]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -113,6 +113,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
           #   Creates a room.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `room` (`Google::Showcase::V1alpha3::Room | Hash`):
+          #     The room to create.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -163,6 +168,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
           #   Retrieves the Room with the given resource name.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of the requested room.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -219,6 +229,14 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
           #   Updates a room.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `room` (`Google::Showcase::V1alpha3::Room | Hash`):
+          #     The room to update.
+          #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+          #     The field mask to determine wich fields are to be updated. If empty, the
+          #     server will assume all fields are to be updated.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -275,6 +293,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
           #   Deletes a room and all of its blurbs.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of the requested room.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -331,6 +354,16 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
           #   Lists all chat rooms.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `page_size` (`Integer`):
+          #     The maximum number of rooms return. Server may return fewer rooms
+          #     than requested. If unspecified, server will pick an appropriate default.
+          #   * `page_token` (`String`):
+          #     The value of google.showcase.v1alpha3.ListRoomsResponse.next_page_token
+          #     returned from the previous call to
+          #     `google.showcase.v1alpha3.Messaging\ListRooms` method.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -386,6 +419,14 @@ module Google
           #   Creates a blurb. If the parent is a room, the blurb is understood to be a
           #   message in that room. If the parent is a profile, the blurb is understood
           #   to be a post on the profile.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `parent` (`String`):
+          #     The resource name of the chat room or user profile that this blurb will
+          #     be tied to.
+          #   * `blurb` (`Google::Showcase::V1alpha3::Blurb | Hash`):
+          #     The blurb to create.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -442,6 +483,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
           #   Retrieves the Blurb with the given resource name.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of the requested blurb.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -498,6 +544,14 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
           #   Updates a blurb.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `blurb` (`Google::Showcase::V1alpha3::Blurb | Hash`):
+          #     The blurb to update.
+          #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+          #     The field mask to determine wich fields are to be updated. If empty, the
+          #     server will assume all fields are to be updated.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -554,6 +608,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
           #   Deletes a blurb.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of the requested blurb.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -612,6 +671,19 @@ module Google
           # @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
           #   Lists blurbs for a specific chat room or user profile depending on the
           #   parent resource name.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `parent` (`String`):
+          #     The resource name of the requested room or profile whos blurbs to list.
+          #   * `page_size` (`Integer`):
+          #     The maximum number of blurbs to return. Server may return fewer
+          #     blurbs than requested. If unspecified, server will pick an appropriate
+          #     default.
+          #   * `page_token` (`String`):
+          #     The value of google.showcase.v1alpha3.ListBlurbsResponse.next_page_token
+          #     returned from the previous call to
+          #     `google.showcase.v1alpha3.Messaging\ListBlurbs` method.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -673,6 +745,24 @@ module Google
           #   This method searches through all blurbs across all rooms and profiles
           #   for blurbs containing to words found in the query. Only posts that
           #   contain an exact match of a queried word will be returned.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `query` (`String`):
+          #     The query used to search for blurbs containing to words of this string.
+          #     Only posts that contain an exact match of a queried word will be returned.
+          #   * `parent` (`String`):
+          #     The rooms or profiles to search. If unset, `SearchBlurbs` will search all
+          #     rooms and all profiles.
+          #   * `page_size` (`Integer`):
+          #     The maximum number of blurbs return. Server may return fewer
+          #     blurbs than requested. If unspecified, server will pick an appropriate
+          #     default.
+          #   * `page_token` (`String`):
+          #     The value of
+          #     google.showcase.v1alpha3.SearchBlurbsResponse.next_page_token
+          #     returned from the previous call to
+          #     `google.showcase.v1alpha3.Messaging\SearchBlurbs` method.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -732,6 +822,13 @@ module Google
           # @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
           #   This returns a stream that emits the blurbs that are created for a
           #   particular chat room or user profile.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of a chat room or user profile whose blurbs to stream.
+          #   * `expire_time` (`Google::Protobuf::Timestamp | Hash`):
+          #     The time at which this stream will close.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -111,17 +111,10 @@ module Google
           ##
           # Creates a room.
           #
-          # @overload create_room(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
-          #     Creates a room.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload create_room(room: nil, options: nil)
-          #   @param room [Google::Showcase::V1alpha3::Room | Hash]
-          #     The room to create.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
+          #   Creates a room.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -134,13 +127,9 @@ module Google
           # @example
           #   TODO
           #
-          def create_room request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def create_room request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateRoomRequest
 
             # Converts hash and nil to an options object
@@ -172,17 +161,10 @@ module Google
           ##
           # Retrieves the Room with the given resource name.
           #
-          # @overload get_room(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
-          #     Retrieves the Room with the given resource name.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload get_room(name: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of the requested room.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
+          #   Retrieves the Room with the given resource name.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -195,13 +177,9 @@ module Google
           # @example
           #   TODO
           #
-          def get_room request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def get_room request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetRoomRequest
 
             # Converts hash and nil to an options object
@@ -239,20 +217,10 @@ module Google
           ##
           # Updates a room.
           #
-          # @overload update_room(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
-          #     Updates a room.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload update_room(room: nil, update_mask: nil, options: nil)
-          #   @param room [Google::Showcase::V1alpha3::Room | Hash]
-          #     The room to update.
-          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
-          #     The field mask to determine wich fields are to be updated. If empty, the
-          #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
+          #   Updates a room.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -265,13 +233,9 @@ module Google
           # @example
           #   TODO
           #
-          def update_room request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def update_room request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateRoomRequest
 
             # Converts hash and nil to an options object
@@ -309,17 +273,10 @@ module Google
           ##
           # Deletes a room and all of its blurbs.
           #
-          # @overload delete_room(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
-          #     Deletes a room and all of its blurbs.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_room(name: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of the requested room.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
+          #   Deletes a room and all of its blurbs.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -332,13 +289,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_room request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_room request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteRoomRequest
 
             # Converts hash and nil to an options object
@@ -376,22 +329,10 @@ module Google
           ##
           # Lists all chat rooms.
           #
-          # @overload list_rooms(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
-          #     Lists all chat rooms.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_rooms(page_size: nil, page_token: nil, options: nil)
-          #   @param page_size [Integer]
-          #     The maximum number of rooms return. Server may return fewer rooms
-          #     than requested. If unspecified, server will pick an appropriate default.
-          #   @param page_token [String]
-          #     The value of google.showcase.v1alpha3.ListRoomsResponse.next_page_token
-          #     returned from the previous call to
-          #     `google.showcase.v1alpha3.Messaging\ListRooms` method.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
+          #   Lists all chat rooms.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Room>]
@@ -404,13 +345,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_rooms request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_rooms request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListRoomsRequest
 
             # Converts hash and nil to an options object
@@ -445,22 +382,12 @@ module Google
           # message in that room. If the parent is a profile, the blurb is understood
           # to be a post on the profile.
           #
-          # @overload create_blurb(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::CreateBlurbRequest | Hash]
-          #     Creates a blurb. If the parent is a room, the blurb is understood to be a
-          #     message in that room. If the parent is a profile, the blurb is understood
-          #     to be a post on the profile.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload create_blurb(parent: nil, blurb: nil, options: nil)
-          #   @param parent [String]
-          #     The resource name of the chat room or user profile that this blurb will
-          #     be tied to.
-          #   @param blurb [Google::Showcase::V1alpha3::Blurb | Hash]
-          #     The blurb to create.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::CreateBlurbRequest | Hash]
+          #   Creates a blurb. If the parent is a room, the blurb is understood to be a
+          #   message in that room. If the parent is a profile, the blurb is understood
+          #   to be a post on the profile.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -473,13 +400,9 @@ module Google
           # @example
           #   TODO
           #
-          def create_blurb request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def create_blurb request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateBlurbRequest
 
             # Converts hash and nil to an options object
@@ -517,17 +440,10 @@ module Google
           ##
           # Retrieves the Blurb with the given resource name.
           #
-          # @overload get_blurb(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
-          #     Retrieves the Blurb with the given resource name.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload get_blurb(name: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of the requested blurb.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
+          #   Retrieves the Blurb with the given resource name.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -540,13 +456,9 @@ module Google
           # @example
           #   TODO
           #
-          def get_blurb request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def get_blurb request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetBlurbRequest
 
             # Converts hash and nil to an options object
@@ -584,20 +496,10 @@ module Google
           ##
           # Updates a blurb.
           #
-          # @overload update_blurb(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
-          #     Updates a blurb.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload update_blurb(blurb: nil, update_mask: nil, options: nil)
-          #   @param blurb [Google::Showcase::V1alpha3::Blurb | Hash]
-          #     The blurb to update.
-          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
-          #     The field mask to determine wich fields are to be updated. If empty, the
-          #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
+          #   Updates a blurb.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -610,13 +512,9 @@ module Google
           # @example
           #   TODO
           #
-          def update_blurb request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def update_blurb request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateBlurbRequest
 
             # Converts hash and nil to an options object
@@ -654,17 +552,10 @@ module Google
           ##
           # Deletes a blurb.
           #
-          # @overload delete_blurb(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
-          #     Deletes a blurb.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_blurb(name: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of the requested blurb.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
+          #   Deletes a blurb.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -677,13 +568,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_blurb request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_blurb request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteBlurbRequest
 
             # Converts hash and nil to an options object
@@ -722,26 +609,11 @@ module Google
           # Lists blurbs for a specific chat room or user profile depending on the
           # parent resource name.
           #
-          # @overload list_blurbs(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
-          #     Lists blurbs for a specific chat room or user profile depending on the
-          #     parent resource name.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_blurbs(parent: nil, page_size: nil, page_token: nil, options: nil)
-          #   @param parent [String]
-          #     The resource name of the requested room or profile whos blurbs to list.
-          #   @param page_size [Integer]
-          #     The maximum number of blurbs to return. Server may return fewer
-          #     blurbs than requested. If unspecified, server will pick an appropriate
-          #     default.
-          #   @param page_token [String]
-          #     The value of google.showcase.v1alpha3.ListBlurbsResponse.next_page_token
-          #     returned from the previous call to
-          #     `google.showcase.v1alpha3.Messaging\ListBlurbs` method.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
+          #   Lists blurbs for a specific chat room or user profile depending on the
+          #   parent resource name.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Blurb>]
@@ -754,13 +626,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_blurbs request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_blurbs request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListBlurbsRequest
 
             # Converts hash and nil to an options object
@@ -801,32 +669,12 @@ module Google
           # for blurbs containing to words found in the query. Only posts that
           # contain an exact match of a queried word will be returned.
           #
-          # @overload search_blurbs(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::SearchBlurbsRequest | Hash]
-          #     This method searches through all blurbs across all rooms and profiles
-          #     for blurbs containing to words found in the query. Only posts that
-          #     contain an exact match of a queried word will be returned.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload search_blurbs(query: nil, parent: nil, page_size: nil, page_token: nil, options: nil)
-          #   @param query [String]
-          #     The query used to search for blurbs containing to words of this string.
-          #     Only posts that contain an exact match of a queried word will be returned.
-          #   @param parent [String]
-          #     The rooms or profiles to search. If unset, `SearchBlurbs` will search all
-          #     rooms and all profiles.
-          #   @param page_size [Integer]
-          #     The maximum number of blurbs return. Server may return fewer
-          #     blurbs than requested. If unspecified, server will pick an appropriate
-          #     default.
-          #   @param page_token [String]
-          #     The value of
-          #     google.showcase.v1alpha3.SearchBlurbsResponse.next_page_token
-          #     returned from the previous call to
-          #     `google.showcase.v1alpha3.Messaging\SearchBlurbs` method.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::SearchBlurbsRequest | Hash]
+          #   This method searches through all blurbs across all rooms and profiles
+          #   for blurbs containing to words found in the query. Only posts that
+          #   contain an exact match of a queried word will be returned.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -839,13 +687,9 @@ module Google
           # @example
           #   TODO
           #
-          def search_blurbs request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def search_blurbs request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::SearchBlurbsRequest
 
             # Converts hash and nil to an options object
@@ -885,20 +729,11 @@ module Google
           # This returns a stream that emits the blurbs that are created for a
           # particular chat room or user profile.
           #
-          # @overload stream_blurbs(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
-          #     This returns a stream that emits the blurbs that are created for a
-          #     particular chat room or user profile.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload stream_blurbs(name: nil, expire_time: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of a chat room or user profile whose blurbs to stream.
-          #   @param expire_time [Google::Protobuf::Timestamp | Hash]
-          #     The time at which this stream will close.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
+          #   This returns a stream that emits the blurbs that are created for a
+          #   particular chat room or user profile.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]
@@ -911,13 +746,9 @@ module Google
           # @example
           #   TODO
           #
-          def stream_blurbs request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def stream_blurbs request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::StreamBlurbsRequest
 
             # Converts hash and nil to an options object
@@ -972,7 +803,7 @@ module Google
           # @example
           #   TODO
           #
-          def send_blurbs request, options: nil, &block
+          def send_blurbs request, options = nil, &block
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -1039,7 +870,7 @@ module Google
           # @example
           #   TODO
           #
-          def connect request, options: nil, &block
+          def connect request, options = nil, &block
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -114,7 +114,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
           #   Creates a room.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -164,7 +164,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
           #   Retrieves the Room with the given resource name.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -220,7 +220,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
           #   Updates a room.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -276,7 +276,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
           #   Deletes a room and all of its blurbs.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -332,7 +332,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
           #   Lists all chat rooms.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Room>]
@@ -387,7 +387,7 @@ module Google
           #   message in that room. If the parent is a profile, the blurb is understood
           #   to be a post on the profile.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -443,7 +443,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
           #   Retrieves the Blurb with the given resource name.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -499,7 +499,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
           #   Updates a blurb.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -555,7 +555,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
           #   Deletes a blurb.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -613,7 +613,7 @@ module Google
           #   Lists blurbs for a specific chat room or user profile depending on the
           #   parent resource name.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Blurb>]
@@ -674,7 +674,7 @@ module Google
           #   for blurbs containing to words found in the query. Only posts that
           #   contain an exact match of a queried word will be returned.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -733,7 +733,7 @@ module Google
           #   This returns a stream that emits the blurbs that are created for a
           #   particular chat room or user profile.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]
@@ -790,7 +790,7 @@ module Google
           # @param request [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::CreateBlurbRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::CreateBlurbRequest} instances.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::SendBlurbsResponse]
@@ -857,7 +857,7 @@ module Google
           # @param request [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::ConnectRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::ConnectRequest} instances.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -112,6 +112,17 @@ module Google
           #
           #   NOTE: the `name` binding below allows API services to override the binding
           #   to use different resource name schemes, such as `users/*/operations`.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation collection.
+          #   * `filter` (`String`):
+          #     The standard list filter.
+          #   * `page_size` (`Integer`):
+          #     The standard list page size.
+          #   * `page_token` (`String`):
+          #     The standard list page token.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -174,6 +185,11 @@ module Google
           #   Gets the latest state of a long-running operation.  Clients can use this
           #   method to poll the operation result at intervals as recommended by the API
           #   service.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation resource.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -237,6 +253,11 @@ module Google
           #   no longer interested in the operation result. It does not cancel the
           #   operation. If the server doesn't support this method, it returns
           #   `google.rpc.Code.UNIMPLEMENTED`.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation resource to be deleted.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -311,6 +332,11 @@ module Google
           #   the operation is not deleted; instead, it becomes an operation with
           #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           #   corresponding to `Code.CANCELLED`.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation resource to be cancelled.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -113,7 +113,7 @@ module Google
           #   NOTE: the `name` binding below allows API services to override the binding
           #   to use different resource name schemes, such as `users/*/operations`.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -175,7 +175,7 @@ module Google
           #   method to poll the operation result at intervals as recommended by the API
           #   service.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -238,7 +238,7 @@ module Google
           #   operation. If the server doesn't support this method, it returns
           #   `google.rpc.Code.UNIMPLEMENTED`.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -312,7 +312,7 @@ module Google
           #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           #   corresponding to `Code.CANCELLED`.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -106,27 +106,14 @@ module Google
           # NOTE: the `name` binding below allows API services to override the binding
           # to use different resource name schemes, such as `users/*/operations`.
           #
-          # @overload list_operations(request, options: nil)
-          #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-          #     Lists operations that match the specified filter in the request. If the
-          #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+          # @param request [Google::Longrunning::ListOperationsRequest | Hash]
+          #   Lists operations that match the specified filter in the request. If the
+          #   server doesn't support this method, it returns `UNIMPLEMENTED`.
           #
-          #     NOTE: the `name` binding below allows API services to override the binding
-          #     to use different resource name schemes, such as `users/*/operations`.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation collection.
-          #   @param filter [String]
-          #     The standard list filter.
-          #   @param page_size [Integer]
-          #     The standard list page size.
-          #   @param page_token [String]
-          #     The standard list page token.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   NOTE: the `name` binding below allows API services to override the binding
+          #   to use different resource name schemes, such as `users/*/operations`.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -139,13 +126,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_operations request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_operations request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
             # Converts hash and nil to an options object
@@ -187,19 +170,12 @@ module Google
           # method to poll the operation result at intervals as recommended by the API
           # service.
           #
-          # @overload get_operation(request, options: nil)
-          #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-          #     Gets the latest state of a long-running operation.  Clients can use this
-          #     method to poll the operation result at intervals as recommended by the API
-          #     service.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload get_operation(name: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation resource.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Longrunning::GetOperationRequest | Hash]
+          #   Gets the latest state of a long-running operation.  Clients can use this
+          #   method to poll the operation result at intervals as recommended by the API
+          #   service.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -212,13 +188,9 @@ module Google
           # @example
           #   TODO
           #
-          def get_operation request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def get_operation request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
             # Converts hash and nil to an options object
@@ -260,20 +232,13 @@ module Google
           # operation. If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.
           #
-          # @overload delete_operation(request, options: nil)
-          #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-          #     Deletes a long-running operation. This method indicates that the client is
-          #     no longer interested in the operation result. It does not cancel the
-          #     operation. If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_operation(name: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation resource to be deleted.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+          #   Deletes a long-running operation. This method indicates that the client is
+          #   no longer interested in the operation result. It does not cancel the
+          #   operation. If the server doesn't support this method, it returns
+          #   `google.rpc.Code.UNIMPLEMENTED`.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -286,13 +251,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_operation request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_operation request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
             # Converts hash and nil to an options object
@@ -339,26 +300,19 @@ module Google
           # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           # corresponding to `Code.CANCELLED`.
           #
-          # @overload cancel_operation(request, options: nil)
-          #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-          #     Starts asynchronous cancellation on a long-running operation.  The server
-          #     makes a best effort to cancel the operation, but success is not
-          #     guaranteed.  If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-          #     other methods to check whether the cancellation succeeded or whether the
-          #     operation completed despite cancellation. On successful cancellation,
-          #     the operation is not deleted; instead, it becomes an operation with
-          #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-          #     corresponding to `Code.CANCELLED`.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload cancel_operation(name: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation resource to be cancelled.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Longrunning::CancelOperationRequest | Hash]
+          #   Starts asynchronous cancellation on a long-running operation.  The server
+          #   makes a best effort to cancel the operation, but success is not
+          #   guaranteed.  If the server doesn't support this method, it returns
+          #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+          #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          #   other methods to check whether the cancellation succeeded or whether the
+          #   operation completed despite cancellation. On successful cancellation,
+          #   the operation is not deleted; instead, it becomes an operation with
+          #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          #   corresponding to `Code.CANCELLED`.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -371,13 +325,9 @@ module Google
           # @example
           #   TODO
           #
-          def cancel_operation request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def cancel_operation request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -107,19 +107,10 @@ module Google
           ##
           # Creates a new testing session.
           #
-          # @overload create_session(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
-          #     Creates a new testing session.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload create_session(session: nil, options: nil)
-          #   @param session [Google::Showcase::V1alpha3::Session | Hash]
-          #     The session to be created.
-          #     Sessions are immutable once they are created (although they can
-          #     be deleted).
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
+          #   Creates a new testing session.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Session]
@@ -132,13 +123,9 @@ module Google
           # @example
           #   TODO
           #
-          def create_session request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def create_session request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateSessionRequest
 
             # Converts hash and nil to an options object
@@ -170,17 +157,10 @@ module Google
           ##
           # Gets a testing session.
           #
-          # @overload get_session(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
-          #     Gets a testing session.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload get_session(name: nil, options: nil)
-          #   @param name [String]
-          #     The session to be retrieved.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
+          #   Gets a testing session.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Session]
@@ -193,13 +173,9 @@ module Google
           # @example
           #   TODO
           #
-          def get_session request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def get_session request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetSessionRequest
 
             # Converts hash and nil to an options object
@@ -237,19 +213,10 @@ module Google
           ##
           # Lists the current test sessions.
           #
-          # @overload list_sessions(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
-          #     Lists the current test sessions.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_sessions(page_size: nil, page_token: nil, options: nil)
-          #   @param page_size [Integer]
-          #     The maximum number of sessions to return per page.
-          #   @param page_token [String]
-          #     The page token, for retrieving subsequent pages.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
+          #   Lists the current test sessions.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Session>]
@@ -262,13 +229,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_sessions request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_sessions request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListSessionsRequest
 
             # Converts hash and nil to an options object
@@ -301,17 +264,10 @@ module Google
           ##
           # Delete a test session.
           #
-          # @overload delete_session(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
-          #     Delete a test session.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_session(name: nil, options: nil)
-          #   @param name [String]
-          #     The session to be deleted.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
+          #   Delete a test session.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -324,13 +280,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_session request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_session request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteSessionRequest
 
             # Converts hash and nil to an options object
@@ -370,19 +322,12 @@ module Google
           # This generates a report detailing which tests have been completed,
           # and an overall rollup.
           #
-          # @overload report_session(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ReportSessionRequest | Hash]
-          #     Report on the status of a session.
-          #     This generates a report detailing which tests have been completed,
-          #     and an overall rollup.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload report_session(name: nil, options: nil)
-          #   @param name [String]
-          #     The session to be reported on.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ReportSessionRequest | Hash]
+          #   Report on the status of a session.
+          #   This generates a report detailing which tests have been completed,
+          #   and an overall rollup.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::ReportSessionResponse]
@@ -395,13 +340,9 @@ module Google
           # @example
           #   TODO
           #
-          def report_session request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def report_session request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ReportSessionRequest
 
             # Converts hash and nil to an options object
@@ -439,21 +380,10 @@ module Google
           ##
           # List the tests of a sessesion.
           #
-          # @overload list_tests(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
-          #     List the tests of a sessesion.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_tests(parent: nil, page_size: nil, page_token: nil, options: nil)
-          #   @param parent [String]
-          #     The session.
-          #   @param page_size [Integer]
-          #     The maximum number of tests to return per page.
-          #   @param page_token [String]
-          #     The page token, for retrieving subsequent pages.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
+          #   List the tests of a sessesion.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Test>]
@@ -466,13 +396,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_tests request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_tests request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListTestsRequest
 
             # Converts hash and nil to an options object
@@ -516,22 +442,15 @@ module Google
           #
           # This method will error if attempting to delete a required test.
           #
-          # @overload delete_test(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::DeleteTestRequest | Hash]
-          #     Explicitly decline to implement a test.
+          # @param request [Google::Showcase::V1alpha3::DeleteTestRequest | Hash]
+          #   Explicitly decline to implement a test.
           #
-          #     This removes the test from subsequent `ListTests` calls, and
-          #     attempting to do the test will error.
+          #   This removes the test from subsequent `ListTests` calls, and
+          #   attempting to do the test will error.
           #
-          #     This method will error if attempting to delete a required test.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_test(name: nil, options: nil)
-          #   @param name [String]
-          #     The test to be deleted.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   This method will error if attempting to delete a required test.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -544,13 +463,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_test request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_test request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteTestRequest
 
             # Converts hash and nil to an options object
@@ -591,24 +506,13 @@ module Google
           # In cases where a test involves registering a final answer at the
           # end of the test, this method provides the means to do so.
           #
-          # @overload verify_test(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::VerifyTestRequest | Hash]
-          #     Register a response to a test.
+          # @param request [Google::Showcase::V1alpha3::VerifyTestRequest | Hash]
+          #   Register a response to a test.
           #
-          #     In cases where a test involves registering a final answer at the
-          #     end of the test, this method provides the means to do so.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload verify_test(name: nil, answer: nil, answers: nil, options: nil)
-          #   @param name [String]
-          #     The test to have an answer registered to it.
-          #   @param answer [String]
-          #     The answer from the test.
-          #   @param answers [String]
-          #     The answers from the test if multiple are to be checked
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   In cases where a test involves registering a final answer at the
+          #   end of the test, this method provides the means to do so.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::VerifyTestResponse]
@@ -621,13 +525,9 @@ module Google
           # @example
           #   TODO
           #
-          def verify_test request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def verify_test request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::VerifyTestRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -110,7 +110,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
           #   Creates a new testing session.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Session]
@@ -160,7 +160,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
           #   Gets a testing session.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Session]
@@ -216,7 +216,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
           #   Lists the current test sessions.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Session>]
@@ -267,7 +267,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
           #   Delete a test session.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -327,7 +327,7 @@ module Google
           #   This generates a report detailing which tests have been completed,
           #   and an overall rollup.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::ReportSessionResponse]
@@ -383,7 +383,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
           #   List the tests of a sessesion.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Test>]
@@ -450,7 +450,7 @@ module Google
           #
           #   This method will error if attempting to delete a required test.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -512,7 +512,7 @@ module Google
           #   In cases where a test involves registering a final answer at the
           #   end of the test, this method provides the means to do so.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::VerifyTestResponse]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -109,6 +109,13 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
           #   Creates a new testing session.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `session` (`Google::Showcase::V1alpha3::Session | Hash`):
+          #     The session to be created.
+          #     Sessions are immutable once they are created (although they can
+          #     be deleted).
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -159,6 +166,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
           #   Gets a testing session.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The session to be retrieved.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -215,6 +227,13 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
           #   Lists the current test sessions.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `page_size` (`Integer`):
+          #     The maximum number of sessions to return per page.
+          #   * `page_token` (`String`):
+          #     The page token, for retrieving subsequent pages.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -266,6 +285,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
           #   Delete a test session.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The session to be deleted.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -326,6 +350,11 @@ module Google
           #   Report on the status of a session.
           #   This generates a report detailing which tests have been completed,
           #   and an overall rollup.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The session to be reported on.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -382,6 +411,15 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
           #   List the tests of a sessesion.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `parent` (`String`):
+          #     The session.
+          #   * `page_size` (`Integer`):
+          #     The maximum number of tests to return per page.
+          #   * `page_token` (`String`):
+          #     The page token, for retrieving subsequent pages.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -449,6 +487,11 @@ module Google
           #   attempting to do the test will error.
           #
           #   This method will error if attempting to delete a required test.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The test to be deleted.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -511,6 +554,15 @@ module Google
           #
           #   In cases where a test involves registering a final answer at the
           #   end of the test, this method provides the means to do so.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The test to have an answer registered to it.
+          #   * `answer` (`String`):
+          #     The answer from the test.
+          #   * `answers` (`String`):
+          #     The answers from the test if multiple are to be checked
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -114,7 +114,7 @@ module Google
             #   Performs synchronous speech recognition: receive results after all audio
             #   has been sent and processed.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Speech::V1::RecognizeResponse]
@@ -170,7 +170,7 @@ module Google
             #   `Operation.error` or an `Operation.response` which contains
             #   a `LongRunningRecognizeResponse` message.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -222,7 +222,7 @@ module Google
             # @param request [Google::Gax::StreamInput, Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeRequest | Hash>]
             #   An enumerable of {Google::Cloud::Speech::V1::StreamingRecognizeRequest} instances.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeResponse>]

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -113,6 +113,14 @@ module Google
             # @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
             #   Performs synchronous speech recognition: receive results after all audio
             #   has been sent and processed.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `config` (`Google::Cloud::Speech::V1::RecognitionConfig | Hash`):
+            #     *Required* Provides information to the recognizer that specifies how to
+            #     process the request.
+            #   * `audio` (`Google::Cloud::Speech::V1::RecognitionAudio | Hash`):
+            #     *Required* The audio data to be recognized.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -169,6 +177,14 @@ module Google
             #   google.longrunning.Operations interface. Returns either an
             #   `Operation.error` or an `Operation.response` which contains
             #   a `LongRunningRecognizeResponse` message.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `config` (`Google::Cloud::Speech::V1::RecognitionConfig | Hash`):
+            #     *Required* Provides information to the recognizer that specifies how to
+            #     process the request.
+            #   * `audio` (`Google::Cloud::Speech::V1::RecognitionAudio | Hash`):
+            #     *Required* The audio data to be recognized.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -110,21 +110,11 @@ module Google
             # Performs synchronous speech recognition: receive results after all audio
             # has been sent and processed.
             #
-            # @overload recognize(request, options: nil)
-            #   @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
-            #     Performs synchronous speech recognition: receive results after all audio
-            #     has been sent and processed.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload recognize(config: nil, audio: nil, options: nil)
-            #   @param config [Google::Cloud::Speech::V1::RecognitionConfig | Hash]
-            #     *Required* Provides information to the recognizer that specifies how to
-            #     process the request.
-            #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
-            #     *Required* The audio data to be recognized.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
+            #   Performs synchronous speech recognition: receive results after all audio
+            #   has been sent and processed.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Speech::V1::RecognizeResponse]
@@ -137,13 +127,9 @@ module Google
             # @example
             #   TODO
             #
-            def recognize request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def recognize request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::RecognizeRequest
 
               # Converts hash and nil to an options object
@@ -178,23 +164,13 @@ module Google
             # `Operation.error` or an `Operation.response` which contains
             # a `LongRunningRecognizeResponse` message.
             #
-            # @overload long_running_recognize(request, options: nil)
-            #   @param request [Google::Cloud::Speech::V1::LongRunningRecognizeRequest | Hash]
-            #     Performs asynchronous speech recognition: receive results via the
-            #     google.longrunning.Operations interface. Returns either an
-            #     `Operation.error` or an `Operation.response` which contains
-            #     a `LongRunningRecognizeResponse` message.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload long_running_recognize(config: nil, audio: nil, options: nil)
-            #   @param config [Google::Cloud::Speech::V1::RecognitionConfig | Hash]
-            #     *Required* Provides information to the recognizer that specifies how to
-            #     process the request.
-            #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
-            #     *Required* The audio data to be recognized.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Cloud::Speech::V1::LongRunningRecognizeRequest | Hash]
+            #   Performs asynchronous speech recognition: receive results via the
+            #   google.longrunning.Operations interface. Returns either an
+            #   `Operation.error` or an `Operation.response` which contains
+            #   a `LongRunningRecognizeResponse` message.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -207,13 +183,9 @@ module Google
             # @example
             #   TODO
             #
-            def long_running_recognize request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def long_running_recognize request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::LongRunningRecognizeRequest
 
               # Converts hash and nil to an options object
@@ -263,7 +235,7 @@ module Google
             # @example
             #   TODO
             #
-            def streaming_recognize request, options: nil, &block
+            def streaming_recognize request, options = nil, &block
               unless request.is_a? Enumerable
                 if request.respond_to? :to_enum
                   request = request.to_enum

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -107,27 +107,14 @@ module Google
             # NOTE: the `name` binding below allows API services to override the binding
             # to use different resource name schemes, such as `users/*/operations`.
             #
-            # @overload list_operations(request, options: nil)
-            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #     Lists operations that match the specified filter in the request. If the
-            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+            # @param request [Google::Longrunning::ListOperationsRequest | Hash]
+            #   Lists operations that match the specified filter in the request. If the
+            #   server doesn't support this method, it returns `UNIMPLEMENTED`.
             #
-            #     NOTE: the `name` binding below allows API services to override the binding
-            #     to use different resource name schemes, such as `users/*/operations`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation collection.
-            #   @param filter [String]
-            #     The standard list filter.
-            #   @param page_size [Integer]
-            #     The standard list page size.
-            #   @param page_token [String]
-            #     The standard list page token.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   NOTE: the `name` binding below allows API services to override the binding
+            #   to use different resource name schemes, such as `users/*/operations`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -140,13 +127,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_operations request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_operations request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
@@ -188,19 +171,12 @@ module Google
             # method to poll the operation result at intervals as recommended by the API
             # service.
             #
-            # @overload get_operation(request, options: nil)
-            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #     Gets the latest state of a long-running operation.  Clients can use this
-            #     method to poll the operation result at intervals as recommended by the API
-            #     service.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload get_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::GetOperationRequest | Hash]
+            #   Gets the latest state of a long-running operation.  Clients can use this
+            #   method to poll the operation result at intervals as recommended by the API
+            #   service.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -213,13 +189,9 @@ module Google
             # @example
             #   TODO
             #
-            def get_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def get_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
@@ -261,20 +233,13 @@ module Google
             # operation. If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
-            # @overload delete_operation(request, options: nil)
-            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #     Deletes a long-running operation. This method indicates that the client is
-            #     no longer interested in the operation result. It does not cancel the
-            #     operation. If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload delete_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource to be deleted.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+            #   Deletes a long-running operation. This method indicates that the client is
+            #   no longer interested in the operation result. It does not cancel the
+            #   operation. If the server doesn't support this method, it returns
+            #   `google.rpc.Code.UNIMPLEMENTED`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -287,13 +252,9 @@ module Google
             # @example
             #   TODO
             #
-            def delete_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def delete_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
@@ -340,26 +301,19 @@ module Google
             # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             # corresponding to `Code.CANCELLED`.
             #
-            # @overload cancel_operation(request, options: nil)
-            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #     Starts asynchronous cancellation on a long-running operation.  The server
-            #     makes a best effort to cancel the operation, but success is not
-            #     guaranteed.  If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-            #     other methods to check whether the cancellation succeeded or whether the
-            #     operation completed despite cancellation. On successful cancellation,
-            #     the operation is not deleted; instead, it becomes an operation with
-            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-            #     corresponding to `Code.CANCELLED`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload cancel_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource to be cancelled.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::CancelOperationRequest | Hash]
+            #   Starts asynchronous cancellation on a long-running operation.  The server
+            #   makes a best effort to cancel the operation, but success is not
+            #   guaranteed.  If the server doesn't support this method, it returns
+            #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+            #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #   other methods to check whether the cancellation succeeded or whether the
+            #   operation completed despite cancellation. On successful cancellation,
+            #   the operation is not deleted; instead, it becomes an operation with
+            #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #   corresponding to `Code.CANCELLED`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -372,13 +326,9 @@ module Google
             # @example
             #   TODO
             #
-            def cancel_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def cancel_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -113,6 +113,17 @@ module Google
             #
             #   NOTE: the `name` binding below allows API services to override the binding
             #   to use different resource name schemes, such as `users/*/operations`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation collection.
+            #   * `filter` (`String`):
+            #     The standard list filter.
+            #   * `page_size` (`Integer`):
+            #     The standard list page size.
+            #   * `page_token` (`String`):
+            #     The standard list page token.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -175,6 +186,11 @@ module Google
             #   Gets the latest state of a long-running operation.  Clients can use this
             #   method to poll the operation result at intervals as recommended by the API
             #   service.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -238,6 +254,11 @@ module Google
             #   no longer interested in the operation result. It does not cancel the
             #   operation. If the server doesn't support this method, it returns
             #   `google.rpc.Code.UNIMPLEMENTED`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource to be deleted.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -312,6 +333,11 @@ module Google
             #   the operation is not deleted; instead, it becomes an operation with
             #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             #   corresponding to `Code.CANCELLED`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource to be cancelled.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -114,7 +114,7 @@ module Google
             #   NOTE: the `name` binding below allows API services to override the binding
             #   to use different resource name schemes, such as `users/*/operations`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -176,7 +176,7 @@ module Google
             #   method to poll the operation result at intervals as recommended by the API
             #   service.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -239,7 +239,7 @@ module Google
             #   operation. If the server doesn't support this method, it returns
             #   `google.rpc.Code.UNIMPLEMENTED`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -313,7 +313,7 @@ module Google
             #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             #   corresponding to `Code.CANCELLED`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -109,17 +109,10 @@ module Google
             ##
             # Run image detection and annotation for a batch of images.
             #
-            # @overload batch_annotate_images(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
-            #     Run image detection and annotation for a batch of images.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload batch_annotate_images(requests: nil, options: nil)
-            #   @param requests [Google::Cloud::Vision::V1::AnnotateImageRequest | Hash]
-            #     Individual image annotation requests for this batch.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
+            #   Run image detection and annotation for a batch of images.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
@@ -132,13 +125,9 @@ module Google
             # @example
             #   TODO
             #
-            def batch_annotate_images request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def batch_annotate_images request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
 
               # Converts hash and nil to an options object
@@ -175,22 +164,15 @@ module Google
             # `Operation.metadata` contains `OperationMetadata` (metadata).
             # `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
             #
-            # @overload async_batch_annotate_files(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest | Hash]
-            #     Run asynchronous image detection and annotation for a list of generic
-            #     files, such as PDF files, which may contain multiple pages and multiple
-            #     images per page. Progress and results can be retrieved through the
-            #     `google.longrunning.Operations` interface.
-            #     `Operation.metadata` contains `OperationMetadata` (metadata).
-            #     `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload async_batch_annotate_files(requests: nil, options: nil)
-            #   @param requests [Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash]
-            #     Individual async file annotation requests for this batch.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest | Hash]
+            #   Run asynchronous image detection and annotation for a list of generic
+            #   files, such as PDF files, which may contain multiple pages and multiple
+            #   images per page. Progress and results can be retrieved through the
+            #   `google.longrunning.Operations` interface.
+            #   `Operation.metadata` contains `OperationMetadata` (metadata).
+            #   `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -203,13 +185,9 @@ module Google
             # @example
             #   TODO
             #
-            def async_batch_annotate_files request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def async_batch_annotate_files request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
 
               # Converts hash and nil to an options object

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -111,6 +111,11 @@ module Google
             #
             # @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
             #   Run image detection and annotation for a batch of images.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `requests` (`Google::Cloud::Vision::V1::AnnotateImageRequest | Hash`):
+            #     Individual image annotation requests for this batch.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -171,6 +176,11 @@ module Google
             #   `google.longrunning.Operations` interface.
             #   `Operation.metadata` contains `OperationMetadata` (metadata).
             #   `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `requests` (`Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash`):
+            #     Individual async file annotation requests for this batch.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -112,7 +112,7 @@ module Google
             # @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
             #   Run image detection and annotation for a batch of images.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
@@ -172,7 +172,7 @@ module Google
             #   `Operation.metadata` contains `OperationMetadata` (metadata).
             #   `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -107,27 +107,14 @@ module Google
             # NOTE: the `name` binding below allows API services to override the binding
             # to use different resource name schemes, such as `users/*/operations`.
             #
-            # @overload list_operations(request, options: nil)
-            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #     Lists operations that match the specified filter in the request. If the
-            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+            # @param request [Google::Longrunning::ListOperationsRequest | Hash]
+            #   Lists operations that match the specified filter in the request. If the
+            #   server doesn't support this method, it returns `UNIMPLEMENTED`.
             #
-            #     NOTE: the `name` binding below allows API services to override the binding
-            #     to use different resource name schemes, such as `users/*/operations`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation collection.
-            #   @param filter [String]
-            #     The standard list filter.
-            #   @param page_size [Integer]
-            #     The standard list page size.
-            #   @param page_token [String]
-            #     The standard list page token.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   NOTE: the `name` binding below allows API services to override the binding
+            #   to use different resource name schemes, such as `users/*/operations`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -140,13 +127,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_operations request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_operations request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
@@ -188,19 +171,12 @@ module Google
             # method to poll the operation result at intervals as recommended by the API
             # service.
             #
-            # @overload get_operation(request, options: nil)
-            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #     Gets the latest state of a long-running operation.  Clients can use this
-            #     method to poll the operation result at intervals as recommended by the API
-            #     service.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload get_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::GetOperationRequest | Hash]
+            #   Gets the latest state of a long-running operation.  Clients can use this
+            #   method to poll the operation result at intervals as recommended by the API
+            #   service.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -213,13 +189,9 @@ module Google
             # @example
             #   TODO
             #
-            def get_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def get_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
@@ -261,20 +233,13 @@ module Google
             # operation. If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
-            # @overload delete_operation(request, options: nil)
-            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #     Deletes a long-running operation. This method indicates that the client is
-            #     no longer interested in the operation result. It does not cancel the
-            #     operation. If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload delete_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource to be deleted.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+            #   Deletes a long-running operation. This method indicates that the client is
+            #   no longer interested in the operation result. It does not cancel the
+            #   operation. If the server doesn't support this method, it returns
+            #   `google.rpc.Code.UNIMPLEMENTED`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -287,13 +252,9 @@ module Google
             # @example
             #   TODO
             #
-            def delete_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def delete_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
@@ -340,26 +301,19 @@ module Google
             # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             # corresponding to `Code.CANCELLED`.
             #
-            # @overload cancel_operation(request, options: nil)
-            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #     Starts asynchronous cancellation on a long-running operation.  The server
-            #     makes a best effort to cancel the operation, but success is not
-            #     guaranteed.  If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-            #     other methods to check whether the cancellation succeeded or whether the
-            #     operation completed despite cancellation. On successful cancellation,
-            #     the operation is not deleted; instead, it becomes an operation with
-            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-            #     corresponding to `Code.CANCELLED`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload cancel_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource to be cancelled.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::CancelOperationRequest | Hash]
+            #   Starts asynchronous cancellation on a long-running operation.  The server
+            #   makes a best effort to cancel the operation, but success is not
+            #   guaranteed.  If the server doesn't support this method, it returns
+            #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+            #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #   other methods to check whether the cancellation succeeded or whether the
+            #   operation completed despite cancellation. On successful cancellation,
+            #   the operation is not deleted; instead, it becomes an operation with
+            #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #   corresponding to `Code.CANCELLED`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -372,13 +326,9 @@ module Google
             # @example
             #   TODO
             #
-            def cancel_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def cancel_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -113,6 +113,17 @@ module Google
             #
             #   NOTE: the `name` binding below allows API services to override the binding
             #   to use different resource name schemes, such as `users/*/operations`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation collection.
+            #   * `filter` (`String`):
+            #     The standard list filter.
+            #   * `page_size` (`Integer`):
+            #     The standard list page size.
+            #   * `page_token` (`String`):
+            #     The standard list page token.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -175,6 +186,11 @@ module Google
             #   Gets the latest state of a long-running operation.  Clients can use this
             #   method to poll the operation result at intervals as recommended by the API
             #   service.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -238,6 +254,11 @@ module Google
             #   no longer interested in the operation result. It does not cancel the
             #   operation. If the server doesn't support this method, it returns
             #   `google.rpc.Code.UNIMPLEMENTED`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource to be deleted.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -312,6 +333,11 @@ module Google
             #   the operation is not deleted; instead, it becomes an operation with
             #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             #   corresponding to `Code.CANCELLED`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource to be cancelled.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -114,7 +114,7 @@ module Google
             #   NOTE: the `name` binding below allows API services to override the binding
             #   to use different resource name schemes, such as `users/*/operations`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -176,7 +176,7 @@ module Google
             #   method to poll the operation result at intervals as recommended by the API
             #   service.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -239,7 +239,7 @@ module Google
             #   operation. If the server doesn't support this method, it returns
             #   `google.rpc.Code.UNIMPLEMENTED`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -313,7 +313,7 @@ module Google
             #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             #   corresponding to `Code.CANCELLED`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -121,6 +121,20 @@ module Google
             #
             #   * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
             #     4096 characters.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     The project in which the ProductSet should be created.
+            #
+            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
+            #   * `product_set` (`Google::Cloud::Vision::V1::ProductSet | Hash`):
+            #     The ProductSet to create.
+            #   * `product_set_id` (`String`):
+            #     A user-supplied resource id for this ProductSet. If set, the server will
+            #     attempt to use this value as the resource id. If it is already in use, an
+            #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
+            #     long. It cannot contain the character `/`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -187,6 +201,17 @@ module Google
             #
             #   * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
             #     than 1.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     The project from which ProductSets should be listed.
+            #
+            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
+            #   * `page_size` (`Integer`):
+            #     The maximum number of items to return. Default 10, maximum 100.
+            #   * `page_token` (`String`):
+            #     The next_page_token returned from a previous List request, if any.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -252,6 +277,14 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the ProductSet does not exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     Resource name of the ProductSet to get.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -322,6 +355,16 @@ module Google
             #   * Returns NOT_FOUND if the ProductSet does not exist.
             #   * Returns INVALID_ARGUMENT if display_name is present in update_mask but
             #     missing from the request or longer than 4096 characters.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `product_set` (`Google::Cloud::Vision::V1::ProductSet | Hash`):
+            #     The ProductSet resource which replaces the one on the server.
+            #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+            #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields to
+            #     update.
+            #     If update_mask isn't specified, all mutable fields are to be updated.
+            #     Valid mask path is `display_name`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -392,6 +435,14 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the ProductSet does not exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     Resource name of the ProductSet to delete.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -462,6 +513,21 @@ module Google
             #     characters.
             #   * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
             #   * Returns INVALID_ARGUMENT if product_category is missing or invalid.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     The project in which the Product should be created.
+            #
+            #     Format is
+            #     `projects/PROJECT_ID/locations/LOC_ID`.
+            #   * `product` (`Google::Cloud::Vision::V1::Product | Hash`):
+            #     The product to create.
+            #   * `product_id` (`String`):
+            #     A user-supplied resource id for this Product. If set, the server will
+            #     attempt to use this value as the resource id. If it is already in use, an
+            #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
+            #     long. It cannot contain the character `/`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -526,6 +592,18 @@ module Google
             #   Possible errors:
             #
             #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     The project OR ProductSet from which Products should be listed.
+            #
+            #     Format:
+            #     `projects/PROJECT_ID/locations/LOC_ID`
+            #   * `page_size` (`Integer`):
+            #     The maximum number of items to return. Default 10, maximum 100.
+            #   * `page_token` (`String`):
+            #     The next_page_token returned from a previous List request, if any.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -591,6 +669,14 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the Product does not exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     Resource name of the Product to get.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -675,6 +761,18 @@ module Google
             #   * Returns INVALID_ARGUMENT if description is present in update_mask but is
             #     longer than 4096 characters.
             #   * Returns INVALID_ARGUMENT if product_category is present in update_mask.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `product` (`Google::Cloud::Vision::V1::Product | Hash`):
+            #     The Product resource which replaces the one on the server.
+            #     product.name is immutable.
+            #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+            #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields
+            #     to update.
+            #     If update_mask isn't specified, all mutable fields are to be updated.
+            #     Valid mask paths include `product_labels`, `display_name`, and
+            #     `description`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -747,6 +845,14 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the product does not exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     Resource name of product to delete.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -839,6 +945,22 @@ module Google
             #   * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
             #     compatible with the parent product's product_category is detected.
             #   * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     Resource name of the product in which to create the reference image.
+            #
+            #     Format is
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
+            #   * `reference_image` (`Google::Cloud::Vision::V1::ReferenceImage | Hash`):
+            #     The reference image to create.
+            #     If an image ID is specified, it is ignored.
+            #   * `reference_image_id` (`String`):
+            #     A user-supplied resource id for the ReferenceImage to be added. If set,
+            #     the server will attempt to use this value as the resource id. If it is
+            #     already in use, an error is returned with code ALREADY_EXISTS. Must be at
+            #     most 128 characters long. It cannot contain the character `/`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -915,6 +1037,15 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the reference image does not exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The resource name of the reference image to delete.
+            #
+            #     Format is:
+            #
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -983,6 +1114,21 @@ module Google
             #   * Returns NOT_FOUND if the parent product does not exist.
             #   * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
             #     than 1.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     Resource name of the product containing the reference images.
+            #
+            #     Format is
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
+            #   * `page_size` (`Integer`):
+            #     The maximum number of items to return. Default 10, maximum 100.
+            #   * `page_token` (`String`):
+            #     A token identifying a page of results to be returned. This is the value
+            #     of `nextPageToken` returned in a previous reference image list request.
+            #
+            #     Defaults to the first page if not specified.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -1048,6 +1194,15 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the specified image does not exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The resource name of the ReferenceImage to get.
+            #
+            #     Format is:
+            #
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -1118,6 +1273,19 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The resource name for the ProductSet to modify.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+            #   * `product` (`String`):
+            #     The resource name for the Product to be added to this ProductSet.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -1182,6 +1350,19 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND If the Product is not found under the ProductSet.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The resource name for the ProductSet to modify.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+            #   * `product` (`String`):
+            #     The resource name for the Product to be removed from this ProductSet.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -1250,6 +1431,18 @@ module Google
             #   Possible errors:
             #
             #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The ProductSet resource for which to retrieve Products.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+            #   * `page_size` (`Integer`):
+            #     The maximum number of items to return. Default 10, maximum 100.
+            #   * `page_token` (`String`):
+            #     The next_page_token returned from a previous List request, if any.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -1327,6 +1520,15 @@ module Google
             #   The input source of this method is a csv file on Google Cloud Storage.
             #   For the format of the csv file please see
             #   [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     The project in which the ProductSets should be imported.
+            #
+            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
+            #   * `input_config` (`Google::Cloud::Vision::V1::ImportProductSetsInputConfig | Hash`):
+            #     The input content for the list of requests.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -122,7 +122,7 @@ module Google
             #   * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
             #     4096 characters.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -188,7 +188,7 @@ module Google
             #   * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
             #     than 1.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ProductSet>]
@@ -253,7 +253,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the ProductSet does not exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -323,7 +323,7 @@ module Google
             #   * Returns INVALID_ARGUMENT if display_name is present in update_mask but
             #     missing from the request or longer than 4096 characters.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -393,7 +393,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the ProductSet does not exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -463,7 +463,7 @@ module Google
             #   * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
             #   * Returns INVALID_ARGUMENT if product_category is missing or invalid.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -527,7 +527,7 @@ module Google
             #
             #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -592,7 +592,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the Product does not exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -676,7 +676,7 @@ module Google
             #     longer than 4096 characters.
             #   * Returns INVALID_ARGUMENT if product_category is present in update_mask.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -748,7 +748,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the product does not exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -840,7 +840,7 @@ module Google
             #     compatible with the parent product's product_category is detected.
             #   * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -916,7 +916,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the reference image does not exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -984,7 +984,7 @@ module Google
             #   * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
             #     than 1.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ReferenceImage>]
@@ -1049,7 +1049,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the specified image does not exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -1119,7 +1119,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1183,7 +1183,7 @@ module Google
             #
             #   * Returns NOT_FOUND If the Product is not found under the ProductSet.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1251,7 +1251,7 @@ module Google
             #
             #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -1328,7 +1328,7 @@ module Google
             #   For the format of the csv file please see
             #   [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -114,31 +114,15 @@ module Google
             # * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
             #   4096 characters.
             #
-            # @overload create_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::CreateProductSetRequest | Hash]
-            #     Creates and returns a new ProductSet resource.
+            # @param request [Google::Cloud::Vision::V1::CreateProductSetRequest | Hash]
+            #   Creates and returns a new ProductSet resource.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
-            #       4096 characters.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload create_product_set(parent: nil, product_set: nil, product_set_id: nil, options: nil)
-            #   @param parent [String]
-            #     The project in which the ProductSet should be created.
-            #
-            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   @param product_set [Google::Cloud::Vision::V1::ProductSet | Hash]
-            #     The ProductSet to create.
-            #   @param product_set_id [String]
-            #     A user-supplied resource id for this ProductSet. If set, the server will
-            #     attempt to use this value as the resource id. If it is already in use, an
-            #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
-            #     long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
+            #     4096 characters.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -151,13 +135,9 @@ module Google
             # @example
             #   TODO
             #
-            def create_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def create_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductSetRequest
 
               # Converts hash and nil to an options object
@@ -200,28 +180,15 @@ module Google
             # * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
             #   than 1.
             #
-            # @overload list_product_sets(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::ListProductSetsRequest | Hash]
-            #     Lists ProductSets in an unspecified order.
+            # @param request [Google::Cloud::Vision::V1::ListProductSetsRequest | Hash]
+            #   Lists ProductSets in an unspecified order.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
-            #       than 1.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_product_sets(parent: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param parent [String]
-            #     The project from which ProductSets should be listed.
-            #
-            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   @param page_size [Integer]
-            #     The maximum number of items to return. Default 10, maximum 100.
-            #   @param page_token [String]
-            #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
+            #     than 1.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ProductSet>]
@@ -234,13 +201,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_product_sets request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_product_sets request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductSetsRequest
 
               # Converts hash and nil to an options object
@@ -283,24 +246,14 @@ module Google
             #
             # * Returns NOT_FOUND if the ProductSet does not exist.
             #
-            # @overload get_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::GetProductSetRequest | Hash]
-            #     Gets information associated with a ProductSet.
+            # @param request [Google::Cloud::Vision::V1::GetProductSetRequest | Hash]
+            #   Gets information associated with a ProductSet.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the ProductSet does not exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload get_product_set(name: nil, options: nil)
-            #   @param name [String]
-            #     Resource name of the ProductSet to get.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the ProductSet does not exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -313,13 +266,9 @@ module Google
             # @example
             #   TODO
             #
-            def get_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def get_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductSetRequest
 
               # Converts hash and nil to an options object
@@ -364,29 +313,17 @@ module Google
             # * Returns INVALID_ARGUMENT if display_name is present in update_mask but
             #   missing from the request or longer than 4096 characters.
             #
-            # @overload update_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::UpdateProductSetRequest | Hash]
-            #     Makes changes to a ProductSet resource.
-            #     Only display_name can be updated currently.
+            # @param request [Google::Cloud::Vision::V1::UpdateProductSetRequest | Hash]
+            #   Makes changes to a ProductSet resource.
+            #   Only display_name can be updated currently.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the ProductSet does not exist.
-            #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but
-            #       missing from the request or longer than 4096 characters.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload update_product_set(product_set: nil, update_mask: nil, options: nil)
-            #   @param product_set [Google::Cloud::Vision::V1::ProductSet | Hash]
-            #     The ProductSet resource which replaces the one on the server.
-            #   @param update_mask [Google::Protobuf::FieldMask | Hash]
-            #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields to
-            #     update.
-            #     If update_mask isn't specified, all mutable fields are to be updated.
-            #     Valid mask path is `display_name`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the ProductSet does not exist.
+            #   * Returns INVALID_ARGUMENT if display_name is present in update_mask but
+            #     missing from the request or longer than 4096 characters.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -399,13 +336,9 @@ module Google
             # @example
             #   TODO
             #
-            def update_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def update_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductSetRequest
 
               # Converts hash and nil to an options object
@@ -450,27 +383,17 @@ module Google
             #
             # * Returns NOT_FOUND if the ProductSet does not exist.
             #
-            # @overload delete_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::DeleteProductSetRequest | Hash]
-            #     Permanently deletes a ProductSet. Products and ReferenceImages in the
-            #     ProductSet are not deleted.
+            # @param request [Google::Cloud::Vision::V1::DeleteProductSetRequest | Hash]
+            #   Permanently deletes a ProductSet. Products and ReferenceImages in the
+            #   ProductSet are not deleted.
             #
-            #     The actual image files are not deleted from Google Cloud Storage.
+            #   The actual image files are not deleted from Google Cloud Storage.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the ProductSet does not exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload delete_product_set(name: nil, options: nil)
-            #   @param name [String]
-            #     Resource name of the ProductSet to delete.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the ProductSet does not exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -483,13 +406,9 @@ module Google
             # @example
             #   TODO
             #
-            def delete_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def delete_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductSetRequest
 
               # Converts hash and nil to an options object
@@ -534,34 +453,17 @@ module Google
             # * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
             # * Returns INVALID_ARGUMENT if product_category is missing or invalid.
             #
-            # @overload create_product(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::CreateProductRequest | Hash]
-            #     Creates and returns a new product resource.
+            # @param request [Google::Cloud::Vision::V1::CreateProductRequest | Hash]
+            #   Creates and returns a new product resource.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
-            #       characters.
-            #     * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
-            #     * Returns INVALID_ARGUMENT if product_category is missing or invalid.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload create_product(parent: nil, product: nil, product_id: nil, options: nil)
-            #   @param parent [String]
-            #     The project in which the Product should be created.
-            #
-            #     Format is
-            #     `projects/PROJECT_ID/locations/LOC_ID`.
-            #   @param product [Google::Cloud::Vision::V1::Product | Hash]
-            #     The product to create.
-            #   @param product_id [String]
-            #     A user-supplied resource id for this Product. If set, the server will
-            #     attempt to use this value as the resource id. If it is already in use, an
-            #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
-            #     long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
+            #     characters.
+            #   * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
+            #   * Returns INVALID_ARGUMENT if product_category is missing or invalid.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -574,13 +476,9 @@ module Google
             # @example
             #   TODO
             #
-            def create_product request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def create_product request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductRequest
 
               # Converts hash and nil to an options object
@@ -622,28 +520,14 @@ module Google
             #
             # * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #
-            # @overload list_products(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::ListProductsRequest | Hash]
-            #     Lists products in an unspecified order.
+            # @param request [Google::Cloud::Vision::V1::ListProductsRequest | Hash]
+            #   Lists products in an unspecified order.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_products(parent: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param parent [String]
-            #     The project OR ProductSet from which Products should be listed.
-            #
-            #     Format:
-            #     `projects/PROJECT_ID/locations/LOC_ID`
-            #   @param page_size [Integer]
-            #     The maximum number of items to return. Default 10, maximum 100.
-            #   @param page_token [String]
-            #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -656,13 +540,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_products request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_products request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsRequest
 
               # Converts hash and nil to an options object
@@ -705,24 +585,14 @@ module Google
             #
             # * Returns NOT_FOUND if the Product does not exist.
             #
-            # @overload get_product(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::GetProductRequest | Hash]
-            #     Gets information associated with a Product.
+            # @param request [Google::Cloud::Vision::V1::GetProductRequest | Hash]
+            #   Gets information associated with a Product.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the Product does not exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload get_product(name: nil, options: nil)
-            #   @param name [String]
-            #     Resource name of the Product to get.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the Product does not exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -735,13 +605,9 @@ module Google
             # @example
             #   TODO
             #
-            def get_product request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def get_product request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductRequest
 
               # Converts hash and nil to an options object
@@ -793,38 +659,24 @@ module Google
             #   longer than 4096 characters.
             # * Returns INVALID_ARGUMENT if product_category is present in update_mask.
             #
-            # @overload update_product(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::UpdateProductRequest | Hash]
-            #     Makes changes to a Product resource.
-            #     Only the `display_name`, `description`, and `labels` fields can be updated
-            #     right now.
+            # @param request [Google::Cloud::Vision::V1::UpdateProductRequest | Hash]
+            #   Makes changes to a Product resource.
+            #   Only the `display_name`, `description`, and `labels` fields can be updated
+            #   right now.
             #
-            #     If labels are updated, the change will not be reflected in queries until
-            #     the next index time.
+            #   If labels are updated, the change will not be reflected in queries until
+            #   the next index time.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the Product does not exist.
-            #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
-            #       missing from the request or longer than 4096 characters.
-            #     * Returns INVALID_ARGUMENT if description is present in update_mask but is
-            #       longer than 4096 characters.
-            #     * Returns INVALID_ARGUMENT if product_category is present in update_mask.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload update_product(product: nil, update_mask: nil, options: nil)
-            #   @param product [Google::Cloud::Vision::V1::Product | Hash]
-            #     The Product resource which replaces the one on the server.
-            #     product.name is immutable.
-            #   @param update_mask [Google::Protobuf::FieldMask | Hash]
-            #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields
-            #     to update.
-            #     If update_mask isn't specified, all mutable fields are to be updated.
-            #     Valid mask paths include `product_labels`, `display_name`, and
-            #     `description`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the Product does not exist.
+            #   * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
+            #     missing from the request or longer than 4096 characters.
+            #   * Returns INVALID_ARGUMENT if description is present in update_mask but is
+            #     longer than 4096 characters.
+            #   * Returns INVALID_ARGUMENT if product_category is present in update_mask.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -837,13 +689,9 @@ module Google
             # @example
             #   TODO
             #
-            def update_product request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def update_product request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductRequest
 
               # Converts hash and nil to an options object
@@ -889,28 +737,18 @@ module Google
             #
             # * Returns NOT_FOUND if the product does not exist.
             #
-            # @overload delete_product(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::DeleteProductRequest | Hash]
-            #     Permanently deletes a product and its reference images.
+            # @param request [Google::Cloud::Vision::V1::DeleteProductRequest | Hash]
+            #   Permanently deletes a product and its reference images.
             #
-            #     Metadata of the product and all its images will be deleted right away, but
-            #     search queries against ProductSets containing the product may still work
-            #     until all related caches are refreshed.
+            #   Metadata of the product and all its images will be deleted right away, but
+            #   search queries against ProductSets containing the product may still work
+            #   until all related caches are refreshed.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the product does not exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload delete_product(name: nil, options: nil)
-            #   @param name [String]
-            #     Resource name of product to delete.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the product does not exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -923,13 +761,9 @@ module Google
             # @example
             #   TODO
             #
-            def delete_product request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def delete_product request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductRequest
 
               # Converts hash and nil to an options object
@@ -985,46 +819,28 @@ module Google
             #   compatible with the parent product's product_category is detected.
             # * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
             #
-            # @overload create_reference_image(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::CreateReferenceImageRequest | Hash]
-            #     Creates and returns a new ReferenceImage resource.
+            # @param request [Google::Cloud::Vision::V1::CreateReferenceImageRequest | Hash]
+            #   Creates and returns a new ReferenceImage resource.
             #
-            #     The `bounding_poly` field is optional. If `bounding_poly` is not specified,
-            #     the system will try to detect regions of interest in the image that are
-            #     compatible with the product_category on the parent product. If it is
-            #     specified, detection is ALWAYS skipped. The system converts polygons into
-            #     non-rotated rectangles.
+            #   The `bounding_poly` field is optional. If `bounding_poly` is not specified,
+            #   the system will try to detect regions of interest in the image that are
+            #   compatible with the product_category on the parent product. If it is
+            #   specified, detection is ALWAYS skipped. The system converts polygons into
+            #   non-rotated rectangles.
             #
-            #     Note that the pipeline will resize the image if the image resolution is too
-            #     large to process (above 50MP).
+            #   Note that the pipeline will resize the image if the image resolution is too
+            #   large to process (above 50MP).
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
-            #       characters.
-            #     * Returns INVALID_ARGUMENT if the product does not exist.
-            #     * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
-            #       compatible with the parent product's product_category is detected.
-            #     * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload create_reference_image(parent: nil, reference_image: nil, reference_image_id: nil, options: nil)
-            #   @param parent [String]
-            #     Resource name of the product in which to create the reference image.
-            #
-            #     Format is
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
-            #   @param reference_image [Google::Cloud::Vision::V1::ReferenceImage | Hash]
-            #     The reference image to create.
-            #     If an image ID is specified, it is ignored.
-            #   @param reference_image_id [String]
-            #     A user-supplied resource id for the ReferenceImage to be added. If set,
-            #     the server will attempt to use this value as the resource id. If it is
-            #     already in use, an error is returned with code ALREADY_EXISTS. Must be at
-            #     most 128 characters long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
+            #     characters.
+            #   * Returns INVALID_ARGUMENT if the product does not exist.
+            #   * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
+            #     compatible with the parent product's product_category is detected.
+            #   * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -1037,13 +853,9 @@ module Google
             # @example
             #   TODO
             #
-            def create_reference_image request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def create_reference_image request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateReferenceImageRequest
 
               # Converts hash and nil to an options object
@@ -1091,31 +903,20 @@ module Google
             #
             # * Returns NOT_FOUND if the reference image does not exist.
             #
-            # @overload delete_reference_image(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::DeleteReferenceImageRequest | Hash]
-            #     Permanently deletes a reference image.
+            # @param request [Google::Cloud::Vision::V1::DeleteReferenceImageRequest | Hash]
+            #   Permanently deletes a reference image.
             #
-            #     The image metadata will be deleted right away, but search queries
-            #     against ProductSets containing the image may still work until all related
-            #     caches are refreshed.
+            #   The image metadata will be deleted right away, but search queries
+            #   against ProductSets containing the image may still work until all related
+            #   caches are refreshed.
             #
-            #     The actual image files are not deleted from Google Cloud Storage.
+            #   The actual image files are not deleted from Google Cloud Storage.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the reference image does not exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload delete_reference_image(name: nil, options: nil)
-            #   @param name [String]
-            #     The resource name of the reference image to delete.
-            #
-            #     Format is:
-            #
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the reference image does not exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1128,13 +929,9 @@ module Google
             # @example
             #   TODO
             #
-            def delete_reference_image request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def delete_reference_image request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteReferenceImageRequest
 
               # Converts hash and nil to an options object
@@ -1178,33 +975,16 @@ module Google
             # * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
             #   than 1.
             #
-            # @overload list_reference_images(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::ListReferenceImagesRequest | Hash]
-            #     Lists reference images.
+            # @param request [Google::Cloud::Vision::V1::ListReferenceImagesRequest | Hash]
+            #   Lists reference images.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the parent product does not exist.
-            #     * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
-            #       than 1.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_reference_images(parent: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param parent [String]
-            #     Resource name of the product containing the reference images.
-            #
-            #     Format is
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
-            #   @param page_size [Integer]
-            #     The maximum number of items to return. Default 10, maximum 100.
-            #   @param page_token [String]
-            #     A token identifying a page of results to be returned. This is the value
-            #     of `nextPageToken` returned in a previous reference image list request.
-            #
-            #     Defaults to the first page if not specified.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the parent product does not exist.
+            #   * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
+            #     than 1.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ReferenceImage>]
@@ -1217,13 +997,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_reference_images request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_reference_images request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListReferenceImagesRequest
 
               # Converts hash and nil to an options object
@@ -1266,25 +1042,14 @@ module Google
             #
             # * Returns NOT_FOUND if the specified image does not exist.
             #
-            # @overload get_reference_image(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::GetReferenceImageRequest | Hash]
-            #     Gets information associated with a ReferenceImage.
+            # @param request [Google::Cloud::Vision::V1::GetReferenceImageRequest | Hash]
+            #   Gets information associated with a ReferenceImage.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the specified image does not exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload get_reference_image(name: nil, options: nil)
-            #   @param name [String]
-            #     The resource name of the ReferenceImage to get.
-            #
-            #     Format is:
-            #
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the specified image does not exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -1297,13 +1062,9 @@ module Google
             # @example
             #   TODO
             #
-            def get_reference_image request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def get_reference_image request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetReferenceImageRequest
 
               # Converts hash and nil to an options object
@@ -1348,32 +1109,17 @@ module Google
             #
             # * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
             #
-            # @overload add_product_to_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::AddProductToProductSetRequest | Hash]
-            #     Adds a Product to the specified ProductSet. If the Product is already
-            #     present, no change is made.
+            # @param request [Google::Cloud::Vision::V1::AddProductToProductSetRequest | Hash]
+            #   Adds a Product to the specified ProductSet. If the Product is already
+            #   present, no change is made.
             #
-            #     One Product can be added to at most 100 ProductSets.
+            #   One Product can be added to at most 100 ProductSets.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload add_product_to_product_set(name: nil, product: nil, options: nil)
-            #   @param name [String]
-            #     The resource name for the ProductSet to modify.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   @param product [String]
-            #     The resource name for the Product to be added to this ProductSet.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1386,13 +1132,9 @@ module Google
             # @example
             #   TODO
             #
-            def add_product_to_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def add_product_to_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AddProductToProductSetRequest
 
               # Converts hash and nil to an options object
@@ -1434,29 +1176,14 @@ module Google
             #
             # * Returns NOT_FOUND If the Product is not found under the ProductSet.
             #
-            # @overload remove_product_from_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest | Hash]
-            #     Removes a Product from the specified ProductSet.
+            # @param request [Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest | Hash]
+            #   Removes a Product from the specified ProductSet.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND If the Product is not found under the ProductSet.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload remove_product_from_product_set(name: nil, product: nil, options: nil)
-            #   @param name [String]
-            #     The resource name for the ProductSet to modify.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   @param product [String]
-            #     The resource name for the Product to be removed from this ProductSet.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND If the Product is not found under the ProductSet.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1469,13 +1196,9 @@ module Google
             # @example
             #   TODO
             #
-            def remove_product_from_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def remove_product_from_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
 
               # Converts hash and nil to an options object
@@ -1519,30 +1242,16 @@ module Google
             #
             # * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #
-            # @overload list_products_in_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::ListProductsInProductSetRequest | Hash]
-            #     Lists the Products in a ProductSet, in an unspecified order. If the
-            #     ProductSet does not exist, the products field of the response will be
-            #     empty.
+            # @param request [Google::Cloud::Vision::V1::ListProductsInProductSetRequest | Hash]
+            #   Lists the Products in a ProductSet, in an unspecified order. If the
+            #   ProductSet does not exist, the products field of the response will be
+            #   empty.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_products_in_product_set(name: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param name [String]
-            #     The ProductSet resource for which to retrieve Products.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   @param page_size [Integer]
-            #     The maximum number of items to return. Default 10, maximum 100.
-            #   @param page_token [String]
-            #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -1555,13 +1264,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_products_in_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_products_in_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsInProductSetRequest
 
               # Converts hash and nil to an options object
@@ -1610,31 +1315,20 @@ module Google
             # For the format of the csv file please see
             # [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
             #
-            # @overload import_product_sets(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::ImportProductSetsRequest | Hash]
-            #     Asynchronous API that imports a list of reference images to specified
-            #     product sets based on a list of image information.
+            # @param request [Google::Cloud::Vision::V1::ImportProductSetsRequest | Hash]
+            #   Asynchronous API that imports a list of reference images to specified
+            #   product sets based on a list of image information.
             #
-            #     The [google.longrunning.Operation][google.longrunning.Operation] API can be
-            #     used to keep track of the progress and results of the request.
-            #     `Operation.metadata` contains `BatchOperationMetadata`. (progress)
-            #     `Operation.response` contains `ImportProductSetsResponse`. (results)
+            #   The [google.longrunning.Operation][google.longrunning.Operation] API can be
+            #   used to keep track of the progress and results of the request.
+            #   `Operation.metadata` contains `BatchOperationMetadata`. (progress)
+            #   `Operation.response` contains `ImportProductSetsResponse`. (results)
             #
-            #     The input source of this method is a csv file on Google Cloud Storage.
-            #     For the format of the csv file please see
-            #     [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload import_product_sets(parent: nil, input_config: nil, options: nil)
-            #   @param parent [String]
-            #     The project in which the ProductSets should be imported.
-            #
-            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   @param input_config [Google::Cloud::Vision::V1::ImportProductSetsInputConfig | Hash]
-            #     The input content for the list of requests.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   The input source of this method is a csv file on Google Cloud Storage.
+            #   For the format of the csv file please see
+            #   [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -1647,13 +1341,9 @@ module Google
             # @example
             #   TODO
             #
-            def import_product_sets request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def import_product_sets request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ImportProductSetsRequest
 
               # Converts hash and nil to an options object

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -107,27 +107,14 @@ module Google
             # NOTE: the `name` binding below allows API services to override the binding
             # to use different resource name schemes, such as `users/*/operations`.
             #
-            # @overload list_operations(request, options: nil)
-            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #     Lists operations that match the specified filter in the request. If the
-            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+            # @param request [Google::Longrunning::ListOperationsRequest | Hash]
+            #   Lists operations that match the specified filter in the request. If the
+            #   server doesn't support this method, it returns `UNIMPLEMENTED`.
             #
-            #     NOTE: the `name` binding below allows API services to override the binding
-            #     to use different resource name schemes, such as `users/*/operations`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation collection.
-            #   @param filter [String]
-            #     The standard list filter.
-            #   @param page_size [Integer]
-            #     The standard list page size.
-            #   @param page_token [String]
-            #     The standard list page token.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   NOTE: the `name` binding below allows API services to override the binding
+            #   to use different resource name schemes, such as `users/*/operations`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -140,13 +127,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_operations request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_operations request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
@@ -188,19 +171,12 @@ module Google
             # method to poll the operation result at intervals as recommended by the API
             # service.
             #
-            # @overload get_operation(request, options: nil)
-            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #     Gets the latest state of a long-running operation.  Clients can use this
-            #     method to poll the operation result at intervals as recommended by the API
-            #     service.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload get_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::GetOperationRequest | Hash]
+            #   Gets the latest state of a long-running operation.  Clients can use this
+            #   method to poll the operation result at intervals as recommended by the API
+            #   service.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -213,13 +189,9 @@ module Google
             # @example
             #   TODO
             #
-            def get_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def get_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
@@ -261,20 +233,13 @@ module Google
             # operation. If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
-            # @overload delete_operation(request, options: nil)
-            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #     Deletes a long-running operation. This method indicates that the client is
-            #     no longer interested in the operation result. It does not cancel the
-            #     operation. If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload delete_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource to be deleted.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+            #   Deletes a long-running operation. This method indicates that the client is
+            #   no longer interested in the operation result. It does not cancel the
+            #   operation. If the server doesn't support this method, it returns
+            #   `google.rpc.Code.UNIMPLEMENTED`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -287,13 +252,9 @@ module Google
             # @example
             #   TODO
             #
-            def delete_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def delete_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
@@ -340,26 +301,19 @@ module Google
             # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             # corresponding to `Code.CANCELLED`.
             #
-            # @overload cancel_operation(request, options: nil)
-            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #     Starts asynchronous cancellation on a long-running operation.  The server
-            #     makes a best effort to cancel the operation, but success is not
-            #     guaranteed.  If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-            #     other methods to check whether the cancellation succeeded or whether the
-            #     operation completed despite cancellation. On successful cancellation,
-            #     the operation is not deleted; instead, it becomes an operation with
-            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-            #     corresponding to `Code.CANCELLED`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload cancel_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource to be cancelled.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::CancelOperationRequest | Hash]
+            #   Starts asynchronous cancellation on a long-running operation.  The server
+            #   makes a best effort to cancel the operation, but success is not
+            #   guaranteed.  If the server doesn't support this method, it returns
+            #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+            #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #   other methods to check whether the cancellation succeeded or whether the
+            #   operation completed despite cancellation. On successful cancellation,
+            #   the operation is not deleted; instead, it becomes an operation with
+            #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #   corresponding to `Code.CANCELLED`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -372,13 +326,9 @@ module Google
             # @example
             #   TODO
             #
-            def cancel_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def cancel_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -113,6 +113,17 @@ module Google
             #
             #   NOTE: the `name` binding below allows API services to override the binding
             #   to use different resource name schemes, such as `users/*/operations`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation collection.
+            #   * `filter` (`String`):
+            #     The standard list filter.
+            #   * `page_size` (`Integer`):
+            #     The standard list page size.
+            #   * `page_token` (`String`):
+            #     The standard list page token.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -175,6 +186,11 @@ module Google
             #   Gets the latest state of a long-running operation.  Clients can use this
             #   method to poll the operation result at intervals as recommended by the API
             #   service.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -238,6 +254,11 @@ module Google
             #   no longer interested in the operation result. It does not cancel the
             #   operation. If the server doesn't support this method, it returns
             #   `google.rpc.Code.UNIMPLEMENTED`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource to be deleted.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -312,6 +333,11 @@ module Google
             #   the operation is not deleted; instead, it becomes an operation with
             #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             #   corresponding to `Code.CANCELLED`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource to be cancelled.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -114,7 +114,7 @@ module Google
             #   NOTE: the `name` binding below allows API services to override the binding
             #   to use different resource name schemes, such as `users/*/operations`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -176,7 +176,7 @@ module Google
             #   method to poll the operation result at intervals as recommended by the API
             #   service.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -239,7 +239,7 @@ module Google
             #   operation. If the server doesn't support this method, it returns
             #   `google.rpc.Code.UNIMPLEMENTED`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -313,7 +313,7 @@ module Google
             #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             #   corresponding to `Code.CANCELLED`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
+++ b/shared/output/gapic/templates/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
@@ -117,7 +117,7 @@ module Google
               # @param request [Google::Ads::Googleads::V1::Services::GetCampaignRequest | Hash]
               #   Returns the requested campaign in full detail.
               # @param options [Google::Gax::ApiCall::Options, Hash]
-              #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+              #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
               #
               # @yield [response, operation] Access the result along with the RPC operation
               # @yieldparam response [Google::Ads::Googleads::V1::Resources::Campaign]
@@ -173,7 +173,7 @@ module Google
               # @param request [Google::Ads::Googleads::V1::Services::MutateCampaignsRequest | Hash]
               #   Creates, updates, or removes campaigns. Operation statuses are returned.
               # @param options [Google::Gax::ApiCall::Options, Hash]
-              #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+              #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
               #
               # @yield [response, operation] Access the result along with the RPC operation
               # @yieldparam response [Google::Ads::Googleads::V1::Services::MutateCampaignsResponse]

--- a/shared/output/gapic/templates/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
+++ b/shared/output/gapic/templates/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
@@ -114,17 +114,10 @@ module Google
               ##
               # Returns the requested campaign in full detail.
               #
-              # @overload get_campaign(request, options: nil)
-              #   @param request [Google::Ads::Googleads::V1::Services::GetCampaignRequest | Hash]
-              #     Returns the requested campaign in full detail.
-              #   @param options [Google::Gax::ApiCall::Options, Hash]
-              #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-              #
-              # @overload get_campaign(resource_name: nil, options: nil)
-              #   @param resource_name [String]
-              #     The resource name of the campaign to fetch.
-              #   @param options [Google::Gax::ApiCall::Options, Hash]
-              #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+              # @param request [Google::Ads::Googleads::V1::Services::GetCampaignRequest | Hash]
+              #   Returns the requested campaign in full detail.
+              # @param options [Google::Gax::ApiCall::Options, Hash]
+              #   Overrides the default settings for this call, e.g, timeout, retries, etc.
               #
               # @yield [response, operation] Access the result along with the RPC operation
               # @yieldparam response [Google::Ads::Googleads::V1::Resources::Campaign]
@@ -137,13 +130,9 @@ module Google
               # @example
               #   TODO
               #
-              def get_campaign request = nil, options: nil, **request_fields, &block
-                raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-                if !request.nil? && !request_fields.empty?
-                  raise ArgumentError, "cannot pass both request object and named arguments"
-                end
+              def get_campaign request, options = nil, &block
+                raise ArgumentError, "request must be provided" if request.nil?
 
-                request ||= request_fields
                 request = Google::Gax::Protobuf.coerce request, to: Google::Ads::Googleads::V1::Services::GetCampaignRequest
 
                 # Converts hash and nil to an options object
@@ -181,27 +170,10 @@ module Google
               ##
               # Creates, updates, or removes campaigns. Operation statuses are returned.
               #
-              # @overload mutate_campaigns(request, options: nil)
-              #   @param request [Google::Ads::Googleads::V1::Services::MutateCampaignsRequest | Hash]
-              #     Creates, updates, or removes campaigns. Operation statuses are returned.
-              #   @param options [Google::Gax::ApiCall::Options, Hash]
-              #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-              #
-              # @overload mutate_campaigns(customer_id: nil, operations: nil, partial_failure: nil, validate_only: nil, options: nil)
-              #   @param customer_id [String]
-              #     The ID of the customer whose campaigns are being modified.
-              #   @param operations [Google::Ads::Googleads::V1::Services::CampaignOperation | Hash]
-              #     The list of operations to perform on individual campaigns.
-              #   @param partial_failure [Boolean]
-              #     If true, successful operations will be carried out and invalid
-              #     operations will return errors. If false, all operations will be carried
-              #     out in one transaction if and only if they are all valid.
-              #     Default is false.
-              #   @param validate_only [Boolean]
-              #     If true, the request is validated but not executed. Only errors are
-              #     returned, not results.
-              #   @param options [Google::Gax::ApiCall::Options, Hash]
-              #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+              # @param request [Google::Ads::Googleads::V1::Services::MutateCampaignsRequest | Hash]
+              #   Creates, updates, or removes campaigns. Operation statuses are returned.
+              # @param options [Google::Gax::ApiCall::Options, Hash]
+              #   Overrides the default settings for this call, e.g, timeout, retries, etc.
               #
               # @yield [response, operation] Access the result along with the RPC operation
               # @yieldparam response [Google::Ads::Googleads::V1::Services::MutateCampaignsResponse]
@@ -214,13 +186,9 @@ module Google
               # @example
               #   TODO
               #
-              def mutate_campaigns request = nil, options: nil, **request_fields, &block
-                raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-                if !request.nil? && !request_fields.empty?
-                  raise ArgumentError, "cannot pass both request object and named arguments"
-                end
+              def mutate_campaigns request, options = nil, &block
+                raise ArgumentError, "request must be provided" if request.nil?
 
-                request ||= request_fields
                 request = Google::Gax::Protobuf.coerce request, to: Google::Ads::Googleads::V1::Services::MutateCampaignsRequest
 
                 # Converts hash and nil to an options object

--- a/shared/output/gapic/templates/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
+++ b/shared/output/gapic/templates/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
@@ -116,6 +116,11 @@ module Google
               #
               # @param request [Google::Ads::Googleads::V1::Services::GetCampaignRequest | Hash]
               #   Returns the requested campaign in full detail.
+              #
+              #   When using a hash, the following fields are supported:
+              #
+              #   * `resource_name` (`String`):
+              #     The resource name of the campaign to fetch.
               # @param options [Google::Gax::ApiCall::Options, Hash]
               #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
               #
@@ -172,6 +177,21 @@ module Google
               #
               # @param request [Google::Ads::Googleads::V1::Services::MutateCampaignsRequest | Hash]
               #   Creates, updates, or removes campaigns. Operation statuses are returned.
+              #
+              #   When using a hash, the following fields are supported:
+              #
+              #   * `customer_id` (`String`):
+              #     The ID of the customer whose campaigns are being modified.
+              #   * `operations` (`Google::Ads::Googleads::V1::Services::CampaignOperation | Hash`):
+              #     The list of operations to perform on individual campaigns.
+              #   * `partial_failure` (`Boolean`):
+              #     If true, successful operations will be carried out and invalid
+              #     operations will return errors. If false, all operations will be carried
+              #     out in one transaction if and only if they are all valid.
+              #     Default is false.
+              #   * `validate_only` (`Boolean`):
+              #     If true, the request is validated but not executed. Only errors are
+              #     returned, not results.
               # @param options [Google::Gax::ApiCall::Options, Hash]
               #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
               #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -119,7 +119,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
           #   This method simply echos the request. This method is showcases unary rpcs.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
@@ -171,7 +171,7 @@ module Google
           #   This method split the given content into words and will pass each word back
           #   through the stream. This method showcases server-side streaming rpcs.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -223,7 +223,7 @@ module Google
           # @param request [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
@@ -283,7 +283,7 @@ module Google
           # @param request [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::EchoRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::EchoRequest} instances.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -343,7 +343,7 @@ module Google
           #   This is similar to the Expand method but instead of returning a stream of
           #   expanded words, this method returns a paged list of expanded words.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -396,7 +396,7 @@ module Google
           #   This method will wait the requested amount of and then return.
           #   This method showcases how a client handles a request timing out.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -118,6 +118,13 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
           #   This method simply echos the request. This method is showcases unary rpcs.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `content` (`String`):
+          #     The content to be echoed by the server.
+          #   * `error` (`Google::Rpc::Status | Hash`):
+          #     The error to be thrown by the server.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -170,6 +177,13 @@ module Google
           # @param request [Google::Showcase::V1alpha3::ExpandRequest | Hash]
           #   This method split the given content into words and will pass each word back
           #   through the stream. This method showcases server-side streaming rpcs.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `content` (`String`):
+          #     The content that will be split into words and returned on the stream.
+          #   * `error` (`Google::Rpc::Status | Hash`):
+          #     The error that is thrown after all words are sent on the stream.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -342,6 +356,15 @@ module Google
           # @param request [Google::Showcase::V1alpha3::PagedExpandRequest | Hash]
           #   This is similar to the Expand method but instead of returning a stream of
           #   expanded words, this method returns a paged list of expanded words.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `content` (`String`):
+          #     The string to expand.
+          #   * `page_size` (`Integer`):
+          #     The amount of words to returned in each page.
+          #   * `page_token` (`String`):
+          #     The position of the page to be returned.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -395,6 +418,18 @@ module Google
           # @param request [Google::Showcase::V1alpha3::WaitRequest | Hash]
           #   This method will wait the requested amount of and then return.
           #   This method showcases how a client handles a request timing out.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `end_time` (`Google::Protobuf::Timestamp | Hash`):
+          #     The time that this operation will complete.
+          #   * `ttl` (`Google::Protobuf::Duration | Hash`):
+          #     The duration of this operation.
+          #   * `error` (`Google::Rpc::Status | Hash`):
+          #     The error that will be returned by the server. If this code is specified
+          #     to be the OK rpc code, an empty response will be returned.
+          #   * `success` (`Google::Showcase::V1alpha3::WaitResponse | Hash`):
+          #     The response to be returned on operation completion.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -116,19 +116,10 @@ module Google
           ##
           # This method simply echos the request. This method is showcases unary rpcs.
           #
-          # @overload echo(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
-          #     This method simply echos the request. This method is showcases unary rpcs.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload echo(content: nil, error: nil, options: nil)
-          #   @param content [String]
-          #     The content to be echoed by the server.
-          #   @param error [Google::Rpc::Status | Hash]
-          #     The error to be thrown by the server.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
+          #   This method simply echos the request. This method is showcases unary rpcs.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
@@ -141,13 +132,9 @@ module Google
           # @example
           #   TODO
           #
-          def echo request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def echo request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::EchoRequest
 
             # Converts hash and nil to an options object
@@ -180,20 +167,11 @@ module Google
           # This method split the given content into words and will pass each word back
           # through the stream. This method showcases server-side streaming rpcs.
           #
-          # @overload expand(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ExpandRequest | Hash]
-          #     This method split the given content into words and will pass each word back
-          #     through the stream. This method showcases server-side streaming rpcs.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload expand(content: nil, error: nil, options: nil)
-          #   @param content [String]
-          #     The content that will be split into words and returned on the stream.
-          #   @param error [Google::Rpc::Status | Hash]
-          #     The error that is thrown after all words are sent on the stream.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ExpandRequest | Hash]
+          #   This method split the given content into words and will pass each word back
+          #   through the stream. This method showcases server-side streaming rpcs.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -206,13 +184,9 @@ module Google
           # @example
           #   TODO
           #
-          def expand request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def expand request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ExpandRequest
 
             # Converts hash and nil to an options object
@@ -262,7 +236,7 @@ module Google
           # @example
           #   TODO
           #
-          def collect request, options: nil, &block
+          def collect request, options = nil, &block
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -322,7 +296,7 @@ module Google
           # @example
           #   TODO
           #
-          def chat request, options: nil, &block
+          def chat request, options = nil, &block
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -365,22 +339,11 @@ module Google
           # This is similar to the Expand method but instead of returning a stream of
           # expanded words, this method returns a paged list of expanded words.
           #
-          # @overload paged_expand(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::PagedExpandRequest | Hash]
-          #     This is similar to the Expand method but instead of returning a stream of
-          #     expanded words, this method returns a paged list of expanded words.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload paged_expand(content: nil, page_size: nil, page_token: nil, options: nil)
-          #   @param content [String]
-          #     The string to expand.
-          #   @param page_size [Integer]
-          #     The amount of words to returned in each page.
-          #   @param page_token [String]
-          #     The position of the page to be returned.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::PagedExpandRequest | Hash]
+          #   This is similar to the Expand method but instead of returning a stream of
+          #   expanded words, this method returns a paged list of expanded words.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -393,13 +356,9 @@ module Google
           # @example
           #   TODO
           #
-          def paged_expand request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def paged_expand request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::PagedExpandRequest
 
             # Converts hash and nil to an options object
@@ -433,25 +392,11 @@ module Google
           # This method will wait the requested amount of and then return.
           # This method showcases how a client handles a request timing out.
           #
-          # @overload wait(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::WaitRequest | Hash]
-          #     This method will wait the requested amount of and then return.
-          #     This method showcases how a client handles a request timing out.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload wait(end_time: nil, ttl: nil, error: nil, success: nil, options: nil)
-          #   @param end_time [Google::Protobuf::Timestamp | Hash]
-          #     The time that this operation will complete.
-          #   @param ttl [Google::Protobuf::Duration | Hash]
-          #     The duration of this operation.
-          #   @param error [Google::Rpc::Status | Hash]
-          #     The error that will be returned by the server. If this code is specified
-          #     to be the OK rpc code, an empty response will be returned.
-          #   @param success [Google::Showcase::V1alpha3::WaitResponse | Hash]
-          #     The response to be returned on operation completion.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::WaitRequest | Hash]
+          #   This method will wait the requested amount of and then return.
+          #   This method showcases how a client handles a request timing out.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -464,13 +409,9 @@ module Google
           # @example
           #   TODO
           #
-          def wait request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def wait request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::WaitRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -114,27 +114,14 @@ module Google
           # NOTE: the `name` binding below allows API services to override the binding
           # to use different resource name schemes, such as `users/*/operations`.
           #
-          # @overload list_operations(request, options: nil)
-          #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-          #     Lists operations that match the specified filter in the request. If the
-          #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+          # @param request [Google::Longrunning::ListOperationsRequest | Hash]
+          #   Lists operations that match the specified filter in the request. If the
+          #   server doesn't support this method, it returns `UNIMPLEMENTED`.
           #
-          #     NOTE: the `name` binding below allows API services to override the binding
-          #     to use different resource name schemes, such as `users/*/operations`.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation collection.
-          #   @param filter [String]
-          #     The standard list filter.
-          #   @param page_size [Integer]
-          #     The standard list page size.
-          #   @param page_token [String]
-          #     The standard list page token.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   NOTE: the `name` binding below allows API services to override the binding
+          #   to use different resource name schemes, such as `users/*/operations`.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -147,13 +134,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_operations request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_operations request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
             # Converts hash and nil to an options object
@@ -195,19 +178,12 @@ module Google
           # method to poll the operation result at intervals as recommended by the API
           # service.
           #
-          # @overload get_operation(request, options: nil)
-          #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-          #     Gets the latest state of a long-running operation.  Clients can use this
-          #     method to poll the operation result at intervals as recommended by the API
-          #     service.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload get_operation(name: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation resource.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Longrunning::GetOperationRequest | Hash]
+          #   Gets the latest state of a long-running operation.  Clients can use this
+          #   method to poll the operation result at intervals as recommended by the API
+          #   service.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -220,13 +196,9 @@ module Google
           # @example
           #   TODO
           #
-          def get_operation request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def get_operation request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
             # Converts hash and nil to an options object
@@ -268,20 +240,13 @@ module Google
           # operation. If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.
           #
-          # @overload delete_operation(request, options: nil)
-          #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-          #     Deletes a long-running operation. This method indicates that the client is
-          #     no longer interested in the operation result. It does not cancel the
-          #     operation. If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_operation(name: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation resource to be deleted.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+          #   Deletes a long-running operation. This method indicates that the client is
+          #   no longer interested in the operation result. It does not cancel the
+          #   operation. If the server doesn't support this method, it returns
+          #   `google.rpc.Code.UNIMPLEMENTED`.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -294,13 +259,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_operation request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_operation request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
             # Converts hash and nil to an options object
@@ -347,26 +308,19 @@ module Google
           # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           # corresponding to `Code.CANCELLED`.
           #
-          # @overload cancel_operation(request, options: nil)
-          #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-          #     Starts asynchronous cancellation on a long-running operation.  The server
-          #     makes a best effort to cancel the operation, but success is not
-          #     guaranteed.  If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-          #     other methods to check whether the cancellation succeeded or whether the
-          #     operation completed despite cancellation. On successful cancellation,
-          #     the operation is not deleted; instead, it becomes an operation with
-          #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-          #     corresponding to `Code.CANCELLED`.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload cancel_operation(name: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation resource to be cancelled.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Longrunning::CancelOperationRequest | Hash]
+          #   Starts asynchronous cancellation on a long-running operation.  The server
+          #   makes a best effort to cancel the operation, but success is not
+          #   guaranteed.  If the server doesn't support this method, it returns
+          #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+          #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          #   other methods to check whether the cancellation succeeded or whether the
+          #   operation completed despite cancellation. On successful cancellation,
+          #   the operation is not deleted; instead, it becomes an operation with
+          #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          #   corresponding to `Code.CANCELLED`.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -379,13 +333,9 @@ module Google
           # @example
           #   TODO
           #
-          def cancel_operation request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def cancel_operation request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -120,6 +120,17 @@ module Google
           #
           #   NOTE: the `name` binding below allows API services to override the binding
           #   to use different resource name schemes, such as `users/*/operations`.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation collection.
+          #   * `filter` (`String`):
+          #     The standard list filter.
+          #   * `page_size` (`Integer`):
+          #     The standard list page size.
+          #   * `page_token` (`String`):
+          #     The standard list page token.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -182,6 +193,11 @@ module Google
           #   Gets the latest state of a long-running operation.  Clients can use this
           #   method to poll the operation result at intervals as recommended by the API
           #   service.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation resource.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -245,6 +261,11 @@ module Google
           #   no longer interested in the operation result. It does not cancel the
           #   operation. If the server doesn't support this method, it returns
           #   `google.rpc.Code.UNIMPLEMENTED`.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation resource to be deleted.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -319,6 +340,11 @@ module Google
           #   the operation is not deleted; instead, it becomes an operation with
           #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           #   corresponding to `Code.CANCELLED`.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation resource to be cancelled.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -121,7 +121,7 @@ module Google
           #   NOTE: the `name` binding below allows API services to override the binding
           #   to use different resource name schemes, such as `users/*/operations`.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -183,7 +183,7 @@ module Google
           #   method to poll the operation result at intervals as recommended by the API
           #   service.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -246,7 +246,7 @@ module Google
           #   operation. If the server doesn't support this method, it returns
           #   `google.rpc.Code.UNIMPLEMENTED`.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -320,7 +320,7 @@ module Google
           #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           #   corresponding to `Code.CANCELLED`.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -115,17 +115,10 @@ module Google
           ##
           # Creates a user.
           #
-          # @overload create_user(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
-          #     Creates a user.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload create_user(user: nil, options: nil)
-          #   @param user [Google::Showcase::V1alpha3::User | Hash]
-          #     The user to create.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
+          #   Creates a user.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -138,13 +131,9 @@ module Google
           # @example
           #   TODO
           #
-          def create_user request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def create_user request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateUserRequest
 
             # Converts hash and nil to an options object
@@ -176,17 +165,10 @@ module Google
           ##
           # Retrieves the User with the given uri.
           #
-          # @overload get_user(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
-          #     Retrieves the User with the given uri.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload get_user(name: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of the requested user.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
+          #   Retrieves the User with the given uri.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -199,13 +181,9 @@ module Google
           # @example
           #   TODO
           #
-          def get_user request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def get_user request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetUserRequest
 
             # Converts hash and nil to an options object
@@ -243,20 +221,10 @@ module Google
           ##
           # Updates a user.
           #
-          # @overload update_user(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
-          #     Updates a user.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload update_user(user: nil, update_mask: nil, options: nil)
-          #   @param user [Google::Showcase::V1alpha3::User | Hash]
-          #     The user to update.
-          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
-          #     The field mask to determine wich fields are to be updated. If empty, the
-          #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
+          #   Updates a user.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -269,13 +237,9 @@ module Google
           # @example
           #   TODO
           #
-          def update_user request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def update_user request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateUserRequest
 
             # Converts hash and nil to an options object
@@ -313,17 +277,10 @@ module Google
           ##
           # Deletes a user, their profile, and all of their authored messages.
           #
-          # @overload delete_user(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
-          #     Deletes a user, their profile, and all of their authored messages.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_user(name: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of the user to delete.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
+          #   Deletes a user, their profile, and all of their authored messages.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -336,13 +293,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_user request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_user request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteUserRequest
 
             # Converts hash and nil to an options object
@@ -380,22 +333,10 @@ module Google
           ##
           # Lists all users.
           #
-          # @overload list_users(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
-          #     Lists all users.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_users(page_size: nil, page_token: nil, options: nil)
-          #   @param page_size [Integer]
-          #     The maximum number of users to return. Server may return fewer users
-          #     than requested. If unspecified, server will pick an appropriate default.
-          #   @param page_token [String]
-          #     The value of google.showcase.v1alpha3.ListUsersResponse.next_page_token
-          #     returned from the previous call to
-          #     `google.showcase.v1alpha3.Identity\ListUsers` method.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
+          #   Lists all users.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::User>]
@@ -408,13 +349,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_users request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_users request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListUsersRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -117,6 +117,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
           #   Creates a user.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `user` (`Google::Showcase::V1alpha3::User | Hash`):
+          #     The user to create.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -167,6 +172,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
           #   Retrieves the User with the given uri.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of the requested user.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -223,6 +233,14 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
           #   Updates a user.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `user` (`Google::Showcase::V1alpha3::User | Hash`):
+          #     The user to update.
+          #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+          #     The field mask to determine wich fields are to be updated. If empty, the
+          #     server will assume all fields are to be updated.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -279,6 +297,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
           #   Deletes a user, their profile, and all of their authored messages.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of the user to delete.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -335,6 +358,16 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
           #   Lists all users.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `page_size` (`Integer`):
+          #     The maximum number of users to return. Server may return fewer users
+          #     than requested. If unspecified, server will pick an appropriate default.
+          #   * `page_token` (`String`):
+          #     The value of google.showcase.v1alpha3.ListUsersResponse.next_page_token
+          #     returned from the previous call to
+          #     `google.showcase.v1alpha3.Identity\ListUsers` method.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -118,7 +118,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
           #   Creates a user.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -168,7 +168,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
           #   Retrieves the User with the given uri.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -224,7 +224,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
           #   Updates a user.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -280,7 +280,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
           #   Deletes a user, their profile, and all of their authored messages.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -336,7 +336,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
           #   Lists all users.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::User>]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -122,7 +122,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
           #   Creates a room.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -172,7 +172,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
           #   Retrieves the Room with the given resource name.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -228,7 +228,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
           #   Updates a room.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -284,7 +284,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
           #   Deletes a room and all of its blurbs.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -340,7 +340,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
           #   Lists all chat rooms.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Room>]
@@ -395,7 +395,7 @@ module Google
           #   message in that room. If the parent is a profile, the blurb is understood
           #   to be a post on the profile.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -451,7 +451,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
           #   Retrieves the Blurb with the given resource name.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -507,7 +507,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
           #   Updates a blurb.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -563,7 +563,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
           #   Deletes a blurb.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -621,7 +621,7 @@ module Google
           #   Lists blurbs for a specific chat room or user profile depending on the
           #   parent resource name.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Blurb>]
@@ -682,7 +682,7 @@ module Google
           #   for blurbs containing to words found in the query. Only posts that
           #   contain an exact match of a queried word will be returned.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -741,7 +741,7 @@ module Google
           #   This returns a stream that emits the blurbs that are created for a
           #   particular chat room or user profile.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]
@@ -798,7 +798,7 @@ module Google
           # @param request [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::CreateBlurbRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::CreateBlurbRequest} instances.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::SendBlurbsResponse]
@@ -865,7 +865,7 @@ module Google
           # @param request [Google::Gax::StreamInput, Enumerable<Google::Showcase::V1alpha3::ConnectRequest | Hash>]
           #   An enumerable of {Google::Showcase::V1alpha3::ConnectRequest} instances.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -121,6 +121,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
           #   Creates a room.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `room` (`Google::Showcase::V1alpha3::Room | Hash`):
+          #     The room to create.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -171,6 +176,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
           #   Retrieves the Room with the given resource name.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of the requested room.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -227,6 +237,14 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
           #   Updates a room.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `room` (`Google::Showcase::V1alpha3::Room | Hash`):
+          #     The room to update.
+          #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+          #     The field mask to determine wich fields are to be updated. If empty, the
+          #     server will assume all fields are to be updated.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -283,6 +301,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
           #   Deletes a room and all of its blurbs.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of the requested room.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -339,6 +362,16 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
           #   Lists all chat rooms.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `page_size` (`Integer`):
+          #     The maximum number of rooms return. Server may return fewer rooms
+          #     than requested. If unspecified, server will pick an appropriate default.
+          #   * `page_token` (`String`):
+          #     The value of google.showcase.v1alpha3.ListRoomsResponse.next_page_token
+          #     returned from the previous call to
+          #     `google.showcase.v1alpha3.Messaging\ListRooms` method.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -394,6 +427,14 @@ module Google
           #   Creates a blurb. If the parent is a room, the blurb is understood to be a
           #   message in that room. If the parent is a profile, the blurb is understood
           #   to be a post on the profile.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `parent` (`String`):
+          #     The resource name of the chat room or user profile that this blurb will
+          #     be tied to.
+          #   * `blurb` (`Google::Showcase::V1alpha3::Blurb | Hash`):
+          #     The blurb to create.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -450,6 +491,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
           #   Retrieves the Blurb with the given resource name.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of the requested blurb.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -506,6 +552,14 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
           #   Updates a blurb.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `blurb` (`Google::Showcase::V1alpha3::Blurb | Hash`):
+          #     The blurb to update.
+          #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+          #     The field mask to determine wich fields are to be updated. If empty, the
+          #     server will assume all fields are to be updated.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -562,6 +616,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
           #   Deletes a blurb.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of the requested blurb.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -620,6 +679,19 @@ module Google
           # @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
           #   Lists blurbs for a specific chat room or user profile depending on the
           #   parent resource name.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `parent` (`String`):
+          #     The resource name of the requested room or profile whos blurbs to list.
+          #   * `page_size` (`Integer`):
+          #     The maximum number of blurbs to return. Server may return fewer
+          #     blurbs than requested. If unspecified, server will pick an appropriate
+          #     default.
+          #   * `page_token` (`String`):
+          #     The value of google.showcase.v1alpha3.ListBlurbsResponse.next_page_token
+          #     returned from the previous call to
+          #     `google.showcase.v1alpha3.Messaging\ListBlurbs` method.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -681,6 +753,24 @@ module Google
           #   This method searches through all blurbs across all rooms and profiles
           #   for blurbs containing to words found in the query. Only posts that
           #   contain an exact match of a queried word will be returned.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `query` (`String`):
+          #     The query used to search for blurbs containing to words of this string.
+          #     Only posts that contain an exact match of a queried word will be returned.
+          #   * `parent` (`String`):
+          #     The rooms or profiles to search. If unset, `SearchBlurbs` will search all
+          #     rooms and all profiles.
+          #   * `page_size` (`Integer`):
+          #     The maximum number of blurbs return. Server may return fewer
+          #     blurbs than requested. If unspecified, server will pick an appropriate
+          #     default.
+          #   * `page_token` (`String`):
+          #     The value of
+          #     google.showcase.v1alpha3.SearchBlurbsResponse.next_page_token
+          #     returned from the previous call to
+          #     `google.showcase.v1alpha3.Messaging\SearchBlurbs` method.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -740,6 +830,13 @@ module Google
           # @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
           #   This returns a stream that emits the blurbs that are created for a
           #   particular chat room or user profile.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The resource name of a chat room or user profile whose blurbs to stream.
+          #   * `expire_time` (`Google::Protobuf::Timestamp | Hash`):
+          #     The time at which this stream will close.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -119,17 +119,10 @@ module Google
           ##
           # Creates a room.
           #
-          # @overload create_room(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
-          #     Creates a room.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload create_room(room: nil, options: nil)
-          #   @param room [Google::Showcase::V1alpha3::Room | Hash]
-          #     The room to create.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
+          #   Creates a room.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -142,13 +135,9 @@ module Google
           # @example
           #   TODO
           #
-          def create_room request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def create_room request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateRoomRequest
 
             # Converts hash and nil to an options object
@@ -180,17 +169,10 @@ module Google
           ##
           # Retrieves the Room with the given resource name.
           #
-          # @overload get_room(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
-          #     Retrieves the Room with the given resource name.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload get_room(name: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of the requested room.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
+          #   Retrieves the Room with the given resource name.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -203,13 +185,9 @@ module Google
           # @example
           #   TODO
           #
-          def get_room request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def get_room request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetRoomRequest
 
             # Converts hash and nil to an options object
@@ -247,20 +225,10 @@ module Google
           ##
           # Updates a room.
           #
-          # @overload update_room(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
-          #     Updates a room.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload update_room(room: nil, update_mask: nil, options: nil)
-          #   @param room [Google::Showcase::V1alpha3::Room | Hash]
-          #     The room to update.
-          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
-          #     The field mask to determine wich fields are to be updated. If empty, the
-          #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
+          #   Updates a room.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -273,13 +241,9 @@ module Google
           # @example
           #   TODO
           #
-          def update_room request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def update_room request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateRoomRequest
 
             # Converts hash and nil to an options object
@@ -317,17 +281,10 @@ module Google
           ##
           # Deletes a room and all of its blurbs.
           #
-          # @overload delete_room(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
-          #     Deletes a room and all of its blurbs.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_room(name: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of the requested room.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
+          #   Deletes a room and all of its blurbs.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -340,13 +297,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_room request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_room request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteRoomRequest
 
             # Converts hash and nil to an options object
@@ -384,22 +337,10 @@ module Google
           ##
           # Lists all chat rooms.
           #
-          # @overload list_rooms(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
-          #     Lists all chat rooms.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_rooms(page_size: nil, page_token: nil, options: nil)
-          #   @param page_size [Integer]
-          #     The maximum number of rooms return. Server may return fewer rooms
-          #     than requested. If unspecified, server will pick an appropriate default.
-          #   @param page_token [String]
-          #     The value of google.showcase.v1alpha3.ListRoomsResponse.next_page_token
-          #     returned from the previous call to
-          #     `google.showcase.v1alpha3.Messaging\ListRooms` method.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
+          #   Lists all chat rooms.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Room>]
@@ -412,13 +353,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_rooms request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_rooms request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListRoomsRequest
 
             # Converts hash and nil to an options object
@@ -453,22 +390,12 @@ module Google
           # message in that room. If the parent is a profile, the blurb is understood
           # to be a post on the profile.
           #
-          # @overload create_blurb(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::CreateBlurbRequest | Hash]
-          #     Creates a blurb. If the parent is a room, the blurb is understood to be a
-          #     message in that room. If the parent is a profile, the blurb is understood
-          #     to be a post on the profile.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload create_blurb(parent: nil, blurb: nil, options: nil)
-          #   @param parent [String]
-          #     The resource name of the chat room or user profile that this blurb will
-          #     be tied to.
-          #   @param blurb [Google::Showcase::V1alpha3::Blurb | Hash]
-          #     The blurb to create.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::CreateBlurbRequest | Hash]
+          #   Creates a blurb. If the parent is a room, the blurb is understood to be a
+          #   message in that room. If the parent is a profile, the blurb is understood
+          #   to be a post on the profile.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -481,13 +408,9 @@ module Google
           # @example
           #   TODO
           #
-          def create_blurb request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def create_blurb request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateBlurbRequest
 
             # Converts hash and nil to an options object
@@ -525,17 +448,10 @@ module Google
           ##
           # Retrieves the Blurb with the given resource name.
           #
-          # @overload get_blurb(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
-          #     Retrieves the Blurb with the given resource name.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload get_blurb(name: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of the requested blurb.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
+          #   Retrieves the Blurb with the given resource name.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -548,13 +464,9 @@ module Google
           # @example
           #   TODO
           #
-          def get_blurb request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def get_blurb request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetBlurbRequest
 
             # Converts hash and nil to an options object
@@ -592,20 +504,10 @@ module Google
           ##
           # Updates a blurb.
           #
-          # @overload update_blurb(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
-          #     Updates a blurb.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload update_blurb(blurb: nil, update_mask: nil, options: nil)
-          #   @param blurb [Google::Showcase::V1alpha3::Blurb | Hash]
-          #     The blurb to update.
-          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
-          #     The field mask to determine wich fields are to be updated. If empty, the
-          #     server will assume all fields are to be updated.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
+          #   Updates a blurb.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -618,13 +520,9 @@ module Google
           # @example
           #   TODO
           #
-          def update_blurb request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def update_blurb request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::UpdateBlurbRequest
 
             # Converts hash and nil to an options object
@@ -662,17 +560,10 @@ module Google
           ##
           # Deletes a blurb.
           #
-          # @overload delete_blurb(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
-          #     Deletes a blurb.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_blurb(name: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of the requested blurb.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
+          #   Deletes a blurb.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -685,13 +576,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_blurb request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_blurb request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteBlurbRequest
 
             # Converts hash and nil to an options object
@@ -730,26 +617,11 @@ module Google
           # Lists blurbs for a specific chat room or user profile depending on the
           # parent resource name.
           #
-          # @overload list_blurbs(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
-          #     Lists blurbs for a specific chat room or user profile depending on the
-          #     parent resource name.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_blurbs(parent: nil, page_size: nil, page_token: nil, options: nil)
-          #   @param parent [String]
-          #     The resource name of the requested room or profile whos blurbs to list.
-          #   @param page_size [Integer]
-          #     The maximum number of blurbs to return. Server may return fewer
-          #     blurbs than requested. If unspecified, server will pick an appropriate
-          #     default.
-          #   @param page_token [String]
-          #     The value of google.showcase.v1alpha3.ListBlurbsResponse.next_page_token
-          #     returned from the previous call to
-          #     `google.showcase.v1alpha3.Messaging\ListBlurbs` method.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
+          #   Lists blurbs for a specific chat room or user profile depending on the
+          #   parent resource name.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Blurb>]
@@ -762,13 +634,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_blurbs request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_blurbs request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListBlurbsRequest
 
             # Converts hash and nil to an options object
@@ -809,32 +677,12 @@ module Google
           # for blurbs containing to words found in the query. Only posts that
           # contain an exact match of a queried word will be returned.
           #
-          # @overload search_blurbs(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::SearchBlurbsRequest | Hash]
-          #     This method searches through all blurbs across all rooms and profiles
-          #     for blurbs containing to words found in the query. Only posts that
-          #     contain an exact match of a queried word will be returned.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload search_blurbs(query: nil, parent: nil, page_size: nil, page_token: nil, options: nil)
-          #   @param query [String]
-          #     The query used to search for blurbs containing to words of this string.
-          #     Only posts that contain an exact match of a queried word will be returned.
-          #   @param parent [String]
-          #     The rooms or profiles to search. If unset, `SearchBlurbs` will search all
-          #     rooms and all profiles.
-          #   @param page_size [Integer]
-          #     The maximum number of blurbs return. Server may return fewer
-          #     blurbs than requested. If unspecified, server will pick an appropriate
-          #     default.
-          #   @param page_token [String]
-          #     The value of
-          #     google.showcase.v1alpha3.SearchBlurbsResponse.next_page_token
-          #     returned from the previous call to
-          #     `google.showcase.v1alpha3.Messaging\SearchBlurbs` method.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::SearchBlurbsRequest | Hash]
+          #   This method searches through all blurbs across all rooms and profiles
+          #   for blurbs containing to words found in the query. Only posts that
+          #   contain an exact match of a queried word will be returned.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -847,13 +695,9 @@ module Google
           # @example
           #   TODO
           #
-          def search_blurbs request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def search_blurbs request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::SearchBlurbsRequest
 
             # Converts hash and nil to an options object
@@ -893,20 +737,11 @@ module Google
           # This returns a stream that emits the blurbs that are created for a
           # particular chat room or user profile.
           #
-          # @overload stream_blurbs(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
-          #     This returns a stream that emits the blurbs that are created for a
-          #     particular chat room or user profile.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload stream_blurbs(name: nil, expire_time: nil, options: nil)
-          #   @param name [String]
-          #     The resource name of a chat room or user profile whose blurbs to stream.
-          #   @param expire_time [Google::Protobuf::Timestamp | Hash]
-          #     The time at which this stream will close.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
+          #   This returns a stream that emits the blurbs that are created for a
+          #   particular chat room or user profile.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]
@@ -919,13 +754,9 @@ module Google
           # @example
           #   TODO
           #
-          def stream_blurbs request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def stream_blurbs request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::StreamBlurbsRequest
 
             # Converts hash and nil to an options object
@@ -980,7 +811,7 @@ module Google
           # @example
           #   TODO
           #
-          def send_blurbs request, options: nil, &block
+          def send_blurbs request, options = nil, &block
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -1047,7 +878,7 @@ module Google
           # @example
           #   TODO
           #
-          def connect request, options: nil, &block
+          def connect request, options = nil, &block
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -114,27 +114,14 @@ module Google
           # NOTE: the `name` binding below allows API services to override the binding
           # to use different resource name schemes, such as `users/*/operations`.
           #
-          # @overload list_operations(request, options: nil)
-          #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-          #     Lists operations that match the specified filter in the request. If the
-          #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+          # @param request [Google::Longrunning::ListOperationsRequest | Hash]
+          #   Lists operations that match the specified filter in the request. If the
+          #   server doesn't support this method, it returns `UNIMPLEMENTED`.
           #
-          #     NOTE: the `name` binding below allows API services to override the binding
-          #     to use different resource name schemes, such as `users/*/operations`.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation collection.
-          #   @param filter [String]
-          #     The standard list filter.
-          #   @param page_size [Integer]
-          #     The standard list page size.
-          #   @param page_token [String]
-          #     The standard list page token.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   NOTE: the `name` binding below allows API services to override the binding
+          #   to use different resource name schemes, such as `users/*/operations`.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -147,13 +134,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_operations request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_operations request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
             # Converts hash and nil to an options object
@@ -195,19 +178,12 @@ module Google
           # method to poll the operation result at intervals as recommended by the API
           # service.
           #
-          # @overload get_operation(request, options: nil)
-          #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-          #     Gets the latest state of a long-running operation.  Clients can use this
-          #     method to poll the operation result at intervals as recommended by the API
-          #     service.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload get_operation(name: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation resource.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Longrunning::GetOperationRequest | Hash]
+          #   Gets the latest state of a long-running operation.  Clients can use this
+          #   method to poll the operation result at intervals as recommended by the API
+          #   service.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -220,13 +196,9 @@ module Google
           # @example
           #   TODO
           #
-          def get_operation request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def get_operation request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
             # Converts hash and nil to an options object
@@ -268,20 +240,13 @@ module Google
           # operation. If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.
           #
-          # @overload delete_operation(request, options: nil)
-          #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-          #     Deletes a long-running operation. This method indicates that the client is
-          #     no longer interested in the operation result. It does not cancel the
-          #     operation. If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_operation(name: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation resource to be deleted.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+          #   Deletes a long-running operation. This method indicates that the client is
+          #   no longer interested in the operation result. It does not cancel the
+          #   operation. If the server doesn't support this method, it returns
+          #   `google.rpc.Code.UNIMPLEMENTED`.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -294,13 +259,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_operation request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_operation request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
             # Converts hash and nil to an options object
@@ -347,26 +308,19 @@ module Google
           # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           # corresponding to `Code.CANCELLED`.
           #
-          # @overload cancel_operation(request, options: nil)
-          #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-          #     Starts asynchronous cancellation on a long-running operation.  The server
-          #     makes a best effort to cancel the operation, but success is not
-          #     guaranteed.  If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-          #     other methods to check whether the cancellation succeeded or whether the
-          #     operation completed despite cancellation. On successful cancellation,
-          #     the operation is not deleted; instead, it becomes an operation with
-          #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-          #     corresponding to `Code.CANCELLED`.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload cancel_operation(name: nil, options: nil)
-          #   @param name [String]
-          #     The name of the operation resource to be cancelled.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Longrunning::CancelOperationRequest | Hash]
+          #   Starts asynchronous cancellation on a long-running operation.  The server
+          #   makes a best effort to cancel the operation, but success is not
+          #   guaranteed.  If the server doesn't support this method, it returns
+          #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+          #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          #   other methods to check whether the cancellation succeeded or whether the
+          #   operation completed despite cancellation. On successful cancellation,
+          #   the operation is not deleted; instead, it becomes an operation with
+          #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          #   corresponding to `Code.CANCELLED`.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -379,13 +333,9 @@ module Google
           # @example
           #   TODO
           #
-          def cancel_operation request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def cancel_operation request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -120,6 +120,17 @@ module Google
           #
           #   NOTE: the `name` binding below allows API services to override the binding
           #   to use different resource name schemes, such as `users/*/operations`.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation collection.
+          #   * `filter` (`String`):
+          #     The standard list filter.
+          #   * `page_size` (`Integer`):
+          #     The standard list page size.
+          #   * `page_token` (`String`):
+          #     The standard list page token.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -182,6 +193,11 @@ module Google
           #   Gets the latest state of a long-running operation.  Clients can use this
           #   method to poll the operation result at intervals as recommended by the API
           #   service.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation resource.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -245,6 +261,11 @@ module Google
           #   no longer interested in the operation result. It does not cancel the
           #   operation. If the server doesn't support this method, it returns
           #   `google.rpc.Code.UNIMPLEMENTED`.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation resource to be deleted.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -319,6 +340,11 @@ module Google
           #   the operation is not deleted; instead, it becomes an operation with
           #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           #   corresponding to `Code.CANCELLED`.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The name of the operation resource to be cancelled.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -121,7 +121,7 @@ module Google
           #   NOTE: the `name` binding below allows API services to override the binding
           #   to use different resource name schemes, such as `users/*/operations`.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -183,7 +183,7 @@ module Google
           #   method to poll the operation result at intervals as recommended by the API
           #   service.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -246,7 +246,7 @@ module Google
           #   operation. If the server doesn't support this method, it returns
           #   `google.rpc.Code.UNIMPLEMENTED`.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -320,7 +320,7 @@ module Google
           #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           #   corresponding to `Code.CANCELLED`.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -118,7 +118,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
           #   Creates a new testing session.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Session]
@@ -168,7 +168,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
           #   Gets a testing session.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Session]
@@ -224,7 +224,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
           #   Lists the current test sessions.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Session>]
@@ -275,7 +275,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
           #   Delete a test session.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -335,7 +335,7 @@ module Google
           #   This generates a report detailing which tests have been completed,
           #   and an overall rollup.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::ReportSessionResponse]
@@ -391,7 +391,7 @@ module Google
           # @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
           #   List the tests of a sessesion.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Test>]
@@ -458,7 +458,7 @@ module Google
           #
           #   This method will error if attempting to delete a required test.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -520,7 +520,7 @@ module Google
           #   In cases where a test involves registering a final answer at the
           #   end of the test, this method provides the means to do so.
           # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::VerifyTestResponse]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -115,19 +115,10 @@ module Google
           ##
           # Creates a new testing session.
           #
-          # @overload create_session(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
-          #     Creates a new testing session.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload create_session(session: nil, options: nil)
-          #   @param session [Google::Showcase::V1alpha3::Session | Hash]
-          #     The session to be created.
-          #     Sessions are immutable once they are created (although they can
-          #     be deleted).
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
+          #   Creates a new testing session.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Session]
@@ -140,13 +131,9 @@ module Google
           # @example
           #   TODO
           #
-          def create_session request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def create_session request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::CreateSessionRequest
 
             # Converts hash and nil to an options object
@@ -178,17 +165,10 @@ module Google
           ##
           # Gets a testing session.
           #
-          # @overload get_session(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
-          #     Gets a testing session.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload get_session(name: nil, options: nil)
-          #   @param name [String]
-          #     The session to be retrieved.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
+          #   Gets a testing session.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Session]
@@ -201,13 +181,9 @@ module Google
           # @example
           #   TODO
           #
-          def get_session request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def get_session request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::GetSessionRequest
 
             # Converts hash and nil to an options object
@@ -245,19 +221,10 @@ module Google
           ##
           # Lists the current test sessions.
           #
-          # @overload list_sessions(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
-          #     Lists the current test sessions.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_sessions(page_size: nil, page_token: nil, options: nil)
-          #   @param page_size [Integer]
-          #     The maximum number of sessions to return per page.
-          #   @param page_token [String]
-          #     The page token, for retrieving subsequent pages.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
+          #   Lists the current test sessions.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Session>]
@@ -270,13 +237,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_sessions request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_sessions request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListSessionsRequest
 
             # Converts hash and nil to an options object
@@ -309,17 +272,10 @@ module Google
           ##
           # Delete a test session.
           #
-          # @overload delete_session(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
-          #     Delete a test session.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_session(name: nil, options: nil)
-          #   @param name [String]
-          #     The session to be deleted.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
+          #   Delete a test session.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -332,13 +288,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_session request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_session request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteSessionRequest
 
             # Converts hash and nil to an options object
@@ -378,19 +330,12 @@ module Google
           # This generates a report detailing which tests have been completed,
           # and an overall rollup.
           #
-          # @overload report_session(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ReportSessionRequest | Hash]
-          #     Report on the status of a session.
-          #     This generates a report detailing which tests have been completed,
-          #     and an overall rollup.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload report_session(name: nil, options: nil)
-          #   @param name [String]
-          #     The session to be reported on.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ReportSessionRequest | Hash]
+          #   Report on the status of a session.
+          #   This generates a report detailing which tests have been completed,
+          #   and an overall rollup.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::ReportSessionResponse]
@@ -403,13 +348,9 @@ module Google
           # @example
           #   TODO
           #
-          def report_session request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def report_session request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ReportSessionRequest
 
             # Converts hash and nil to an options object
@@ -447,21 +388,10 @@ module Google
           ##
           # List the tests of a sessesion.
           #
-          # @overload list_tests(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
-          #     List the tests of a sessesion.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload list_tests(parent: nil, page_size: nil, page_token: nil, options: nil)
-          #   @param parent [String]
-          #     The session.
-          #   @param page_size [Integer]
-          #     The maximum number of tests to return per page.
-          #   @param page_token [String]
-          #     The page token, for retrieving subsequent pages.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          # @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
+          #   List the tests of a sessesion.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Test>]
@@ -474,13 +404,9 @@ module Google
           # @example
           #   TODO
           #
-          def list_tests request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def list_tests request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::ListTestsRequest
 
             # Converts hash and nil to an options object
@@ -524,22 +450,15 @@ module Google
           #
           # This method will error if attempting to delete a required test.
           #
-          # @overload delete_test(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::DeleteTestRequest | Hash]
-          #     Explicitly decline to implement a test.
+          # @param request [Google::Showcase::V1alpha3::DeleteTestRequest | Hash]
+          #   Explicitly decline to implement a test.
           #
-          #     This removes the test from subsequent `ListTests` calls, and
-          #     attempting to do the test will error.
+          #   This removes the test from subsequent `ListTests` calls, and
+          #   attempting to do the test will error.
           #
-          #     This method will error if attempting to delete a required test.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload delete_test(name: nil, options: nil)
-          #   @param name [String]
-          #     The test to be deleted.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   This method will error if attempting to delete a required test.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -552,13 +471,9 @@ module Google
           # @example
           #   TODO
           #
-          def delete_test request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def delete_test request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::DeleteTestRequest
 
             # Converts hash and nil to an options object
@@ -599,24 +514,13 @@ module Google
           # In cases where a test involves registering a final answer at the
           # end of the test, this method provides the means to do so.
           #
-          # @overload verify_test(request, options: nil)
-          #   @param request [Google::Showcase::V1alpha3::VerifyTestRequest | Hash]
-          #     Register a response to a test.
+          # @param request [Google::Showcase::V1alpha3::VerifyTestRequest | Hash]
+          #   Register a response to a test.
           #
-          #     In cases where a test involves registering a final answer at the
-          #     end of the test, this method provides the means to do so.
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-          #
-          # @overload verify_test(name: nil, answer: nil, answers: nil, options: nil)
-          #   @param name [String]
-          #     The test to have an answer registered to it.
-          #   @param answer [String]
-          #     The answer from the test.
-          #   @param answers [String]
-          #     The answers from the test if multiple are to be checked
-          #   @param options [Google::Gax::ApiCall::Options, Hash]
-          #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+          #   In cases where a test involves registering a final answer at the
+          #   end of the test, this method provides the means to do so.
+          # @param options [Google::Gax::ApiCall::Options, Hash]
+          #   Overrides the default settings for this call, e.g, timeout, retries, etc.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::VerifyTestResponse]
@@ -629,13 +533,9 @@ module Google
           # @example
           #   TODO
           #
-          def verify_test request = nil, options: nil, **request_fields, &block
-            raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-            if !request.nil? && !request_fields.empty?
-              raise ArgumentError, "cannot pass both request object and named arguments"
-            end
+          def verify_test request, options = nil, &block
+            raise ArgumentError, "request must be provided" if request.nil?
 
-            request ||= request_fields
             request = Google::Gax::Protobuf.coerce request, to: Google::Showcase::V1alpha3::VerifyTestRequest
 
             # Converts hash and nil to an options object

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -117,6 +117,13 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
           #   Creates a new testing session.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `session` (`Google::Showcase::V1alpha3::Session | Hash`):
+          #     The session to be created.
+          #     Sessions are immutable once they are created (although they can
+          #     be deleted).
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -167,6 +174,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
           #   Gets a testing session.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The session to be retrieved.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -223,6 +235,13 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
           #   Lists the current test sessions.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `page_size` (`Integer`):
+          #     The maximum number of sessions to return per page.
+          #   * `page_token` (`String`):
+          #     The page token, for retrieving subsequent pages.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -274,6 +293,11 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
           #   Delete a test session.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The session to be deleted.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -334,6 +358,11 @@ module Google
           #   Report on the status of a session.
           #   This generates a report detailing which tests have been completed,
           #   and an overall rollup.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The session to be reported on.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -390,6 +419,15 @@ module Google
           #
           # @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
           #   List the tests of a sessesion.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `parent` (`String`):
+          #     The session.
+          #   * `page_size` (`Integer`):
+          #     The maximum number of tests to return per page.
+          #   * `page_token` (`String`):
+          #     The page token, for retrieving subsequent pages.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -457,6 +495,11 @@ module Google
           #   attempting to do the test will error.
           #
           #   This method will error if attempting to delete a required test.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The test to be deleted.
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
@@ -519,6 +562,15 @@ module Google
           #
           #   In cases where a test involves registering a final answer at the
           #   end of the test, this method provides the means to do so.
+          #
+          #   When using a hash, the following fields are supported:
+          #
+          #   * `name` (`String`):
+          #     The test to have an answer registered to it.
+          #   * `answer` (`String`):
+          #     The answer from the test.
+          #   * `answers` (`String`):
+          #     The answers from the test if multiple are to be checked
           # @param options [Google::Gax::ApiCall::Options, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -121,6 +121,14 @@ module Google
             # @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
             #   Performs synchronous speech recognition: receive results after all audio
             #   has been sent and processed.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `config` (`Google::Cloud::Speech::V1::RecognitionConfig | Hash`):
+            #     *Required* Provides information to the recognizer that specifies how to
+            #     process the request.
+            #   * `audio` (`Google::Cloud::Speech::V1::RecognitionAudio | Hash`):
+            #     *Required* The audio data to be recognized.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -177,6 +185,14 @@ module Google
             #   google.longrunning.Operations interface. Returns either an
             #   `Operation.error` or an `Operation.response` which contains
             #   a `LongRunningRecognizeResponse` message.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `config` (`Google::Cloud::Speech::V1::RecognitionConfig | Hash`):
+            #     *Required* Provides information to the recognizer that specifies how to
+            #     process the request.
+            #   * `audio` (`Google::Cloud::Speech::V1::RecognitionAudio | Hash`):
+            #     *Required* The audio data to be recognized.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -122,7 +122,7 @@ module Google
             #   Performs synchronous speech recognition: receive results after all audio
             #   has been sent and processed.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Speech::V1::RecognizeResponse]
@@ -178,7 +178,7 @@ module Google
             #   `Operation.error` or an `Operation.response` which contains
             #   a `LongRunningRecognizeResponse` message.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -230,7 +230,7 @@ module Google
             # @param request [Google::Gax::StreamInput, Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeRequest | Hash>]
             #   An enumerable of {Google::Cloud::Speech::V1::StreamingRecognizeRequest} instances.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeResponse>]

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -118,21 +118,11 @@ module Google
             # Performs synchronous speech recognition: receive results after all audio
             # has been sent and processed.
             #
-            # @overload recognize(request, options: nil)
-            #   @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
-            #     Performs synchronous speech recognition: receive results after all audio
-            #     has been sent and processed.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload recognize(config: nil, audio: nil, options: nil)
-            #   @param config [Google::Cloud::Speech::V1::RecognitionConfig | Hash]
-            #     *Required* Provides information to the recognizer that specifies how to
-            #     process the request.
-            #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
-            #     *Required* The audio data to be recognized.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
+            #   Performs synchronous speech recognition: receive results after all audio
+            #   has been sent and processed.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Speech::V1::RecognizeResponse]
@@ -145,13 +135,9 @@ module Google
             # @example
             #   TODO
             #
-            def recognize request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def recognize request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::RecognizeRequest
 
               # Converts hash and nil to an options object
@@ -186,23 +172,13 @@ module Google
             # `Operation.error` or an `Operation.response` which contains
             # a `LongRunningRecognizeResponse` message.
             #
-            # @overload long_running_recognize(request, options: nil)
-            #   @param request [Google::Cloud::Speech::V1::LongRunningRecognizeRequest | Hash]
-            #     Performs asynchronous speech recognition: receive results via the
-            #     google.longrunning.Operations interface. Returns either an
-            #     `Operation.error` or an `Operation.response` which contains
-            #     a `LongRunningRecognizeResponse` message.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload long_running_recognize(config: nil, audio: nil, options: nil)
-            #   @param config [Google::Cloud::Speech::V1::RecognitionConfig | Hash]
-            #     *Required* Provides information to the recognizer that specifies how to
-            #     process the request.
-            #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
-            #     *Required* The audio data to be recognized.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Cloud::Speech::V1::LongRunningRecognizeRequest | Hash]
+            #   Performs asynchronous speech recognition: receive results via the
+            #   google.longrunning.Operations interface. Returns either an
+            #   `Operation.error` or an `Operation.response` which contains
+            #   a `LongRunningRecognizeResponse` message.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -215,13 +191,9 @@ module Google
             # @example
             #   TODO
             #
-            def long_running_recognize request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def long_running_recognize request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Speech::V1::LongRunningRecognizeRequest
 
               # Converts hash and nil to an options object
@@ -271,7 +243,7 @@ module Google
             # @example
             #   TODO
             #
-            def streaming_recognize request, options: nil, &block
+            def streaming_recognize request, options = nil, &block
               unless request.is_a? Enumerable
                 if request.respond_to? :to_enum
                   request = request.to_enum

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -122,7 +122,7 @@ module Google
             #   NOTE: the `name` binding below allows API services to override the binding
             #   to use different resource name schemes, such as `users/*/operations`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -184,7 +184,7 @@ module Google
             #   method to poll the operation result at intervals as recommended by the API
             #   service.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -247,7 +247,7 @@ module Google
             #   operation. If the server doesn't support this method, it returns
             #   `google.rpc.Code.UNIMPLEMENTED`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -321,7 +321,7 @@ module Google
             #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             #   corresponding to `Code.CANCELLED`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -121,6 +121,17 @@ module Google
             #
             #   NOTE: the `name` binding below allows API services to override the binding
             #   to use different resource name schemes, such as `users/*/operations`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation collection.
+            #   * `filter` (`String`):
+            #     The standard list filter.
+            #   * `page_size` (`Integer`):
+            #     The standard list page size.
+            #   * `page_token` (`String`):
+            #     The standard list page token.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -183,6 +194,11 @@ module Google
             #   Gets the latest state of a long-running operation.  Clients can use this
             #   method to poll the operation result at intervals as recommended by the API
             #   service.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -246,6 +262,11 @@ module Google
             #   no longer interested in the operation result. It does not cancel the
             #   operation. If the server doesn't support this method, it returns
             #   `google.rpc.Code.UNIMPLEMENTED`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource to be deleted.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -320,6 +341,11 @@ module Google
             #   the operation is not deleted; instead, it becomes an operation with
             #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             #   corresponding to `Code.CANCELLED`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource to be cancelled.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -115,27 +115,14 @@ module Google
             # NOTE: the `name` binding below allows API services to override the binding
             # to use different resource name schemes, such as `users/*/operations`.
             #
-            # @overload list_operations(request, options: nil)
-            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #     Lists operations that match the specified filter in the request. If the
-            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+            # @param request [Google::Longrunning::ListOperationsRequest | Hash]
+            #   Lists operations that match the specified filter in the request. If the
+            #   server doesn't support this method, it returns `UNIMPLEMENTED`.
             #
-            #     NOTE: the `name` binding below allows API services to override the binding
-            #     to use different resource name schemes, such as `users/*/operations`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation collection.
-            #   @param filter [String]
-            #     The standard list filter.
-            #   @param page_size [Integer]
-            #     The standard list page size.
-            #   @param page_token [String]
-            #     The standard list page token.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   NOTE: the `name` binding below allows API services to override the binding
+            #   to use different resource name schemes, such as `users/*/operations`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -148,13 +135,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_operations request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_operations request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
@@ -196,19 +179,12 @@ module Google
             # method to poll the operation result at intervals as recommended by the API
             # service.
             #
-            # @overload get_operation(request, options: nil)
-            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #     Gets the latest state of a long-running operation.  Clients can use this
-            #     method to poll the operation result at intervals as recommended by the API
-            #     service.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload get_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::GetOperationRequest | Hash]
+            #   Gets the latest state of a long-running operation.  Clients can use this
+            #   method to poll the operation result at intervals as recommended by the API
+            #   service.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -221,13 +197,9 @@ module Google
             # @example
             #   TODO
             #
-            def get_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def get_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
@@ -269,20 +241,13 @@ module Google
             # operation. If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
-            # @overload delete_operation(request, options: nil)
-            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #     Deletes a long-running operation. This method indicates that the client is
-            #     no longer interested in the operation result. It does not cancel the
-            #     operation. If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload delete_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource to be deleted.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+            #   Deletes a long-running operation. This method indicates that the client is
+            #   no longer interested in the operation result. It does not cancel the
+            #   operation. If the server doesn't support this method, it returns
+            #   `google.rpc.Code.UNIMPLEMENTED`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -295,13 +260,9 @@ module Google
             # @example
             #   TODO
             #
-            def delete_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def delete_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
@@ -348,26 +309,19 @@ module Google
             # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             # corresponding to `Code.CANCELLED`.
             #
-            # @overload cancel_operation(request, options: nil)
-            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #     Starts asynchronous cancellation on a long-running operation.  The server
-            #     makes a best effort to cancel the operation, but success is not
-            #     guaranteed.  If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-            #     other methods to check whether the cancellation succeeded or whether the
-            #     operation completed despite cancellation. On successful cancellation,
-            #     the operation is not deleted; instead, it becomes an operation with
-            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-            #     corresponding to `Code.CANCELLED`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload cancel_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource to be cancelled.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::CancelOperationRequest | Hash]
+            #   Starts asynchronous cancellation on a long-running operation.  The server
+            #   makes a best effort to cancel the operation, but success is not
+            #   guaranteed.  If the server doesn't support this method, it returns
+            #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+            #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #   other methods to check whether the cancellation succeeded or whether the
+            #   operation completed despite cancellation. On successful cancellation,
+            #   the operation is not deleted; instead, it becomes an operation with
+            #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #   corresponding to `Code.CANCELLED`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -380,13 +334,9 @@ module Google
             # @example
             #   TODO
             #
-            def cancel_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def cancel_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -117,17 +117,10 @@ module Google
             ##
             # Run image detection and annotation for a batch of images.
             #
-            # @overload batch_annotate_images(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
-            #     Run image detection and annotation for a batch of images.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload batch_annotate_images(requests: nil, options: nil)
-            #   @param requests [Google::Cloud::Vision::V1::AnnotateImageRequest | Hash]
-            #     Individual image annotation requests for this batch.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
+            #   Run image detection and annotation for a batch of images.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
@@ -140,13 +133,9 @@ module Google
             # @example
             #   TODO
             #
-            def batch_annotate_images request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def batch_annotate_images request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
 
               # Converts hash and nil to an options object
@@ -183,22 +172,15 @@ module Google
             # `Operation.metadata` contains `OperationMetadata` (metadata).
             # `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
             #
-            # @overload async_batch_annotate_files(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest | Hash]
-            #     Run asynchronous image detection and annotation for a list of generic
-            #     files, such as PDF files, which may contain multiple pages and multiple
-            #     images per page. Progress and results can be retrieved through the
-            #     `google.longrunning.Operations` interface.
-            #     `Operation.metadata` contains `OperationMetadata` (metadata).
-            #     `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload async_batch_annotate_files(requests: nil, options: nil)
-            #   @param requests [Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash]
-            #     Individual async file annotation requests for this batch.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest | Hash]
+            #   Run asynchronous image detection and annotation for a list of generic
+            #   files, such as PDF files, which may contain multiple pages and multiple
+            #   images per page. Progress and results can be retrieved through the
+            #   `google.longrunning.Operations` interface.
+            #   `Operation.metadata` contains `OperationMetadata` (metadata).
+            #   `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -211,13 +193,9 @@ module Google
             # @example
             #   TODO
             #
-            def async_batch_annotate_files request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def async_batch_annotate_files request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
 
               # Converts hash and nil to an options object

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -119,6 +119,11 @@ module Google
             #
             # @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
             #   Run image detection and annotation for a batch of images.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `requests` (`Google::Cloud::Vision::V1::AnnotateImageRequest | Hash`):
+            #     Individual image annotation requests for this batch.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -179,6 +184,11 @@ module Google
             #   `google.longrunning.Operations` interface.
             #   `Operation.metadata` contains `OperationMetadata` (metadata).
             #   `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `requests` (`Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash`):
+            #     Individual async file annotation requests for this batch.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -120,7 +120,7 @@ module Google
             # @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
             #   Run image detection and annotation for a batch of images.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
@@ -180,7 +180,7 @@ module Google
             #   `Operation.metadata` contains `OperationMetadata` (metadata).
             #   `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -122,7 +122,7 @@ module Google
             #   NOTE: the `name` binding below allows API services to override the binding
             #   to use different resource name schemes, such as `users/*/operations`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -184,7 +184,7 @@ module Google
             #   method to poll the operation result at intervals as recommended by the API
             #   service.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -247,7 +247,7 @@ module Google
             #   operation. If the server doesn't support this method, it returns
             #   `google.rpc.Code.UNIMPLEMENTED`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -321,7 +321,7 @@ module Google
             #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             #   corresponding to `Code.CANCELLED`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -121,6 +121,17 @@ module Google
             #
             #   NOTE: the `name` binding below allows API services to override the binding
             #   to use different resource name schemes, such as `users/*/operations`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation collection.
+            #   * `filter` (`String`):
+            #     The standard list filter.
+            #   * `page_size` (`Integer`):
+            #     The standard list page size.
+            #   * `page_token` (`String`):
+            #     The standard list page token.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -183,6 +194,11 @@ module Google
             #   Gets the latest state of a long-running operation.  Clients can use this
             #   method to poll the operation result at intervals as recommended by the API
             #   service.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -246,6 +262,11 @@ module Google
             #   no longer interested in the operation result. It does not cancel the
             #   operation. If the server doesn't support this method, it returns
             #   `google.rpc.Code.UNIMPLEMENTED`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource to be deleted.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -320,6 +341,11 @@ module Google
             #   the operation is not deleted; instead, it becomes an operation with
             #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             #   corresponding to `Code.CANCELLED`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource to be cancelled.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -115,27 +115,14 @@ module Google
             # NOTE: the `name` binding below allows API services to override the binding
             # to use different resource name schemes, such as `users/*/operations`.
             #
-            # @overload list_operations(request, options: nil)
-            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #     Lists operations that match the specified filter in the request. If the
-            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+            # @param request [Google::Longrunning::ListOperationsRequest | Hash]
+            #   Lists operations that match the specified filter in the request. If the
+            #   server doesn't support this method, it returns `UNIMPLEMENTED`.
             #
-            #     NOTE: the `name` binding below allows API services to override the binding
-            #     to use different resource name schemes, such as `users/*/operations`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation collection.
-            #   @param filter [String]
-            #     The standard list filter.
-            #   @param page_size [Integer]
-            #     The standard list page size.
-            #   @param page_token [String]
-            #     The standard list page token.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   NOTE: the `name` binding below allows API services to override the binding
+            #   to use different resource name schemes, such as `users/*/operations`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -148,13 +135,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_operations request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_operations request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
@@ -196,19 +179,12 @@ module Google
             # method to poll the operation result at intervals as recommended by the API
             # service.
             #
-            # @overload get_operation(request, options: nil)
-            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #     Gets the latest state of a long-running operation.  Clients can use this
-            #     method to poll the operation result at intervals as recommended by the API
-            #     service.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload get_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::GetOperationRequest | Hash]
+            #   Gets the latest state of a long-running operation.  Clients can use this
+            #   method to poll the operation result at intervals as recommended by the API
+            #   service.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -221,13 +197,9 @@ module Google
             # @example
             #   TODO
             #
-            def get_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def get_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
@@ -269,20 +241,13 @@ module Google
             # operation. If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
-            # @overload delete_operation(request, options: nil)
-            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #     Deletes a long-running operation. This method indicates that the client is
-            #     no longer interested in the operation result. It does not cancel the
-            #     operation. If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload delete_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource to be deleted.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+            #   Deletes a long-running operation. This method indicates that the client is
+            #   no longer interested in the operation result. It does not cancel the
+            #   operation. If the server doesn't support this method, it returns
+            #   `google.rpc.Code.UNIMPLEMENTED`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -295,13 +260,9 @@ module Google
             # @example
             #   TODO
             #
-            def delete_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def delete_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
@@ -348,26 +309,19 @@ module Google
             # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             # corresponding to `Code.CANCELLED`.
             #
-            # @overload cancel_operation(request, options: nil)
-            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #     Starts asynchronous cancellation on a long-running operation.  The server
-            #     makes a best effort to cancel the operation, but success is not
-            #     guaranteed.  If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-            #     other methods to check whether the cancellation succeeded or whether the
-            #     operation completed despite cancellation. On successful cancellation,
-            #     the operation is not deleted; instead, it becomes an operation with
-            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-            #     corresponding to `Code.CANCELLED`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload cancel_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource to be cancelled.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::CancelOperationRequest | Hash]
+            #   Starts asynchronous cancellation on a long-running operation.  The server
+            #   makes a best effort to cancel the operation, but success is not
+            #   guaranteed.  If the server doesn't support this method, it returns
+            #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+            #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #   other methods to check whether the cancellation succeeded or whether the
+            #   operation completed despite cancellation. On successful cancellation,
+            #   the operation is not deleted; instead, it becomes an operation with
+            #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #   corresponding to `Code.CANCELLED`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -380,13 +334,9 @@ module Google
             # @example
             #   TODO
             #
-            def cancel_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def cancel_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -130,7 +130,7 @@ module Google
             #   * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
             #     4096 characters.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -196,7 +196,7 @@ module Google
             #   * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
             #     than 1.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ProductSet>]
@@ -261,7 +261,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the ProductSet does not exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -331,7 +331,7 @@ module Google
             #   * Returns INVALID_ARGUMENT if display_name is present in update_mask but
             #     missing from the request or longer than 4096 characters.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -401,7 +401,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the ProductSet does not exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -471,7 +471,7 @@ module Google
             #   * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
             #   * Returns INVALID_ARGUMENT if product_category is missing or invalid.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -535,7 +535,7 @@ module Google
             #
             #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -600,7 +600,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the Product does not exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -684,7 +684,7 @@ module Google
             #     longer than 4096 characters.
             #   * Returns INVALID_ARGUMENT if product_category is present in update_mask.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -756,7 +756,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the product does not exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -848,7 +848,7 @@ module Google
             #     compatible with the parent product's product_category is detected.
             #   * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -924,7 +924,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the reference image does not exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -992,7 +992,7 @@ module Google
             #   * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
             #     than 1.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ReferenceImage>]
@@ -1057,7 +1057,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the specified image does not exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -1127,7 +1127,7 @@ module Google
             #
             #   * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1191,7 +1191,7 @@ module Google
             #
             #   * Returns NOT_FOUND If the Product is not found under the ProductSet.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1259,7 +1259,7 @@ module Google
             #
             #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -1336,7 +1336,7 @@ module Google
             #   For the format of the csv file please see
             #   [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -122,31 +122,15 @@ module Google
             # * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
             #   4096 characters.
             #
-            # @overload create_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::CreateProductSetRequest | Hash]
-            #     Creates and returns a new ProductSet resource.
+            # @param request [Google::Cloud::Vision::V1::CreateProductSetRequest | Hash]
+            #   Creates and returns a new ProductSet resource.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
-            #       4096 characters.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload create_product_set(parent: nil, product_set: nil, product_set_id: nil, options: nil)
-            #   @param parent [String]
-            #     The project in which the ProductSet should be created.
-            #
-            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   @param product_set [Google::Cloud::Vision::V1::ProductSet | Hash]
-            #     The ProductSet to create.
-            #   @param product_set_id [String]
-            #     A user-supplied resource id for this ProductSet. If set, the server will
-            #     attempt to use this value as the resource id. If it is already in use, an
-            #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
-            #     long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
+            #     4096 characters.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -159,13 +143,9 @@ module Google
             # @example
             #   TODO
             #
-            def create_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def create_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductSetRequest
 
               # Converts hash and nil to an options object
@@ -208,28 +188,15 @@ module Google
             # * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
             #   than 1.
             #
-            # @overload list_product_sets(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::ListProductSetsRequest | Hash]
-            #     Lists ProductSets in an unspecified order.
+            # @param request [Google::Cloud::Vision::V1::ListProductSetsRequest | Hash]
+            #   Lists ProductSets in an unspecified order.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
-            #       than 1.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_product_sets(parent: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param parent [String]
-            #     The project from which ProductSets should be listed.
-            #
-            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   @param page_size [Integer]
-            #     The maximum number of items to return. Default 10, maximum 100.
-            #   @param page_token [String]
-            #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
+            #     than 1.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ProductSet>]
@@ -242,13 +209,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_product_sets request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_product_sets request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductSetsRequest
 
               # Converts hash and nil to an options object
@@ -291,24 +254,14 @@ module Google
             #
             # * Returns NOT_FOUND if the ProductSet does not exist.
             #
-            # @overload get_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::GetProductSetRequest | Hash]
-            #     Gets information associated with a ProductSet.
+            # @param request [Google::Cloud::Vision::V1::GetProductSetRequest | Hash]
+            #   Gets information associated with a ProductSet.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the ProductSet does not exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload get_product_set(name: nil, options: nil)
-            #   @param name [String]
-            #     Resource name of the ProductSet to get.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the ProductSet does not exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -321,13 +274,9 @@ module Google
             # @example
             #   TODO
             #
-            def get_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def get_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductSetRequest
 
               # Converts hash and nil to an options object
@@ -372,29 +321,17 @@ module Google
             # * Returns INVALID_ARGUMENT if display_name is present in update_mask but
             #   missing from the request or longer than 4096 characters.
             #
-            # @overload update_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::UpdateProductSetRequest | Hash]
-            #     Makes changes to a ProductSet resource.
-            #     Only display_name can be updated currently.
+            # @param request [Google::Cloud::Vision::V1::UpdateProductSetRequest | Hash]
+            #   Makes changes to a ProductSet resource.
+            #   Only display_name can be updated currently.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the ProductSet does not exist.
-            #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but
-            #       missing from the request or longer than 4096 characters.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload update_product_set(product_set: nil, update_mask: nil, options: nil)
-            #   @param product_set [Google::Cloud::Vision::V1::ProductSet | Hash]
-            #     The ProductSet resource which replaces the one on the server.
-            #   @param update_mask [Google::Protobuf::FieldMask | Hash]
-            #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields to
-            #     update.
-            #     If update_mask isn't specified, all mutable fields are to be updated.
-            #     Valid mask path is `display_name`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the ProductSet does not exist.
+            #   * Returns INVALID_ARGUMENT if display_name is present in update_mask but
+            #     missing from the request or longer than 4096 characters.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -407,13 +344,9 @@ module Google
             # @example
             #   TODO
             #
-            def update_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def update_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductSetRequest
 
               # Converts hash and nil to an options object
@@ -458,27 +391,17 @@ module Google
             #
             # * Returns NOT_FOUND if the ProductSet does not exist.
             #
-            # @overload delete_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::DeleteProductSetRequest | Hash]
-            #     Permanently deletes a ProductSet. Products and ReferenceImages in the
-            #     ProductSet are not deleted.
+            # @param request [Google::Cloud::Vision::V1::DeleteProductSetRequest | Hash]
+            #   Permanently deletes a ProductSet. Products and ReferenceImages in the
+            #   ProductSet are not deleted.
             #
-            #     The actual image files are not deleted from Google Cloud Storage.
+            #   The actual image files are not deleted from Google Cloud Storage.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the ProductSet does not exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload delete_product_set(name: nil, options: nil)
-            #   @param name [String]
-            #     Resource name of the ProductSet to delete.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the ProductSet does not exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -491,13 +414,9 @@ module Google
             # @example
             #   TODO
             #
-            def delete_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def delete_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductSetRequest
 
               # Converts hash and nil to an options object
@@ -542,34 +461,17 @@ module Google
             # * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
             # * Returns INVALID_ARGUMENT if product_category is missing or invalid.
             #
-            # @overload create_product(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::CreateProductRequest | Hash]
-            #     Creates and returns a new product resource.
+            # @param request [Google::Cloud::Vision::V1::CreateProductRequest | Hash]
+            #   Creates and returns a new product resource.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
-            #       characters.
-            #     * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
-            #     * Returns INVALID_ARGUMENT if product_category is missing or invalid.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload create_product(parent: nil, product: nil, product_id: nil, options: nil)
-            #   @param parent [String]
-            #     The project in which the Product should be created.
-            #
-            #     Format is
-            #     `projects/PROJECT_ID/locations/LOC_ID`.
-            #   @param product [Google::Cloud::Vision::V1::Product | Hash]
-            #     The product to create.
-            #   @param product_id [String]
-            #     A user-supplied resource id for this Product. If set, the server will
-            #     attempt to use this value as the resource id. If it is already in use, an
-            #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
-            #     long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
+            #     characters.
+            #   * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
+            #   * Returns INVALID_ARGUMENT if product_category is missing or invalid.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -582,13 +484,9 @@ module Google
             # @example
             #   TODO
             #
-            def create_product request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def create_product request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductRequest
 
               # Converts hash and nil to an options object
@@ -630,28 +528,14 @@ module Google
             #
             # * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #
-            # @overload list_products(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::ListProductsRequest | Hash]
-            #     Lists products in an unspecified order.
+            # @param request [Google::Cloud::Vision::V1::ListProductsRequest | Hash]
+            #   Lists products in an unspecified order.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_products(parent: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param parent [String]
-            #     The project OR ProductSet from which Products should be listed.
-            #
-            #     Format:
-            #     `projects/PROJECT_ID/locations/LOC_ID`
-            #   @param page_size [Integer]
-            #     The maximum number of items to return. Default 10, maximum 100.
-            #   @param page_token [String]
-            #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -664,13 +548,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_products request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_products request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsRequest
 
               # Converts hash and nil to an options object
@@ -713,24 +593,14 @@ module Google
             #
             # * Returns NOT_FOUND if the Product does not exist.
             #
-            # @overload get_product(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::GetProductRequest | Hash]
-            #     Gets information associated with a Product.
+            # @param request [Google::Cloud::Vision::V1::GetProductRequest | Hash]
+            #   Gets information associated with a Product.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the Product does not exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload get_product(name: nil, options: nil)
-            #   @param name [String]
-            #     Resource name of the Product to get.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the Product does not exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -743,13 +613,9 @@ module Google
             # @example
             #   TODO
             #
-            def get_product request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def get_product request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductRequest
 
               # Converts hash and nil to an options object
@@ -801,38 +667,24 @@ module Google
             #   longer than 4096 characters.
             # * Returns INVALID_ARGUMENT if product_category is present in update_mask.
             #
-            # @overload update_product(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::UpdateProductRequest | Hash]
-            #     Makes changes to a Product resource.
-            #     Only the `display_name`, `description`, and `labels` fields can be updated
-            #     right now.
+            # @param request [Google::Cloud::Vision::V1::UpdateProductRequest | Hash]
+            #   Makes changes to a Product resource.
+            #   Only the `display_name`, `description`, and `labels` fields can be updated
+            #   right now.
             #
-            #     If labels are updated, the change will not be reflected in queries until
-            #     the next index time.
+            #   If labels are updated, the change will not be reflected in queries until
+            #   the next index time.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the Product does not exist.
-            #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
-            #       missing from the request or longer than 4096 characters.
-            #     * Returns INVALID_ARGUMENT if description is present in update_mask but is
-            #       longer than 4096 characters.
-            #     * Returns INVALID_ARGUMENT if product_category is present in update_mask.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload update_product(product: nil, update_mask: nil, options: nil)
-            #   @param product [Google::Cloud::Vision::V1::Product | Hash]
-            #     The Product resource which replaces the one on the server.
-            #     product.name is immutable.
-            #   @param update_mask [Google::Protobuf::FieldMask | Hash]
-            #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields
-            #     to update.
-            #     If update_mask isn't specified, all mutable fields are to be updated.
-            #     Valid mask paths include `product_labels`, `display_name`, and
-            #     `description`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the Product does not exist.
+            #   * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
+            #     missing from the request or longer than 4096 characters.
+            #   * Returns INVALID_ARGUMENT if description is present in update_mask but is
+            #     longer than 4096 characters.
+            #   * Returns INVALID_ARGUMENT if product_category is present in update_mask.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -845,13 +697,9 @@ module Google
             # @example
             #   TODO
             #
-            def update_product request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def update_product request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductRequest
 
               # Converts hash and nil to an options object
@@ -897,28 +745,18 @@ module Google
             #
             # * Returns NOT_FOUND if the product does not exist.
             #
-            # @overload delete_product(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::DeleteProductRequest | Hash]
-            #     Permanently deletes a product and its reference images.
+            # @param request [Google::Cloud::Vision::V1::DeleteProductRequest | Hash]
+            #   Permanently deletes a product and its reference images.
             #
-            #     Metadata of the product and all its images will be deleted right away, but
-            #     search queries against ProductSets containing the product may still work
-            #     until all related caches are refreshed.
+            #   Metadata of the product and all its images will be deleted right away, but
+            #   search queries against ProductSets containing the product may still work
+            #   until all related caches are refreshed.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the product does not exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload delete_product(name: nil, options: nil)
-            #   @param name [String]
-            #     Resource name of product to delete.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the product does not exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -931,13 +769,9 @@ module Google
             # @example
             #   TODO
             #
-            def delete_product request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def delete_product request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductRequest
 
               # Converts hash and nil to an options object
@@ -993,46 +827,28 @@ module Google
             #   compatible with the parent product's product_category is detected.
             # * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
             #
-            # @overload create_reference_image(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::CreateReferenceImageRequest | Hash]
-            #     Creates and returns a new ReferenceImage resource.
+            # @param request [Google::Cloud::Vision::V1::CreateReferenceImageRequest | Hash]
+            #   Creates and returns a new ReferenceImage resource.
             #
-            #     The `bounding_poly` field is optional. If `bounding_poly` is not specified,
-            #     the system will try to detect regions of interest in the image that are
-            #     compatible with the product_category on the parent product. If it is
-            #     specified, detection is ALWAYS skipped. The system converts polygons into
-            #     non-rotated rectangles.
+            #   The `bounding_poly` field is optional. If `bounding_poly` is not specified,
+            #   the system will try to detect regions of interest in the image that are
+            #   compatible with the product_category on the parent product. If it is
+            #   specified, detection is ALWAYS skipped. The system converts polygons into
+            #   non-rotated rectangles.
             #
-            #     Note that the pipeline will resize the image if the image resolution is too
-            #     large to process (above 50MP).
+            #   Note that the pipeline will resize the image if the image resolution is too
+            #   large to process (above 50MP).
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
-            #       characters.
-            #     * Returns INVALID_ARGUMENT if the product does not exist.
-            #     * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
-            #       compatible with the parent product's product_category is detected.
-            #     * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload create_reference_image(parent: nil, reference_image: nil, reference_image_id: nil, options: nil)
-            #   @param parent [String]
-            #     Resource name of the product in which to create the reference image.
-            #
-            #     Format is
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
-            #   @param reference_image [Google::Cloud::Vision::V1::ReferenceImage | Hash]
-            #     The reference image to create.
-            #     If an image ID is specified, it is ignored.
-            #   @param reference_image_id [String]
-            #     A user-supplied resource id for the ReferenceImage to be added. If set,
-            #     the server will attempt to use this value as the resource id. If it is
-            #     already in use, an error is returned with code ALREADY_EXISTS. Must be at
-            #     most 128 characters long. It cannot contain the character `/`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
+            #     characters.
+            #   * Returns INVALID_ARGUMENT if the product does not exist.
+            #   * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
+            #     compatible with the parent product's product_category is detected.
+            #   * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -1045,13 +861,9 @@ module Google
             # @example
             #   TODO
             #
-            def create_reference_image request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def create_reference_image request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateReferenceImageRequest
 
               # Converts hash and nil to an options object
@@ -1099,31 +911,20 @@ module Google
             #
             # * Returns NOT_FOUND if the reference image does not exist.
             #
-            # @overload delete_reference_image(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::DeleteReferenceImageRequest | Hash]
-            #     Permanently deletes a reference image.
+            # @param request [Google::Cloud::Vision::V1::DeleteReferenceImageRequest | Hash]
+            #   Permanently deletes a reference image.
             #
-            #     The image metadata will be deleted right away, but search queries
-            #     against ProductSets containing the image may still work until all related
-            #     caches are refreshed.
+            #   The image metadata will be deleted right away, but search queries
+            #   against ProductSets containing the image may still work until all related
+            #   caches are refreshed.
             #
-            #     The actual image files are not deleted from Google Cloud Storage.
+            #   The actual image files are not deleted from Google Cloud Storage.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the reference image does not exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload delete_reference_image(name: nil, options: nil)
-            #   @param name [String]
-            #     The resource name of the reference image to delete.
-            #
-            #     Format is:
-            #
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the reference image does not exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1136,13 +937,9 @@ module Google
             # @example
             #   TODO
             #
-            def delete_reference_image request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def delete_reference_image request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteReferenceImageRequest
 
               # Converts hash and nil to an options object
@@ -1186,33 +983,16 @@ module Google
             # * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
             #   than 1.
             #
-            # @overload list_reference_images(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::ListReferenceImagesRequest | Hash]
-            #     Lists reference images.
+            # @param request [Google::Cloud::Vision::V1::ListReferenceImagesRequest | Hash]
+            #   Lists reference images.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the parent product does not exist.
-            #     * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
-            #       than 1.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_reference_images(parent: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param parent [String]
-            #     Resource name of the product containing the reference images.
-            #
-            #     Format is
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
-            #   @param page_size [Integer]
-            #     The maximum number of items to return. Default 10, maximum 100.
-            #   @param page_token [String]
-            #     A token identifying a page of results to be returned. This is the value
-            #     of `nextPageToken` returned in a previous reference image list request.
-            #
-            #     Defaults to the first page if not specified.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the parent product does not exist.
+            #   * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
+            #     than 1.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ReferenceImage>]
@@ -1225,13 +1005,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_reference_images request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_reference_images request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListReferenceImagesRequest
 
               # Converts hash and nil to an options object
@@ -1274,25 +1050,14 @@ module Google
             #
             # * Returns NOT_FOUND if the specified image does not exist.
             #
-            # @overload get_reference_image(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::GetReferenceImageRequest | Hash]
-            #     Gets information associated with a ReferenceImage.
+            # @param request [Google::Cloud::Vision::V1::GetReferenceImageRequest | Hash]
+            #   Gets information associated with a ReferenceImage.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the specified image does not exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload get_reference_image(name: nil, options: nil)
-            #   @param name [String]
-            #     The resource name of the ReferenceImage to get.
-            #
-            #     Format is:
-            #
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the specified image does not exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -1305,13 +1070,9 @@ module Google
             # @example
             #   TODO
             #
-            def get_reference_image request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def get_reference_image request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetReferenceImageRequest
 
               # Converts hash and nil to an options object
@@ -1356,32 +1117,17 @@ module Google
             #
             # * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
             #
-            # @overload add_product_to_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::AddProductToProductSetRequest | Hash]
-            #     Adds a Product to the specified ProductSet. If the Product is already
-            #     present, no change is made.
+            # @param request [Google::Cloud::Vision::V1::AddProductToProductSetRequest | Hash]
+            #   Adds a Product to the specified ProductSet. If the Product is already
+            #   present, no change is made.
             #
-            #     One Product can be added to at most 100 ProductSets.
+            #   One Product can be added to at most 100 ProductSets.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload add_product_to_product_set(name: nil, product: nil, options: nil)
-            #   @param name [String]
-            #     The resource name for the ProductSet to modify.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   @param product [String]
-            #     The resource name for the Product to be added to this ProductSet.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1394,13 +1140,9 @@ module Google
             # @example
             #   TODO
             #
-            def add_product_to_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def add_product_to_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AddProductToProductSetRequest
 
               # Converts hash and nil to an options object
@@ -1442,29 +1184,14 @@ module Google
             #
             # * Returns NOT_FOUND If the Product is not found under the ProductSet.
             #
-            # @overload remove_product_from_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest | Hash]
-            #     Removes a Product from the specified ProductSet.
+            # @param request [Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest | Hash]
+            #   Removes a Product from the specified ProductSet.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns NOT_FOUND If the Product is not found under the ProductSet.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload remove_product_from_product_set(name: nil, product: nil, options: nil)
-            #   @param name [String]
-            #     The resource name for the ProductSet to modify.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   @param product [String]
-            #     The resource name for the Product to be removed from this ProductSet.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns NOT_FOUND If the Product is not found under the ProductSet.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1477,13 +1204,9 @@ module Google
             # @example
             #   TODO
             #
-            def remove_product_from_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def remove_product_from_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
 
               # Converts hash and nil to an options object
@@ -1527,30 +1250,16 @@ module Google
             #
             # * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #
-            # @overload list_products_in_product_set(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::ListProductsInProductSetRequest | Hash]
-            #     Lists the Products in a ProductSet, in an unspecified order. If the
-            #     ProductSet does not exist, the products field of the response will be
-            #     empty.
+            # @param request [Google::Cloud::Vision::V1::ListProductsInProductSetRequest | Hash]
+            #   Lists the Products in a ProductSet, in an unspecified order. If the
+            #   ProductSet does not exist, the products field of the response will be
+            #   empty.
             #
-            #     Possible errors:
+            #   Possible errors:
             #
-            #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_products_in_product_set(name: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param name [String]
-            #     The ProductSet resource for which to retrieve Products.
-            #
-            #     Format is:
-            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   @param page_size [Integer]
-            #     The maximum number of items to return. Default 10, maximum 100.
-            #   @param page_token [String]
-            #     The next_page_token returned from a previous List request, if any.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -1563,13 +1272,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_products_in_product_set request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_products_in_product_set request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsInProductSetRequest
 
               # Converts hash and nil to an options object
@@ -1618,31 +1323,20 @@ module Google
             # For the format of the csv file please see
             # [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
             #
-            # @overload import_product_sets(request, options: nil)
-            #   @param request [Google::Cloud::Vision::V1::ImportProductSetsRequest | Hash]
-            #     Asynchronous API that imports a list of reference images to specified
-            #     product sets based on a list of image information.
+            # @param request [Google::Cloud::Vision::V1::ImportProductSetsRequest | Hash]
+            #   Asynchronous API that imports a list of reference images to specified
+            #   product sets based on a list of image information.
             #
-            #     The [google.longrunning.Operation][google.longrunning.Operation] API can be
-            #     used to keep track of the progress and results of the request.
-            #     `Operation.metadata` contains `BatchOperationMetadata`. (progress)
-            #     `Operation.response` contains `ImportProductSetsResponse`. (results)
+            #   The [google.longrunning.Operation][google.longrunning.Operation] API can be
+            #   used to keep track of the progress and results of the request.
+            #   `Operation.metadata` contains `BatchOperationMetadata`. (progress)
+            #   `Operation.response` contains `ImportProductSetsResponse`. (results)
             #
-            #     The input source of this method is a csv file on Google Cloud Storage.
-            #     For the format of the csv file please see
-            #     [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload import_product_sets(parent: nil, input_config: nil, options: nil)
-            #   @param parent [String]
-            #     The project in which the ProductSets should be imported.
-            #
-            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   @param input_config [Google::Cloud::Vision::V1::ImportProductSetsInputConfig | Hash]
-            #     The input content for the list of requests.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   The input source of this method is a csv file on Google Cloud Storage.
+            #   For the format of the csv file please see
+            #   [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -1655,13 +1349,9 @@ module Google
             # @example
             #   TODO
             #
-            def import_product_sets request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def import_product_sets request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ImportProductSetsRequest
 
               # Converts hash and nil to an options object

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -129,6 +129,20 @@ module Google
             #
             #   * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
             #     4096 characters.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     The project in which the ProductSet should be created.
+            #
+            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
+            #   * `product_set` (`Google::Cloud::Vision::V1::ProductSet | Hash`):
+            #     The ProductSet to create.
+            #   * `product_set_id` (`String`):
+            #     A user-supplied resource id for this ProductSet. If set, the server will
+            #     attempt to use this value as the resource id. If it is already in use, an
+            #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
+            #     long. It cannot contain the character `/`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -195,6 +209,17 @@ module Google
             #
             #   * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
             #     than 1.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     The project from which ProductSets should be listed.
+            #
+            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
+            #   * `page_size` (`Integer`):
+            #     The maximum number of items to return. Default 10, maximum 100.
+            #   * `page_token` (`String`):
+            #     The next_page_token returned from a previous List request, if any.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -260,6 +285,14 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the ProductSet does not exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     Resource name of the ProductSet to get.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -330,6 +363,16 @@ module Google
             #   * Returns NOT_FOUND if the ProductSet does not exist.
             #   * Returns INVALID_ARGUMENT if display_name is present in update_mask but
             #     missing from the request or longer than 4096 characters.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `product_set` (`Google::Cloud::Vision::V1::ProductSet | Hash`):
+            #     The ProductSet resource which replaces the one on the server.
+            #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+            #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields to
+            #     update.
+            #     If update_mask isn't specified, all mutable fields are to be updated.
+            #     Valid mask path is `display_name`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -400,6 +443,14 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the ProductSet does not exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     Resource name of the ProductSet to delete.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -470,6 +521,21 @@ module Google
             #     characters.
             #   * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
             #   * Returns INVALID_ARGUMENT if product_category is missing or invalid.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     The project in which the Product should be created.
+            #
+            #     Format is
+            #     `projects/PROJECT_ID/locations/LOC_ID`.
+            #   * `product` (`Google::Cloud::Vision::V1::Product | Hash`):
+            #     The product to create.
+            #   * `product_id` (`String`):
+            #     A user-supplied resource id for this Product. If set, the server will
+            #     attempt to use this value as the resource id. If it is already in use, an
+            #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
+            #     long. It cannot contain the character `/`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -534,6 +600,18 @@ module Google
             #   Possible errors:
             #
             #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     The project OR ProductSet from which Products should be listed.
+            #
+            #     Format:
+            #     `projects/PROJECT_ID/locations/LOC_ID`
+            #   * `page_size` (`Integer`):
+            #     The maximum number of items to return. Default 10, maximum 100.
+            #   * `page_token` (`String`):
+            #     The next_page_token returned from a previous List request, if any.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -599,6 +677,14 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the Product does not exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     Resource name of the Product to get.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -683,6 +769,18 @@ module Google
             #   * Returns INVALID_ARGUMENT if description is present in update_mask but is
             #     longer than 4096 characters.
             #   * Returns INVALID_ARGUMENT if product_category is present in update_mask.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `product` (`Google::Cloud::Vision::V1::Product | Hash`):
+            #     The Product resource which replaces the one on the server.
+            #     product.name is immutable.
+            #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+            #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields
+            #     to update.
+            #     If update_mask isn't specified, all mutable fields are to be updated.
+            #     Valid mask paths include `product_labels`, `display_name`, and
+            #     `description`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -755,6 +853,14 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the product does not exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     Resource name of product to delete.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -847,6 +953,22 @@ module Google
             #   * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
             #     compatible with the parent product's product_category is detected.
             #   * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     Resource name of the product in which to create the reference image.
+            #
+            #     Format is
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
+            #   * `reference_image` (`Google::Cloud::Vision::V1::ReferenceImage | Hash`):
+            #     The reference image to create.
+            #     If an image ID is specified, it is ignored.
+            #   * `reference_image_id` (`String`):
+            #     A user-supplied resource id for the ReferenceImage to be added. If set,
+            #     the server will attempt to use this value as the resource id. If it is
+            #     already in use, an error is returned with code ALREADY_EXISTS. Must be at
+            #     most 128 characters long. It cannot contain the character `/`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -923,6 +1045,15 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the reference image does not exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The resource name of the reference image to delete.
+            #
+            #     Format is:
+            #
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -991,6 +1122,21 @@ module Google
             #   * Returns NOT_FOUND if the parent product does not exist.
             #   * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
             #     than 1.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     Resource name of the product containing the reference images.
+            #
+            #     Format is
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
+            #   * `page_size` (`Integer`):
+            #     The maximum number of items to return. Default 10, maximum 100.
+            #   * `page_token` (`String`):
+            #     A token identifying a page of results to be returned. This is the value
+            #     of `nextPageToken` returned in a previous reference image list request.
+            #
+            #     Defaults to the first page if not specified.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -1056,6 +1202,15 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the specified image does not exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The resource name of the ReferenceImage to get.
+            #
+            #     Format is:
+            #
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -1126,6 +1281,19 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The resource name for the ProductSet to modify.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+            #   * `product` (`String`):
+            #     The resource name for the Product to be added to this ProductSet.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -1190,6 +1358,19 @@ module Google
             #   Possible errors:
             #
             #   * Returns NOT_FOUND If the Product is not found under the ProductSet.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The resource name for the ProductSet to modify.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+            #   * `product` (`String`):
+            #     The resource name for the Product to be removed from this ProductSet.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -1258,6 +1439,18 @@ module Google
             #   Possible errors:
             #
             #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The ProductSet resource for which to retrieve Products.
+            #
+            #     Format is:
+            #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
+            #   * `page_size` (`Integer`):
+            #     The maximum number of items to return. Default 10, maximum 100.
+            #   * `page_token` (`String`):
+            #     The next_page_token returned from a previous List request, if any.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -1335,6 +1528,15 @@ module Google
             #   The input source of this method is a csv file on Google Cloud Storage.
             #   For the format of the csv file please see
             #   [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `parent` (`String`):
+            #     The project in which the ProductSets should be imported.
+            #
+            #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
+            #   * `input_config` (`Google::Cloud::Vision::V1::ImportProductSetsInputConfig | Hash`):
+            #     The input content for the list of requests.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -122,7 +122,7 @@ module Google
             #   NOTE: the `name` binding below allows API services to override the binding
             #   to use different resource name schemes, such as `users/*/operations`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -184,7 +184,7 @@ module Google
             #   method to poll the operation result at intervals as recommended by the API
             #   service.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -247,7 +247,7 @@ module Google
             #   operation. If the server doesn't support this method, it returns
             #   `google.rpc.Code.UNIMPLEMENTED`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -321,7 +321,7 @@ module Google
             #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             #   corresponding to `Code.CANCELLED`.
             # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -121,6 +121,17 @@ module Google
             #
             #   NOTE: the `name` binding below allows API services to override the binding
             #   to use different resource name schemes, such as `users/*/operations`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation collection.
+            #   * `filter` (`String`):
+            #     The standard list filter.
+            #   * `page_size` (`Integer`):
+            #     The standard list page size.
+            #   * `page_token` (`String`):
+            #     The standard list page token.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -183,6 +194,11 @@ module Google
             #   Gets the latest state of a long-running operation.  Clients can use this
             #   method to poll the operation result at intervals as recommended by the API
             #   service.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -246,6 +262,11 @@ module Google
             #   no longer interested in the operation result. It does not cancel the
             #   operation. If the server doesn't support this method, it returns
             #   `google.rpc.Code.UNIMPLEMENTED`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource to be deleted.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -320,6 +341,11 @@ module Google
             #   the operation is not deleted; instead, it becomes an operation with
             #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             #   corresponding to `Code.CANCELLED`.
+            #
+            #   When using a hash, the following fields are supported:
+            #
+            #   * `name` (`String`):
+            #     The name of the operation resource to be cancelled.
             # @param options [Google::Gax::ApiCall::Options, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -115,27 +115,14 @@ module Google
             # NOTE: the `name` binding below allows API services to override the binding
             # to use different resource name schemes, such as `users/*/operations`.
             #
-            # @overload list_operations(request, options: nil)
-            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #     Lists operations that match the specified filter in the request. If the
-            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+            # @param request [Google::Longrunning::ListOperationsRequest | Hash]
+            #   Lists operations that match the specified filter in the request. If the
+            #   server doesn't support this method, it returns `UNIMPLEMENTED`.
             #
-            #     NOTE: the `name` binding below allows API services to override the binding
-            #     to use different resource name schemes, such as `users/*/operations`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation collection.
-            #   @param filter [String]
-            #     The standard list filter.
-            #   @param page_size [Integer]
-            #     The standard list page size.
-            #   @param page_token [String]
-            #     The standard list page token.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            #   NOTE: the `name` binding below allows API services to override the binding
+            #   to use different resource name schemes, such as `users/*/operations`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -148,13 +135,9 @@ module Google
             # @example
             #   TODO
             #
-            def list_operations request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def list_operations request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
@@ -196,19 +179,12 @@ module Google
             # method to poll the operation result at intervals as recommended by the API
             # service.
             #
-            # @overload get_operation(request, options: nil)
-            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #     Gets the latest state of a long-running operation.  Clients can use this
-            #     method to poll the operation result at intervals as recommended by the API
-            #     service.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload get_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::GetOperationRequest | Hash]
+            #   Gets the latest state of a long-running operation.  Clients can use this
+            #   method to poll the operation result at intervals as recommended by the API
+            #   service.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -221,13 +197,9 @@ module Google
             # @example
             #   TODO
             #
-            def get_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def get_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
@@ -269,20 +241,13 @@ module Google
             # operation. If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
-            # @overload delete_operation(request, options: nil)
-            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #     Deletes a long-running operation. This method indicates that the client is
-            #     no longer interested in the operation result. It does not cancel the
-            #     operation. If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload delete_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource to be deleted.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+            #   Deletes a long-running operation. This method indicates that the client is
+            #   no longer interested in the operation result. It does not cancel the
+            #   operation. If the server doesn't support this method, it returns
+            #   `google.rpc.Code.UNIMPLEMENTED`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -295,13 +260,9 @@ module Google
             # @example
             #   TODO
             #
-            def delete_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def delete_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
@@ -348,26 +309,19 @@ module Google
             # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             # corresponding to `Code.CANCELLED`.
             #
-            # @overload cancel_operation(request, options: nil)
-            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #     Starts asynchronous cancellation on a long-running operation.  The server
-            #     makes a best effort to cancel the operation, but success is not
-            #     guaranteed.  If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-            #     other methods to check whether the cancellation succeeded or whether the
-            #     operation completed despite cancellation. On successful cancellation,
-            #     the operation is not deleted; instead, it becomes an operation with
-            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-            #     corresponding to `Code.CANCELLED`.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
-            #
-            # @overload cancel_operation(name: nil, options: nil)
-            #   @param name [String]
-            #     The name of the operation resource to be cancelled.
-            #   @param options [Google::Gax::ApiCall::Options, Hash]
-            #     Overrides the default settings for this call, e.g, timeout, retries, etc.
+            # @param request [Google::Longrunning::CancelOperationRequest | Hash]
+            #   Starts asynchronous cancellation on a long-running operation.  The server
+            #   makes a best effort to cancel the operation, but success is not
+            #   guaranteed.  If the server doesn't support this method, it returns
+            #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+            #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #   other methods to check whether the cancellation succeeded or whether the
+            #   operation completed despite cancellation. On successful cancellation,
+            #   the operation is not deleted; instead, it becomes an operation with
+            #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #   corresponding to `Code.CANCELLED`.
+            # @param options [Google::Gax::ApiCall::Options, Hash]
+            #   Overrides the default settings for this call, e.g, timeout, retries, etc.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -380,13 +334,9 @@ module Google
             # @example
             #   TODO
             #
-            def cancel_operation request = nil, options: nil, **request_fields, &block
-              raise ArgumentError, "request must be provided" if request.nil? && request_fields.empty?
-              if !request.nil? && !request_fields.empty?
-                raise ArgumentError, "cannot pass both request object and named arguments"
-              end
+            def cancel_operation request, options = nil, &block
+              raise ArgumentError, "request must be provided" if request.nil?
 
-              request ||= request_fields
               request = Google::Gax::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object


### PR DESCRIPTION
This PR changes the Client RPC methods to use positional arguments instead of the mixed positional/named arguments. This is needed to work around Protobuf [adding the `#to_hash` method to the resource classes](https://github.com/protocolbuffers/protobuf/pull/6166).

This PR is dependent on googleapis/gax-ruby#208.