### PR TITLE
Remove most rubocop exclusions

### DIFF
--- a/gapic-common/.rubocop.yml
+++ b/gapic-common/.rubocop.yml
@@ -3,22 +3,11 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "gapic-common.gemspec"
     - "test/**/*"
 
-Metrics/AbcSize:
+Metrics/BlockLength:
   Exclude:
-    - "lib/gapic/config.rb"
-Metrics/CyclomaticComplexity:
-  Exclude:
-    - "lib/gapic/config.rb"
-Metrics/MethodLength:
-  Exclude:
-    - "lib/gapic/config.rb"
-Metrics/PerceivedComplexity:
-  Exclude:
-    - "lib/gapic/config.rb"
-    - "lib/gapic/grpc/service_stub.rb"
+    - gapic-common.gemspec
 
 Naming/FileName:
   Exclude:
@@ -29,9 +18,6 @@ Style/Documentation:
     - "lib/gapic/grpc/service_stub/rpc_call.rb"
     - "lib/gapic/errors.rb"
     - "lib/gapic/grpc/status_details.rb"
-Style/GuardClause:
-  Exclude:
-    - "lib/gapic/grpc/service_stub.rb"
 Style/CaseEquality:
   Exclude:
     - "lib/gapic/config.rb"

--- a/gapic-common/lib/gapic/config.rb
+++ b/gapic-common/lib/gapic/config.rb
@@ -60,7 +60,13 @@ module Gapic
 
       name_ivar = "@#{name}".to_sym
 
-      # create getter
+      create_getter name_ivar, name, default
+      create_setter name_ivar, name_setter, default, validator
+    end
+
+    private
+
+    def create_getter name_ivar, name, default
       define_method name do
         return instance_variable_get name_ivar if instance_variable_defined? name_ivar
 
@@ -71,8 +77,9 @@ module Gapic
 
         default
       end
+    end
 
-      # create setter
+    def create_setter name_ivar, name_setter, default, validator
       define_method name_setter do |new_value|
         valid_value = validator.call new_value
         if new_value.nil?

--- a/gapic-generator-ads/.rubocop.yml
+++ b/gapic-generator-ads/.rubocop.yml
@@ -9,13 +9,6 @@ AllCops:
 Documentation:
   Enabled: false
 
-Metrics/AbcSize:
-  Exclude:
-    - lib/gapic/generators/ads_generator.rb
-Metrics/LineLength:
-  Exclude:
-    - lib/gapic/generators/ads_generator.rb
-
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 Style/MethodCallWithArgsParentheses:

--- a/gapic-generator-ads/lib/gapic/generators/ads_generator.rb
+++ b/gapic-generator-ads/lib/gapic/generators/ads_generator.rb
@@ -33,6 +33,10 @@ module Gapic
         use_templates! File.join __dir__, "../../../templates/ads"
       end
 
+      # Disable Rubocop because we expect generate to grow and violate more
+      # and more style rules.
+      # rubocop:disable all
+
       # Generates all the files for the API.
       #
       # @return [Array<
@@ -68,6 +72,8 @@ module Gapic
 
         files
       end
+
+      # rubocop:enable all
 
       private
 

--- a/gapic-generator/.rubocop.yml
+++ b/gapic-generator/.rubocop.yml
@@ -6,16 +6,20 @@ AllCops:
   Exclude:
     - lib/**/*.pb.rb
     - expected_output/**/*
-    - templates/default/helpers/**/*
     - test/gapic/annotations/**/*
     - test/gapic/presenters/**/*
 
-Metrics/ClassLength:
-  Exclude:
-    - lib/gapic/schema/loader.rb
 Metrics/BlockLength:
   Exclude:
     - gapic-generator.gemspec
+Metrics/ClassLength:
+  Exclude:
+    - templates/default/helpers/presenters/**/*
+
+Style/Documentation:
+  Exclude:
+    - test/**/*
+    - templates/default/helpers/**/*
 
 Style/Alias:
   EnforcedStyle: prefer_alias_method

