### PR TITLE
Restore named argument documentation

### DIFF
--- a/gapic-generator/templates/default/service/client/method/docs/_request_normal.erb
+++ b/gapic-generator/templates/default/service/client/method/docs/_request_normal.erb
@@ -1,14 +1,18 @@
 <%- assert_locals method -%>
-# @param request [<%= method.request_type %> | Hash]
+# @overload <%= method.name %>(request, options = nil)
+#   @param request [<%= method.request_type %> | Hash]
 <%- if method.doc_description -%>
-<%= indent method.doc_description, "#   " %>
+<%= indent method.doc_description, "#     " %>
 <%- end -%>
+#   @param options [Google::Gax::ApiCall::Options, Hash]
+#     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
 #
-#   When using a hash, the following fields are supported:
-#
+<%- arg_list = method.arguments.map { |arg| "#{arg.name}: nil"}.join ", " -%>
+# @overload <%= method.name %>(<%= arg_list %>)
 <%- method.arguments.each do |arg| -%>
-#   * `<%= arg.name %>` (`<%= arg.doc_types %>`)<%- if arg.doc_description -%>:
+#   @param <%= arg.name %> [<%= arg.doc_types %>]
+<%- if arg.doc_description -%>
 <%= indent arg.doc_description, "#     " %>
 <%- end -%>
-<%- end -%># @param options [Google::Gax::ApiCall::Options, Hash]
-#   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+<%- end -%>
+#

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -108,17 +108,18 @@ module Google
           ##
           # This method simply echos the request. This method is showcases unary rpcs.
           #
-          # @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
-          #   This method simply echos the request. This method is showcases unary rpcs.
+          # @overload echo(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
+          #     This method simply echos the request. This method is showcases unary rpcs.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `content` (`String`):
+          # @overload echo(content: nil, error: nil)
+          #   @param content [String]
           #     The content to be echoed by the server.
-          #   * `error` (`Google::Rpc::Status | Hash`):
+          #   @param error [Google::Rpc::Status | Hash]
           #     The error to be thrown by the server.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
@@ -161,18 +162,19 @@ module Google
           # This method split the given content into words and will pass each word back
           # through the stream. This method showcases server-side streaming rpcs.
           #
-          # @param request [Google::Showcase::V1alpha3::ExpandRequest | Hash]
-          #   This method split the given content into words and will pass each word back
-          #   through the stream. This method showcases server-side streaming rpcs.
+          # @overload expand(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ExpandRequest | Hash]
+          #     This method split the given content into words and will pass each word back
+          #     through the stream. This method showcases server-side streaming rpcs.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `content` (`String`):
+          # @overload expand(content: nil, error: nil)
+          #   @param content [String]
           #     The content that will be split into words and returned on the stream.
-          #   * `error` (`Google::Rpc::Status | Hash`):
+          #   @param error [Google::Rpc::Status | Hash]
           #     The error that is thrown after all words are sent on the stream.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -325,20 +327,21 @@ module Google
           # This is similar to the Expand method but instead of returning a stream of
           # expanded words, this method returns a paged list of expanded words.
           #
-          # @param request [Google::Showcase::V1alpha3::PagedExpandRequest | Hash]
-          #   This is similar to the Expand method but instead of returning a stream of
-          #   expanded words, this method returns a paged list of expanded words.
+          # @overload paged_expand(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::PagedExpandRequest | Hash]
+          #     This is similar to the Expand method but instead of returning a stream of
+          #     expanded words, this method returns a paged list of expanded words.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `content` (`String`):
+          # @overload paged_expand(content: nil, page_size: nil, page_token: nil)
+          #   @param content [String]
           #     The string to expand.
-          #   * `page_size` (`Integer`):
+          #   @param page_size [Integer]
           #     The amount of words to returned in each page.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The position of the page to be returned.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -383,23 +386,24 @@ module Google
           # This method will wait the requested amount of and then return.
           # This method showcases how a client handles a request timing out.
           #
-          # @param request [Google::Showcase::V1alpha3::WaitRequest | Hash]
-          #   This method will wait the requested amount of and then return.
-          #   This method showcases how a client handles a request timing out.
+          # @overload wait(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::WaitRequest | Hash]
+          #     This method will wait the requested amount of and then return.
+          #     This method showcases how a client handles a request timing out.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `end_time` (`Google::Protobuf::Timestamp | Hash`):
+          # @overload wait(end_time: nil, ttl: nil, error: nil, success: nil)
+          #   @param end_time [Google::Protobuf::Timestamp | Hash]
           #     The time that this operation will complete.
-          #   * `ttl` (`Google::Protobuf::Duration | Hash`):
+          #   @param ttl [Google::Protobuf::Duration | Hash]
           #     The duration of this operation.
-          #   * `error` (`Google::Rpc::Status | Hash`):
+          #   @param error [Google::Rpc::Status | Hash]
           #     The error that will be returned by the server. If this code is specified
           #     to be the OK rpc code, an empty response will be returned.
-          #   * `success` (`Google::Showcase::V1alpha3::WaitResponse | Hash`):
+          #   @param success [Google::Showcase::V1alpha3::WaitResponse | Hash]
           #     The response to be returned on operation completion.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -106,25 +106,26 @@ module Google
           # NOTE: the `name` binding below allows API services to override the binding
           # to use different resource name schemes, such as `users/*/operations`.
           #
-          # @param request [Google::Longrunning::ListOperationsRequest | Hash]
-          #   Lists operations that match the specified filter in the request. If the
-          #   server doesn't support this method, it returns `UNIMPLEMENTED`.
+          # @overload list_operations(request, options = nil)
+          #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
+          #     Lists operations that match the specified filter in the request. If the
+          #     server doesn't support this method, it returns `UNIMPLEMENTED`.
           #
-          #   NOTE: the `name` binding below allows API services to override the binding
-          #   to use different resource name schemes, such as `users/*/operations`.
+          #     NOTE: the `name` binding below allows API services to override the binding
+          #     to use different resource name schemes, such as `users/*/operations`.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+          #   @param name [String]
           #     The name of the operation collection.
-          #   * `filter` (`String`):
+          #   @param filter [String]
           #     The standard list filter.
-          #   * `page_size` (`Integer`):
+          #   @param page_size [Integer]
           #     The standard list page size.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The standard list page token.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -177,17 +178,18 @@ module Google
           # method to poll the operation result at intervals as recommended by the API
           # service.
           #
-          # @param request [Google::Longrunning::GetOperationRequest | Hash]
-          #   Gets the latest state of a long-running operation.  Clients can use this
-          #   method to poll the operation result at intervals as recommended by the API
-          #   service.
+          # @overload get_operation(request, options = nil)
+          #   @param request [Google::Longrunning::GetOperationRequest | Hash]
+          #     Gets the latest state of a long-running operation.  Clients can use this
+          #     method to poll the operation result at intervals as recommended by the API
+          #     service.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload get_operation(name: nil)
+          #   @param name [String]
           #     The name of the operation resource.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -240,18 +242,19 @@ module Google
           # operation. If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.
           #
-          # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-          #   Deletes a long-running operation. This method indicates that the client is
-          #   no longer interested in the operation result. It does not cancel the
-          #   operation. If the server doesn't support this method, it returns
-          #   `google.rpc.Code.UNIMPLEMENTED`.
+          # @overload delete_operation(request, options = nil)
+          #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+          #     Deletes a long-running operation. This method indicates that the client is
+          #     no longer interested in the operation result. It does not cancel the
+          #     operation. If the server doesn't support this method, it returns
+          #     `google.rpc.Code.UNIMPLEMENTED`.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_operation(name: nil)
+          #   @param name [String]
           #     The name of the operation resource to be deleted.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -308,24 +311,25 @@ module Google
           # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           # corresponding to `Code.CANCELLED`.
           #
-          # @param request [Google::Longrunning::CancelOperationRequest | Hash]
-          #   Starts asynchronous cancellation on a long-running operation.  The server
-          #   makes a best effort to cancel the operation, but success is not
-          #   guaranteed.  If the server doesn't support this method, it returns
-          #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-          #   other methods to check whether the cancellation succeeded or whether the
-          #   operation completed despite cancellation. On successful cancellation,
-          #   the operation is not deleted; instead, it becomes an operation with
-          #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-          #   corresponding to `Code.CANCELLED`.
+          # @overload cancel_operation(request, options = nil)
+          #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
+          #     Starts asynchronous cancellation on a long-running operation.  The server
+          #     makes a best effort to cancel the operation, but success is not
+          #     guaranteed.  If the server doesn't support this method, it returns
+          #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+          #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          #     other methods to check whether the cancellation succeeded or whether the
+          #     operation completed despite cancellation. On successful cancellation,
+          #     the operation is not deleted; instead, it becomes an operation with
+          #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          #     corresponding to `Code.CANCELLED`.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload cancel_operation(name: nil)
+          #   @param name [String]
           #     The name of the operation resource to be cancelled.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -107,15 +107,16 @@ module Google
           ##
           # Creates a user.
           #
-          # @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
-          #   Creates a user.
+          # @overload create_user(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
+          #     Creates a user.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `user` (`Google::Showcase::V1alpha3::User | Hash`):
+          # @overload create_user(user: nil)
+          #   @param user [Google::Showcase::V1alpha3::User | Hash]
           #     The user to create.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -157,15 +158,16 @@ module Google
           ##
           # Retrieves the User with the given uri.
           #
-          # @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
-          #   Retrieves the User with the given uri.
+          # @overload get_user(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
+          #     Retrieves the User with the given uri.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload get_user(name: nil)
+          #   @param name [String]
           #     The resource name of the requested user.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -213,18 +215,19 @@ module Google
           ##
           # Updates a user.
           #
-          # @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
-          #   Updates a user.
+          # @overload update_user(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
+          #     Updates a user.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `user` (`Google::Showcase::V1alpha3::User | Hash`):
+          # @overload update_user(user: nil, update_mask: nil)
+          #   @param user [Google::Showcase::V1alpha3::User | Hash]
           #     The user to update.
-          #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -272,15 +275,16 @@ module Google
           ##
           # Deletes a user, their profile, and all of their authored messages.
           #
-          # @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
-          #   Deletes a user, their profile, and all of their authored messages.
+          # @overload delete_user(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
+          #     Deletes a user, their profile, and all of their authored messages.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_user(name: nil)
+          #   @param name [String]
           #     The resource name of the user to delete.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -328,20 +332,21 @@ module Google
           ##
           # Lists all users.
           #
-          # @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
-          #   Lists all users.
+          # @overload list_users(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
+          #     Lists all users.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `page_size` (`Integer`):
+          # @overload list_users(page_size: nil, page_token: nil)
+          #   @param page_size [Integer]
           #     The maximum number of users to return. Server may return fewer users
           #     than requested. If unspecified, server will pick an appropriate default.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The value of google.showcase.v1alpha3.ListUsersResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Identity\ListUsers` method.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::User>]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -111,15 +111,16 @@ module Google
           ##
           # Creates a room.
           #
-          # @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
-          #   Creates a room.
+          # @overload create_room(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
+          #     Creates a room.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `room` (`Google::Showcase::V1alpha3::Room | Hash`):
+          # @overload create_room(room: nil)
+          #   @param room [Google::Showcase::V1alpha3::Room | Hash]
           #     The room to create.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -161,15 +162,16 @@ module Google
           ##
           # Retrieves the Room with the given resource name.
           #
-          # @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
-          #   Retrieves the Room with the given resource name.
+          # @overload get_room(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
+          #     Retrieves the Room with the given resource name.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload get_room(name: nil)
+          #   @param name [String]
           #     The resource name of the requested room.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -217,18 +219,19 @@ module Google
           ##
           # Updates a room.
           #
-          # @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
-          #   Updates a room.
+          # @overload update_room(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
+          #     Updates a room.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `room` (`Google::Showcase::V1alpha3::Room | Hash`):
+          # @overload update_room(room: nil, update_mask: nil)
+          #   @param room [Google::Showcase::V1alpha3::Room | Hash]
           #     The room to update.
-          #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -276,15 +279,16 @@ module Google
           ##
           # Deletes a room and all of its blurbs.
           #
-          # @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
-          #   Deletes a room and all of its blurbs.
+          # @overload delete_room(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
+          #     Deletes a room and all of its blurbs.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_room(name: nil)
+          #   @param name [String]
           #     The resource name of the requested room.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -332,20 +336,21 @@ module Google
           ##
           # Lists all chat rooms.
           #
-          # @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
-          #   Lists all chat rooms.
+          # @overload list_rooms(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
+          #     Lists all chat rooms.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `page_size` (`Integer`):
+          # @overload list_rooms(page_size: nil, page_token: nil)
+          #   @param page_size [Integer]
           #     The maximum number of rooms return. Server may return fewer rooms
           #     than requested. If unspecified, server will pick an appropriate default.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The value of google.showcase.v1alpha3.ListRoomsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\ListRooms` method.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Room>]
@@ -391,20 +396,21 @@ module Google
           # message in that room. If the parent is a profile, the blurb is understood
           # to be a post on the profile.
           #
-          # @param request [Google::Showcase::V1alpha3::CreateBlurbRequest | Hash]
-          #   Creates a blurb. If the parent is a room, the blurb is understood to be a
-          #   message in that room. If the parent is a profile, the blurb is understood
-          #   to be a post on the profile.
+          # @overload create_blurb(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::CreateBlurbRequest | Hash]
+          #     Creates a blurb. If the parent is a room, the blurb is understood to be a
+          #     message in that room. If the parent is a profile, the blurb is understood
+          #     to be a post on the profile.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `parent` (`String`):
+          # @overload create_blurb(parent: nil, blurb: nil)
+          #   @param parent [String]
           #     The resource name of the chat room or user profile that this blurb will
           #     be tied to.
-          #   * `blurb` (`Google::Showcase::V1alpha3::Blurb | Hash`):
+          #   @param blurb [Google::Showcase::V1alpha3::Blurb | Hash]
           #     The blurb to create.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -452,15 +458,16 @@ module Google
           ##
           # Retrieves the Blurb with the given resource name.
           #
-          # @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
-          #   Retrieves the Blurb with the given resource name.
+          # @overload get_blurb(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
+          #     Retrieves the Blurb with the given resource name.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload get_blurb(name: nil)
+          #   @param name [String]
           #     The resource name of the requested blurb.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -508,18 +515,19 @@ module Google
           ##
           # Updates a blurb.
           #
-          # @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
-          #   Updates a blurb.
+          # @overload update_blurb(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
+          #     Updates a blurb.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `blurb` (`Google::Showcase::V1alpha3::Blurb | Hash`):
+          # @overload update_blurb(blurb: nil, update_mask: nil)
+          #   @param blurb [Google::Showcase::V1alpha3::Blurb | Hash]
           #     The blurb to update.
-          #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -567,15 +575,16 @@ module Google
           ##
           # Deletes a blurb.
           #
