### PR TITLE
Update Google Ads Docker file paths

### DIFF
--- a/gapic-generator-ads/docker-entrypoint.sh
+++ b/gapic-generator-ads/docker-entrypoint.sh
@@ -33,3 +33,17 @@ exec grpc_tools_ruby_protoc \
         --ruby_ads_out=/workspace/out/ \
         --ruby_ads_opt="configuration=/workspace/config.yml" \
         `find /workspace/in/ -name *.proto`
+
+# Fix file paths
+# Ensure google_ads exists
+mkdir -p /workspace/out/lib/google/ads/google_ads
+# Move all googleads files to google_ads
+mv -v /workspace/out/lib/google/ads/googleads/* /workspace/out/lib/google/ads/google_ads
+# Remove googleads directory
+rm -rf /workspace/out/lib/google/ads/googleads
+
+# Fix requires
+# Fix require with double quote
+find /workspace/out/lib/google/ads -name "*.rb" -type f -exec sed -i '' -e 's/require "google\/ads\/googleads/require "google\/ads\/google_ads/g' {} +
+# Fix require with single quote
+find /workspace/out/lib/google/ads -name "*.rb" -type f -exec sed -i '' -e 's/require \'google\/ads\/googleads/require \'google\/ads\/google_ads/g' {} +

--- a/gapic-generator-ads/docker-entrypoint.sh
+++ b/gapic-generator-ads/docker-entrypoint.sh
@@ -26,13 +26,13 @@ while true; do
 done
 
 mkdir -p /workspace/out/lib
-exec grpc_tools_ruby_protoc \
-        --proto_path=/workspace/common-protos/ --proto_path=/workspace/in/ \
-        --ruby_out=/workspace/out/lib \
-        --grpc_out=/workspace/out/lib \
-        --ruby_ads_out=/workspace/out/ \
-        --ruby_ads_opt="configuration=/workspace/config.yml" \
-        `find /workspace/in/ -name *.proto`
+grpc_tools_ruby_protoc \
+  --proto_path=/workspace/common-protos/ --proto_path=/workspace/in/ \
+  --ruby_out=/workspace/out/lib \
+  --grpc_out=/workspace/out/lib \
+  --ruby_ads_out=/workspace/out/ \
+  --ruby_ads_opt="configuration=/workspace/config.yml" \
+  `find /workspace/in/ -name *.proto`
 
 # Fix file paths
 # Ensure google_ads exists

--- a/gapic-generator-ads/docker-entrypoint.sh
+++ b/gapic-generator-ads/docker-entrypoint.sh
@@ -37,8 +37,8 @@ grpc_tools_ruby_protoc \
 # Fix file paths
 # Ensure google_ads exists
 mkdir -p /workspace/out/lib/google/ads/google_ads
-# Move all googleads files to google_ads
-mv -v /workspace/out/lib/google/ads/googleads/* /workspace/out/lib/google/ads/google_ads
+# Copy all googleads files to google_ads
+cp -r /workspace/out/lib/google/ads/googleads/* /workspace/out/lib/google/ads/google_ads
 # Remove googleads directory
 rm -rf /workspace/out/lib/google/ads/googleads
 

--- a/gapic-generator-ads/docker-entrypoint.sh
+++ b/gapic-generator-ads/docker-entrypoint.sh
@@ -44,6 +44,6 @@ rm -rf /workspace/out/lib/google/ads/googleads
 
 # Fix requires
 # Fix require with double quote
-find /workspace/out/lib/google/ads -name "*.rb" -type f -exec sed -i '' -e 's/require "google\/ads\/googleads/require "google\/ads\/google_ads/g' {} +
+find /workspace/out/lib/google/ads -name "*.rb" -type f -exec sed -i -e 's/require "google\/ads\/googleads/require "google\/ads\/google_ads/g' {} \;
 # Fix require with single quote
-find /workspace/out/lib/google/ads -name "*.rb" -type f -exec sed -i '' -e 's/require \'google\/ads\/googleads/require \'google\/ads\/google_ads/g' {} +
+find /workspace/out/lib/google/ads -name "*.rb" -type f -exec sed -i -e "s/require 'google\/ads\/googleads/require 'google\/ads\/google_ads/g" {} \;


### PR DESCRIPTION
Update the Google Ads docker image to change the file paths of the files generated by the protobuf and grpc plugins.