### PR TITLE
Add docker entrypoint for ads

### DIFF
--- a/gapic-generator-ads/Dockerfile
+++ b/gapic-generator-ads/Dockerfile
@@ -14,8 +14,9 @@
 
 ##
 # Builder image.
-# Creates /workspace/gapic-generator.gem which is later copied into the
-# final runtime image.
+# Creates /workspace/gapic-generator-ads.gem (and possibly also
+# /workspace/gapic-generator.gem if building the base gem from master).
+# These gem files are copied into the final runtime image.
 ##
 FROM ruby:2.6-stretch as builder
 WORKDIR /workspace
@@ -23,8 +24,14 @@ WORKDIR /workspace
 # Copy code from the local directory.
 COPY . /workspace/
 
-# Create a build of the gapic-generator gem from source.
-RUN gem build -o gapic-generator.gem gapic-generator.gemspec
+# Build the base generator from source if the directory is present.
+RUN if [ -d tmp/gapic-generator ]; then \
+      cd tmp/gapic-generator \
+      && gem build -o ../../gapic-generator.gem gapic-generator.gemspec \
+    ;fi
+
+# Create a build of the gapic-generator-ads gem from source.
+RUN gem build -o gapic-generator-ads.gem gapic-generator-ads.gemspec
 
 
 ##
@@ -40,9 +47,15 @@ COPY --from=gcr.io/gapic-images/api-common-protos:beta /protos/ /workspace/commo
 # Copy gems from the builder.
 COPY --from=builder /workspace/*.gem /workspace/
 
-# Install the generator and other needed tools.
-RUN gem install grpc-tools ./gapic-generator.gem \
-    && rm gapic-generator.gem \
+# Install the base generator first if it was built from source.
+RUN if [ -f gapic-generator.gem ]; then \
+      gem install gapic-generator.gem \
+      && rm gapic-generator.gem \
+    ;fi
+
+# Install the subgenerator and other needed tools.
+RUN gem install grpc-tools gapic-generator-ads.gem \
+    && rm gapic-generator-ads.gem \
     && mkdir -p --mode=777 /.cache
 
 # Install the entrypoint.

--- a/gapic-generator-ads/Gemfile
+++ b/gapic-generator-ads/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-# Specify your gem's dependencies in gapic-generator-cloud.gemspec
+# Specify your gem's dependencies in gapic-generator-ads.gemspec
 gemspec
 
 gem "gapic-generator", path: "../gapic-generator"

--- a/gapic-generator-ads/LICENSE
+++ b/gapic-generator-ads/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/gapic-generator-ads/Rakefile
+++ b/gapic-generator-ads/Rakefile
@@ -65,6 +65,25 @@ task :console do
   IRB.start
 end
 
+desc "Build the docker image."
+task :image, :name do |_t, args|
+  image_name = args[:name] || "ruby-gapic-generator-ads"
+  sh "docker build -t #{image_name} ."
+end
+namespace :image do
+  desc "Build the docker image using the local base image code"
+  task :local, :name do |_t, args|
+    image_name = args[:name] || "ruby-gapic-generator-ads"
+    mkdir_p "tmp"
+    base_source_dir = File.join File.dirname(__dir__), "gapic-generator"
+    base_tmp_dir = File.join __dir__, "tmp", "gapic-generator"
+    rm_rf base_tmp_dir
+    cp_r base_source_dir, base_tmp_dir
+    sh "docker build -t #{image_name} ."
+    rm_r base_tmp_dir
+  end
+end
+
 def api service
   require "google/gapic/schema/api"
   bin_proto = File.binread "proto_input/#{service}_desc.bin"

--- a/gapic-generator-ads/docker-entrypoint.sh
+++ b/gapic-generator-ads/docker-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# enable extended globbing for flag pattern matching
+shopt -s extglob
+
+# Parse out options.
+while true; do
+  case "$1" in
+    --ruby-ads* ) echo "Skipping unrecognized ruby-ads flag: $1" >&2; shift ;;
+    --* | +([[:word:][:punct:]]) ) shift ;;
+    * ) break ;;
+  esac
+done
+
+mkdir -p /workspace/out/lib
+exec grpc_tools_ruby_protoc \
+        --proto_path=/workspace/common-protos/ --proto_path=/workspace/in/ \
+        --ruby_out=/workspace/out/lib \
+        --grpc_out=/workspace/out/lib \
+        --ruby_ads_out=/workspace/out/ \
+        --ruby_ads_opt="configuration=/workspace/config.yml" \
+        `find /workspace/in/ -name *.proto`

--- a/gapic-generator-ads/gapic-generator-ads.gemspec
+++ b/gapic-generator-ads/gapic-generator-ads.gemspec
@@ -31,13 +31,10 @@ Gem::Specification.new do |spec|
   spec.summary       = "An API Client Generator for Ruby in Ruby!"
   spec.homepage      = "https://github.com/googleapis/gapic-generator-ruby"
 
-  # Specify which files should be added to the gem when it is released. The `git
-  # ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir File.expand_path(__dir__) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      f.match %r{^(test|spec|features)/}
-    end
-  end
+  spec.files         = Dir.glob("bin/*") + Dir.glob("lib/**/*.rb") +
+                       Dir.glob("templates/**/*.{rb,erb}") +
+                       Dir.glob("*.md") +
+                       ["LICENSE"]
   spec.bindir        = "bin"
   spec.executables   = ["protoc-gen-ruby_ads"]
   spec.require_paths = ["lib"]