-          # @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
-          #   Deletes a blurb.
+          # @overload delete_blurb(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
+          #     Deletes a blurb.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_blurb(name: nil)
+          #   @param name [String]
           #     The resource name of the requested blurb.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -624,24 +633,25 @@ module Google
           # Lists blurbs for a specific chat room or user profile depending on the
           # parent resource name.
           #
-          # @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
-          #   Lists blurbs for a specific chat room or user profile depending on the
-          #   parent resource name.
+          # @overload list_blurbs(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
+          #     Lists blurbs for a specific chat room or user profile depending on the
+          #     parent resource name.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `parent` (`String`):
+          # @overload list_blurbs(parent: nil, page_size: nil, page_token: nil)
+          #   @param parent [String]
           #     The resource name of the requested room or profile whos blurbs to list.
-          #   * `page_size` (`Integer`):
+          #   @param page_size [Integer]
           #     The maximum number of blurbs to return. Server may return fewer
           #     blurbs than requested. If unspecified, server will pick an appropriate
           #     default.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The value of google.showcase.v1alpha3.ListBlurbsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\ListBlurbs` method.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Blurb>]
@@ -693,30 +703,31 @@ module Google
           # for blurbs containing to words found in the query. Only posts that
           # contain an exact match of a queried word will be returned.
           #
-          # @param request [Google::Showcase::V1alpha3::SearchBlurbsRequest | Hash]
-          #   This method searches through all blurbs across all rooms and profiles
-          #   for blurbs containing to words found in the query. Only posts that
-          #   contain an exact match of a queried word will be returned.
+          # @overload search_blurbs(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::SearchBlurbsRequest | Hash]
+          #     This method searches through all blurbs across all rooms and profiles
+          #     for blurbs containing to words found in the query. Only posts that
+          #     contain an exact match of a queried word will be returned.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `query` (`String`):
+          # @overload search_blurbs(query: nil, parent: nil, page_size: nil, page_token: nil)
+          #   @param query [String]
           #     The query used to search for blurbs containing to words of this string.
           #     Only posts that contain an exact match of a queried word will be returned.
-          #   * `parent` (`String`):
+          #   @param parent [String]
           #     The rooms or profiles to search. If unset, `SearchBlurbs` will search all
           #     rooms and all profiles.
-          #   * `page_size` (`Integer`):
+          #   @param page_size [Integer]
           #     The maximum number of blurbs return. Server may return fewer
           #     blurbs than requested. If unspecified, server will pick an appropriate
           #     default.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The value of
           #     google.showcase.v1alpha3.SearchBlurbsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\SearchBlurbs` method.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -767,18 +778,19 @@ module Google
           # This returns a stream that emits the blurbs that are created for a
           # particular chat room or user profile.
           #
-          # @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
-          #   This returns a stream that emits the blurbs that are created for a
-          #   particular chat room or user profile.
+          # @overload stream_blurbs(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
+          #     This returns a stream that emits the blurbs that are created for a
+          #     particular chat room or user profile.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload stream_blurbs(name: nil, expire_time: nil)
+          #   @param name [String]
           #     The resource name of a chat room or user profile whose blurbs to stream.
-          #   * `expire_time` (`Google::Protobuf::Timestamp | Hash`):
+          #   @param expire_time [Google::Protobuf::Timestamp | Hash]
           #     The time at which this stream will close.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -106,25 +106,26 @@ module Google
           # NOTE: the `name` binding below allows API services to override the binding
           # to use different resource name schemes, such as `users/*/operations`.
           #
-          # @param request [Google::Longrunning::ListOperationsRequest | Hash]
-          #   Lists operations that match the specified filter in the request. If the
-          #   server doesn't support this method, it returns `UNIMPLEMENTED`.
+          # @overload list_operations(request, options = nil)
+          #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
+          #     Lists operations that match the specified filter in the request. If the
+          #     server doesn't support this method, it returns `UNIMPLEMENTED`.
           #
-          #   NOTE: the `name` binding below allows API services to override the binding
-          #   to use different resource name schemes, such as `users/*/operations`.
+          #     NOTE: the `name` binding below allows API services to override the binding
+          #     to use different resource name schemes, such as `users/*/operations`.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+          #   @param name [String]
           #     The name of the operation collection.
-          #   * `filter` (`String`):
+          #   @param filter [String]
           #     The standard list filter.
-          #   * `page_size` (`Integer`):
+          #   @param page_size [Integer]
           #     The standard list page size.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The standard list page token.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -177,17 +178,18 @@ module Google
           # method to poll the operation result at intervals as recommended by the API
           # service.
           #
-          # @param request [Google::Longrunning::GetOperationRequest | Hash]
-          #   Gets the latest state of a long-running operation.  Clients can use this
-          #   method to poll the operation result at intervals as recommended by the API
-          #   service.
+          # @overload get_operation(request, options = nil)
+          #   @param request [Google::Longrunning::GetOperationRequest | Hash]
+          #     Gets the latest state of a long-running operation.  Clients can use this
+          #     method to poll the operation result at intervals as recommended by the API
+          #     service.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload get_operation(name: nil)
+          #   @param name [String]
           #     The name of the operation resource.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -240,18 +242,19 @@ module Google
           # operation. If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.
           #
-          # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-          #   Deletes a long-running operation. This method indicates that the client is
-          #   no longer interested in the operation result. It does not cancel the
-          #   operation. If the server doesn't support this method, it returns
-          #   `google.rpc.Code.UNIMPLEMENTED`.
+          # @overload delete_operation(request, options = nil)
+          #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+          #     Deletes a long-running operation. This method indicates that the client is
+          #     no longer interested in the operation result. It does not cancel the
+          #     operation. If the server doesn't support this method, it returns
+          #     `google.rpc.Code.UNIMPLEMENTED`.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_operation(name: nil)
+          #   @param name [String]
           #     The name of the operation resource to be deleted.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -308,24 +311,25 @@ module Google
           # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           # corresponding to `Code.CANCELLED`.
           #
-          # @param request [Google::Longrunning::CancelOperationRequest | Hash]
-          #   Starts asynchronous cancellation on a long-running operation.  The server
-          #   makes a best effort to cancel the operation, but success is not
-          #   guaranteed.  If the server doesn't support this method, it returns
-          #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-          #   other methods to check whether the cancellation succeeded or whether the
-          #   operation completed despite cancellation. On successful cancellation,
-          #   the operation is not deleted; instead, it becomes an operation with
-          #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-          #   corresponding to `Code.CANCELLED`.
+          # @overload cancel_operation(request, options = nil)
+          #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
+          #     Starts asynchronous cancellation on a long-running operation.  The server
+          #     makes a best effort to cancel the operation, but success is not
+          #     guaranteed.  If the server doesn't support this method, it returns
+          #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+          #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          #     other methods to check whether the cancellation succeeded or whether the
+          #     operation completed despite cancellation. On successful cancellation,
+          #     the operation is not deleted; instead, it becomes an operation with
+          #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          #     corresponding to `Code.CANCELLED`.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload cancel_operation(name: nil)
+          #   @param name [String]
           #     The name of the operation resource to be cancelled.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -107,17 +107,18 @@ module Google
           ##
           # Creates a new testing session.
           #
-          # @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
-          #   Creates a new testing session.
+          # @overload create_session(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
+          #     Creates a new testing session.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `session` (`Google::Showcase::V1alpha3::Session | Hash`):
+          # @overload create_session(session: nil)
+          #   @param session [Google::Showcase::V1alpha3::Session | Hash]
           #     The session to be created.
           #     Sessions are immutable once they are created (although they can
           #     be deleted).
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Session]
@@ -159,15 +160,16 @@ module Google
           ##
           # Gets a testing session.
           #
-          # @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
-          #   Gets a testing session.
+          # @overload get_session(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
+          #     Gets a testing session.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload get_session(name: nil)
+          #   @param name [String]
           #     The session to be retrieved.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Session]
@@ -215,17 +217,18 @@ module Google
           ##
           # Lists the current test sessions.
           #
-          # @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
-          #   Lists the current test sessions.
+          # @overload list_sessions(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
+          #     Lists the current test sessions.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `page_size` (`Integer`):
+          # @overload list_sessions(page_size: nil, page_token: nil)
+          #   @param page_size [Integer]
           #     The maximum number of sessions to return per page.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The page token, for retrieving subsequent pages.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Session>]
@@ -269,15 +272,16 @@ module Google
           ##
           # Delete a test session.
           #
-          # @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
-          #   Delete a test session.
+          # @overload delete_session(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
+          #     Delete a test session.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_session(name: nil)
+          #   @param name [String]
           #     The session to be deleted.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -327,17 +331,18 @@ module Google
           # This generates a report detailing which tests have been completed,
           # and an overall rollup.
           #
-          # @param request [Google::Showcase::V1alpha3::ReportSessionRequest | Hash]
-          #   Report on the status of a session.
-          #   This generates a report detailing which tests have been completed,
-          #   and an overall rollup.
+          # @overload report_session(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ReportSessionRequest | Hash]
+          #     Report on the status of a session.
+          #     This generates a report detailing which tests have been completed,
+          #     and an overall rollup.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload report_session(name: nil)
+          #   @param name [String]
           #     The session to be reported on.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::ReportSessionResponse]
@@ -385,19 +390,20 @@ module Google
           ##
           # List the tests of a sessesion.
           #
-          # @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
-          #   List the tests of a sessesion.
+          # @overload list_tests(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
+          #     List the tests of a sessesion.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `parent` (`String`):
+          # @overload list_tests(parent: nil, page_size: nil, page_token: nil)
+          #   @param parent [String]
           #     The session.
-          #   * `page_size` (`Integer`):
+          #   @param page_size [Integer]
           #     The maximum number of tests to return per page.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The page token, for retrieving subsequent pages.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Test>]
@@ -452,20 +458,21 @@ module Google
           #
           # This method will error if attempting to delete a required test.
           #
-          # @param request [Google::Showcase::V1alpha3::DeleteTestRequest | Hash]
-          #   Explicitly decline to implement a test.
+          # @overload delete_test(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::DeleteTestRequest | Hash]
+          #     Explicitly decline to implement a test.
           #
-          #   This removes the test from subsequent `ListTests` calls, and
-          #   attempting to do the test will error.
+          #     This removes the test from subsequent `ListTests` calls, and
+          #     attempting to do the test will error.
           #
-          #   This method will error if attempting to delete a required test.
+          #     This method will error if attempting to delete a required test.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_test(name: nil)
+          #   @param name [String]
           #     The test to be deleted.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -516,22 +523,23 @@ module Google
           # In cases where a test involves registering a final answer at the
           # end of the test, this method provides the means to do so.
           #
-          # @param request [Google::Showcase::V1alpha3::VerifyTestRequest | Hash]
-          #   Register a response to a test.
+          # @overload verify_test(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::VerifyTestRequest | Hash]
+          #     Register a response to a test.
           #
-          #   In cases where a test involves registering a final answer at the
-          #   end of the test, this method provides the means to do so.
+          #     In cases where a test involves registering a final answer at the
+          #     end of the test, this method provides the means to do so.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload verify_test(name: nil, answer: nil, answers: nil)
+          #   @param name [String]
           #     The test to have an answer registered to it.
-          #   * `answer` (`String`):
+          #   @param answer [String]
           #     The answer from the test.
-          #   * `answers` (`String`):
+          #   @param answers [String]
           #     The answers from the test if multiple are to be checked
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::VerifyTestResponse]

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -110,19 +110,20 @@ module Google
             # Performs synchronous speech recognition: receive results after all audio
             # has been sent and processed.
             #
-            # @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
-            #   Performs synchronous speech recognition: receive results after all audio
-            #   has been sent and processed.
+            # @overload recognize(request, options = nil)
+            #   @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
+            #     Performs synchronous speech recognition: receive results after all audio
+            #     has been sent and processed.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `config` (`Google::Cloud::Speech::V1::RecognitionConfig | Hash`):
+            # @overload recognize(config: nil, audio: nil)
+            #   @param config [Google::Cloud::Speech::V1::RecognitionConfig | Hash]
             #     *Required* Provides information to the recognizer that specifies how to
             #     process the request.
-            #   * `audio` (`Google::Cloud::Speech::V1::RecognitionAudio | Hash`):
+            #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
             #     *Required* The audio data to be recognized.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Speech::V1::RecognizeResponse]
@@ -167,21 +168,22 @@ module Google
             # `Operation.error` or an `Operation.response` which contains
             # a `LongRunningRecognizeResponse` message.
             #
-            # @param request [Google::Cloud::Speech::V1::LongRunningRecognizeRequest | Hash]
-            #   Performs asynchronous speech recognition: receive results via the
-            #   google.longrunning.Operations interface. Returns either an
-            #   `Operation.error` or an `Operation.response` which contains
-            #   a `LongRunningRecognizeResponse` message.
+            # @overload long_running_recognize(request, options = nil)
+            #   @param request [Google::Cloud::Speech::V1::LongRunningRecognizeRequest | Hash]
+            #     Performs asynchronous speech recognition: receive results via the
+            #     google.longrunning.Operations interface. Returns either an
+            #     `Operation.error` or an `Operation.response` which contains
+            #     a `LongRunningRecognizeResponse` message.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `config` (`Google::Cloud::Speech::V1::RecognitionConfig | Hash`):
+            # @overload long_running_recognize(config: nil, audio: nil)
+            #   @param config [Google::Cloud::Speech::V1::RecognitionConfig | Hash]
             #     *Required* Provides information to the recognizer that specifies how to
             #     process the request.
-            #   * `audio` (`Google::Cloud::Speech::V1::RecognitionAudio | Hash`):
+            #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
             #     *Required* The audio data to be recognized.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -107,25 +107,26 @@ module Google
             # NOTE: the `name` binding below allows API services to override the binding
             # to use different resource name schemes, such as `users/*/operations`.
             #
-            # @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #   Lists operations that match the specified filter in the request. If the
-            #   server doesn't support this method, it returns `UNIMPLEMENTED`.
+            # @overload list_operations(request, options = nil)
+            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
+            #     Lists operations that match the specified filter in the request. If the
+            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
             #
-            #   NOTE: the `name` binding below allows API services to override the binding
-            #   to use different resource name schemes, such as `users/*/operations`.
+            #     NOTE: the `name` binding below allows API services to override the binding
+            #     to use different resource name schemes, such as `users/*/operations`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+            #   @param name [String]
             #     The name of the operation collection.
-            #   * `filter` (`String`):
+            #   @param filter [String]
             #     The standard list filter.
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The standard list page size.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     The standard list page token.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -178,17 +179,18 @@ module Google
             # method to poll the operation result at intervals as recommended by the API
             # service.
             #
-            # @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #   Gets the latest state of a long-running operation.  Clients can use this
-            #   method to poll the operation result at intervals as recommended by the API
-            #   service.
+            # @overload get_operation(request, options = nil)
+            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
+            #     Gets the latest state of a long-running operation.  Clients can use this
+            #     method to poll the operation result at intervals as recommended by the API
+            #     service.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload get_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -241,18 +243,19 @@ module Google
             # operation. If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
