### PR TITLE
Patch protoc grpc plugin output

### DIFF
--- a/gapic-generator-ads/docker-entrypoint.sh
+++ b/gapic-generator-ads/docker-entrypoint.sh
@@ -47,3 +47,7 @@ rm -rf /workspace/out/lib/google/ads/googleads
 find /workspace/out/lib/google/ads -name "*.rb" -type f -exec sed -i -e 's/require "google\/ads\/googleads/require "google\/ads\/google_ads/g' {} \;
 # Fix require with single quote
 find /workspace/out/lib/google/ads -name "*.rb" -type f -exec sed -i -e "s/require 'google\/ads\/googleads/require 'google\/ads\/google_ads/g" {} \;
+
+# Fix the protoc-gen-grpc output not respecting ruby_package:
+# See https://github.com/grpc/grpc/issues/19438
+find /workspace/out/lib/google/ads -name "*.rb" -type f -exec sed -i -e 's/Google::Ads::Googleads::/Google::Ads::GoogleAds::/g' {} \;


### PR DESCRIPTION
This PR corrects the protoc-gen-grpc output to so the referenced messages correctly honors the `ruby_package` set in the Google Ads protos. This is a manual fix and will only work for Google Ads until the upstream bug is fixed. (See grpc/grpc#19438)

With this patch, you can generate the Google Ads ruby files using the following:

```sh
cd ~/gapic-generator-ruby

cd gapic-generator-ads
bundle exec rake image:local
cd ..

rm -rf ads-output
mkdir -p ads-output

sh gapic.sh --image ruby-gapic-generator-ads -p `pwd`/shared/googleapis -i google/ads/googleads/v1 -o ../../ads-output --config ../config/googleads.yml
```

Then grepping the output for "Googleads" only returns the README for the YARD documentation directory:

```
$ grep -r "Googleads" ads-output
ads-output/proto_docs/README.md:# Google Ads Googleads Protocol Buffer Documentation
```