### PR TITLE
Use current git SHA as image tag for ads docker image.

### DIFF
--- a/gapic-generator-ads/Rakefile
+++ b/gapic-generator-ads/Rakefile
@@ -68,7 +68,7 @@ end
 desc "Build the docker image."
 task :image, :name do |_t, args|
   image_name = args[:name] || "ruby-gapic-generator-ads"
-  sh "docker build -t #{image_name} ."
+  sh "docker build -t #{image_name}:$(git rev-parse HEAD) ."
 end
 namespace :image do
   desc "Build the docker image using the local base image code"
@@ -79,7 +79,7 @@ namespace :image do
     base_tmp_dir = File.join __dir__, "tmp", "gapic-generator"
     rm_rf base_tmp_dir
     cp_r base_source_dir, base_tmp_dir
-    sh "docker build -t #{image_name} ."
+    sh "docker build -t #{image_name}:$(git rev-parse HEAD) ."
     rm_r base_tmp_dir
   end
 end


### PR DESCRIPTION
This is done so that we know exactly to which code we're referring
before we bake our container and so that we can switch back and forth
easily.