-            # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #   Deletes a long-running operation. This method indicates that the client is
-            #   no longer interested in the operation result. It does not cancel the
-            #   operation. If the server doesn't support this method, it returns
-            #   `google.rpc.Code.UNIMPLEMENTED`.
+            # @overload delete_operation(request, options = nil)
+            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+            #     Deletes a long-running operation. This method indicates that the client is
+            #     no longer interested in the operation result. It does not cancel the
+            #     operation. If the server doesn't support this method, it returns
+            #     `google.rpc.Code.UNIMPLEMENTED`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload delete_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource to be deleted.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -309,24 +312,25 @@ module Google
             # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             # corresponding to `Code.CANCELLED`.
             #
-            # @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #   Starts asynchronous cancellation on a long-running operation.  The server
-            #   makes a best effort to cancel the operation, but success is not
-            #   guaranteed.  If the server doesn't support this method, it returns
-            #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-            #   other methods to check whether the cancellation succeeded or whether the
-            #   operation completed despite cancellation. On successful cancellation,
-            #   the operation is not deleted; instead, it becomes an operation with
-            #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-            #   corresponding to `Code.CANCELLED`.
+            # @overload cancel_operation(request, options = nil)
+            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
+            #     Starts asynchronous cancellation on a long-running operation.  The server
+            #     makes a best effort to cancel the operation, but success is not
+            #     guaranteed.  If the server doesn't support this method, it returns
+            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #     other methods to check whether the cancellation succeeded or whether the
+            #     operation completed despite cancellation. On successful cancellation,
+            #     the operation is not deleted; instead, it becomes an operation with
+            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #     corresponding to `Code.CANCELLED`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload cancel_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource to be cancelled.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -109,15 +109,16 @@ module Google
             ##
             # Run image detection and annotation for a batch of images.
             #
-            # @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
-            #   Run image detection and annotation for a batch of images.
+            # @overload batch_annotate_images(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
+            #     Run image detection and annotation for a batch of images.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `requests` (`Google::Cloud::Vision::V1::AnnotateImageRequest | Hash`):
+            # @overload batch_annotate_images(requests: nil)
+            #   @param requests [Google::Cloud::Vision::V1::AnnotateImageRequest | Hash]
             #     Individual image annotation requests for this batch.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
@@ -164,20 +165,21 @@ module Google
             # `Operation.metadata` contains `OperationMetadata` (metadata).
             # `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
             #
-            # @param request [Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest | Hash]
-            #   Run asynchronous image detection and annotation for a list of generic
-            #   files, such as PDF files, which may contain multiple pages and multiple
-            #   images per page. Progress and results can be retrieved through the
-            #   `google.longrunning.Operations` interface.
-            #   `Operation.metadata` contains `OperationMetadata` (metadata).
-            #   `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
+            # @overload async_batch_annotate_files(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest | Hash]
+            #     Run asynchronous image detection and annotation for a list of generic
+            #     files, such as PDF files, which may contain multiple pages and multiple
+            #     images per page. Progress and results can be retrieved through the
+            #     `google.longrunning.Operations` interface.
+            #     `Operation.metadata` contains `OperationMetadata` (metadata).
+            #     `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `requests` (`Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash`):
+            # @overload async_batch_annotate_files(requests: nil)
+            #   @param requests [Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash]
             #     Individual async file annotation requests for this batch.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -107,25 +107,26 @@ module Google
             # NOTE: the `name` binding below allows API services to override the binding
             # to use different resource name schemes, such as `users/*/operations`.
             #
-            # @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #   Lists operations that match the specified filter in the request. If the
-            #   server doesn't support this method, it returns `UNIMPLEMENTED`.
+            # @overload list_operations(request, options = nil)
+            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
+            #     Lists operations that match the specified filter in the request. If the
+            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
             #
-            #   NOTE: the `name` binding below allows API services to override the binding
-            #   to use different resource name schemes, such as `users/*/operations`.
+            #     NOTE: the `name` binding below allows API services to override the binding
+            #     to use different resource name schemes, such as `users/*/operations`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+            #   @param name [String]
             #     The name of the operation collection.
-            #   * `filter` (`String`):
+            #   @param filter [String]
             #     The standard list filter.
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The standard list page size.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     The standard list page token.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -178,17 +179,18 @@ module Google
             # method to poll the operation result at intervals as recommended by the API
             # service.
             #
-            # @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #   Gets the latest state of a long-running operation.  Clients can use this
-            #   method to poll the operation result at intervals as recommended by the API
-            #   service.
+            # @overload get_operation(request, options = nil)
+            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
+            #     Gets the latest state of a long-running operation.  Clients can use this
+            #     method to poll the operation result at intervals as recommended by the API
+            #     service.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload get_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -241,18 +243,19 @@ module Google
             # operation. If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
-            # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #   Deletes a long-running operation. This method indicates that the client is
-            #   no longer interested in the operation result. It does not cancel the
-            #   operation. If the server doesn't support this method, it returns
-            #   `google.rpc.Code.UNIMPLEMENTED`.
+            # @overload delete_operation(request, options = nil)
+            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+            #     Deletes a long-running operation. This method indicates that the client is
+            #     no longer interested in the operation result. It does not cancel the
+            #     operation. If the server doesn't support this method, it returns
+            #     `google.rpc.Code.UNIMPLEMENTED`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload delete_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource to be deleted.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -309,24 +312,25 @@ module Google
             # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             # corresponding to `Code.CANCELLED`.
             #
-            # @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #   Starts asynchronous cancellation on a long-running operation.  The server
-            #   makes a best effort to cancel the operation, but success is not
-            #   guaranteed.  If the server doesn't support this method, it returns
-            #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-            #   other methods to check whether the cancellation succeeded or whether the
-            #   operation completed despite cancellation. On successful cancellation,
-            #   the operation is not deleted; instead, it becomes an operation with
-            #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-            #   corresponding to `Code.CANCELLED`.
+            # @overload cancel_operation(request, options = nil)
+            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
+            #     Starts asynchronous cancellation on a long-running operation.  The server
+            #     makes a best effort to cancel the operation, but success is not
+            #     guaranteed.  If the server doesn't support this method, it returns
+            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #     other methods to check whether the cancellation succeeded or whether the
+            #     operation completed despite cancellation. On successful cancellation,
+            #     the operation is not deleted; instead, it becomes an operation with
+            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #     corresponding to `Code.CANCELLED`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload cancel_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource to be cancelled.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -114,29 +114,30 @@ module Google
             # * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
             #   4096 characters.
             #
-            # @param request [Google::Cloud::Vision::V1::CreateProductSetRequest | Hash]
-            #   Creates and returns a new ProductSet resource.
+            # @overload create_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::CreateProductSetRequest | Hash]
+            #     Creates and returns a new ProductSet resource.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
-            #     4096 characters.
+            #     * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
+            #       4096 characters.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload create_product_set(parent: nil, product_set: nil, product_set_id: nil)
+            #   @param parent [String]
             #     The project in which the ProductSet should be created.
             #
             #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   * `product_set` (`Google::Cloud::Vision::V1::ProductSet | Hash`):
+            #   @param product_set [Google::Cloud::Vision::V1::ProductSet | Hash]
             #     The ProductSet to create.
-            #   * `product_set_id` (`String`):
+            #   @param product_set_id [String]
             #     A user-supplied resource id for this ProductSet. If set, the server will
             #     attempt to use this value as the resource id. If it is already in use, an
             #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
             #     long. It cannot contain the character `/`.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -189,26 +190,27 @@ module Google
             # * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
             #   than 1.
             #
-            # @param request [Google::Cloud::Vision::V1::ListProductSetsRequest | Hash]
-            #   Lists ProductSets in an unspecified order.
+            # @overload list_product_sets(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::ListProductSetsRequest | Hash]
+            #     Lists ProductSets in an unspecified order.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
-            #     than 1.
+            #     * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
+            #       than 1.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload list_product_sets(parent: nil, page_size: nil, page_token: nil)
+            #   @param parent [String]
             #     The project from which ProductSets should be listed.
             #
             #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The maximum number of items to return. Default 10, maximum 100.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ProductSet>]
@@ -262,22 +264,23 @@ module Google
             #
             # * Returns NOT_FOUND if the ProductSet does not exist.
             #
-            # @param request [Google::Cloud::Vision::V1::GetProductSetRequest | Hash]
-            #   Gets information associated with a ProductSet.
+            # @overload get_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::GetProductSetRequest | Hash]
+            #     Gets information associated with a ProductSet.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the ProductSet does not exist.
+            #     * Returns NOT_FOUND if the ProductSet does not exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload get_product_set(name: nil)
+            #   @param name [String]
             #     Resource name of the ProductSet to get.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -332,27 +335,28 @@ module Google
             # * Returns INVALID_ARGUMENT if display_name is present in update_mask but
             #   missing from the request or longer than 4096 characters.
             #
-            # @param request [Google::Cloud::Vision::V1::UpdateProductSetRequest | Hash]
-            #   Makes changes to a ProductSet resource.
-            #   Only display_name can be updated currently.
+            # @overload update_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::UpdateProductSetRequest | Hash]
+            #     Makes changes to a ProductSet resource.
+            #     Only display_name can be updated currently.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the ProductSet does not exist.
-            #   * Returns INVALID_ARGUMENT if display_name is present in update_mask but
-            #     missing from the request or longer than 4096 characters.
+            #     * Returns NOT_FOUND if the ProductSet does not exist.
+            #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but
+            #       missing from the request or longer than 4096 characters.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `product_set` (`Google::Cloud::Vision::V1::ProductSet | Hash`):
+            # @overload update_product_set(product_set: nil, update_mask: nil)
+            #   @param product_set [Google::Cloud::Vision::V1::ProductSet | Hash]
             #     The ProductSet resource which replaces the one on the server.
-            #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+            #   @param update_mask [Google::Protobuf::FieldMask | Hash]
             #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields to
             #     update.
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask path is `display_name`.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -407,25 +411,26 @@ module Google
             #
             # * Returns NOT_FOUND if the ProductSet does not exist.
             #
-            # @param request [Google::Cloud::Vision::V1::DeleteProductSetRequest | Hash]
-            #   Permanently deletes a ProductSet. Products and ReferenceImages in the
-            #   ProductSet are not deleted.
+            # @overload delete_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::DeleteProductSetRequest | Hash]
+            #     Permanently deletes a ProductSet. Products and ReferenceImages in the
+            #     ProductSet are not deleted.
             #
-            #   The actual image files are not deleted from Google Cloud Storage.
+            #     The actual image files are not deleted from Google Cloud Storage.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the ProductSet does not exist.
+            #     * Returns NOT_FOUND if the ProductSet does not exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload delete_product_set(name: nil)
+            #   @param name [String]
             #     Resource name of the ProductSet to delete.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -480,32 +485,33 @@ module Google
             # * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
             # * Returns INVALID_ARGUMENT if product_category is missing or invalid.
             #
-            # @param request [Google::Cloud::Vision::V1::CreateProductRequest | Hash]
-            #   Creates and returns a new product resource.
+            # @overload create_product(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::CreateProductRequest | Hash]
+            #     Creates and returns a new product resource.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
-            #     characters.
-            #   * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
-            #   * Returns INVALID_ARGUMENT if product_category is missing or invalid.
+            #     * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
+            #       characters.
+            #     * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
+            #     * Returns INVALID_ARGUMENT if product_category is missing or invalid.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload create_product(parent: nil, product: nil, product_id: nil)
+            #   @param parent [String]
             #     The project in which the Product should be created.
             #
             #     Format is
             #     `projects/PROJECT_ID/locations/LOC_ID`.
-            #   * `product` (`Google::Cloud::Vision::V1::Product | Hash`):
+            #   @param product [Google::Cloud::Vision::V1::Product | Hash]
             #     The product to create.
-            #   * `product_id` (`String`):
+            #   @param product_id [String]
             #     A user-supplied resource id for this Product. If set, the server will
             #     attempt to use this value as the resource id. If it is already in use, an
             #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
             #     long. It cannot contain the character `/`.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -557,26 +563,27 @@ module Google
             #
             # * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #
-            # @param request [Google::Cloud::Vision::V1::ListProductsRequest | Hash]
-            #   Lists products in an unspecified order.
+            # @overload list_products(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::ListProductsRequest | Hash]
+            #     Lists products in an unspecified order.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload list_products(parent: nil, page_size: nil, page_token: nil)
+            #   @param parent [String]
             #     The project OR ProductSet from which Products should be listed.
             #
             #     Format:
             #     `projects/PROJECT_ID/locations/LOC_ID`
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The maximum number of items to return. Default 10, maximum 100.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -630,22 +637,23 @@ module Google
             #
             # * Returns NOT_FOUND if the Product does not exist.
             #
-            # @param request [Google::Cloud::Vision::V1::GetProductRequest | Hash]
-            #   Gets information associated with a Product.
+            # @overload get_product(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::GetProductRequest | Hash]
+            #     Gets information associated with a Product.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the Product does not exist.
+            #     * Returns NOT_FOUND if the Product does not exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload get_product(name: nil)
+            #   @param name [String]
             #     Resource name of the Product to get.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -707,36 +715,37 @@ module Google
             #   longer than 4096 characters.
             # * Returns INVALID_ARGUMENT if product_category is present in update_mask.
             #
-            # @param request [Google::Cloud::Vision::V1::UpdateProductRequest | Hash]
-            #   Makes changes to a Product resource.
-            #   Only the `display_name`, `description`, and `labels` fields can be updated
-            #   right now.
+            # @overload update_product(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::UpdateProductRequest | Hash]
+            #     Makes changes to a Product resource.
+            #     Only the `display_name`, `description`, and `labels` fields can be updated
+            #     right now.
             #
-            #   If labels are updated, the change will not be reflected in queries until
-            #   the next index time.
+            #     If labels are updated, the change will not be reflected in queries until
+            #     the next index time.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the Product does not exist.
-            #   * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
-            #     missing from the request or longer than 4096 characters.
-            #   * Returns INVALID_ARGUMENT if description is present in update_mask but is
-            #     longer than 4096 characters.
-            #   * Returns INVALID_ARGUMENT if product_category is present in update_mask.
+            #     * Returns NOT_FOUND if the Product does not exist.
+            #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
+            #       missing from the request or longer than 4096 characters.
+            #     * Returns INVALID_ARGUMENT if description is present in update_mask but is
+            #       longer than 4096 characters.
+            #     * Returns INVALID_ARGUMENT if product_category is present in update_mask.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `product` (`Google::Cloud::Vision::V1::Product | Hash`):
+            # @overload update_product(product: nil, update_mask: nil)
+            #   @param product [Google::Cloud::Vision::V1::Product | Hash]
             #     The Product resource which replaces the one on the server.
             #     product.name is immutable.
-            #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+            #   @param update_mask [Google::Protobuf::FieldMask | Hash]
             #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields
             #     to update.
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask paths include `product_labels`, `display_name`, and
             #     `description`.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -792,26 +801,27 @@ module Google
             #
             # * Returns NOT_FOUND if the product does not exist.
             #
