### PR TITLE
Don't use client timeout on RPC calls

### DIFF
--- a/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
@@ -23,6 +23,5 @@ metadata[:"x-goog-request-params"] ||= request_params_header
 options.apply_defaults timeout: @config.rpcs.<%= method.name %>.timeout,
                        metadata: metadata,
                        retry_policy: @config.rpcs.<%= method.name %>.retry_policy
-options.apply_defaults timeout: @config.timeout,
-                       metadata: @config.metadata,
+options.apply_defaults metadata: @config.metadata,
                        retry_policy: @config.retry_policy

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
@@ -154,8 +154,7 @@ module Google
                 options.apply_defaults timeout:      @config.rpcs.get_campaign.timeout,
                                        metadata:     metadata,
                                        retry_policy: @config.rpcs.get_campaign.retry_policy
-                options.apply_defaults timeout:      @config.timeout,
-                                       metadata:     @config.metadata,
+                options.apply_defaults metadata:     @config.metadata,
                                        retry_policy: @config.retry_policy
 
                 @campaign_service_stub.call_rpc :get_campaign, request, options: options, operation_callback: block
@@ -223,8 +222,7 @@ module Google
                 options.apply_defaults timeout:      @config.rpcs.mutate_campaigns.timeout,
                                        metadata:     metadata,
                                        retry_policy: @config.rpcs.mutate_campaigns.retry_policy
-                options.apply_defaults timeout:      @config.timeout,
-                                       metadata:     @config.metadata,
+                options.apply_defaults metadata:     @config.metadata,
                                        retry_policy: @config.retry_policy
 
                 @campaign_service_stub.call_rpc :mutate_campaigns, request, options: options, operation_callback: block

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -150,8 +150,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.echo.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.echo.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @echo_stub.call_rpc :echo, request, options: options, operation_callback: block
@@ -205,8 +204,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.expand.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.expand.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @echo_stub.call_rpc :expand, request, options: options, operation_callback: block
@@ -260,8 +258,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.collect.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.collect.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @echo_stub.call_rpc :collect, request, options: options, operation_callback: block
@@ -315,8 +312,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.chat.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.chat.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @echo_stub.call_rpc :chat, request, options: options, operation_callback: block
@@ -372,8 +368,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.paged_expand.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.paged_expand.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, options }
@@ -434,8 +429,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.wait.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.wait.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -162,8 +162,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_operations.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -226,8 +225,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.get_operation.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -291,8 +289,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_operation.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
@@ -366,8 +363,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.cancel_operation.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -147,8 +147,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.create_user.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.create_user.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @identity_stub.call_rpc :create_user, request, options: options, operation_callback: block
@@ -204,8 +203,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.get_user.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.get_user.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @identity_stub.call_rpc :get_user, request, options: options, operation_callback: block
@@ -264,8 +262,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.update_user.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.update_user.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @identity_stub.call_rpc :update_user, request, options: options, operation_callback: block
@@ -321,8 +318,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_user.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_user.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @identity_stub.call_rpc :delete_user, request, options: options, operation_callback: block
@@ -377,8 +373,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_users.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_users.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, options }

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -151,8 +151,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.create_room.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.create_room.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :create_room, request, options: options, operation_callback: block
@@ -208,8 +207,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.get_room.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.get_room.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :get_room, request, options: options, operation_callback: block
@@ -268,8 +266,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.update_room.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.update_room.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :update_room, request, options: options, operation_callback: block
@@ -325,8 +322,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_room.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_room.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :delete_room, request, options: options, operation_callback: block
@@ -381,8 +377,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_rooms.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_rooms.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, options }
@@ -447,8 +442,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.create_blurb.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.create_blurb.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :create_blurb, request, options: options, operation_callback: block
@@ -504,8 +498,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.get_blurb.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.get_blurb.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :get_blurb, request, options: options, operation_callback: block
@@ -564,8 +557,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.update_blurb.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.update_blurb.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :update_blurb, request, options: options, operation_callback: block
@@ -621,8 +613,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_blurb.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_blurb.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :delete_blurb, request, options: options, operation_callback: block
@@ -688,8 +679,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_blurbs.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_blurbs.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, options }
@@ -764,8 +754,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.search_blurbs.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.search_blurbs.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -827,8 +816,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.stream_blurbs.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.stream_blurbs.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :stream_blurbs, request, options: options, operation_callback: block
@@ -887,8 +875,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.send_blurbs.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.send_blurbs.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :send_blurbs, request, options: options, operation_callback: block
@@ -943,8 +930,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.connect.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.connect.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :connect, request, options: options, operation_callback: block

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -162,8 +162,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_operations.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -226,8 +225,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.get_operation.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -291,8 +289,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_operation.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
@@ -366,8 +363,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.cancel_operation.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block

