### PR TITLE
Update GemPresenter#title

### DIFF
--- a/gapic-generator/templates/default/helpers/presenters/gem_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/gem_presenter.rb
@@ -63,7 +63,7 @@ class GemPresenter
 
   def title
     gem_config(:title) ||
-      name.split("-").map(&:camelize).join(" ")
+      namespace.split("::").join(" ")
   end
 
   def version

--- a/shared/output/ads/googleads/proto_docs/README.md
+++ b/shared/output/ads/googleads/proto_docs/README.md
@@ -1,4 +1,4 @@
-# Google Ads Googleads Protocol Buffer Documentation
+# Google Ads GoogleAds Protocol Buffer Documentation
 
 These files are for the YARD documentation of the generated protobuf files.
 They are not intended to be required or loaded at runtime.


### PR DESCRIPTION
Use namespace as the basis for the title fallback when a
title is not specified in the config file.