### PR TITLE
Add tests for showcase operations client

### DIFF
--- a/shared/test/showcase/echo/chat_test.rb
+++ b/shared/test/showcase/echo/chat_test.rb
@@ -20,11 +20,7 @@ require "grpc"
 
 class ChatTest < ShowcaseTest
   def test_chat
-    client = Google::Showcase::V1beta1::Echo::Client.new do |config|
-      config.credentials = GRPC::Core::Channel.new(
-        "localhost:7469", nil, :this_channel_is_insecure
-      )
-    end
+    client = new_client
 
     pull_count = 0
 

--- a/shared/test/showcase/echo/chat_test.rb
+++ b/shared/test/showcase/echo/chat_test.rb
@@ -19,14 +19,16 @@ require "google/showcase/v1beta1/echo"
 require "grpc"
 
 class ChatTest < ShowcaseTest
-  def test_chat
-    client = new_client
+  def setup
+    @client = new_client
+  end
 
+  def test_chat
     pull_count = 0
 
     stream_input = Gapic::StreamInput.new
 
-    responses = client.chat stream_input
+    responses = @client.chat stream_input
 
     Thread.new do
       10.times do |n|

--- a/shared/test/showcase/echo/collect_test.rb
+++ b/shared/test/showcase/echo/collect_test.rb
@@ -20,11 +20,7 @@ require "grpc"
 
 class CollectTest < ShowcaseTest
   def test_collect
-    client = Google::Showcase::V1beta1::Echo::Client.new do |config|
-      config.credentials = GRPC::Core::Channel.new(
-        "localhost:7469", nil, :this_channel_is_insecure
-      )
-    end
+    client = new_client
 
     stream_input = Gapic::StreamInput.new
 

--- a/shared/test/showcase/echo/collect_test.rb
+++ b/shared/test/showcase/echo/collect_test.rb
@@ -19,9 +19,11 @@ require "google/showcase/v1beta1/echo"
 require "grpc"
 
 class CollectTest < ShowcaseTest
-  def test_collect
-    client = new_client
+  def setup
+    @client = new_client
+  end
 
+  def test_collect
     stream_input = Gapic::StreamInput.new
 
     Thread.new do
@@ -32,7 +34,7 @@ class CollectTest < ShowcaseTest
       stream_input.close
     end
 
-    response = client.collect stream_input
+    response = @client.collect stream_input
 
     assert_equal "well hello there old friend", response.content
   end

--- a/shared/test/showcase/echo/echo_test.rb
+++ b/shared/test/showcase/echo/echo_test.rb
@@ -20,12 +20,10 @@ require "grpc"
 
 class EchoTest < ShowcaseTest
   def test_echo
-    client = Google::Showcase::V1beta1::Echo::Client.new do |config|
-      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    end
+    client = new_client
 
-    response = client.echo content: 'hi there!'
+    response = client.echo content: "hi there!"
 
-    assert_equal 'hi there!', response.content
+    assert_equal "hi there!", response.content
   end
 end

--- a/shared/test/showcase/echo/echo_test.rb
+++ b/shared/test/showcase/echo/echo_test.rb
@@ -19,10 +19,12 @@ require "google/showcase/v1beta1/echo"
 require "grpc"
 
 class EchoTest < ShowcaseTest
-  def test_echo
-    client = new_client
+  def setup
+    @client = new_client
+  end
 
-    response = client.echo content: "hi there!"
+  def test_echo
+    response = @client.echo content: "hi there!"
 
     assert_equal "hi there!", response.content
   end

--- a/shared/test/showcase/echo/expand_test.rb
+++ b/shared/test/showcase/echo/expand_test.rb
@@ -20,9 +20,7 @@ require "grpc"
 
 class ExpandTest < ShowcaseTest
   def test_expand
-    client = Google::Showcase::V1beta1::Echo::Client.new do |config|
-      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    end
+    client = new_client
 
     request_content = "The quick brown fox jumps over the lazy dog"
 

--- a/shared/test/showcase/echo/expand_test.rb
+++ b/shared/test/showcase/echo/expand_test.rb
@@ -19,12 +19,14 @@ require "google/showcase/v1beta1/echo"
 require "grpc"
 
 class ExpandTest < ShowcaseTest
-  def test_expand
-    client = new_client
+  def setup
+    @client = new_client
+  end
 
+  def test_expand
     request_content = "The quick brown fox jumps over the lazy dog"
 