--- a/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -149,8 +149,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.create_session.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.create_session.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @testing_stub.call_rpc :create_session, request, options: options, operation_callback: block
@@ -206,8 +205,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.get_session.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.get_session.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @testing_stub.call_rpc :get_session, request, options: options, operation_callback: block
@@ -259,8 +257,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_sessions.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_sessions.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, options }
@@ -318,8 +315,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_session.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_session.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @testing_stub.call_rpc :delete_session, request, options: options, operation_callback: block
@@ -379,8 +375,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.report_session.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.report_session.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @testing_stub.call_rpc :report_session, request, options: options, operation_callback: block
@@ -440,8 +435,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_tests.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_tests.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, options }
@@ -509,8 +503,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_test.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_test.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @testing_stub.call_rpc :delete_test, request, options: options, operation_callback: block
@@ -576,8 +569,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.verify_test.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.verify_test.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @testing_stub.call_rpc :verify_test, request, options: options, operation_callback: block

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -154,8 +154,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.recognize.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.recognize.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @speech_stub.call_rpc :recognize, request, options: options, operation_callback: block
@@ -214,8 +213,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.long_running_recognize.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.long_running_recognize.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -270,8 +268,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.streaming_recognize.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.streaming_recognize.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @speech_stub.call_rpc :streaming_recognize, request, options: options, operation_callback: block

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -163,8 +163,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_operations.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -227,8 +226,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.get_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -292,8 +290,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.delete_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
@@ -367,8 +364,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.cancel_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -149,8 +149,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.batch_annotate_images.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.batch_annotate_images.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @image_annotator_stub.call_rpc :batch_annotate_images, request, options: options, operation_callback: block
@@ -210,8 +209,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.async_batch_annotate_files.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.async_batch_annotate_files.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -163,8 +163,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_operations.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -227,8 +226,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.get_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -292,8 +290,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.delete_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
@@ -367,8 +364,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.cancel_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -174,8 +174,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.create_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.create_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :create_product_set, request, options: options, operation_callback: block
@@ -247,8 +246,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_product_sets.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_product_sets.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, options }
@@ -317,8 +315,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.get_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.get_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :get_product_set, request, options: options, operation_callback: block
@@ -393,8 +390,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.update_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.update_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :update_product_set, request, options: options, operation_callback: block
@@ -467,8 +463,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.delete_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.delete_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :delete_product_set, request, options: options, operation_callback: block
@@ -548,8 +543,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.create_product.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.create_product.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :create_product, request, options: options, operation_callback: block
@@ -620,8 +614,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_products.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_products.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, options }
@@ -690,8 +683,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.get_product.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.get_product.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :get_product, request, options: options, operation_callback: block
@@ -782,8 +774,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.update_product.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.update_product.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :update_product, request, options: options, operation_callback: block
@@ -858,8 +849,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.delete_product.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.delete_product.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :delete_product, request, options: options, operation_callback: block
@@ -962,8 +952,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.create_reference_image.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.create_reference_image.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :create_reference_image, request, options: options, operation_callback: block
@@ -1043,8 +1032,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.delete_reference_image.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.delete_reference_image.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :delete_reference_image, request, options: options, operation_callback: block
@@ -1122,8 +1110,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_reference_images.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_reference_images.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, options }
@@ -1193,8 +1180,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.get_reference_image.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.get_reference_image.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :get_reference_image, request, options: options, operation_callback: block
@@ -1272,8 +1258,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.add_product_to_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.add_product_to_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :add_product_to_product_set, request, options: options, operation_callback: block
@@ -1345,8 +1330,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.remove_product_from_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.remove_product_from_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :remove_product_from_product_set, request, options: options, operation_callback: block
@@ -1421,8 +1405,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_products_in_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_products_in_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, options }
@@ -1504,8 +1487,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.import_product_sets.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.import_product_sets.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -163,8 +163,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_operations.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -227,8 +226,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.get_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -292,8 +290,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.delete_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
@@ -367,8 +364,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.cancel_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/client.rb
@@ -158,8 +158,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.echo.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.echo.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @echo_stub.call_rpc :echo, request, options: options, operation_callback: block
@@ -213,8 +212,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.expand.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.expand.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @echo_stub.call_rpc :expand, request, options: options, operation_callback: block
@@ -268,8 +266,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.collect.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.collect.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @echo_stub.call_rpc :collect, request, options: options, operation_callback: block
@@ -323,8 +320,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.chat.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.chat.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @echo_stub.call_rpc :chat, request, options: options, operation_callback: block
@@ -380,8 +376,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.paged_expand.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.paged_expand.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, options }
@@ -442,8 +437,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.wait.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.wait.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/echo/operations.rb
@@ -170,8 +170,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_operations.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -234,8 +233,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.get_operation.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -299,8 +297,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_operation.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
@@ -374,8 +371,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.cancel_operation.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/identity/client.rb
@@ -155,8 +155,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.create_user.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.create_user.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @identity_stub.call_rpc :create_user, request, options: options, operation_callback: block
@@ -212,8 +211,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.get_user.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.get_user.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @identity_stub.call_rpc :get_user, request, options: options, operation_callback: block
@@ -272,8 +270,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.update_user.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.update_user.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @identity_stub.call_rpc :update_user, request, options: options, operation_callback: block
@@ -329,8 +326,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_user.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_user.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @identity_stub.call_rpc :delete_user, request, options: options, operation_callback: block
@@ -385,8 +381,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_users.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_users.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, options }

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/client.rb
@@ -159,8 +159,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.create_room.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.create_room.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :create_room, request, options: options, operation_callback: block
@@ -216,8 +215,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.get_room.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.get_room.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :get_room, request, options: options, operation_callback: block
@@ -276,8 +274,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.update_room.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.update_room.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :update_room, request, options: options, operation_callback: block
@@ -333,8 +330,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_room.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_room.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :delete_room, request, options: options, operation_callback: block
@@ -389,8 +385,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_rooms.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_rooms.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, options }
@@ -455,8 +450,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.create_blurb.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.create_blurb.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :create_blurb, request, options: options, operation_callback: block
@@ -512,8 +506,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.get_blurb.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.get_blurb.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :get_blurb, request, options: options, operation_callback: block
@@ -572,8 +565,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.update_blurb.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.update_blurb.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :update_blurb, request, options: options, operation_callback: block
@@ -629,8 +621,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_blurb.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_blurb.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :delete_blurb, request, options: options, operation_callback: block
@@ -696,8 +687,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_blurbs.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_blurbs.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, options }
@@ -772,8 +762,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.search_blurbs.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.search_blurbs.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -835,8 +824,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.stream_blurbs.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.stream_blurbs.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :stream_blurbs, request, options: options, operation_callback: block
@@ -895,8 +883,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.send_blurbs.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.send_blurbs.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :send_blurbs, request, options: options, operation_callback: block
@@ -951,8 +938,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.connect.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.connect.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :connect, request, options: options, operation_callback: block

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/messaging/operations.rb
@@ -170,8 +170,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_operations.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -234,8 +233,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.get_operation.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -299,8 +297,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_operation.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
@@ -374,8 +371,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.cancel_operation.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1alpha3/testing/client.rb
@@ -157,8 +157,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.create_session.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.create_session.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @testing_stub.call_rpc :create_session, request, options: options, operation_callback: block
@@ -214,8 +213,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.get_session.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.get_session.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @testing_stub.call_rpc :get_session, request, options: options, operation_callback: block
@@ -267,8 +265,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_sessions.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_sessions.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, options }
@@ -326,8 +323,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_session.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_session.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @testing_stub.call_rpc :delete_session, request, options: options, operation_callback: block
@@ -387,8 +383,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.report_session.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.report_session.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @testing_stub.call_rpc :report_session, request, options: options, operation_callback: block
@@ -448,8 +443,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.list_tests.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.list_tests.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, options }
@@ -517,8 +511,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.delete_test.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.delete_test.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @testing_stub.call_rpc :delete_test, request, options: options, operation_callback: block
@@ -584,8 +577,7 @@ module Google
             options.apply_defaults timeout:      @config.rpcs.verify_test.timeout,
                                    metadata:     metadata,
                                    retry_policy: @config.rpcs.verify_test.retry_policy