-            # @param request [Google::Cloud::Vision::V1::DeleteProductRequest | Hash]
-            #   Permanently deletes a product and its reference images.
+            # @overload delete_product(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::DeleteProductRequest | Hash]
+            #     Permanently deletes a product and its reference images.
             #
-            #   Metadata of the product and all its images will be deleted right away, but
-            #   search queries against ProductSets containing the product may still work
-            #   until all related caches are refreshed.
+            #     Metadata of the product and all its images will be deleted right away, but
+            #     search queries against ProductSets containing the product may still work
+            #     until all related caches are refreshed.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the product does not exist.
+            #     * Returns NOT_FOUND if the product does not exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload delete_product(name: nil)
+            #   @param name [String]
             #     Resource name of product to delete.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -877,44 +887,45 @@ module Google
             #   compatible with the parent product's product_category is detected.
             # * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
             #
-            # @param request [Google::Cloud::Vision::V1::CreateReferenceImageRequest | Hash]
-            #   Creates and returns a new ReferenceImage resource.
+            # @overload create_reference_image(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::CreateReferenceImageRequest | Hash]
+            #     Creates and returns a new ReferenceImage resource.
             #
-            #   The `bounding_poly` field is optional. If `bounding_poly` is not specified,
-            #   the system will try to detect regions of interest in the image that are
-            #   compatible with the product_category on the parent product. If it is
-            #   specified, detection is ALWAYS skipped. The system converts polygons into
-            #   non-rotated rectangles.
+            #     The `bounding_poly` field is optional. If `bounding_poly` is not specified,
+            #     the system will try to detect regions of interest in the image that are
+            #     compatible with the product_category on the parent product. If it is
+            #     specified, detection is ALWAYS skipped. The system converts polygons into
+            #     non-rotated rectangles.
             #
-            #   Note that the pipeline will resize the image if the image resolution is too
-            #   large to process (above 50MP).
+            #     Note that the pipeline will resize the image if the image resolution is too
+            #     large to process (above 50MP).
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
-            #     characters.
-            #   * Returns INVALID_ARGUMENT if the product does not exist.
-            #   * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
-            #     compatible with the parent product's product_category is detected.
-            #   * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
+            #     * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
+            #       characters.
+            #     * Returns INVALID_ARGUMENT if the product does not exist.
+            #     * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
+            #       compatible with the parent product's product_category is detected.
+            #     * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload create_reference_image(parent: nil, reference_image: nil, reference_image_id: nil)
+            #   @param parent [String]
             #     Resource name of the product in which to create the reference image.
             #
             #     Format is
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
-            #   * `reference_image` (`Google::Cloud::Vision::V1::ReferenceImage | Hash`):
+            #   @param reference_image [Google::Cloud::Vision::V1::ReferenceImage | Hash]
             #     The reference image to create.
             #     If an image ID is specified, it is ignored.
-            #   * `reference_image_id` (`String`):
+            #   @param reference_image_id [String]
             #     A user-supplied resource id for the ReferenceImage to be added. If set,
             #     the server will attempt to use this value as the resource id. If it is
             #     already in use, an error is returned with code ALREADY_EXISTS. Must be at
             #     most 128 characters long. It cannot contain the character `/`.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -972,29 +983,30 @@ module Google
             #
             # * Returns NOT_FOUND if the reference image does not exist.
             #
-            # @param request [Google::Cloud::Vision::V1::DeleteReferenceImageRequest | Hash]
-            #   Permanently deletes a reference image.
+            # @overload delete_reference_image(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::DeleteReferenceImageRequest | Hash]
+            #     Permanently deletes a reference image.
             #
-            #   The image metadata will be deleted right away, but search queries
-            #   against ProductSets containing the image may still work until all related
-            #   caches are refreshed.
+            #     The image metadata will be deleted right away, but search queries
+            #     against ProductSets containing the image may still work until all related
+            #     caches are refreshed.
             #
-            #   The actual image files are not deleted from Google Cloud Storage.
+            #     The actual image files are not deleted from Google Cloud Storage.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the reference image does not exist.
+            #     * Returns NOT_FOUND if the reference image does not exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload delete_reference_image(name: nil)
+            #   @param name [String]
             #     The resource name of the reference image to delete.
             #
             #     Format is:
             #
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1048,31 +1060,32 @@ module Google
             # * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
             #   than 1.
             #
-            # @param request [Google::Cloud::Vision::V1::ListReferenceImagesRequest | Hash]
-            #   Lists reference images.
+            # @overload list_reference_images(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::ListReferenceImagesRequest | Hash]
+            #     Lists reference images.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the parent product does not exist.
-            #   * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
-            #     than 1.
+            #     * Returns NOT_FOUND if the parent product does not exist.
+            #     * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
+            #       than 1.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload list_reference_images(parent: nil, page_size: nil, page_token: nil)
+            #   @param parent [String]
             #     Resource name of the product containing the reference images.
             #
             #     Format is
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The maximum number of items to return. Default 10, maximum 100.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     A token identifying a page of results to be returned. This is the value
             #     of `nextPageToken` returned in a previous reference image list request.
             #
             #     Defaults to the first page if not specified.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ReferenceImage>]
@@ -1126,23 +1139,24 @@ module Google
             #
             # * Returns NOT_FOUND if the specified image does not exist.
             #
-            # @param request [Google::Cloud::Vision::V1::GetReferenceImageRequest | Hash]
-            #   Gets information associated with a ReferenceImage.
+            # @overload get_reference_image(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::GetReferenceImageRequest | Hash]
+            #     Gets information associated with a ReferenceImage.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the specified image does not exist.
+            #     * Returns NOT_FOUND if the specified image does not exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload get_reference_image(name: nil)
+            #   @param name [String]
             #     The resource name of the ReferenceImage to get.
             #
             #     Format is:
             #
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -1197,30 +1211,31 @@ module Google
             #
             # * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
             #
-            # @param request [Google::Cloud::Vision::V1::AddProductToProductSetRequest | Hash]
-            #   Adds a Product to the specified ProductSet. If the Product is already
-            #   present, no change is made.
+            # @overload add_product_to_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::AddProductToProductSetRequest | Hash]
+            #     Adds a Product to the specified ProductSet. If the Product is already
+            #     present, no change is made.
             #
-            #   One Product can be added to at most 100 ProductSets.
+            #     One Product can be added to at most 100 ProductSets.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
+            #     * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload add_product_to_product_set(name: nil, product: nil)
+            #   @param name [String]
             #     The resource name for the ProductSet to modify.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   * `product` (`String`):
+            #   @param product [String]
             #     The resource name for the Product to be added to this ProductSet.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1272,27 +1287,28 @@ module Google
             #
             # * Returns NOT_FOUND If the Product is not found under the ProductSet.
             #
-            # @param request [Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest | Hash]
-            #   Removes a Product from the specified ProductSet.
+            # @overload remove_product_from_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest | Hash]
+            #     Removes a Product from the specified ProductSet.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND If the Product is not found under the ProductSet.
+            #     * Returns NOT_FOUND If the Product is not found under the ProductSet.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload remove_product_from_product_set(name: nil, product: nil)
+            #   @param name [String]
             #     The resource name for the ProductSet to modify.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   * `product` (`String`):
+            #   @param product [String]
             #     The resource name for the Product to be removed from this ProductSet.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1346,28 +1362,29 @@ module Google
             #
             # * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #
-            # @param request [Google::Cloud::Vision::V1::ListProductsInProductSetRequest | Hash]
-            #   Lists the Products in a ProductSet, in an unspecified order. If the
-            #   ProductSet does not exist, the products field of the response will be
-            #   empty.
+            # @overload list_products_in_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::ListProductsInProductSetRequest | Hash]
+            #     Lists the Products in a ProductSet, in an unspecified order. If the
+            #     ProductSet does not exist, the products field of the response will be
+            #     empty.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload list_products_in_product_set(name: nil, page_size: nil, page_token: nil)
+            #   @param name [String]
             #     The ProductSet resource for which to retrieve Products.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The maximum number of items to return. Default 10, maximum 100.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -1427,29 +1444,30 @@ module Google
             # For the format of the csv file please see
             # [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
             #
-            # @param request [Google::Cloud::Vision::V1::ImportProductSetsRequest | Hash]
-            #   Asynchronous API that imports a list of reference images to specified
-            #   product sets based on a list of image information.
+            # @overload import_product_sets(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::ImportProductSetsRequest | Hash]
+            #     Asynchronous API that imports a list of reference images to specified
+            #     product sets based on a list of image information.
             #
-            #   The [google.longrunning.Operation][google.longrunning.Operation] API can be
-            #   used to keep track of the progress and results of the request.
-            #   `Operation.metadata` contains `BatchOperationMetadata`. (progress)
-            #   `Operation.response` contains `ImportProductSetsResponse`. (results)
+            #     The [google.longrunning.Operation][google.longrunning.Operation] API can be
+            #     used to keep track of the progress and results of the request.
+            #     `Operation.metadata` contains `BatchOperationMetadata`. (progress)
+            #     `Operation.response` contains `ImportProductSetsResponse`. (results)
             #
-            #   The input source of this method is a csv file on Google Cloud Storage.
-            #   For the format of the csv file please see
-            #   [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+            #     The input source of this method is a csv file on Google Cloud Storage.
+            #     For the format of the csv file please see
+            #     [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload import_product_sets(parent: nil, input_config: nil)
+            #   @param parent [String]
             #     The project in which the ProductSets should be imported.
             #
             #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   * `input_config` (`Google::Cloud::Vision::V1::ImportProductSetsInputConfig | Hash`):
+            #   @param input_config [Google::Cloud::Vision::V1::ImportProductSetsInputConfig | Hash]
             #     The input content for the list of requests.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -107,25 +107,26 @@ module Google
             # NOTE: the `name` binding below allows API services to override the binding
             # to use different resource name schemes, such as `users/*/operations`.
             #
-            # @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #   Lists operations that match the specified filter in the request. If the
-            #   server doesn't support this method, it returns `UNIMPLEMENTED`.
+            # @overload list_operations(request, options = nil)
+            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
+            #     Lists operations that match the specified filter in the request. If the
+            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
             #
-            #   NOTE: the `name` binding below allows API services to override the binding
-            #   to use different resource name schemes, such as `users/*/operations`.
+            #     NOTE: the `name` binding below allows API services to override the binding
+            #     to use different resource name schemes, such as `users/*/operations`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+            #   @param name [String]
             #     The name of the operation collection.
-            #   * `filter` (`String`):
+            #   @param filter [String]
             #     The standard list filter.
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The standard list page size.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     The standard list page token.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -178,17 +179,18 @@ module Google
             # method to poll the operation result at intervals as recommended by the API
             # service.
             #
-            # @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #   Gets the latest state of a long-running operation.  Clients can use this
-            #   method to poll the operation result at intervals as recommended by the API
-            #   service.
+            # @overload get_operation(request, options = nil)
+            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
+            #     Gets the latest state of a long-running operation.  Clients can use this
+            #     method to poll the operation result at intervals as recommended by the API
+            #     service.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload get_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -241,18 +243,19 @@ module Google
             # operation. If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
-            # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #   Deletes a long-running operation. This method indicates that the client is
-            #   no longer interested in the operation result. It does not cancel the
-            #   operation. If the server doesn't support this method, it returns
-            #   `google.rpc.Code.UNIMPLEMENTED`.
+            # @overload delete_operation(request, options = nil)
+            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+            #     Deletes a long-running operation. This method indicates that the client is
+            #     no longer interested in the operation result. It does not cancel the
+            #     operation. If the server doesn't support this method, it returns
+            #     `google.rpc.Code.UNIMPLEMENTED`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload delete_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource to be deleted.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -309,24 +312,25 @@ module Google
             # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             # corresponding to `Code.CANCELLED`.
             #
-            # @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #   Starts asynchronous cancellation on a long-running operation.  The server
-            #   makes a best effort to cancel the operation, but success is not
-            #   guaranteed.  If the server doesn't support this method, it returns
-            #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-            #   other methods to check whether the cancellation succeeded or whether the
-            #   operation completed despite cancellation. On successful cancellation,
-            #   the operation is not deleted; instead, it becomes an operation with
-            #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-            #   corresponding to `Code.CANCELLED`.
+            # @overload cancel_operation(request, options = nil)
+            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
+            #     Starts asynchronous cancellation on a long-running operation.  The server
+            #     makes a best effort to cancel the operation, but success is not
+            #     guaranteed.  If the server doesn't support this method, it returns
+            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #     other methods to check whether the cancellation succeeded or whether the
+            #     operation completed despite cancellation. On successful cancellation,
+            #     the operation is not deleted; instead, it becomes an operation with
+            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #     corresponding to `Code.CANCELLED`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload cancel_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource to be cancelled.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/googleads/lib/google/ads/googleads/v1/services/campaign_service/client.rb
+++ b/shared/output/gapic/templates/googleads/lib/google/ads/googleads/v1/services/campaign_service/client.rb
@@ -114,15 +114,16 @@ module Google
               ##
               # Returns the requested campaign in full detail.
               #
-              # @param request [Google::Ads::GoogleAds::V1::Services::GetCampaignRequest | Hash]
-              #   Returns the requested campaign in full detail.
+              # @overload get_campaign(request, options = nil)
+              #   @param request [Google::Ads::GoogleAds::V1::Services::GetCampaignRequest | Hash]
+              #     Returns the requested campaign in full detail.
+              #   @param options [Google::Gax::ApiCall::Options, Hash]
+              #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
               #
-              #   When using a hash, the following fields are supported:
-              #
-              #   * `resource_name` (`String`):
+              # @overload get_campaign(resource_name: nil)
+              #   @param resource_name [String]
               #     The resource name of the campaign to fetch.
-              # @param options [Google::Gax::ApiCall::Options, Hash]
-              #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+              #
               #
               # @yield [response, operation] Access the result along with the RPC operation
               # @yieldparam response [Google::Ads::GoogleAds::V1::Resources::Campaign]
@@ -170,25 +171,26 @@ module Google
               ##
               # Creates, updates, or removes campaigns. Operation statuses are returned.
               #
-              # @param request [Google::Ads::GoogleAds::V1::Services::MutateCampaignsRequest | Hash]
-              #   Creates, updates, or removes campaigns. Operation statuses are returned.
+              # @overload mutate_campaigns(request, options = nil)
+              #   @param request [Google::Ads::GoogleAds::V1::Services::MutateCampaignsRequest | Hash]
+              #     Creates, updates, or removes campaigns. Operation statuses are returned.
+              #   @param options [Google::Gax::ApiCall::Options, Hash]
+              #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
               #
-              #   When using a hash, the following fields are supported:
-              #
-              #   * `customer_id` (`String`):
+              # @overload mutate_campaigns(customer_id: nil, operations: nil, partial_failure: nil, validate_only: nil)
+              #   @param customer_id [String]
               #     The ID of the customer whose campaigns are being modified.