-    response_enum = client.expand content: request_content
+    response_enum = @client.expand content: request_content
 
     assert_equal request_content, response_enum.to_a.map(&:content).join(" ")
   end

--- a/shared/test/showcase/echo/operations_test.rb
+++ b/shared/test/showcase/echo/operations_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "base64"
+require "test_helper"
+require "google/showcase/v1beta1/echo"
+require "grpc"
+
+class EchoTest < ShowcaseTest
+  def test_raise_invalid_get_operation
+    client = new_operations_client
+
+    assert_raises(Gapic::NotFoundError) { client.get_operation name: "thing1" }
+  end
+
+  def test_get_operation
+    client = new_operations_client
+
+    prefix = "operations/google.showcase.v1beta1.Echo/Wait/"
+    wait_type = Google::Showcase::V1beta1::WaitRequest
+    wait_request = Base64.encode64(wait_type.encode(wait_type.new(ttl: 200))).chop
+    op = client.get_operation name: prefix + wait_request
+
+    waited = wait_type.decode(Base64.decode64(op.name.delete_prefix(prefix)))
+    assert_instance_of wait_type, waited
+  end
+
+  def test_list_operations
+    client = new_operations_client
+
+    enumerable = client.list_operations name: "a/thing/to/remember"
+
+    assert_equal 1, enumerable.response.operations.count
+  end
+
+  def test_delete_operation
+    client = new_operations_client
+
+    response = client.delete_operation name: "foo"
+
+    assert_instance_of Google::Protobuf::Empty, response
+  end
+
+  def test_cancel_operation
+    client = new_operations_client
+
+    response = client.cancel_operation name: "bar"
+
+    assert_instance_of Google::Protobuf::Empty, response
+  end
+end

--- a/shared/test/showcase/echo/operations_test.rb
+++ b/shared/test/showcase/echo/operations_test.rb
@@ -19,45 +19,39 @@ require "test_helper"
 require "google/showcase/v1beta1/echo"
 require "grpc"
 
-class EchoTest < ShowcaseTest
-  def test_raise_invalid_get_operation
-    client = new_operations_client
+class OperationsTest < ShowcaseTest
+  def setup
+    @client = new_operations_client
+  end
 
-    assert_raises(Gapic::NotFoundError) { client.get_operation name: "thing1" }
+  def test_raise_invalid_get_operation
+    assert_raises(Gapic::NotFoundError) { @client.get_operation name: "thing1" }
   end
 
   def test_get_operation
-    client = new_operations_client
-
     prefix = "operations/google.showcase.v1beta1.Echo/Wait/"
     wait_type = Google::Showcase::V1beta1::WaitRequest
     wait_request = Base64.encode64(wait_type.encode(wait_type.new(ttl: 200))).chop
-    op = client.get_operation name: prefix + wait_request
+    op = @client.get_operation name: prefix + wait_request
 
     waited = wait_type.decode(Base64.decode64(op.name.delete_prefix(prefix)))
     assert_instance_of wait_type, waited
   end
 
   def test_list_operations
-    client = new_operations_client
-
-    enumerable = client.list_operations name: "a/thing/to/remember"
+    enumerable = @client.list_operations name: "a/thing/to/remember"
 
     assert_equal 1, enumerable.response.operations.count
   end
 
   def test_delete_operation
-    client = new_operations_client
-
-    response = client.delete_operation name: "foo"
+    response = @client.delete_operation name: "foo"
 
     assert_instance_of Google::Protobuf::Empty, response
   end
 
   def test_cancel_operation
-    client = new_operations_client
-
-    response = client.cancel_operation name: "bar"
+    response = @client.cancel_operation name: "bar"
 
     assert_instance_of Google::Protobuf::Empty, response
   end

--- a/shared/test/showcase/echo/paged_expand_test.rb
+++ b/shared/test/showcase/echo/paged_expand_test.rb
@@ -19,12 +19,14 @@ require "google/showcase/v1beta1/echo"
 require "grpc"
 
 class PagedExpandTest < ShowcaseTest
-  def test_paged_expand
-    client = new_client
+  def setup
+    @client = new_client
+  end
 
+  def test_paged_expand
     request_content = "The quick brown fox jumps over the lazy dog"
 
-    response_enum = client.paged_expand content: request_content
+    response_enum = @client.paged_expand content: request_content
 
     assert_kind_of Gapic::PagedEnumerable, response_enum
 
