### PR TITLE
 Use Gax header helper

### DIFF
--- a/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
@@ -5,12 +5,9 @@ options = Google::Gax::ApiCall::Options.new options.to_h if options.respond_to? 
 # Customize the options with defaults
 metadata = @config.rpcs.<%= method.name %>.metadata.to_h
 
-x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-x_goog_api_client_header << "gapic/#{<%= method.service.gem.version_name_full %>}"
-x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join(" ")
+# Set x-goog-api-client header
+metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+  lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "<%= method.service.gem.version_name_full %>"
 <%- if method.routing_params? -%>
 
 header_params = {

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,7 +6,7 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "googleapis/gax-ruby"
+gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/headers"
 gem "grpc-tools", "~> 1.18"
 gem "minitest", "~> 5.0"
 gem "minitest-autotest", "~> 1.0"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -6,7 +6,7 @@ gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
 gem "googleapis-common-protos", [">= 1.3.9", "< 2.0"]
 gem "googleapis-common-protos-types", [">= 1.0.4", "< 2.0"]
-gem "google-gax", github: "blowmage/gax-ruby", branch: "2.0/headers"
+gem "google-gax", github: "googleapis/gax-ruby"
 gem "grpc-tools", "~> 1.18"
 gem "minitest", "~> 5.0"
 gem "minitest-autotest", "~> 1.0"

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -142,12 +142,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.echo.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.echo.timeout,
                                    metadata:     metadata,
@@ -198,12 +195,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.expand.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.expand.timeout,
                                    metadata:     metadata,
@@ -255,12 +249,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.collect.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.collect.timeout,
                                    metadata:     metadata,
@@ -312,12 +303,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.chat.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.chat.timeout,
                                    metadata:     metadata,
@@ -370,12 +358,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.paged_expand.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.paged_expand.timeout,
                                    metadata:     metadata,
@@ -433,12 +418,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.wait.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.wait.timeout,
                                    metadata:     metadata,

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -148,12 +148,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_operations.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -213,12 +210,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_operation.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -279,12 +273,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_operation.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -355,12 +346,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -139,12 +139,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.create_user.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.create_user.timeout,
                                    metadata:     metadata,
@@ -191,12 +188,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_user.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -252,12 +246,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.update_user.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "user.name" => request.user.name
@@ -310,12 +301,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_user.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -373,12 +361,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_users.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.list_users.timeout,
                                    metadata:     metadata,

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -143,12 +143,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.create_room.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.create_room.timeout,
                                    metadata:     metadata,
@@ -195,12 +192,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_room.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -256,12 +250,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.update_room.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "room.name" => request.room.name
@@ -314,12 +305,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_room.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -377,12 +365,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_rooms.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.list_rooms.timeout,
                                    metadata:     metadata,
@@ -438,12 +423,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.create_blurb.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "parent" => request.parent
@@ -496,12 +478,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_blurb.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -557,12 +536,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.update_blurb.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "blurb.name" => request.blurb.name
@@ -615,12 +591,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_blurb.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -683,12 +656,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_blurbs.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "parent" => request.parent
@@ -760,12 +730,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.search_blurbs.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "parent" => request.parent
@@ -824,12 +791,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.stream_blurbs.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -886,12 +850,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.send_blurbs.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "parent" => request.parent
@@ -950,12 +911,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.connect.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.connect.timeout,
                                    metadata:     metadata,

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -148,12 +148,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_operations.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -213,12 +210,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_operation.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -279,12 +273,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_operation.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -355,12 +346,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -141,12 +141,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.create_session.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.create_session.timeout,
                                    metadata:     metadata,
@@ -193,12 +190,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_session.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -253,12 +247,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_sessions.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.list_sessions.timeout,
                                    metadata:     metadata,
@@ -307,12 +298,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_session.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -369,12 +357,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.report_session.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -431,12 +416,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_tests.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -501,12 +483,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_test.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -569,12 +548,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.verify_test.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -146,12 +146,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.recognize.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               options.apply_defaults timeout:      @config.rpcs.recognize.timeout,
                                      metadata:     metadata,
@@ -207,12 +204,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.long_running_recognize.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               options.apply_defaults timeout:      @config.rpcs.long_running_recognize.timeout,
                                      metadata:     metadata,
@@ -265,12 +259,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.streaming_recognize.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               options.apply_defaults timeout:      @config.rpcs.streaming_recognize.timeout,
                                      metadata:     metadata,

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -149,12 +149,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_operations.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -214,12 +211,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -280,12 +274,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -356,12 +347,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               header_params = {
                 "name" => request.name

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -141,12 +141,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.batch_annotate_images.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               options.apply_defaults timeout:      @config.rpcs.batch_annotate_images.timeout,
                                      metadata:     metadata,
@@ -203,12 +200,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.async_batch_annotate_files.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               options.apply_defaults timeout:      @config.rpcs.async_batch_annotate_files.timeout,
                                      metadata:     metadata,

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -149,12 +149,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_operations.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -214,12 +211,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -280,12 +274,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -356,12 +347,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -160,12 +160,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.create_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent
@@ -234,12 +231,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_product_sets.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent
@@ -305,12 +299,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -382,12 +373,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.update_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "product_set.name" => request.product_set.name
@@ -457,12 +445,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -539,12 +524,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.create_product.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent
@@ -612,12 +594,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_products.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent
@@ -683,12 +662,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_product.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -776,12 +752,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.update_product.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "product.name" => request.product.name
@@ -853,12 +826,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_product.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -958,12 +928,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.create_reference_image.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent
@@ -1040,12 +1007,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_reference_image.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -1120,12 +1084,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_reference_images.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent
@@ -1192,12 +1153,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_reference_image.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -1272,12 +1230,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.add_product_to_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -1346,12 +1301,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.remove_product_from_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -1423,12 +1375,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_products_in_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -1507,12 +1456,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.import_product_sets.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -149,12 +149,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_operations.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -214,12 +211,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -280,12 +274,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -356,12 +347,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name

--- a/shared/output/gapic/templates/googleads/lib/google/ads/googleads/v1/services/campaign_service/client.rb
+++ b/shared/output/gapic/templates/googleads/lib/google/ads/googleads/v1/services/campaign_service/client.rb
@@ -146,12 +146,9 @@ module Google
                 # Customize the options with defaults
                 metadata = @config.rpcs.get_campaign.metadata.to_h
 
-                x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-                x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-                x_goog_api_client_header << "gapic/#{Google::Ads::GoogleAds::VERSION}"
-                x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-                x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-                metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+                # Set x-goog-api-client header
+                metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                  lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Ads::GoogleAds::VERSION"
 
                 header_params = {
                   "resource_name" => request.resource_name
@@ -214,12 +211,9 @@ module Google
                 # Customize the options with defaults
                 metadata = @config.rpcs.mutate_campaigns.metadata.to_h
 
-                x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-                x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-                x_goog_api_client_header << "gapic/#{Google::Ads::GoogleAds::VERSION}"
-                x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-                x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-                metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+                # Set x-goog-api-client header
+                metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                  lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Ads::GoogleAds::VERSION"
 
                 header_params = {
                   "customer_id" => request.customer_id

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -150,12 +150,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.echo.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.echo.timeout,
                                    metadata:     metadata,
@@ -206,12 +203,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.expand.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.expand.timeout,
                                    metadata:     metadata,
@@ -263,12 +257,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.collect.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.collect.timeout,
                                    metadata:     metadata,
@@ -320,12 +311,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.chat.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.chat.timeout,
                                    metadata:     metadata,
@@ -378,12 +366,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.paged_expand.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.paged_expand.timeout,
                                    metadata:     metadata,
@@ -441,12 +426,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.wait.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.wait.timeout,
                                    metadata:     metadata,

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -156,12 +156,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_operations.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -221,12 +218,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_operation.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -287,12 +281,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_operation.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -363,12 +354,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -147,12 +147,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.create_user.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.create_user.timeout,
                                    metadata:     metadata,
@@ -199,12 +196,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_user.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -260,12 +254,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.update_user.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "user.name" => request.user.name
@@ -318,12 +309,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_user.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -381,12 +369,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_users.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.list_users.timeout,
                                    metadata:     metadata,

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -151,12 +151,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.create_room.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.create_room.timeout,
                                    metadata:     metadata,
@@ -203,12 +200,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_room.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -264,12 +258,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.update_room.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "room.name" => request.room.name
@@ -322,12 +313,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_room.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -385,12 +373,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_rooms.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.list_rooms.timeout,
                                    metadata:     metadata,
@@ -446,12 +431,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.create_blurb.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "parent" => request.parent
@@ -504,12 +486,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_blurb.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -565,12 +544,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.update_blurb.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "blurb.name" => request.blurb.name
@@ -623,12 +599,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_blurb.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -691,12 +664,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_blurbs.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "parent" => request.parent
@@ -768,12 +738,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.search_blurbs.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "parent" => request.parent
@@ -832,12 +799,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.stream_blurbs.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -894,12 +858,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.send_blurbs.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "parent" => request.parent
@@ -958,12 +919,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.connect.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.connect.timeout,
                                    metadata:     metadata,

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -156,12 +156,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_operations.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -221,12 +218,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_operation.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -287,12 +281,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_operation.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -363,12 +354,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -149,12 +149,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.create_session.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.create_session.timeout,
                                    metadata:     metadata,
@@ -201,12 +198,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_session.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -261,12 +255,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_sessions.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             options.apply_defaults timeout:      @config.rpcs.list_sessions.timeout,
                                    metadata:     metadata,
@@ -315,12 +306,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_session.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -377,12 +365,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.report_session.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -439,12 +424,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_tests.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -509,12 +491,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_test.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name
@@ -577,12 +556,9 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.verify_test.metadata.to_h
 
-            x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-            x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-            x_goog_api_client_header << "gapic/#{Google::Showcase::VERSION}"
-            x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-            x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-            metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+            # Set x-goog-api-client header
+            metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+              lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Showcase::VERSION"
 
             header_params = {
               "name" => request.name

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -154,12 +154,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.recognize.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               options.apply_defaults timeout:      @config.rpcs.recognize.timeout,
                                      metadata:     metadata,
@@ -215,12 +212,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.long_running_recognize.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               options.apply_defaults timeout:      @config.rpcs.long_running_recognize.timeout,
                                      metadata:     metadata,
@@ -273,12 +267,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.streaming_recognize.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               options.apply_defaults timeout:      @config.rpcs.streaming_recognize.timeout,
                                      metadata:     metadata,

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -157,12 +157,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_operations.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -222,12 +219,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -288,12 +282,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -364,12 +355,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Speech::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Speech::VERSION"
 
               header_params = {
                 "name" => request.name

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -149,12 +149,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.batch_annotate_images.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               options.apply_defaults timeout:      @config.rpcs.batch_annotate_images.timeout,
                                      metadata:     metadata,
@@ -211,12 +208,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.async_batch_annotate_files.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               options.apply_defaults timeout:      @config.rpcs.async_batch_annotate_files.timeout,
                                      metadata:     metadata,

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -157,12 +157,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_operations.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -222,12 +219,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -288,12 +282,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -364,12 +355,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -168,12 +168,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.create_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent
@@ -242,12 +239,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_product_sets.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent
@@ -313,12 +307,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -390,12 +381,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.update_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "product_set.name" => request.product_set.name
@@ -465,12 +453,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -547,12 +532,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.create_product.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent
@@ -620,12 +602,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_products.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent
@@ -691,12 +670,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_product.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -784,12 +760,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.update_product.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "product.name" => request.product.name
@@ -861,12 +834,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_product.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -966,12 +936,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.create_reference_image.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent
@@ -1048,12 +1015,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_reference_image.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -1128,12 +1092,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_reference_images.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent
@@ -1200,12 +1161,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_reference_image.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -1280,12 +1238,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.add_product_to_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -1354,12 +1309,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.remove_product_from_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -1431,12 +1383,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_products_in_product_set.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -1515,12 +1464,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.import_product_sets.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "parent" => request.parent

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -157,12 +157,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_operations.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -222,12 +219,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -288,12 +282,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name
@@ -364,12 +355,9 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-              x_goog_api_client_header = ["gl-ruby/#{RUBY_VERSION}"]
-              x_goog_api_client_header << "#{@config.lib_name}/#{@config.lib_version}" if @config.lib_name
-              x_goog_api_client_header << "gapic/#{Google::Cloud::Vision::VERSION}"
-              x_goog_api_client_header << "gax/#{Google::Gax::VERSION}"
-              x_goog_api_client_header << "grpc/#{GRPC::VERSION}"
-              metadata[:"x-goog-api-client"] ||= x_goog_api_client_header.join " "
+              # Set x-goog-api-client header
+              metadata[:"x-goog-api-client"] ||= Google::Gax::Headers.x_goog_api_client \
+                lib_name: @config.lib_name, lib_version: @config.lib_version, gapic_version: "Google::Cloud::Vision::VERSION"
 
               header_params = {
                 "name" => request.name


### PR DESCRIPTION
Move this common code to Gax so the GAPIC client can do less. This is dependent on googleapis/gax-ruby#210.