-              #   * `operations` (`Google::Ads::GoogleAds::V1::Services::CampaignOperation | Hash`):
+              #   @param operations [Google::Ads::GoogleAds::V1::Services::CampaignOperation | Hash]
               #     The list of operations to perform on individual campaigns.
-              #   * `partial_failure` (`Boolean`):
+              #   @param partial_failure [Boolean]
               #     If true, successful operations will be carried out and invalid
               #     operations will return errors. If false, all operations will be carried
               #     out in one transaction if and only if they are all valid.
               #     Default is false.
-              #   * `validate_only` (`Boolean`):
+              #   @param validate_only [Boolean]
               #     If true, the request is validated but not executed. Only errors are
               #     returned, not results.
-              # @param options [Google::Gax::ApiCall::Options, Hash]
-              #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+              #
               #
               # @yield [response, operation] Access the result along with the RPC operation
               # @yieldparam response [Google::Ads::GoogleAds::V1::Services::MutateCampaignsResponse]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -116,17 +116,18 @@ module Google
           ##
           # This method simply echos the request. This method is showcases unary rpcs.
           #
-          # @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
-          #   This method simply echos the request. This method is showcases unary rpcs.
+          # @overload echo(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::EchoRequest | Hash]
+          #     This method simply echos the request. This method is showcases unary rpcs.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `content` (`String`):
+          # @overload echo(content: nil, error: nil)
+          #   @param content [String]
           #     The content to be echoed by the server.
-          #   * `error` (`Google::Rpc::Status | Hash`):
+          #   @param error [Google::Rpc::Status | Hash]
           #     The error to be thrown by the server.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::EchoResponse]
@@ -169,18 +170,19 @@ module Google
           # This method split the given content into words and will pass each word back
           # through the stream. This method showcases server-side streaming rpcs.
           #
-          # @param request [Google::Showcase::V1alpha3::ExpandRequest | Hash]
-          #   This method split the given content into words and will pass each word back
-          #   through the stream. This method showcases server-side streaming rpcs.
+          # @overload expand(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ExpandRequest | Hash]
+          #     This method split the given content into words and will pass each word back
+          #     through the stream. This method showcases server-side streaming rpcs.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `content` (`String`):
+          # @overload expand(content: nil, error: nil)
+          #   @param content [String]
           #     The content that will be split into words and returned on the stream.
-          #   * `error` (`Google::Rpc::Status | Hash`):
+          #   @param error [Google::Rpc::Status | Hash]
           #     The error that is thrown after all words are sent on the stream.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -333,20 +335,21 @@ module Google
           # This is similar to the Expand method but instead of returning a stream of
           # expanded words, this method returns a paged list of expanded words.
           #
-          # @param request [Google::Showcase::V1alpha3::PagedExpandRequest | Hash]
-          #   This is similar to the Expand method but instead of returning a stream of
-          #   expanded words, this method returns a paged list of expanded words.
+          # @overload paged_expand(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::PagedExpandRequest | Hash]
+          #     This is similar to the Expand method but instead of returning a stream of
+          #     expanded words, this method returns a paged list of expanded words.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `content` (`String`):
+          # @overload paged_expand(content: nil, page_size: nil, page_token: nil)
+          #   @param content [String]
           #     The string to expand.
-          #   * `page_size` (`Integer`):
+          #   @param page_size [Integer]
           #     The amount of words to returned in each page.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The position of the page to be returned.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::EchoResponse>]
@@ -391,23 +394,24 @@ module Google
           # This method will wait the requested amount of and then return.
           # This method showcases how a client handles a request timing out.
           #
-          # @param request [Google::Showcase::V1alpha3::WaitRequest | Hash]
-          #   This method will wait the requested amount of and then return.
-          #   This method showcases how a client handles a request timing out.
+          # @overload wait(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::WaitRequest | Hash]
+          #     This method will wait the requested amount of and then return.
+          #     This method showcases how a client handles a request timing out.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `end_time` (`Google::Protobuf::Timestamp | Hash`):
+          # @overload wait(end_time: nil, ttl: nil, error: nil, success: nil)
+          #   @param end_time [Google::Protobuf::Timestamp | Hash]
           #     The time that this operation will complete.
-          #   * `ttl` (`Google::Protobuf::Duration | Hash`):
+          #   @param ttl [Google::Protobuf::Duration | Hash]
           #     The duration of this operation.
-          #   * `error` (`Google::Rpc::Status | Hash`):
+          #   @param error [Google::Rpc::Status | Hash]
           #     The error that will be returned by the server. If this code is specified
           #     to be the OK rpc code, an empty response will be returned.
-          #   * `success` (`Google::Showcase::V1alpha3::WaitResponse | Hash`):
+          #   @param success [Google::Showcase::V1alpha3::WaitResponse | Hash]
           #     The response to be returned on operation completion.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -114,25 +114,26 @@ module Google
           # NOTE: the `name` binding below allows API services to override the binding
           # to use different resource name schemes, such as `users/*/operations`.
           #
-          # @param request [Google::Longrunning::ListOperationsRequest | Hash]
-          #   Lists operations that match the specified filter in the request. If the
-          #   server doesn't support this method, it returns `UNIMPLEMENTED`.
+          # @overload list_operations(request, options = nil)
+          #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
+          #     Lists operations that match the specified filter in the request. If the
+          #     server doesn't support this method, it returns `UNIMPLEMENTED`.
           #
-          #   NOTE: the `name` binding below allows API services to override the binding
-          #   to use different resource name schemes, such as `users/*/operations`.
+          #     NOTE: the `name` binding below allows API services to override the binding
+          #     to use different resource name schemes, such as `users/*/operations`.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+          #   @param name [String]
           #     The name of the operation collection.
-          #   * `filter` (`String`):
+          #   @param filter [String]
           #     The standard list filter.
-          #   * `page_size` (`Integer`):
+          #   @param page_size [Integer]
           #     The standard list page size.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The standard list page token.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -185,17 +186,18 @@ module Google
           # method to poll the operation result at intervals as recommended by the API
           # service.
           #
-          # @param request [Google::Longrunning::GetOperationRequest | Hash]
-          #   Gets the latest state of a long-running operation.  Clients can use this
-          #   method to poll the operation result at intervals as recommended by the API
-          #   service.
+          # @overload get_operation(request, options = nil)
+          #   @param request [Google::Longrunning::GetOperationRequest | Hash]
+          #     Gets the latest state of a long-running operation.  Clients can use this
+          #     method to poll the operation result at intervals as recommended by the API
+          #     service.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload get_operation(name: nil)
+          #   @param name [String]
           #     The name of the operation resource.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -248,18 +250,19 @@ module Google
           # operation. If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.
           #
-          # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-          #   Deletes a long-running operation. This method indicates that the client is
-          #   no longer interested in the operation result. It does not cancel the
-          #   operation. If the server doesn't support this method, it returns
-          #   `google.rpc.Code.UNIMPLEMENTED`.
+          # @overload delete_operation(request, options = nil)
+          #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+          #     Deletes a long-running operation. This method indicates that the client is
+          #     no longer interested in the operation result. It does not cancel the
+          #     operation. If the server doesn't support this method, it returns
+          #     `google.rpc.Code.UNIMPLEMENTED`.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_operation(name: nil)
+          #   @param name [String]
           #     The name of the operation resource to be deleted.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -316,24 +319,25 @@ module Google
           # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           # corresponding to `Code.CANCELLED`.
           #
-          # @param request [Google::Longrunning::CancelOperationRequest | Hash]
-          #   Starts asynchronous cancellation on a long-running operation.  The server
-          #   makes a best effort to cancel the operation, but success is not
-          #   guaranteed.  If the server doesn't support this method, it returns
-          #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-          #   other methods to check whether the cancellation succeeded or whether the
-          #   operation completed despite cancellation. On successful cancellation,
-          #   the operation is not deleted; instead, it becomes an operation with
-          #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-          #   corresponding to `Code.CANCELLED`.
+          # @overload cancel_operation(request, options = nil)
+          #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
+          #     Starts asynchronous cancellation on a long-running operation.  The server
+          #     makes a best effort to cancel the operation, but success is not
+          #     guaranteed.  If the server doesn't support this method, it returns
+          #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+          #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          #     other methods to check whether the cancellation succeeded or whether the
+          #     operation completed despite cancellation. On successful cancellation,
+          #     the operation is not deleted; instead, it becomes an operation with
+          #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          #     corresponding to `Code.CANCELLED`.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload cancel_operation(name: nil)
+          #   @param name [String]
           #     The name of the operation resource to be cancelled.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -115,15 +115,16 @@ module Google
           ##
           # Creates a user.
           #
-          # @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
-          #   Creates a user.
+          # @overload create_user(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::CreateUserRequest | Hash]
+          #     Creates a user.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `user` (`Google::Showcase::V1alpha3::User | Hash`):
+          # @overload create_user(user: nil)
+          #   @param user [Google::Showcase::V1alpha3::User | Hash]
           #     The user to create.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -165,15 +166,16 @@ module Google
           ##
           # Retrieves the User with the given uri.
           #
-          # @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
-          #   Retrieves the User with the given uri.
+          # @overload get_user(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::GetUserRequest | Hash]
+          #     Retrieves the User with the given uri.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload get_user(name: nil)
+          #   @param name [String]
           #     The resource name of the requested user.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -221,18 +223,19 @@ module Google
           ##
           # Updates a user.
           #
-          # @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
-          #   Updates a user.
+          # @overload update_user(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::UpdateUserRequest | Hash]
+          #     Updates a user.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `user` (`Google::Showcase::V1alpha3::User | Hash`):
+          # @overload update_user(user: nil, update_mask: nil)
+          #   @param user [Google::Showcase::V1alpha3::User | Hash]
           #     The user to update.
-          #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::User]
@@ -280,15 +283,16 @@ module Google
           ##
           # Deletes a user, their profile, and all of their authored messages.
           #
-          # @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
-          #   Deletes a user, their profile, and all of their authored messages.
+          # @overload delete_user(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::DeleteUserRequest | Hash]
+          #     Deletes a user, their profile, and all of their authored messages.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_user(name: nil)
+          #   @param name [String]
           #     The resource name of the user to delete.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -336,20 +340,21 @@ module Google
           ##
           # Lists all users.
           #
-          # @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
-          #   Lists all users.
+          # @overload list_users(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ListUsersRequest | Hash]
+          #     Lists all users.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `page_size` (`Integer`):
+          # @overload list_users(page_size: nil, page_token: nil)
+          #   @param page_size [Integer]
           #     The maximum number of users to return. Server may return fewer users
           #     than requested. If unspecified, server will pick an appropriate default.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The value of google.showcase.v1alpha3.ListUsersResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Identity\ListUsers` method.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::User>]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -119,15 +119,16 @@ module Google
           ##
           # Creates a room.
           #
-          # @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
-          #   Creates a room.
+          # @overload create_room(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::CreateRoomRequest | Hash]
+          #     Creates a room.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `room` (`Google::Showcase::V1alpha3::Room | Hash`):
+          # @overload create_room(room: nil)
+          #   @param room [Google::Showcase::V1alpha3::Room | Hash]
           #     The room to create.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -169,15 +170,16 @@ module Google
           ##
           # Retrieves the Room with the given resource name.
           #
-          # @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
-          #   Retrieves the Room with the given resource name.
+          # @overload get_room(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::GetRoomRequest | Hash]
+          #     Retrieves the Room with the given resource name.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload get_room(name: nil)
+          #   @param name [String]
           #     The resource name of the requested room.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -225,18 +227,19 @@ module Google
           ##
           # Updates a room.
           #
-          # @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
-          #   Updates a room.
+          # @overload update_room(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::UpdateRoomRequest | Hash]
+          #     Updates a room.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `room` (`Google::Showcase::V1alpha3::Room | Hash`):
+          # @overload update_room(room: nil, update_mask: nil)
+          #   @param room [Google::Showcase::V1alpha3::Room | Hash]
           #     The room to update.
-          #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Room]
@@ -284,15 +287,16 @@ module Google
           ##
           # Deletes a room and all of its blurbs.
           #
-          # @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
-          #   Deletes a room and all of its blurbs.
+          # @overload delete_room(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::DeleteRoomRequest | Hash]
+          #     Deletes a room and all of its blurbs.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_room(name: nil)
+          #   @param name [String]
           #     The resource name of the requested room.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -340,20 +344,21 @@ module Google
           ##
           # Lists all chat rooms.
           #
-          # @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
-          #   Lists all chat rooms.
+          # @overload list_rooms(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ListRoomsRequest | Hash]
+          #     Lists all chat rooms.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `page_size` (`Integer`):
+          # @overload list_rooms(page_size: nil, page_token: nil)
+          #   @param page_size [Integer]
           #     The maximum number of rooms return. Server may return fewer rooms
           #     than requested. If unspecified, server will pick an appropriate default.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The value of google.showcase.v1alpha3.ListRoomsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\ListRooms` method.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Room>]
@@ -399,20 +404,21 @@ module Google
           # message in that room. If the parent is a profile, the blurb is understood
           # to be a post on the profile.
           #
-          # @param request [Google::Showcase::V1alpha3::CreateBlurbRequest | Hash]
-          #   Creates a blurb. If the parent is a room, the blurb is understood to be a
-          #   message in that room. If the parent is a profile, the blurb is understood
-          #   to be a post on the profile.
+          # @overload create_blurb(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::CreateBlurbRequest | Hash]
+          #     Creates a blurb. If the parent is a room, the blurb is understood to be a
+          #     message in that room. If the parent is a profile, the blurb is understood
+          #     to be a post on the profile.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `parent` (`String`):
+          # @overload create_blurb(parent: nil, blurb: nil)
+          #   @param parent [String]
           #     The resource name of the chat room or user profile that this blurb will
           #     be tied to.
-          #   * `blurb` (`Google::Showcase::V1alpha3::Blurb | Hash`):
+          #   @param blurb [Google::Showcase::V1alpha3::Blurb | Hash]
           #     The blurb to create.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -460,15 +466,16 @@ module Google
           ##
           # Retrieves the Blurb with the given resource name.
           #
-          # @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
-          #   Retrieves the Blurb with the given resource name.
+          # @overload get_blurb(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::GetBlurbRequest | Hash]
+          #     Retrieves the Blurb with the given resource name.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload get_blurb(name: nil)
+          #   @param name [String]
           #     The resource name of the requested blurb.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -516,18 +523,19 @@ module Google
           ##
           # Updates a blurb.
           #
-          # @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
-          #   Updates a blurb.
+          # @overload update_blurb(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::UpdateBlurbRequest | Hash]
+          #     Updates a blurb.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `blurb` (`Google::Showcase::V1alpha3::Blurb | Hash`):
+          # @overload update_blurb(blurb: nil, update_mask: nil)
+          #   @param blurb [Google::Showcase::V1alpha3::Blurb | Hash]
           #     The blurb to update.
-          #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Blurb]
@@ -575,15 +583,16 @@ module Google
           ##
           # Deletes a blurb.
           #
