### PR TITLE
Mark fields as readonly in docs

### DIFF
--- a/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
@@ -47,6 +47,11 @@ class FieldPresenter
     end
   end
 
+  def doc_attribute_type
+    mode = @field.output_only? ? "r" : "rw"
+    "@!attribute [#{mode}] #{@field.name}"
+  end
+
   def output_doc_types
     return message_ruby_type @field.message if @field.message?
     doc_types

--- a/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
@@ -24,7 +24,7 @@ class MethodPresenter
 
   def initialize api, method
     @api = api
-    @method  = method
+    @method = method
   end
 
   def service

--- a/gapic-generator/templates/default/proto_docs/_message.erb
+++ b/gapic-generator/templates/default/proto_docs/_message.erb
@@ -3,7 +3,7 @@
 <%= indent message.doc_description, "# " %>
 <%- end -%>
 <%- message.fields.each do |field| -%>
-# @!attribute [rw] <%= field.name %>
+<%= indent field.doc_attribute_type, "# " %>
 #   @return [<%= field.output_doc_types %>]
 <%- if field.doc_description -%>
 <%= indent field.doc_description, "#     " %>

--- a/gapic-generator/test/gapic/presenters/method/showcase_field_test.rb
+++ b/gapic-generator/test/gapic/presenters/method/showcase_field_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+
+class ShowcaseIdentityFieldTest < PresenterTest
+  def presenter method_name
+    method_presenter :showcase, "Identity", method_name
+  end
+
+  def presenter_for_field method_presenter, field_name
+    method_presenter.fields.find { |f| f.name == field_name }
+  end
+
+  def test_showcase_User_name_field
+    fp = field_presenter :showcase, "google.showcase.v1beta1.User", "name"
+
+    assert_equal "name", fp.name
+    assert_equal "@!attribute [rw] name", fp.doc_attribute_type
+    assert_equal "String", fp.output_doc_types
+    assert_equal "The resource name of the user.\n", fp.doc_description
+    assert_equal "\"hello world\"", fp.default_value
+    assert_equal "", fp.type_name
+    assert_nil fp.type_name_full
+  end
+
+  def test_showcase_User_create_time_field
+    fp = field_presenter :showcase, "google.showcase.v1beta1.User", "create_time"
+
+    assert_equal "create_time", fp.name
+    assert_equal "@!attribute [r] create_time", fp.doc_attribute_type
+    assert_equal "Google::Protobuf::Timestamp", fp.output_doc_types
+    assert_equal "The timestamp at which the user was created.\n", fp.doc_description
+    assert_equal "{}", fp.default_value
+    assert_equal ".google.protobuf.Timestamp", fp.type_name
+    assert_equal "Google::Protobuf::Timestamp", fp.type_name_full
+  end
+
+  def test_showcase_CreateUser_fields
+    mp = presenter "CreateUser"
+    assert_equal 1, mp.fields.count
+
+    fp = presenter_for_field mp, "user"
+    assert_equal "user", fp.name
+    assert_equal "@!attribute [rw] user", fp.doc_attribute_type
+    assert_equal "Google::Showcase::V1beta1::User", fp.output_doc_types
+    assert_equal "The user to create.\n", fp.doc_description
+    assert_equal "{}", fp.default_value
+    assert_equal ".google.showcase.v1beta1.User", fp.type_name
+    assert_equal "Google::Showcase::V1beta1::User", fp.type_name_full
+  end
+
+  def test_showcase_ListUsers_fields
+    mp = presenter "ListUsers"
+    assert_equal 2, mp.fields.count
+
+    fp = presenter_for_field mp, "page_size"
+    assert_equal "page_size", fp.name
+    assert_equal "@!attribute [rw] page_size", fp.doc_attribute_type
+    assert_equal "Integer", fp.output_doc_types
+    assert_equal %q(The maximum number of users to return. Server may return fewer users
+than requested. If unspecified, server will pick an appropriate default.
+), fp.doc_description
+    assert_equal "42", fp.default_value
+    assert_equal "", fp.type_name
+    assert_nil fp.type_name_full
+
+    fp = presenter_for_field mp, "page_token"
+    assert_equal "page_token", fp.name
+    assert_equal "@!attribute [rw] page_token", fp.doc_attribute_type
+    assert_equal "String", fp.output_doc_types
+    assert_equal %q(The value of google.showcase.v1beta1.ListUsersResponse.next_page_token
+returned from the previous call to
+`google.showcase.v1beta1.Identity\\ListUsers` method.
+), fp.doc_description
+    assert_equal "\"hello world\"", fp.default_value
+    assert_equal "", fp.type_name
+    assert_nil fp.type_name_full
+  end
+end