--- a/gapic-generator/templates/default/helpers/presenters/enum_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/enum_presenter.rb
@@ -32,7 +32,7 @@ class EnumPresenter
       .docs
       .leading_comments
       .each_line
-      .map { |line| (line.start_with? " ") ? line[1..-1] : line }
+      .map { |line| line.start_with?(" ") ? line[1..-1] : line }
       .join
   end
 

--- a/gapic-generator/templates/default/helpers/presenters/enum_value_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/enum_value_presenter.rb
@@ -30,7 +30,7 @@ class EnumValuePresenter
       .docs
       .leading_comments
       .each_line
-      .map { |line| (line.start_with? " ") ? line[1..-1] : line }
+      .map { |line| line.start_with?(" ") ? line[1..-1] : line }
       .join
   end
 

--- a/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
@@ -60,7 +60,7 @@ class FieldPresenter
       .docs
       .leading_comments
       .each_line
-      .map { |line| (line.start_with? " ") ? line[1..-1] : line }
+      .map { |line| line.start_with?(" ") ? line[1..-1] : line }
       .join
   end
 

--- a/gapic-generator/templates/default/helpers/presenters/file_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/file_presenter.rb
@@ -48,6 +48,6 @@ class FilePresenter
   end
 
   def docs_file_path
-    @file.name.gsub(".proto", ".rb")
+    @file.name.gsub ".proto", ".rb"
   end
 end

--- a/gapic-generator/templates/default/helpers/presenters/message_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/message_presenter.rb
@@ -42,7 +42,7 @@ class MessagePresenter
       .docs
       .leading_comments
       .each_line
-      .map { |line| (line.start_with? " ") ? line[1..-1] : line }
+      .map { |line| line.start_with?(" ") ? line[1..-1] : line }
       .join
   end
 

--- a/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
@@ -24,7 +24,7 @@ class MethodPresenter
 
   def initialize api, method
     @api = api
-    @method  = method
+    @method = method
   end
 
   def service
@@ -56,7 +56,7 @@ class MethodPresenter
       .docs
       .leading_comments
       .each_line
-      .map { |line| (line.start_with? " ") ? line[1..-1] : line }
+      .map { |line| line.start_with?(" ") ? line[1..-1] : line }
       .join
   end
 
@@ -105,18 +105,18 @@ class MethodPresenter
     if lro?
       return [
         OpenStruct.new(
-          name: "operation",
+          name:      "operation",
           doc_types: "Gapic::Operation"
         )
       ]
     end
     [
       OpenStruct.new(
-        name: "result",
+        name:      "result",
         doc_types: return_type
       ),
       OpenStruct.new(
-        name: "operation",
+        name:      "operation",
         doc_types: "GRPC::ActiveCall::Operation"
       )
     ]
@@ -161,7 +161,7 @@ class MethodPresenter
   #
   def routing_params
     segments = Gapic::PathTemplate.parse method_path
-    segments.select { |s| s.is_a? Gapic::PathTemplate::Segment }.map &:name
+    segments.select { |s| s.is_a? Gapic::PathTemplate::Segment }.map(&:name)
   end
 
   def routing_params?
@@ -219,11 +219,13 @@ class MethodPresenter
 
   def method_path
     return "" if @method.http.nil?
-    return @method.http.get unless @method.http.get.empty?
-    return @method.http.post unless @method.http.post.empty?
-    return @method.http.put unless @method.http.put.empty?
-    return @method.http.patch unless @method.http.patch.empty?
-    return @method.http.delete unless @method.http.delete.empty?
+
+    method = [
+      @method.http.get, @method.http.post, @method.http.put,
+      @method.http.patch, @method.http.delete
+    ].find { |x| !x.empty? }
+    return method unless method.nil?
+
     return @method.http.custom.path unless @method.http.custom.nil?
   end
 

--- a/gapic-generator/templates/default/helpers/presenters/resource_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/resource_presenter.rb
@@ -20,17 +20,16 @@ require "active_support/inflector"
 
 class ResourcePresenter
   def initialize name, path_template
-    @name     = name
+    @name = name
     @path_template = path_template
     @segments = Gapic::PathTemplate.parse path_template
 
     # URI path template verification for expected proto resource usage