-          # @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
-          #   Deletes a blurb.
+          # @overload delete_blurb(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::DeleteBlurbRequest | Hash]
+          #     Deletes a blurb.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_blurb(name: nil)
+          #   @param name [String]
           #     The resource name of the requested blurb.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -632,24 +641,25 @@ module Google
           # Lists blurbs for a specific chat room or user profile depending on the
           # parent resource name.
           #
-          # @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
-          #   Lists blurbs for a specific chat room or user profile depending on the
-          #   parent resource name.
+          # @overload list_blurbs(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ListBlurbsRequest | Hash]
+          #     Lists blurbs for a specific chat room or user profile depending on the
+          #     parent resource name.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `parent` (`String`):
+          # @overload list_blurbs(parent: nil, page_size: nil, page_token: nil)
+          #   @param parent [String]
           #     The resource name of the requested room or profile whos blurbs to list.
-          #   * `page_size` (`Integer`):
+          #   @param page_size [Integer]
           #     The maximum number of blurbs to return. Server may return fewer
           #     blurbs than requested. If unspecified, server will pick an appropriate
           #     default.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The value of google.showcase.v1alpha3.ListBlurbsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\ListBlurbs` method.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Blurb>]
@@ -701,30 +711,31 @@ module Google
           # for blurbs containing to words found in the query. Only posts that
           # contain an exact match of a queried word will be returned.
           #
-          # @param request [Google::Showcase::V1alpha3::SearchBlurbsRequest | Hash]
-          #   This method searches through all blurbs across all rooms and profiles
-          #   for blurbs containing to words found in the query. Only posts that
-          #   contain an exact match of a queried word will be returned.
+          # @overload search_blurbs(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::SearchBlurbsRequest | Hash]
+          #     This method searches through all blurbs across all rooms and profiles
+          #     for blurbs containing to words found in the query. Only posts that
+          #     contain an exact match of a queried word will be returned.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `query` (`String`):
+          # @overload search_blurbs(query: nil, parent: nil, page_size: nil, page_token: nil)
+          #   @param query [String]
           #     The query used to search for blurbs containing to words of this string.
           #     Only posts that contain an exact match of a queried word will be returned.
-          #   * `parent` (`String`):
+          #   @param parent [String]
           #     The rooms or profiles to search. If unset, `SearchBlurbs` will search all
           #     rooms and all profiles.
-          #   * `page_size` (`Integer`):
+          #   @param page_size [Integer]
           #     The maximum number of blurbs return. Server may return fewer
           #     blurbs than requested. If unspecified, server will pick an appropriate
           #     default.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The value of
           #     google.showcase.v1alpha3.SearchBlurbsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1alpha3.Messaging\SearchBlurbs` method.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -775,18 +786,19 @@ module Google
           # This returns a stream that emits the blurbs that are created for a
           # particular chat room or user profile.
           #
-          # @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
-          #   This returns a stream that emits the blurbs that are created for a
-          #   particular chat room or user profile.
+          # @overload stream_blurbs(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::StreamBlurbsRequest | Hash]
+          #     This returns a stream that emits the blurbs that are created for a
+          #     particular chat room or user profile.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload stream_blurbs(name: nil, expire_time: nil)
+          #   @param name [String]
           #     The resource name of a chat room or user profile whose blurbs to stream.
-          #   * `expire_time` (`Google::Protobuf::Timestamp | Hash`):
+          #   @param expire_time [Google::Protobuf::Timestamp | Hash]
           #     The time at which this stream will close.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1alpha3::StreamBlurbsResponse>]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -114,25 +114,26 @@ module Google
           # NOTE: the `name` binding below allows API services to override the binding
           # to use different resource name schemes, such as `users/*/operations`.
           #
-          # @param request [Google::Longrunning::ListOperationsRequest | Hash]
-          #   Lists operations that match the specified filter in the request. If the
-          #   server doesn't support this method, it returns `UNIMPLEMENTED`.
+          # @overload list_operations(request, options = nil)
+          #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
+          #     Lists operations that match the specified filter in the request. If the
+          #     server doesn't support this method, it returns `UNIMPLEMENTED`.
           #
-          #   NOTE: the `name` binding below allows API services to override the binding
-          #   to use different resource name schemes, such as `users/*/operations`.
+          #     NOTE: the `name` binding below allows API services to override the binding
+          #     to use different resource name schemes, such as `users/*/operations`.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+          #   @param name [String]
           #     The name of the operation collection.
-          #   * `filter` (`String`):
+          #   @param filter [String]
           #     The standard list filter.
-          #   * `page_size` (`Integer`):
+          #   @param page_size [Integer]
           #     The standard list page size.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The standard list page token.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -185,17 +186,18 @@ module Google
           # method to poll the operation result at intervals as recommended by the API
           # service.
           #
-          # @param request [Google::Longrunning::GetOperationRequest | Hash]
-          #   Gets the latest state of a long-running operation.  Clients can use this
-          #   method to poll the operation result at intervals as recommended by the API
-          #   service.
+          # @overload get_operation(request, options = nil)
+          #   @param request [Google::Longrunning::GetOperationRequest | Hash]
+          #     Gets the latest state of a long-running operation.  Clients can use this
+          #     method to poll the operation result at intervals as recommended by the API
+          #     service.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload get_operation(name: nil)
+          #   @param name [String]
           #     The name of the operation resource.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::Operation]
@@ -248,18 +250,19 @@ module Google
           # operation. If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.
           #
-          # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-          #   Deletes a long-running operation. This method indicates that the client is
-          #   no longer interested in the operation result. It does not cancel the
-          #   operation. If the server doesn't support this method, it returns
-          #   `google.rpc.Code.UNIMPLEMENTED`.
+          # @overload delete_operation(request, options = nil)
+          #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+          #     Deletes a long-running operation. This method indicates that the client is
+          #     no longer interested in the operation result. It does not cancel the
+          #     operation. If the server doesn't support this method, it returns
+          #     `google.rpc.Code.UNIMPLEMENTED`.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_operation(name: nil)
+          #   @param name [String]
           #     The name of the operation resource to be deleted.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -316,24 +319,25 @@ module Google
           # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
           # corresponding to `Code.CANCELLED`.
           #
-          # @param request [Google::Longrunning::CancelOperationRequest | Hash]
-          #   Starts asynchronous cancellation on a long-running operation.  The server
-          #   makes a best effort to cancel the operation, but success is not
-          #   guaranteed.  If the server doesn't support this method, it returns
-          #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-          #   other methods to check whether the cancellation succeeded or whether the
-          #   operation completed despite cancellation. On successful cancellation,
-          #   the operation is not deleted; instead, it becomes an operation with
-          #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-          #   corresponding to `Code.CANCELLED`.
+          # @overload cancel_operation(request, options = nil)
+          #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
+          #     Starts asynchronous cancellation on a long-running operation.  The server
+          #     makes a best effort to cancel the operation, but success is not
+          #     guaranteed.  If the server doesn't support this method, it returns
+          #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+          #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          #     other methods to check whether the cancellation succeeded or whether the
+          #     operation completed despite cancellation. On successful cancellation,
+          #     the operation is not deleted; instead, it becomes an operation with
+          #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          #     corresponding to `Code.CANCELLED`.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload cancel_operation(name: nil)
+          #   @param name [String]
           #     The name of the operation resource to be cancelled.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -115,17 +115,18 @@ module Google
           ##
           # Creates a new testing session.
           #
-          # @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
-          #   Creates a new testing session.
+          # @overload create_session(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::CreateSessionRequest | Hash]
+          #     Creates a new testing session.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `session` (`Google::Showcase::V1alpha3::Session | Hash`):
+          # @overload create_session(session: nil)
+          #   @param session [Google::Showcase::V1alpha3::Session | Hash]
           #     The session to be created.
           #     Sessions are immutable once they are created (although they can
           #     be deleted).
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Session]
@@ -167,15 +168,16 @@ module Google
           ##
           # Gets a testing session.
           #
-          # @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
-          #   Gets a testing session.
+          # @overload get_session(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::GetSessionRequest | Hash]
+          #     Gets a testing session.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload get_session(name: nil)
+          #   @param name [String]
           #     The session to be retrieved.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::Session]
@@ -223,17 +225,18 @@ module Google
           ##
           # Lists the current test sessions.
           #
-          # @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
-          #   Lists the current test sessions.
+          # @overload list_sessions(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ListSessionsRequest | Hash]
+          #     Lists the current test sessions.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `page_size` (`Integer`):
+          # @overload list_sessions(page_size: nil, page_token: nil)
+          #   @param page_size [Integer]
           #     The maximum number of sessions to return per page.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The page token, for retrieving subsequent pages.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Session>]
@@ -277,15 +280,16 @@ module Google
           ##
           # Delete a test session.
           #
-          # @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
-          #   Delete a test session.
+          # @overload delete_session(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::DeleteSessionRequest | Hash]
+          #     Delete a test session.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_session(name: nil)
+          #   @param name [String]
           #     The session to be deleted.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -335,17 +339,18 @@ module Google
           # This generates a report detailing which tests have been completed,
           # and an overall rollup.
           #
-          # @param request [Google::Showcase::V1alpha3::ReportSessionRequest | Hash]
-          #   Report on the status of a session.
-          #   This generates a report detailing which tests have been completed,
-          #   and an overall rollup.
+          # @overload report_session(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ReportSessionRequest | Hash]
+          #     Report on the status of a session.
+          #     This generates a report detailing which tests have been completed,
+          #     and an overall rollup.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload report_session(name: nil)
+          #   @param name [String]
           #     The session to be reported on.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::ReportSessionResponse]
@@ -393,19 +398,20 @@ module Google
           ##
           # List the tests of a sessesion.
           #
-          # @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
-          #   List the tests of a sessesion.
+          # @overload list_tests(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::ListTestsRequest | Hash]
+          #     List the tests of a sessesion.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `parent` (`String`):
+          # @overload list_tests(parent: nil, page_size: nil, page_token: nil)
+          #   @param parent [String]
           #     The session.
-          #   * `page_size` (`Integer`):
+          #   @param page_size [Integer]
           #     The maximum number of tests to return per page.
-          #   * `page_token` (`String`):
+          #   @param page_token [String]
           #     The page token, for retrieving subsequent pages.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Gax::PagedEnumerable<Google::Showcase::V1alpha3::Test>]
@@ -460,20 +466,21 @@ module Google
           #
           # This method will error if attempting to delete a required test.
           #
-          # @param request [Google::Showcase::V1alpha3::DeleteTestRequest | Hash]
-          #   Explicitly decline to implement a test.
+          # @overload delete_test(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::DeleteTestRequest | Hash]
+          #     Explicitly decline to implement a test.
           #
-          #   This removes the test from subsequent `ListTests` calls, and
-          #   attempting to do the test will error.
+          #     This removes the test from subsequent `ListTests` calls, and
+          #     attempting to do the test will error.
           #
-          #   This method will error if attempting to delete a required test.
+          #     This method will error if attempting to delete a required test.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload delete_test(name: nil)
+          #   @param name [String]
           #     The test to be deleted.
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -524,22 +531,23 @@ module Google
           # In cases where a test involves registering a final answer at the
           # end of the test, this method provides the means to do so.
           #
-          # @param request [Google::Showcase::V1alpha3::VerifyTestRequest | Hash]
-          #   Register a response to a test.
+          # @overload verify_test(request, options = nil)
+          #   @param request [Google::Showcase::V1alpha3::VerifyTestRequest | Hash]
+          #     Register a response to a test.
           #
-          #   In cases where a test involves registering a final answer at the
-          #   end of the test, this method provides the means to do so.
+          #     In cases where a test involves registering a final answer at the
+          #     end of the test, this method provides the means to do so.
+          #   @param options [Google::Gax::ApiCall::Options, Hash]
+          #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
-          #   When using a hash, the following fields are supported:
-          #
-          #   * `name` (`String`):
+          # @overload verify_test(name: nil, answer: nil, answers: nil)
+          #   @param name [String]
           #     The test to have an answer registered to it.
-          #   * `answer` (`String`):
+          #   @param answer [String]
           #     The answer from the test.
-          #   * `answers` (`String`):
+          #   @param answers [String]
           #     The answers from the test if multiple are to be checked
-          # @param options [Google::Gax::ApiCall::Options, Hash]
-          #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1alpha3::VerifyTestResponse]

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -118,19 +118,20 @@ module Google
             # Performs synchronous speech recognition: receive results after all audio
             # has been sent and processed.
             #
-            # @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
-            #   Performs synchronous speech recognition: receive results after all audio
-            #   has been sent and processed.
+            # @overload recognize(request, options = nil)
+            #   @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
+            #     Performs synchronous speech recognition: receive results after all audio
+            #     has been sent and processed.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `config` (`Google::Cloud::Speech::V1::RecognitionConfig | Hash`):
+            # @overload recognize(config: nil, audio: nil)
+            #   @param config [Google::Cloud::Speech::V1::RecognitionConfig | Hash]
             #     *Required* Provides information to the recognizer that specifies how to
             #     process the request.
-            #   * `audio` (`Google::Cloud::Speech::V1::RecognitionAudio | Hash`):
+            #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
             #     *Required* The audio data to be recognized.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Speech::V1::RecognizeResponse]
@@ -175,21 +176,22 @@ module Google
             # `Operation.error` or an `Operation.response` which contains
             # a `LongRunningRecognizeResponse` message.
             #
-            # @param request [Google::Cloud::Speech::V1::LongRunningRecognizeRequest | Hash]
-            #   Performs asynchronous speech recognition: receive results via the
-            #   google.longrunning.Operations interface. Returns either an
-            #   `Operation.error` or an `Operation.response` which contains
-            #   a `LongRunningRecognizeResponse` message.
+            # @overload long_running_recognize(request, options = nil)
+            #   @param request [Google::Cloud::Speech::V1::LongRunningRecognizeRequest | Hash]
+            #     Performs asynchronous speech recognition: receive results via the
+            #     google.longrunning.Operations interface. Returns either an
+            #     `Operation.error` or an `Operation.response` which contains
+            #     a `LongRunningRecognizeResponse` message.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `config` (`Google::Cloud::Speech::V1::RecognitionConfig | Hash`):
+            # @overload long_running_recognize(config: nil, audio: nil)
+            #   @param config [Google::Cloud::Speech::V1::RecognitionConfig | Hash]
             #     *Required* Provides information to the recognizer that specifies how to
             #     process the request.
-            #   * `audio` (`Google::Cloud::Speech::V1::RecognitionAudio | Hash`):
+            #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
             #     *Required* The audio data to be recognized.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -115,25 +115,26 @@ module Google
             # NOTE: the `name` binding below allows API services to override the binding
             # to use different resource name schemes, such as `users/*/operations`.
             #
-            # @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #   Lists operations that match the specified filter in the request. If the
-            #   server doesn't support this method, it returns `UNIMPLEMENTED`.
+            # @overload list_operations(request, options = nil)
+            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
+            #     Lists operations that match the specified filter in the request. If the
+            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
             #