@@ -34,11 +36,9 @@ class PagedExpandTest < ShowcaseTest
   end
 
   def test_page_size
-    client = new_client
-
     request_content = "The quick brown fox jumps over the lazy dog"
 
-    response_enum = client.paged_expand content: request_content, page_size: 2
+    response_enum = @client.paged_expand content: request_content, page_size: 2
 
     assert_kind_of Gapic::PagedEnumerable, response_enum
     assert_kind_of Google::Showcase::V1beta1::PagedExpandResponse, response_enum.page.response

--- a/shared/test/showcase/echo/paged_expand_test.rb
+++ b/shared/test/showcase/echo/paged_expand_test.rb
@@ -20,9 +20,7 @@ require "grpc"
 
 class PagedExpandTest < ShowcaseTest
   def test_paged_expand
-    client = Google::Showcase::V1beta1::Echo::Client.new do |config|
-      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    end
+    client = new_client
 
     request_content = "The quick brown fox jumps over the lazy dog"
 
@@ -36,9 +34,7 @@ class PagedExpandTest < ShowcaseTest
   end
 
   def test_page_size
-    client = Google::Showcase::V1beta1::Echo::Client.new do |config|
-      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    end
+    client = new_client
 
     request_content = "The quick brown fox jumps over the lazy dog"
 

--- a/shared/test/showcase/echo/wait_test.rb
+++ b/shared/test/showcase/echo/wait_test.rb
@@ -19,10 +19,12 @@ require "google/showcase/v1beta1/echo"
 require "grpc"
 
 class WaitTest < ShowcaseTest
-  def test_wait
-    client = new_client
+  def setup
+    @client = new_client
+  end
 
-    operation = client.wait ttl: { nanos: 500000 }, success: { content: "hi there!" }
+  def test_wait
+    operation = @client.wait ttl: { nanos: 500000 }, success: { content: "hi there!" }
 
     refute operation.done?
     operation.wait_until_done!
@@ -33,9 +35,7 @@ class WaitTest < ShowcaseTest
   end
 
   def test_wait_error
-    client = new_client
-
-    operation = client.wait ttl: { nanos: 500000 }, error: Google::Rpc::Status.new(message: "nope")
+    operation = @client.wait ttl: { nanos: 500000 }, error: Google::Rpc::Status.new(message: "nope")
 
     refute operation.done?
     operation.wait_until_done!

--- a/shared/test/showcase/echo/wait_test.rb
+++ b/shared/test/showcase/echo/wait_test.rb
@@ -20,9 +20,7 @@ require "grpc"
 
 class WaitTest < ShowcaseTest
   def test_wait
-    client = Google::Showcase::V1beta1::Echo::Client.new do |config|
-      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    end
+    client = new_client
 
     operation = client.wait ttl: { nanos: 500000 }, success: { content: "hi there!" }
 
@@ -35,9 +33,7 @@ class WaitTest < ShowcaseTest
   end
 
   def test_wait_error
-    client = Google::Showcase::V1beta1::Echo::Client.new do |config|
-      config.credentials = GRPC::Core::Channel.new("localhost:7469", nil, :this_channel_is_insecure)
-    end
+    client = new_client
 
     operation = client.wait ttl: { nanos: 500000 }, error: Google::Rpc::Status.new(message: "nope")
 

--- a/shared/test/test_helper.rb
+++ b/shared/test/test_helper.rb
@@ -39,6 +39,18 @@ def generate_library_for_test imports, protos
 end
 
 class ShowcaseTest < Minitest::Test
+  def new_client
+    Google::Showcase::V1beta1::Echo::Client.new do |config|
+      config.credentials = GRPC::Core::Channel.new "localhost:7469", nil, :this_channel_is_insecure
+    end
+  end
+
+  def new_operations_client
+    Google::Showcase::V1beta1::Echo::Operations.new do |config|
+      config.credentials = GRPC::Core::Channel.new "localhost:7469", nil, :this_channel_is_insecure
+    end
+  end
+
   @showcase_id = begin
     server_id = nil
     if ENV['CI'].nil?


### PR DESCRIPTION
Ads tests for new methods in showcase 0.4.0 and consolidate all the `Google::Showcase::V1beta1::Echo::Client.new` calls.

Note that `list_operations` produces a oneof deserialization error when used with the `page_size` parameter. I don't think it's critical that these tests cover that (it may be a server side issue), but I could not figure out why the error is thrown.