--- a/gapic-generator-cloud/Dockerfile
+++ b/gapic-generator-cloud/Dockerfile
@@ -61,6 +61,3 @@ RUN gem install grpc-tools gapic-generator-cloud.gem \
 # Install the entrypoint.
 COPY ./docker-entrypoint.sh /workspace/entrypoint.sh
 ENTRYPOINT ["/workspace/entrypoint.sh"]
-
-# TEMP: Remove after google-style-0.3.1 is released
-RUN chmod -R a+r /usr/local/bundle/gems/google-style-0.3.0

--- a/gapic-generator-cloud/Rakefile
+++ b/gapic-generator-cloud/Rakefile
@@ -79,7 +79,7 @@ namespace :image do
     mkdir_p "tmp"
     base_source_dir = File.join File.dirname(__dir__), "gapic-generator"
     base_tmp_dir = File.join __dir__, "tmp", "gapic-generator"
-    rm_r base_tmp_dir
+    rm_rf base_tmp_dir
     cp_r base_source_dir, base_tmp_dir
     sh "docker build -t #{image_name} ."
     rm_r base_tmp_dir

--- a/gapic-generator-cloud/gapic-generator-cloud.gemspec
+++ b/gapic-generator-cloud/gapic-generator-cloud.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir.glob("bin/*") + Dir.glob("lib/**/*.rb") +
                        Dir.glob("templates/**/*.{rb,erb}") +
-                       Dir.glob("*.md") + Dir.glob("*-rubocop.yml") +
-                       ["LICENSE"]
+                       Dir.glob("*.md") +
+                       ["LICENSE", "cloud-rubocop.yml"]
   spec.bindir        = "bin"
   spec.executables   = ["protoc-gen-ruby_cloud"]
   spec.require_paths = ["lib"]

--- a/gapic-generator/gapic-generator.gemspec
+++ b/gapic-generator/gapic-generator.gemspec
@@ -29,13 +29,11 @@ Gem::Specification.new do |spec|
   spec.summary       = "An API Client Generator for Ruby in Ruby!"
   spec.homepage      = "https://github.com/googleapis/gapic-generator-ruby"
 
-  spec.files         = Dir.glob("bin/*") +
+  spec.files         = Dir.glob("bin/*") + Dir.glob("lib/**/*.rb") +
                        Dir.glob("gem_templates/**/*.erb") +
-                       Dir.glob("lib/**/*.rb") +
                        Dir.glob("templates/**/*.{rb,erb}") +
                        Dir.glob("*.md") +
-                       Dir.glob("*-rubocop.yml") +
-                       ["LICENSE"]
+                       ["LICENSE", "default-rubocop.yml"]
   spec.bindir        = "bin"
   spec.executables   = ["gapic-generator", "protoc-gen-ruby_gapic"]
   spec.require_paths = ["lib"]

--- a/gapic-generator/gem_templates/gemspec.erb
+++ b/gapic-generator/gem_templates/gemspec.erb
@@ -18,12 +18,9 @@ Gem::Specification.new do |spec|
   spec.summary       = "An API Client Generator for Ruby in Ruby!"
   spec.homepage      = "https://github.com/googleapis/gapic-generator-ruby"
 
-  spec.files         = Dir.glob("bin/*") +
-                       Dir.glob("lib/**/*.rb") +
+  spec.files         = Dir.glob("bin/*") + Dir.glob("lib/**/*.rb") +
                        Dir.glob("templates/**/*.{rb,erb}") +
-                       Dir.glob("*.md") +
-                       Dir.glob("*-rubocop.yml") +
-                       ["LICENSE"]
+                       Dir.glob("*.md")
   spec.bindir        = "bin"
   spec.executables   = ["protoc-gen-ruby_<%= gem_name %>"]
   spec.require_paths = ["lib"]

--- a/shared/output/gapic/gems/my_plugin/gapic-generator-my_plugin.gemspec
+++ b/shared/output/gapic/gems/my_plugin/gapic-generator-my_plugin.gemspec
@@ -31,12 +31,9 @@ Gem::Specification.new do |spec|
   spec.summary       = "An API Client Generator for Ruby in Ruby!"
   spec.homepage      = "https://github.com/googleapis/gapic-generator-ruby"
 
-  spec.files         = Dir.glob("bin/*") +
-                       Dir.glob("lib/**/*.rb") +
+  spec.files         = Dir.glob("bin/*") + Dir.glob("lib/**/*.rb") +
                        Dir.glob("templates/**/*.{rb,erb}") +
-                       Dir.glob("*.md") +
-                       Dir.glob("*-rubocop.yml") +
-                       ["LICENSE"]
+                       Dir.glob("*.md")
   spec.bindir        = "bin"
   spec.executables   = ["protoc-gen-ruby_my_plugin"]
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Applies the changes in #162 to the gapic-generator-ads directory. This should allow invocation of the ads generator.
* Create `gapic-generator-ads/Dockerfile` and `gapic-generator-ads/docker-entrypoint.sh`.
* Add `image` and `image:local` rake tasks to gapic-generator-ads.
* Update gapic-generator-ads.gemspec so it doesn't invoke git.

Also some other fixes and cleanup:
* Fix a cloud->ads typo in `gapic-generator-ads/Gemfile`.
* Add `gapic-generator-ads/LICENSE` file.
* Remove a permissions hack from the other Dockerfiles now that google-style 0.3.1 is released.
* Fix a crash in gapic-generator-cloud's `image:local` rake task.
* Fix the gemspec for new subgenerator gems so they don't try to include files that are not part of the subgenerator as initially generated.