-            options.apply_defaults timeout:      @config.timeout,
-                                   metadata:     @config.metadata,
+            options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
             @testing_stub.call_rpc :verify_test, request, options: options, operation_callback: block

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -162,8 +162,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.recognize.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.recognize.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @speech_stub.call_rpc :recognize, request, options: options, operation_callback: block
@@ -222,8 +221,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.long_running_recognize.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.long_running_recognize.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -278,8 +276,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.streaming_recognize.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.streaming_recognize.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @speech_stub.call_rpc :streaming_recognize, request, options: options, operation_callback: block

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -171,8 +171,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_operations.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -235,8 +234,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.get_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -300,8 +298,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.delete_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
@@ -375,8 +372,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.cancel_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -157,8 +157,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.batch_annotate_images.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.batch_annotate_images.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @image_annotator_stub.call_rpc :batch_annotate_images, request, options: options, operation_callback: block
@@ -218,8 +217,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.async_batch_annotate_files.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.async_batch_annotate_files.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -171,8 +171,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_operations.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -235,8 +234,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.get_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -300,8 +298,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.delete_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
@@ -375,8 +372,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.cancel_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -182,8 +182,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.create_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.create_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :create_product_set, request, options: options, operation_callback: block
@@ -255,8 +254,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_product_sets.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_product_sets.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, options }
@@ -325,8 +323,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.get_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.get_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :get_product_set, request, options: options, operation_callback: block
@@ -401,8 +398,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.update_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.update_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :update_product_set, request, options: options, operation_callback: block
@@ -475,8 +471,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.delete_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.delete_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :delete_product_set, request, options: options, operation_callback: block
@@ -556,8 +551,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.create_product.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.create_product.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :create_product, request, options: options, operation_callback: block
@@ -628,8 +622,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_products.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_products.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, options }
@@ -698,8 +691,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.get_product.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.get_product.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :get_product, request, options: options, operation_callback: block
@@ -790,8 +782,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.update_product.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.update_product.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :update_product, request, options: options, operation_callback: block
@@ -866,8 +857,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.delete_product.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.delete_product.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :delete_product, request, options: options, operation_callback: block
@@ -970,8 +960,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.create_reference_image.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.create_reference_image.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :create_reference_image, request, options: options, operation_callback: block
@@ -1051,8 +1040,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.delete_reference_image.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.delete_reference_image.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :delete_reference_image, request, options: options, operation_callback: block
@@ -1130,8 +1118,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_reference_images.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_reference_images.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, options }
@@ -1201,8 +1188,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.get_reference_image.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.get_reference_image.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :get_reference_image, request, options: options, operation_callback: block
@@ -1280,8 +1266,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.add_product_to_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.add_product_to_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :add_product_to_product_set, request, options: options, operation_callback: block
@@ -1353,8 +1338,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.remove_product_from_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.remove_product_from_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :remove_product_from_product_set, request, options: options, operation_callback: block
@@ -1429,8 +1413,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_products_in_product_set.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_products_in_product_set.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, options }
@@ -1512,8 +1495,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.import_product_sets.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.import_product_sets.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -171,8 +171,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.list_operations.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.list_operations.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -235,8 +234,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.get_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.get_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
@@ -300,8 +298,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.delete_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.delete_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
@@ -375,8 +372,7 @@ module Google
               options.apply_defaults timeout:      @config.rpcs.cancel_operation.timeout,
                                      metadata:     metadata,
                                      retry_policy: @config.rpcs.cancel_operation.retry_policy
-              options.apply_defaults timeout:      @config.timeout,
-                                     metadata:     @config.metadata,
+              options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block


### PR DESCRIPTION
Don't over-specify the RPC call options.
Allow the GRPC client to use its configured timeout setting.

[closes #192]