-            #   NOTE: the `name` binding below allows API services to override the binding
-            #   to use different resource name schemes, such as `users/*/operations`.
+            #     NOTE: the `name` binding below allows API services to override the binding
+            #     to use different resource name schemes, such as `users/*/operations`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+            #   @param name [String]
             #     The name of the operation collection.
-            #   * `filter` (`String`):
+            #   @param filter [String]
             #     The standard list filter.
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The standard list page size.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     The standard list page token.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -186,17 +187,18 @@ module Google
             # method to poll the operation result at intervals as recommended by the API
             # service.
             #
-            # @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #   Gets the latest state of a long-running operation.  Clients can use this
-            #   method to poll the operation result at intervals as recommended by the API
-            #   service.
+            # @overload get_operation(request, options = nil)
+            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
+            #     Gets the latest state of a long-running operation.  Clients can use this
+            #     method to poll the operation result at intervals as recommended by the API
+            #     service.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload get_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -249,18 +251,19 @@ module Google
             # operation. If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
-            # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #   Deletes a long-running operation. This method indicates that the client is
-            #   no longer interested in the operation result. It does not cancel the
-            #   operation. If the server doesn't support this method, it returns
-            #   `google.rpc.Code.UNIMPLEMENTED`.
+            # @overload delete_operation(request, options = nil)
+            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+            #     Deletes a long-running operation. This method indicates that the client is
+            #     no longer interested in the operation result. It does not cancel the
+            #     operation. If the server doesn't support this method, it returns
+            #     `google.rpc.Code.UNIMPLEMENTED`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload delete_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource to be deleted.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -317,24 +320,25 @@ module Google
             # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             # corresponding to `Code.CANCELLED`.
             #
-            # @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #   Starts asynchronous cancellation on a long-running operation.  The server
-            #   makes a best effort to cancel the operation, but success is not
-            #   guaranteed.  If the server doesn't support this method, it returns
-            #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-            #   other methods to check whether the cancellation succeeded or whether the
-            #   operation completed despite cancellation. On successful cancellation,
-            #   the operation is not deleted; instead, it becomes an operation with
-            #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-            #   corresponding to `Code.CANCELLED`.
+            # @overload cancel_operation(request, options = nil)
+            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
+            #     Starts asynchronous cancellation on a long-running operation.  The server
+            #     makes a best effort to cancel the operation, but success is not
+            #     guaranteed.  If the server doesn't support this method, it returns
+            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #     other methods to check whether the cancellation succeeded or whether the
+            #     operation completed despite cancellation. On successful cancellation,
+            #     the operation is not deleted; instead, it becomes an operation with
+            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #     corresponding to `Code.CANCELLED`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload cancel_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource to be cancelled.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -117,15 +117,16 @@ module Google
             ##
             # Run image detection and annotation for a batch of images.
             #
-            # @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
-            #   Run image detection and annotation for a batch of images.
+            # @overload batch_annotate_images(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
+            #     Run image detection and annotation for a batch of images.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `requests` (`Google::Cloud::Vision::V1::AnnotateImageRequest | Hash`):
+            # @overload batch_annotate_images(requests: nil)
+            #   @param requests [Google::Cloud::Vision::V1::AnnotateImageRequest | Hash]
             #     Individual image annotation requests for this batch.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
@@ -172,20 +173,21 @@ module Google
             # `Operation.metadata` contains `OperationMetadata` (metadata).
             # `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
             #
-            # @param request [Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest | Hash]
-            #   Run asynchronous image detection and annotation for a list of generic
-            #   files, such as PDF files, which may contain multiple pages and multiple
-            #   images per page. Progress and results can be retrieved through the
-            #   `google.longrunning.Operations` interface.
-            #   `Operation.metadata` contains `OperationMetadata` (metadata).
-            #   `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
+            # @overload async_batch_annotate_files(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest | Hash]
+            #     Run asynchronous image detection and annotation for a list of generic
+            #     files, such as PDF files, which may contain multiple pages and multiple
+            #     images per page. Progress and results can be retrieved through the
+            #     `google.longrunning.Operations` interface.
+            #     `Operation.metadata` contains `OperationMetadata` (metadata).
+            #     `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `requests` (`Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash`):
+            # @overload async_batch_annotate_files(requests: nil)
+            #   @param requests [Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash]
             #     Individual async file annotation requests for this batch.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -115,25 +115,26 @@ module Google
             # NOTE: the `name` binding below allows API services to override the binding
             # to use different resource name schemes, such as `users/*/operations`.
             #
-            # @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #   Lists operations that match the specified filter in the request. If the
-            #   server doesn't support this method, it returns `UNIMPLEMENTED`.
+            # @overload list_operations(request, options = nil)
+            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
+            #     Lists operations that match the specified filter in the request. If the
+            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
             #
-            #   NOTE: the `name` binding below allows API services to override the binding
-            #   to use different resource name schemes, such as `users/*/operations`.
+            #     NOTE: the `name` binding below allows API services to override the binding
+            #     to use different resource name schemes, such as `users/*/operations`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+            #   @param name [String]
             #     The name of the operation collection.
-            #   * `filter` (`String`):
+            #   @param filter [String]
             #     The standard list filter.
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The standard list page size.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     The standard list page token.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -186,17 +187,18 @@ module Google
             # method to poll the operation result at intervals as recommended by the API
             # service.
             #
-            # @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #   Gets the latest state of a long-running operation.  Clients can use this
-            #   method to poll the operation result at intervals as recommended by the API
-            #   service.
+            # @overload get_operation(request, options = nil)
+            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
+            #     Gets the latest state of a long-running operation.  Clients can use this
+            #     method to poll the operation result at intervals as recommended by the API
+            #     service.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload get_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -249,18 +251,19 @@ module Google
             # operation. If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
-            # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #   Deletes a long-running operation. This method indicates that the client is
-            #   no longer interested in the operation result. It does not cancel the
-            #   operation. If the server doesn't support this method, it returns
-            #   `google.rpc.Code.UNIMPLEMENTED`.
+            # @overload delete_operation(request, options = nil)
+            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+            #     Deletes a long-running operation. This method indicates that the client is
+            #     no longer interested in the operation result. It does not cancel the
+            #     operation. If the server doesn't support this method, it returns
+            #     `google.rpc.Code.UNIMPLEMENTED`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload delete_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource to be deleted.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -317,24 +320,25 @@ module Google
             # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             # corresponding to `Code.CANCELLED`.
             #
-            # @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #   Starts asynchronous cancellation on a long-running operation.  The server
-            #   makes a best effort to cancel the operation, but success is not
-            #   guaranteed.  If the server doesn't support this method, it returns
-            #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-            #   other methods to check whether the cancellation succeeded or whether the
-            #   operation completed despite cancellation. On successful cancellation,
-            #   the operation is not deleted; instead, it becomes an operation with
-            #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-            #   corresponding to `Code.CANCELLED`.
+            # @overload cancel_operation(request, options = nil)
+            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
+            #     Starts asynchronous cancellation on a long-running operation.  The server
+            #     makes a best effort to cancel the operation, but success is not
+            #     guaranteed.  If the server doesn't support this method, it returns
+            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #     other methods to check whether the cancellation succeeded or whether the
+            #     operation completed despite cancellation. On successful cancellation,
+            #     the operation is not deleted; instead, it becomes an operation with
+            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #     corresponding to `Code.CANCELLED`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload cancel_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource to be cancelled.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -122,29 +122,30 @@ module Google
             # * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
             #   4096 characters.
             #
-            # @param request [Google::Cloud::Vision::V1::CreateProductSetRequest | Hash]
-            #   Creates and returns a new ProductSet resource.
+            # @overload create_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::CreateProductSetRequest | Hash]
+            #     Creates and returns a new ProductSet resource.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
-            #     4096 characters.
+            #     * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
+            #       4096 characters.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload create_product_set(parent: nil, product_set: nil, product_set_id: nil)
+            #   @param parent [String]
             #     The project in which the ProductSet should be created.
             #
             #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   * `product_set` (`Google::Cloud::Vision::V1::ProductSet | Hash`):
+            #   @param product_set [Google::Cloud::Vision::V1::ProductSet | Hash]
             #     The ProductSet to create.
-            #   * `product_set_id` (`String`):
+            #   @param product_set_id [String]
             #     A user-supplied resource id for this ProductSet. If set, the server will
             #     attempt to use this value as the resource id. If it is already in use, an
             #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
             #     long. It cannot contain the character `/`.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -197,26 +198,27 @@ module Google
             # * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
             #   than 1.
             #
-            # @param request [Google::Cloud::Vision::V1::ListProductSetsRequest | Hash]
-            #   Lists ProductSets in an unspecified order.
+            # @overload list_product_sets(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::ListProductSetsRequest | Hash]
+            #     Lists ProductSets in an unspecified order.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
-            #     than 1.
+            #     * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
+            #       than 1.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload list_product_sets(parent: nil, page_size: nil, page_token: nil)
+            #   @param parent [String]
             #     The project from which ProductSets should be listed.
             #
             #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The maximum number of items to return. Default 10, maximum 100.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ProductSet>]
@@ -270,22 +272,23 @@ module Google
             #
             # * Returns NOT_FOUND if the ProductSet does not exist.
             #
-            # @param request [Google::Cloud::Vision::V1::GetProductSetRequest | Hash]
-            #   Gets information associated with a ProductSet.
+            # @overload get_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::GetProductSetRequest | Hash]
+            #     Gets information associated with a ProductSet.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the ProductSet does not exist.
+            #     * Returns NOT_FOUND if the ProductSet does not exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload get_product_set(name: nil)
+            #   @param name [String]
             #     Resource name of the ProductSet to get.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -340,27 +343,28 @@ module Google
             # * Returns INVALID_ARGUMENT if display_name is present in update_mask but
             #   missing from the request or longer than 4096 characters.
             #
-            # @param request [Google::Cloud::Vision::V1::UpdateProductSetRequest | Hash]
-            #   Makes changes to a ProductSet resource.
-            #   Only display_name can be updated currently.
+            # @overload update_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::UpdateProductSetRequest | Hash]
+            #     Makes changes to a ProductSet resource.
+            #     Only display_name can be updated currently.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the ProductSet does not exist.
-            #   * Returns INVALID_ARGUMENT if display_name is present in update_mask but
-            #     missing from the request or longer than 4096 characters.
+            #     * Returns NOT_FOUND if the ProductSet does not exist.
+            #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but
+            #       missing from the request or longer than 4096 characters.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `product_set` (`Google::Cloud::Vision::V1::ProductSet | Hash`):
+            # @overload update_product_set(product_set: nil, update_mask: nil)
+            #   @param product_set [Google::Cloud::Vision::V1::ProductSet | Hash]
             #     The ProductSet resource which replaces the one on the server.
-            #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+            #   @param update_mask [Google::Protobuf::FieldMask | Hash]
             #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields to
             #     update.
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask path is `display_name`.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -415,25 +419,26 @@ module Google
             #
             # * Returns NOT_FOUND if the ProductSet does not exist.
             #
-            # @param request [Google::Cloud::Vision::V1::DeleteProductSetRequest | Hash]
-            #   Permanently deletes a ProductSet. Products and ReferenceImages in the
-            #   ProductSet are not deleted.
+            # @overload delete_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::DeleteProductSetRequest | Hash]
+            #     Permanently deletes a ProductSet. Products and ReferenceImages in the
+            #     ProductSet are not deleted.
             #
-            #   The actual image files are not deleted from Google Cloud Storage.
+            #     The actual image files are not deleted from Google Cloud Storage.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the ProductSet does not exist.
+            #     * Returns NOT_FOUND if the ProductSet does not exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload delete_product_set(name: nil)
+            #   @param name [String]
             #     Resource name of the ProductSet to delete.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -488,32 +493,33 @@ module Google
             # * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
             # * Returns INVALID_ARGUMENT if product_category is missing or invalid.
             #
-            # @param request [Google::Cloud::Vision::V1::CreateProductRequest | Hash]
-            #   Creates and returns a new product resource.
+            # @overload create_product(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::CreateProductRequest | Hash]
+            #     Creates and returns a new product resource.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
-            #     characters.
-            #   * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
-            #   * Returns INVALID_ARGUMENT if product_category is missing or invalid.
+            #     * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
+            #       characters.
+            #     * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
+            #     * Returns INVALID_ARGUMENT if product_category is missing or invalid.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload create_product(parent: nil, product: nil, product_id: nil)
+            #   @param parent [String]
             #     The project in which the Product should be created.
             #
             #     Format is
             #     `projects/PROJECT_ID/locations/LOC_ID`.
-            #   * `product` (`Google::Cloud::Vision::V1::Product | Hash`):
+            #   @param product [Google::Cloud::Vision::V1::Product | Hash]
             #     The product to create.
-            #   * `product_id` (`String`):
+            #   @param product_id [String]
             #     A user-supplied resource id for this Product. If set, the server will
             #     attempt to use this value as the resource id. If it is already in use, an
             #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
             #     long. It cannot contain the character `/`.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -565,26 +571,27 @@ module Google
             #
             # * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #
-            # @param request [Google::Cloud::Vision::V1::ListProductsRequest | Hash]
-            #   Lists products in an unspecified order.
+            # @overload list_products(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::ListProductsRequest | Hash]
+            #     Lists products in an unspecified order.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload list_products(parent: nil, page_size: nil, page_token: nil)
+            #   @param parent [String]
             #     The project OR ProductSet from which Products should be listed.
             #
             #     Format:
             #     `projects/PROJECT_ID/locations/LOC_ID`
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The maximum number of items to return. Default 10, maximum 100.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -638,22 +645,23 @@ module Google
             #
             # * Returns NOT_FOUND if the Product does not exist.
             #
-            # @param request [Google::Cloud::Vision::V1::GetProductRequest | Hash]
-            #   Gets information associated with a Product.
+            # @overload get_product(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::GetProductRequest | Hash]
+            #     Gets information associated with a Product.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the Product does not exist.
+            #     * Returns NOT_FOUND if the Product does not exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload get_product(name: nil)
+            #   @param name [String]
             #     Resource name of the Product to get.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -715,36 +723,37 @@ module Google
             #   longer than 4096 characters.
             # * Returns INVALID_ARGUMENT if product_category is present in update_mask.
             #
-            # @param request [Google::Cloud::Vision::V1::UpdateProductRequest | Hash]
-            #   Makes changes to a Product resource.
-            #   Only the `display_name`, `description`, and `labels` fields can be updated
-            #   right now.
+            # @overload update_product(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::UpdateProductRequest | Hash]
+            #     Makes changes to a Product resource.
+            #     Only the `display_name`, `description`, and `labels` fields can be updated
+            #     right now.
             #