--- a/gapic-generator/test/test_helper.rb
+++ b/gapic-generator/test/test_helper.rb
@@ -88,6 +88,13 @@ class PresenterTest < Minitest::Test
     refute_nil method
     MethodPresenter.new api_obj, method
   end
+
+  def field_presenter api_name, message_name, field_name
+    api_obj = api api_name
+    message = api_obj.messages.find { |m| m.address.join(".") == message_name }
+    field = message.fields.find { |f| f.name == field_name }
+    FieldPresenter.new api_obj, message, field
+  end
 end
 
 class GemTest < Minitest::Test

--- a/shared/output/cloud/showcase/proto_docs/google/showcase/v1beta1/identity.rb
+++ b/shared/output/cloud/showcase/proto_docs/google/showcase/v1beta1/identity.rb
@@ -27,10 +27,10 @@ module Google
       # @!attribute [rw] email
       #   @return [String]
       #     The email address of the user.
-      # @!attribute [rw] create_time
+      # @!attribute [r] create_time
       #   @return [Google::Protobuf::Timestamp]
       #     The timestamp at which the user was created.
-      # @!attribute [rw] update_time
+      # @!attribute [r] update_time
       #   @return [Google::Protobuf::Timestamp]
       #     The latest timestamp at which the user was updated.
       class User

--- a/shared/output/cloud/showcase/proto_docs/google/showcase/v1beta1/messaging.rb
+++ b/shared/output/cloud/showcase/proto_docs/google/showcase/v1beta1/messaging.rb
@@ -27,10 +27,10 @@ module Google
       # @!attribute [rw] description
       #   @return [String]
       #     The description of the chat room.
-      # @!attribute [rw] create_time
+      # @!attribute [r] create_time
       #   @return [Google::Protobuf::Timestamp]
       #     The timestamp at which the room was created.
-      # @!attribute [rw] update_time
+      # @!attribute [r] update_time
       #   @return [Google::Protobuf::Timestamp]
       #     The latest timestamp at which the room was updated.
       class Room
@@ -128,10 +128,10 @@ module Google
       # @!attribute [rw] image
       #   @return [String]
       #     The image content of this blurb.
-      # @!attribute [rw] create_time
+      # @!attribute [r] create_time
       #   @return [Google::Protobuf::Timestamp]
       #     The timestamp at which the blurb was created.
-      # @!attribute [rw] update_time
+      # @!attribute [r] update_time
       #   @return [Google::Protobuf::Timestamp]
       #     The latest timestamp at which the blurb was updated.
       class Blurb

--- a/shared/output/gapic/templates/showcase/proto_docs/google/showcase/v1beta1/identity.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/showcase/v1beta1/identity.rb
@@ -35,10 +35,10 @@ module Google
       # @!attribute [rw] email
       #   @return [String]
       #     The email address of the user.
-      # @!attribute [rw] create_time
+      # @!attribute [r] create_time
       #   @return [Google::Protobuf::Timestamp]
       #     The timestamp at which the user was created.
-      # @!attribute [rw] update_time
+      # @!attribute [r] update_time
       #   @return [Google::Protobuf::Timestamp]
       #     The latest timestamp at which the user was updated.
       class User

--- a/shared/output/gapic/templates/showcase/proto_docs/google/showcase/v1beta1/messaging.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/showcase/v1beta1/messaging.rb
@@ -35,10 +35,10 @@ module Google
       # @!attribute [rw] description
       #   @return [String]
       #     The description of the chat room.
-      # @!attribute [rw] create_time
+      # @!attribute [r] create_time
       #   @return [Google::Protobuf::Timestamp]
       #     The timestamp at which the room was created.
-      # @!attribute [rw] update_time
+      # @!attribute [r] update_time
       #   @return [Google::Protobuf::Timestamp]
       #     The latest timestamp at which the room was updated.
       class Room
@@ -136,7 +136,7 @@ module Google
       # @!attribute [rw] image
       #   @return [String]
       #     The image content of this blurb.
-      # @!attribute [rw] create_time
+      # @!attribute [r] create_time
       #   @return [Google::Protobuf::Timestamp]
       #     The timestamp at which the blurb was created.
       # @!attribute [rw] update_time


### PR DESCRIPTION
Marks the attribute as readonly in the generated docs if the `OUTPUT_ONLY` flag is set on the field.

I also added a field presenter test. Happy to add more tests as part of this PR, but I'm looking for advice on the structure. Should we have a folder under `test/gapic/presenter/field`, keep it with the method-level tests as I've done here since those presenters are fairly related, etc.? Alternatively, I can defer to #173 if you'd prefer to wait on adding these.

[resolves #103]