-    if positional_args? @segments
-      raise ArgumentError, "only resources with named segments are supported, " \
-                           " not #{path_template}"
-    end
     if named_arg_patterns? @segments
       raise ArgumentError, "only resources without named patterns are supported, " \
+                           " not #{path_template}"
+    elsif positional_args? @segments
+      raise ArgumentError, "only resources with named segments are supported, " \
                            " not #{path_template}"
     end
   end
@@ -49,15 +48,15 @@ class ResourcePresenter
 
   def arguments
     # We only expect that named args are present
-    arg_segments(@segments).map do |arg|
+    arg_structs = arg_segments(@segments).map do |arg|
       OpenStruct.new(
-        name: arg.name,
-        msg: "#{arg.name} cannot contain /",
+        name:   arg.name,
+        msg:    "#{arg.name} cannot contain /",
         regexp: "/([^/]+)/"
       )
-    end.tap do |arg_structs|
-      arg_structs.last.regexp = nil
     end
+    arg_structs.last.regexp = nil
+    arg_structs
   end
 
   def path_string

--- a/gapic-generator/templates/default/helpers/presenters/service_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/service_presenter.rb
@@ -139,7 +139,7 @@ class ServicePresenter
   end
 
   def client_proto_name
-    @service.address.join(".")
+    @service.address.join "."
   end
 
   def credentials_name
@@ -177,7 +177,7 @@ class ServicePresenter
   def references
     @references ||= begin
       m = @service.parent.messages.select(&:resource)
-      m.sort_by! { |m1| m1.name }
+      m.sort_by!(&:name)
       # TODO: ResourceDescriptor#pattern is a list of patterns
       # How do we handle there being more than one pattern?
       m.map { |m1| ResourcePresenter.new m1.name, m1.resource.pattern.first }

--- a/shared/.rubocop.yml
+++ b/shared/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_gem:
   google-style: google-style.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
   Exclude:
-    - expected_output/**/*
+    - "protobuf/**/*"
+    - "output/**/*"
+    - "test/**/*"

--- a/shared/Gemfile
+++ b/shared/Gemfile
@@ -2,9 +2,9 @@
 
 source "https://rubygems.org"
 
+gem "gapic-common", path: "../gapic-common"
 gem "gapic-generator", path: "../gapic-generator"
 gem "gapic-generator-cloud", path: "../gapic-generator-cloud"
-gem "gapic-common", path: "../gapic-common"
 gem "grpc-tools", "~> 1.18"
 gem "minitest", "~> 5.0"
 gem "minitest-autotest", "~> 1.0"

--- a/shared/Rakefile
+++ b/shared/Rakefile
@@ -22,6 +22,8 @@ task :gen do
   Rake::Task["gen:garbage"].invoke
   Rake::Task["gen:googleads"].invoke
 end
+
+# rubocop:disable Metrics/BlockLength
 namespace :gen do
   desc "Generate the binary input files for speech"
   task :speech do
@@ -71,6 +73,7 @@ namespace :gen do
     generate_input_file "googleads", googleads_protos
   end
 end
+# rubocop:enable Metrics/BlockLength
 
 require "rake/testtask"
 desc "Run functional tests for all custom protos"
@@ -118,7 +121,7 @@ def generate_input_file service, protos
 
   Dir.mktmpdir do |tmp|
     protoc_cmd = [
-      "bundle exec grpc_tools_ruby_protoc #{Array(protos).join " "}",
+      "bundle exec grpc_tools_ruby_protoc #{Array(protos).join ' '}",
       "--proto_path=api-common-protos/",
       "--proto_path=googleapis/",
       "--proto_path=protos/",


### PR DESCRIPTION
A series of small refactors to satisfy rubocop and adds a rubocop config to the `shared` project. 

It does not quite finish #191. The following exclusions still remain, but I'm not sure any are worth tackling now:
  + equality issue (gapic-common)
  + Missing documentation (many gems)
  + Long presenter classes (seems ok to me)
  + Tests (seems ok to me)
  + All cops disabled in the `cloud_generator` and `ads_generator`