-            #   If labels are updated, the change will not be reflected in queries until
-            #   the next index time.
+            #     If labels are updated, the change will not be reflected in queries until
+            #     the next index time.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the Product does not exist.
-            #   * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
-            #     missing from the request or longer than 4096 characters.
-            #   * Returns INVALID_ARGUMENT if description is present in update_mask but is
-            #     longer than 4096 characters.
-            #   * Returns INVALID_ARGUMENT if product_category is present in update_mask.
+            #     * Returns NOT_FOUND if the Product does not exist.
+            #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
+            #       missing from the request or longer than 4096 characters.
+            #     * Returns INVALID_ARGUMENT if description is present in update_mask but is
+            #       longer than 4096 characters.
+            #     * Returns INVALID_ARGUMENT if product_category is present in update_mask.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `product` (`Google::Cloud::Vision::V1::Product | Hash`):
+            # @overload update_product(product: nil, update_mask: nil)
+            #   @param product [Google::Cloud::Vision::V1::Product | Hash]
             #     The Product resource which replaces the one on the server.
             #     product.name is immutable.
-            #   * `update_mask` (`Google::Protobuf::FieldMask | Hash`):
+            #   @param update_mask [Google::Protobuf::FieldMask | Hash]
             #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields
             #     to update.
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask paths include `product_labels`, `display_name`, and
             #     `description`.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -800,26 +809,27 @@ module Google
             #
             # * Returns NOT_FOUND if the product does not exist.
             #
-            # @param request [Google::Cloud::Vision::V1::DeleteProductRequest | Hash]
-            #   Permanently deletes a product and its reference images.
+            # @overload delete_product(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::DeleteProductRequest | Hash]
+            #     Permanently deletes a product and its reference images.
             #
-            #   Metadata of the product and all its images will be deleted right away, but
-            #   search queries against ProductSets containing the product may still work
-            #   until all related caches are refreshed.
+            #     Metadata of the product and all its images will be deleted right away, but
+            #     search queries against ProductSets containing the product may still work
+            #     until all related caches are refreshed.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the product does not exist.
+            #     * Returns NOT_FOUND if the product does not exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload delete_product(name: nil)
+            #   @param name [String]
             #     Resource name of product to delete.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -885,44 +895,45 @@ module Google
             #   compatible with the parent product's product_category is detected.
             # * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
             #
-            # @param request [Google::Cloud::Vision::V1::CreateReferenceImageRequest | Hash]
-            #   Creates and returns a new ReferenceImage resource.
+            # @overload create_reference_image(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::CreateReferenceImageRequest | Hash]
+            #     Creates and returns a new ReferenceImage resource.
             #
-            #   The `bounding_poly` field is optional. If `bounding_poly` is not specified,
-            #   the system will try to detect regions of interest in the image that are
-            #   compatible with the product_category on the parent product. If it is
-            #   specified, detection is ALWAYS skipped. The system converts polygons into
-            #   non-rotated rectangles.
+            #     The `bounding_poly` field is optional. If `bounding_poly` is not specified,
+            #     the system will try to detect regions of interest in the image that are
+            #     compatible with the product_category on the parent product. If it is
+            #     specified, detection is ALWAYS skipped. The system converts polygons into
+            #     non-rotated rectangles.
             #
-            #   Note that the pipeline will resize the image if the image resolution is too
-            #   large to process (above 50MP).
+            #     Note that the pipeline will resize the image if the image resolution is too
+            #     large to process (above 50MP).
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
-            #     characters.
-            #   * Returns INVALID_ARGUMENT if the product does not exist.
-            #   * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
-            #     compatible with the parent product's product_category is detected.
-            #   * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
+            #     * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
+            #       characters.
+            #     * Returns INVALID_ARGUMENT if the product does not exist.
+            #     * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
+            #       compatible with the parent product's product_category is detected.
+            #     * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload create_reference_image(parent: nil, reference_image: nil, reference_image_id: nil)
+            #   @param parent [String]
             #     Resource name of the product in which to create the reference image.
             #
             #     Format is
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
-            #   * `reference_image` (`Google::Cloud::Vision::V1::ReferenceImage | Hash`):
+            #   @param reference_image [Google::Cloud::Vision::V1::ReferenceImage | Hash]
             #     The reference image to create.
             #     If an image ID is specified, it is ignored.
-            #   * `reference_image_id` (`String`):
+            #   @param reference_image_id [String]
             #     A user-supplied resource id for the ReferenceImage to be added. If set,
             #     the server will attempt to use this value as the resource id. If it is
             #     already in use, an error is returned with code ALREADY_EXISTS. Must be at
             #     most 128 characters long. It cannot contain the character `/`.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -980,29 +991,30 @@ module Google
             #
             # * Returns NOT_FOUND if the reference image does not exist.
             #
-            # @param request [Google::Cloud::Vision::V1::DeleteReferenceImageRequest | Hash]
-            #   Permanently deletes a reference image.
+            # @overload delete_reference_image(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::DeleteReferenceImageRequest | Hash]
+            #     Permanently deletes a reference image.
             #
-            #   The image metadata will be deleted right away, but search queries
-            #   against ProductSets containing the image may still work until all related
-            #   caches are refreshed.
+            #     The image metadata will be deleted right away, but search queries
+            #     against ProductSets containing the image may still work until all related
+            #     caches are refreshed.
             #
-            #   The actual image files are not deleted from Google Cloud Storage.
+            #     The actual image files are not deleted from Google Cloud Storage.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the reference image does not exist.
+            #     * Returns NOT_FOUND if the reference image does not exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload delete_reference_image(name: nil)
+            #   @param name [String]
             #     The resource name of the reference image to delete.
             #
             #     Format is:
             #
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1056,31 +1068,32 @@ module Google
             # * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
             #   than 1.
             #
-            # @param request [Google::Cloud::Vision::V1::ListReferenceImagesRequest | Hash]
-            #   Lists reference images.
+            # @overload list_reference_images(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::ListReferenceImagesRequest | Hash]
+            #     Lists reference images.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the parent product does not exist.
-            #   * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
-            #     than 1.
+            #     * Returns NOT_FOUND if the parent product does not exist.
+            #     * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
+            #       than 1.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload list_reference_images(parent: nil, page_size: nil, page_token: nil)
+            #   @param parent [String]
             #     Resource name of the product containing the reference images.
             #
             #     Format is
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The maximum number of items to return. Default 10, maximum 100.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     A token identifying a page of results to be returned. This is the value
             #     of `nextPageToken` returned in a previous reference image list request.
             #
             #     Defaults to the first page if not specified.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::ReferenceImage>]
@@ -1134,23 +1147,24 @@ module Google
             #
             # * Returns NOT_FOUND if the specified image does not exist.
             #
-            # @param request [Google::Cloud::Vision::V1::GetReferenceImageRequest | Hash]
-            #   Gets information associated with a ReferenceImage.
+            # @overload get_reference_image(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::GetReferenceImageRequest | Hash]
+            #     Gets information associated with a ReferenceImage.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the specified image does not exist.
+            #     * Returns NOT_FOUND if the specified image does not exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload get_reference_image(name: nil)
+            #   @param name [String]
             #     The resource name of the ReferenceImage to get.
             #
             #     Format is:
             #
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -1205,30 +1219,31 @@ module Google
             #
             # * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
             #
-            # @param request [Google::Cloud::Vision::V1::AddProductToProductSetRequest | Hash]
-            #   Adds a Product to the specified ProductSet. If the Product is already
-            #   present, no change is made.
+            # @overload add_product_to_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::AddProductToProductSetRequest | Hash]
+            #     Adds a Product to the specified ProductSet. If the Product is already
+            #     present, no change is made.
             #
-            #   One Product can be added to at most 100 ProductSets.
+            #     One Product can be added to at most 100 ProductSets.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
+            #     * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload add_product_to_product_set(name: nil, product: nil)
+            #   @param name [String]
             #     The resource name for the ProductSet to modify.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   * `product` (`String`):
+            #   @param product [String]
             #     The resource name for the Product to be added to this ProductSet.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1280,27 +1295,28 @@ module Google
             #
             # * Returns NOT_FOUND If the Product is not found under the ProductSet.
             #
-            # @param request [Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest | Hash]
-            #   Removes a Product from the specified ProductSet.
+            # @overload remove_product_from_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest | Hash]
+            #     Removes a Product from the specified ProductSet.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns NOT_FOUND If the Product is not found under the ProductSet.
+            #     * Returns NOT_FOUND If the Product is not found under the ProductSet.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload remove_product_from_product_set(name: nil, product: nil)
+            #   @param name [String]
             #     The resource name for the ProductSet to modify.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   * `product` (`String`):
+            #   @param product [String]
             #     The resource name for the Product to be removed from this ProductSet.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1354,28 +1370,29 @@ module Google
             #
             # * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #
-            # @param request [Google::Cloud::Vision::V1::ListProductsInProductSetRequest | Hash]
-            #   Lists the Products in a ProductSet, in an unspecified order. If the
-            #   ProductSet does not exist, the products field of the response will be
-            #   empty.
+            # @overload list_products_in_product_set(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::ListProductsInProductSetRequest | Hash]
+            #     Lists the Products in a ProductSet, in an unspecified order. If the
+            #     ProductSet does not exist, the products field of the response will be
+            #     empty.
             #
-            #   Possible errors:
+            #     Possible errors:
             #
-            #   * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload list_products_in_product_set(name: nil, page_size: nil, page_token: nil)
+            #   @param name [String]
             #     The ProductSet resource for which to retrieve Products.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The maximum number of items to return. Default 10, maximum 100.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -1435,29 +1452,30 @@ module Google
             # For the format of the csv file please see
             # [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
             #
-            # @param request [Google::Cloud::Vision::V1::ImportProductSetsRequest | Hash]
-            #   Asynchronous API that imports a list of reference images to specified
-            #   product sets based on a list of image information.
+            # @overload import_product_sets(request, options = nil)
+            #   @param request [Google::Cloud::Vision::V1::ImportProductSetsRequest | Hash]
+            #     Asynchronous API that imports a list of reference images to specified
+            #     product sets based on a list of image information.
             #
-            #   The [google.longrunning.Operation][google.longrunning.Operation] API can be
-            #   used to keep track of the progress and results of the request.
-            #   `Operation.metadata` contains `BatchOperationMetadata`. (progress)
-            #   `Operation.response` contains `ImportProductSetsResponse`. (results)
+            #     The [google.longrunning.Operation][google.longrunning.Operation] API can be
+            #     used to keep track of the progress and results of the request.
+            #     `Operation.metadata` contains `BatchOperationMetadata`. (progress)
+            #     `Operation.response` contains `ImportProductSetsResponse`. (results)
             #
-            #   The input source of this method is a csv file on Google Cloud Storage.
-            #   For the format of the csv file please see
-            #   [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+            #     The input source of this method is a csv file on Google Cloud Storage.
+            #     For the format of the csv file please see
+            #     [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `parent` (`String`):
+            # @overload import_product_sets(parent: nil, input_config: nil)
+            #   @param parent [String]
             #     The project in which the ProductSets should be imported.
             #
             #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   * `input_config` (`Google::Cloud::Vision::V1::ImportProductSetsInputConfig | Hash`):
+            #   @param input_config [Google::Cloud::Vision::V1::ImportProductSetsInputConfig | Hash]
             #     The input content for the list of requests.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -115,25 +115,26 @@ module Google
             # NOTE: the `name` binding below allows API services to override the binding
             # to use different resource name schemes, such as `users/*/operations`.
             #
-            # @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #   Lists operations that match the specified filter in the request. If the
-            #   server doesn't support this method, it returns `UNIMPLEMENTED`.
+            # @overload list_operations(request, options = nil)
+            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
+            #     Lists operations that match the specified filter in the request. If the
+            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
             #
-            #   NOTE: the `name` binding below allows API services to override the binding
-            #   to use different resource name schemes, such as `users/*/operations`.
+            #     NOTE: the `name` binding below allows API services to override the binding
+            #     to use different resource name schemes, such as `users/*/operations`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+            #   @param name [String]
             #     The name of the operation collection.
-            #   * `filter` (`String`):
+            #   @param filter [String]
             #     The standard list filter.
-            #   * `page_size` (`Integer`):
+            #   @param page_size [Integer]
             #     The standard list page size.
-            #   * `page_token` (`String`):
+            #   @param page_token [String]
             #     The standard list page token.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::PagedEnumerable<Google::Gax::Operation>]
@@ -186,17 +187,18 @@ module Google
             # method to poll the operation result at intervals as recommended by the API
             # service.
             #
-            # @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #   Gets the latest state of a long-running operation.  Clients can use this
-            #   method to poll the operation result at intervals as recommended by the API
-            #   service.
+            # @overload get_operation(request, options = nil)
+            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
+            #     Gets the latest state of a long-running operation.  Clients can use this
+            #     method to poll the operation result at intervals as recommended by the API
+            #     service.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload get_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Gax::Operation]
@@ -249,18 +251,19 @@ module Google
             # operation. If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
-            # @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #   Deletes a long-running operation. This method indicates that the client is
-            #   no longer interested in the operation result. It does not cancel the
-            #   operation. If the server doesn't support this method, it returns
-            #   `google.rpc.Code.UNIMPLEMENTED`.
+            # @overload delete_operation(request, options = nil)
+            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
+            #     Deletes a long-running operation. This method indicates that the client is
+            #     no longer interested in the operation result. It does not cancel the
+            #     operation. If the server doesn't support this method, it returns
+            #     `google.rpc.Code.UNIMPLEMENTED`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload delete_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource to be deleted.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -317,24 +320,25 @@ module Google
             # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
             # corresponding to `Code.CANCELLED`.
             #
-            # @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #   Starts asynchronous cancellation on a long-running operation.  The server
-            #   makes a best effort to cancel the operation, but success is not
-            #   guaranteed.  If the server doesn't support this method, it returns
-            #   `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #   [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
-            #   other methods to check whether the cancellation succeeded or whether the
-            #   operation completed despite cancellation. On successful cancellation,
-            #   the operation is not deleted; instead, it becomes an operation with
-            #   an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-            #   corresponding to `Code.CANCELLED`.
+            # @overload cancel_operation(request, options = nil)
+            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
+            #     Starts asynchronous cancellation on a long-running operation.  The server
+            #     makes a best effort to cancel the operation, but success is not
+            #     guaranteed.  If the server doesn't support this method, it returns
+            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
+            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #     other methods to check whether the cancellation succeeded or whether the
+            #     operation completed despite cancellation. On successful cancellation,
+            #     the operation is not deleted; instead, it becomes an operation with
+            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #     corresponding to `Code.CANCELLED`.
+            #   @param options [Google::Gax::ApiCall::Options, Hash]
+            #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
-            #   When using a hash, the following fields are supported:
-            #
-            #   * `name` (`String`):
+            # @overload cancel_operation(name: nil)
+            #   @param name [String]
             #     The name of the operation resource to be cancelled.
-            # @param options [Google::Gax::ApiCall::Options, Hash]
-            #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
+            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]


### PR DESCRIPTION
The named arg method docs were removed when the methods were switched
to use positional args. This change restores the previous named arg
docs, except the named args cannot specify the optional call options.
This demonstrates how we can use the positonal args as named args.