### PR TITLE
Fix unit test coerce and local class names

### DIFF
--- a/gapic-generator-ads/test/gapic/presenters/service_test.rb
+++ b/gapic-generator-ads/test/gapic/presenters/service_test.rb
@@ -78,6 +78,12 @@ class GoogleAdsServiceTest < PresenterTest
                  presenter.test_client_operations_file_path
   end
 
+  def test_mock_names
+    assert_equal "MockCampaignServiceCredentialsServices", presenter.test_mock_credentials_class_name
+    assert_equal "MockGrpcCampaignServiceStubServices", presenter.test_mock_service_stub_class_name
+    assert_equal "CustomTestCampaignServiceErrorServices", presenter.test_mock_error_class_name
+  end
+
   def test_stub_name
     assert_equal "campaign_service_stub", presenter.stub_name
   end

--- a/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
@@ -97,6 +97,10 @@ class FieldPresenter
     ruby_namespace @api, type_name
   end
 
+  def as_kwarg value: nil
+    "#{name}: #{value || name}"
+  end
+
   protected
 
   def message_ruby_type message

--- a/gapic-generator/templates/default/helpers/presenters/service_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/service_presenter.rb
@@ -262,6 +262,18 @@ class ServicePresenter
     { "grpc.service_config_disable_resolution" => 1 }
   end
 
+  def test_mock_credentials_class_name
+    local_mock_class_name prefix: "Mock", suffix: "Credentials"
+  end
+
+  def test_mock_service_stub_class_name
+    local_mock_class_name prefix: "MockGrpc", suffix: "Stub"
+  end
+
+  def test_mock_error_class_name
+    local_mock_class_name prefix: "CustomTest", suffix: "Error"
+  end
+
   private
 
   def default_config key
@@ -269,5 +281,9 @@ class ServicePresenter
     return unless @service.parent.parent.configuration[:defaults][:service]
 
     @service.parent.parent.configuration[:defaults][:service][key]
+  end
+
+  def local_mock_class_name prefix: "", suffix: ""
+    "#{prefix}#{name}#{suffix}#{version}"
   end
 end

--- a/gapic-generator/templates/default/service/test/_setup.erb
+++ b/gapic-generator/templates/default/service/test/_setup.erb
@@ -8,9 +8,10 @@ require "<%= service.proto_service_require %>"
 require "<%= service.proto_services_require %>"
 require "<%= service.service_require %>"
 
-class CustomTestErrorV1 < StandardError; end
+class <%= service.test_mock_error_class_name %> < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class <%= service.test_mock_service_stub_class_name %>
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -37,7 +38,7 @@ class MockGrpcClientStubV1
   end
 end
 
-class Mock<%= service.name %>Credentials<%= service.version %> < <%= service.credentials_name_full %>
+class <%= service.test_mock_credentials_class_name %> < <%= service.credentials_name_full %>
   def initialize method_name
     @method_name = method_name
   end

--- a/gapic-generator/templates/default/service/test/client.erb
+++ b/gapic-generator/templates/default/service/test/client.erb
@@ -3,7 +3,12 @@
 describe <%= service.client_name_full %> do
 <% service.methods.each do |method| %>
 <%= indent render(partial: "service/test/method/#{method.kind}",
-                  locals: { method: method }), 2 %>
+                  locals: { 
+                    method: method,
+                    test_mock_error_class_name: service.test_mock_error_class_name,
+                    test_mock_service_stub_class_name: service.test_mock_service_stub_class_name,
+                    test_mock_credentials_class_name: service.test_mock_credentials_class_name
+                  }), 2 %>
 <% if method != service.methods.last %>
 
 <% end %>

--- a/gapic-generator/templates/default/service/test/client_operations.erb
+++ b/gapic-generator/templates/default/service/test/client_operations.erb
@@ -3,7 +3,13 @@
 describe <%= service.operations_name_full %> do
 <% service.lro_service.methods.each do |method| %>
 <%= indent render(partial: "service/test/method/#{method.kind}",
-                  locals: { client_name_full: service.operations_name_full, method: method }), 2 %>
+                  locals: {
+                    method: method,
+                    client_name_full: service.operations_name_full,
+                    test_mock_error_class_name: service.test_mock_error_class_name,
+                    test_mock_service_stub_class_name: service.test_mock_service_stub_class_name,
+                    test_mock_credentials_class_name: service.test_mock_credentials_class_name
+                  }), 2 %>
 <% if method != service.lro_service.methods.last %>
 
 <% end %>

--- a/gapic-generator/templates/default/service/test/method/_assert_field_equal.erb
+++ b/gapic-generator/templates/default/service/test/method/_assert_field_equal.erb
@@ -1,0 +1,6 @@
+<%- assert_locals field -%>
+<%- if field.type_name_full.nil? -%>
+assert_equal <%= field.name %>, request.<%= field.name %>
+<%- else -%>
+assert_equal Gapic::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
+<%- end -%>

--- a/gapic-generator/templates/default/service/test/method/_bidi.erb
+++ b/gapic-generator/templates/default/service/test/method/_bidi.erb
@@ -1,7 +1,7 @@
-<%- assert_locals method -%>
+<%- assert_locals method, test_mock_error_class_name, test_mock_service_stub_class_name, test_mock_credentials_class_name -%>
 describe "<%= method.name %>" do
   let :custom_error do
-    CustomTestErrorV1.new "Custom test error for <%= method.service.client_name_full %>#<%= method.name %>."
+    <%= test_mock_error_class_name %>.new "Custom test error for <%= method.service.client_name_full %>#<%= method.name %>."
   end
 
   it "invokes <%= method.name %> without error" do
@@ -12,7 +12,7 @@ describe "<%= method.name %>" do
 <%- if method.return_type.nil? -%>
     expected_response = {}
 <%- else -%>
-    expected_response = Gapic::Protobuf.coerce {}, to: <%= method.return_type %>
+    expected_response = Gapic::Protobuf.coerce({}, to: <%= method.return_type %>)
 <%- end -%>
 
     # Mock Grpc layer
@@ -20,10 +20,10 @@ describe "<%= method.name %>" do
       request = requests.first
       OpenStruct.new execute: [expected_response]
     end
-    mock_stub = MockGrpcClientStubV1.new :<%= method.name %>, mock_method
+    mock_stub = <%= test_mock_service_stub_class_name %>.new :<%= method.name %>, mock_method
 
     # Mock auth layer
-    mock_credentials = MockSpeechCredentialsV1.new "<%= method.name %>"
+    mock_credentials = <%= test_mock_credentials_class_name %>.new "<%= method.name %>"
 
     <%= method.service.proto_service_stub_name_full %>.stub :new, mock_stub do
       <%= method.service.credentials_name_full %>.stub :default, mock_credentials do
@@ -45,10 +45,10 @@ describe "<%= method.name %>" do
 
     # Mock Grpc layer
     mock_method = proc { raise custom_error }
-    mock_stub = MockGrpcClientStubV1.new :<%= method.name %>, mock_method
+    mock_stub = <%= test_mock_service_stub_class_name %>.new :<%= method.name %>, mock_method
 
     # Mock auth layer
-    mock_credentials = MockSpeechCredentialsV1.new "<%= method.name %>"
+    mock_credentials = <%= test_mock_credentials_class_name %>.new "<%= method.name %>"
 
     <%= method.service.proto_service_stub_name_full %>.stub :new, mock_stub do
       <%= method.service.credentials_name_full %>.stub :default, mock_credentials do

--- a/gapic-generator/templates/default/service/test/method/_bidi.erb
+++ b/gapic-generator/templates/default/service/test/method/_bidi.erb
@@ -9,8 +9,11 @@ describe "<%= method.name %>" do
     request = {}
 
     # Create expected grpc response
+<%- if method.return_type.nil? -%>
     expected_response = {}
-    expected_response = Gapic::Protobuf.coerce expected_response, to: <%= method.return_type %>
+<%- else -%>
+    expected_response = Gapic::Protobuf.coerce {}, to: <%= method.return_type %>
+<%- end -%>
 
     # Mock Grpc layer
     mock_method = proc do |requests|

--- a/gapic-generator/templates/default/service/test/method/_client.erb
+++ b/gapic-generator/templates/default/service/test/method/_client.erb
@@ -1,7 +1,7 @@
-<%- assert_locals method -%>
+<%- assert_locals method, test_mock_error_class_name, test_mock_service_stub_class_name, test_mock_credentials_class_name -%>
 describe "<%= method.name %>" do
   let :custom_error do
-    CustomTestErrorV1.new "Custom test error for <%= method.service.client_name_full %>#<%= method.name %>."
+    <%= test_mock_error_class_name %>.new "Custom test error for <%= method.service.client_name_full %>#<%= method.name %>."
   end
 
   it "invokes <%= method.name %> without error" do
@@ -12,7 +12,7 @@ describe "<%= method.name %>" do
 <%- if method.return_type.nil? -%>
     expected_response = {}
 <%- else -%>
-    expected_response = Gapic::Protobuf.coerce {}, to: <%= method.return_type %>
+    expected_response = Gapic::Protobuf.coerce({}, to: <%= method.return_type %>)
 <%- end -%>
 
     # Mock Grpc layer
@@ -20,10 +20,10 @@ describe "<%= method.name %>" do
       request = requests.first
       OpenStruct.new execute: [expected_response]
     end
-    mock_stub = MockGrpcClientStubV1.new :<%= method.name %>, mock_method
+    mock_stub = <%= test_mock_service_stub_class_name %>.new :<%= method.name %>, mock_method
 
     # Mock auth layer
-    mock_credentials = MockSpeechCredentialsV1.new "<%= method.name %>"
+    mock_credentials = <%= test_mock_credentials_class_name %>.new "<%= method.name %>"
 
     <%= method.service.proto_service_stub_name_full %>.stub :new, mock_stub do
       <%= method.service.credentials_name_full %>.stub :default, mock_credentials do
@@ -44,10 +44,10 @@ describe "<%= method.name %>" do
 
     # Mock Grpc layer
     mock_method = proc { raise custom_error }
-    mock_stub = MockGrpcClientStubV1.new :<%= method.name %>, mock_method
+    mock_stub = <%= test_mock_service_stub_class_name %>.new :<%= method.name %>, mock_method
 
     # Mock auth layer
-    mock_credentials = MockSpeechCredentialsV1.new "<%= method.name %>"
+    mock_credentials = <%= test_mock_credentials_class_name %>.new "<%= method.name %>"
 
     <%= method.service.proto_service_stub_name_full %>.stub :new, mock_stub do
       <%= method.service.credentials_name_full %>.stub :default, mock_credentials do

--- a/gapic-generator/templates/default/service/test/method/_client.erb
+++ b/gapic-generator/templates/default/service/test/method/_client.erb
@@ -9,8 +9,11 @@ describe "<%= method.name %>" do
     request = {}
 
     # Create expected grpc response
+<%- if method.return_type.nil? -%>
     expected_response = {}
-    expected_response = Gapic::Protobuf.coerce expected_response, to: <%= method.return_type %>
+<%- else -%>
+    expected_response = Gapic::Protobuf.coerce {}, to: <%= method.return_type %>
+<%- end -%>
 
     # Mock Grpc layer
     mock_method = proc do |requests|

--- a/gapic-generator/templates/default/service/test/method/_normal.erb
+++ b/gapic-generator/templates/default/service/test/method/_normal.erb
@@ -1,8 +1,8 @@
-<%- assert_locals method -%>
+<%- assert_locals method, test_mock_error_class_name, test_mock_service_stub_class_name, test_mock_credentials_class_name -%>
 <%- full_client_name = defined?(client_name_full) ? client_name_full : method.service.client_name_full -%>
 describe "<%= method.name %>" do
   let :custom_error do
-    CustomTestErrorV1.new "Custom test error for <%= full_client_name %>#<%= method.name %>."
+    <%= test_mock_error_class_name %>.new "Custom test error for <%= full_client_name %>#<%= method.name %>."
   end
 
 <%- if method.lro? -%>
@@ -13,7 +13,7 @@ describe "<%= method.name %>" do
 <%- if method.return_type.nil? -%>
     expected_response = {}
 <%- else -%>
-    expected_response = Gapic::Protobuf.coerce {}, to: <%= method.return_type %>
+    expected_response = Gapic::Protobuf.coerce({}, to: <%= method.return_type %>)
 <%- end -%>
     result = Google::Protobuf::Any.new
     result.pack expected_response
@@ -31,10 +31,10 @@ describe "<%= method.name %>" do
 <%- end -%>
       OpenStruct.new execute: operation
     end
-    mock_stub = MockGrpcClientStubV1.new :<%= method.name %>, mock_method
+    mock_stub = <%= test_mock_service_stub_class_name %>.new :<%= method.name %>, mock_method
 
     # Mock auth layer
-    mock_credentials = MockSpeechCredentialsV1.new "<%= method.name %>"
+    mock_credentials = <%= test_mock_credentials_class_name %>.new "<%= method.name %>"
 
     <%= method.service.proto_service_stub_name_full %>.stub :new, mock_stub do
       <%= method.service.credentials_name_full %>.stub :default, mock_credentials do
@@ -70,10 +70,10 @@ describe "<%= method.name %>" do
 <%- end -%>
       OpenStruct.new execute: operation
     end
-    mock_stub = MockGrpcClientStubV1.new :<%= method.name %>, mock_method
+    mock_stub = <%= test_mock_service_stub_class_name %>.new :<%= method.name %>, mock_method
 
     # Mock auth layer
-    mock_credentials = MockSpeechCredentialsV1.new "<%= method.name %>"
+    mock_credentials = <%= test_mock_credentials_class_name %>.new "<%= method.name %>"
 
     <%= method.service.proto_service_stub_name_full %>.stub :new, mock_stub do
       <%= method.service.credentials_name_full %>.stub :default, mock_credentials do
@@ -96,7 +96,7 @@ describe "<%= method.name %>" do
 <%- if method.return_type.nil? -%>
     expected_response = {}
 <%- else -%>
-    expected_response = Gapic::Protobuf.coerce {}, to: <%= method.return_type %>
+    expected_response = Gapic::Protobuf.coerce({}, to: <%= method.return_type %>)
 <%- end -%>
 
     # Mock Grpc layer
@@ -107,10 +107,10 @@ describe "<%= method.name %>" do
 <%- end -%>
       OpenStruct.new execute: expected_response
     end
-    mock_stub = MockGrpcClientStubV1.new :<%= method.name %>, mock_method
+    mock_stub = <%= test_mock_service_stub_class_name %>.new :<%= method.name %>, mock_method
 
     # Mock auth layer
-    mock_credentials = MockSpeechCredentialsV1.new "<%= method.name %>"
+    mock_credentials = <%= test_mock_credentials_class_name %>.new "<%= method.name %>"
 
     <%= method.service.proto_service_stub_name_full %>.stub :new, mock_stub do
       <%= method.service.credentials_name_full %>.stub :default, mock_credentials do
@@ -144,10 +144,10 @@ describe "<%= method.name %>" do
 <%- end -%>
       raise custom_error
     end
-    mock_stub = MockGrpcClientStubV1.new :<%= method.name %>, mock_method
+    mock_stub = <%= test_mock_service_stub_class_name %>.new :<%= method.name %>, mock_method
 
     # Mock auth layer
-    mock_credentials = MockSpeechCredentialsV1.new "<%= method.name %>"
+    mock_credentials = <%= test_mock_credentials_class_name %>.new "<%= method.name %>"
 
     <%= method.service.proto_service_stub_name_full %>.stub :new, mock_stub do
       <%= method.service.credentials_name_full %>.stub :default, mock_credentials do

--- a/gapic-generator/templates/default/service/test/method/_normal.erb
+++ b/gapic-generator/templates/default/service/test/method/_normal.erb
@@ -27,7 +27,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 4 %>
+<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 6 %>
 <%- end -%>
       OpenStruct.new execute: operation
     end
@@ -66,7 +66,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 4 %>
+<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 6 %>
 <%- end -%>
       OpenStruct.new execute: operation
     end
@@ -103,7 +103,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 4 %>
+<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 6 %>
 <%- end -%>
       OpenStruct.new execute: expected_response
     end
@@ -140,7 +140,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 4 %>
+<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 6 %>
 <%- end -%>
       raise custom_error
     end

--- a/gapic-generator/templates/default/service/test/method/_normal.erb
+++ b/gapic-generator/templates/default/service/test/method/_normal.erb
@@ -10,8 +10,11 @@ describe "<%= method.name %>" do
 <%= indent render(partial: "service/test/method/fields", locals: { method: method }), 4 %>
 
     # Create expected grpc response
+<%- if method.return_type.nil? -%>
     expected_response = {}
-    expected_response = Gapic::Protobuf.coerce expected_response, to: <%= method.return_type %>
+<%- else -%>
+    expected_response = Gapic::Protobuf.coerce {}, to: <%= method.return_type %>
+<%- end -%>
     result = Google::Protobuf::Any.new
     result.pack expected_response
     operation = Google::Longrunning::Operation.new(
@@ -24,7 +27,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Gapic::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
+<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 4 %>
 <%- end -%>
       OpenStruct.new execute: operation
     end
@@ -63,7 +66,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Gapic::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
+<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 4 %>
 <%- end -%>
       OpenStruct.new execute: operation
     end
@@ -90,14 +93,17 @@ describe "<%= method.name %>" do
 <%= indent render(partial: "service/test/method/fields", locals: { method: method }), 4 %>
 
     # Create expected grpc response
+<%- if method.return_type.nil? -%>
     expected_response = {}
-    expected_response = Gapic::Protobuf.coerce expected_response, to: <%= method.return_type %>
+<%- else -%>
+    expected_response = Gapic::Protobuf.coerce {}, to: <%= method.return_type %>
+<%- end -%>
 
     # Mock Grpc layer
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Gapic::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
+<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 4 %>
 <%- end -%>
       OpenStruct.new execute: expected_response
     end
@@ -134,7 +140,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Gapic::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
+<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 4 %>
 <%- end -%>
       raise custom_error
     end

--- a/gapic-generator/templates/default/service/test/method/_normal.erb
+++ b/gapic-generator/templates/default/service/test/method/_normal.erb
@@ -41,7 +41,7 @@ describe "<%= method.name %>" do
         client = <%= full_client_name %>.new
 
         # Call method
-        response = client.<%= method.name %> <%= method.fields.map(&:name).join ", " %>
+        response = client.<%= method.name %> <%= method.fields.map(&:as_kwarg).join ", " %>
 
         # Verify the response
         assert_equal expected_response, response.response
@@ -80,7 +80,7 @@ describe "<%= method.name %>" do
         client = <%= full_client_name %>.new
 
         # Call method
-        response = client.<%= method.name %> <%= method.fields.map(&:name).join ", " %>
+        response = client.<%= method.name %> <%= method.fields.map(&:as_kwarg).join ", " %>
 
         # Verify the response
         assert response.error?
@@ -117,13 +117,13 @@ describe "<%= method.name %>" do
         client = <%= full_client_name %>.new
 
         # Call method
-        response = client.<%= method.name %> <%= method.fields.map(&:name).join ", " %>
+        response = client.<%= method.name %> <%= method.fields.map(&:as_kwarg).join ", " %>
 
         # Verify the response
         assert_equal expected_response, response
 
         # Call method with block
-        client.<%= method.name %> <%= method.fields.map(&:name).join ", " %> do |resp, operation|
+        client.<%= method.name %> <%= method.fields.map(&:as_kwarg).join ", " %> do |resp, operation|
           # Verify the response
           assert_equal expected_response, resp
           refute_nil operation
@@ -155,7 +155,7 @@ describe "<%= method.name %>" do
 
         # Call method
         err = assert_raises Gapic::GapicError do
-          client.<%= method.name %> <%= method.fields.map(&:name).join ", " %>
+          client.<%= method.name %> <%= method.fields.map(&:as_kwarg).join ", " %>
         end
 
         # Verify the GapicError wrapped the custom error that was raised.

--- a/gapic-generator/templates/default/service/test/method/_server.erb
+++ b/gapic-generator/templates/default/service/test/method/_server.erb
@@ -1,7 +1,7 @@
-<%- assert_locals method -%>
+<%- assert_locals method, test_mock_error_class_name, test_mock_service_stub_class_name, test_mock_credentials_class_name -%>
 describe "<%= method.name %>" do
   let :custom_error do
-    CustomTestErrorV1.new "Custom test error for <%= method.service.client_name_full %>#<%= method.name %>."
+    <%= test_mock_error_class_name %>.new "Custom test error for <%= method.service.client_name_full %>#<%= method.name %>."
   end
 
   it "invokes <%= method.name %> without error" do
@@ -11,7 +11,7 @@ describe "<%= method.name %>" do
 <%- if method.return_type.nil? -%>
     expected_response = {}
 <%- else -%>
-    expected_response = Gapic::Protobuf.coerce {}, to: <%= method.return_type %>
+    expected_response = Gapic::Protobuf.coerce({}, to: <%= method.return_type %>)
 <%- end -%>
 
     # Mock Grpc layer
@@ -22,10 +22,10 @@ describe "<%= method.name %>" do
 <%- end -%>
       OpenStruct.new execute: expected_response
     end
-    mock_stub = MockGrpcClientStubV1.new :<%= method.name %>, mock_method
+    mock_stub = <%= test_mock_service_stub_class_name %>.new :<%= method.name %>, mock_method
 
     # Mock auth layer
-    mock_credentials = MockSpeechCredentialsV1.new "<%= method.name %>"
+    mock_credentials = <%= test_mock_credentials_class_name %>.new "<%= method.name %>"
 
     <%= method.service.proto_service_stub_name_full %>.stub :new, mock_stub do
       <%= method.service.credentials_name_full %>.stub :default, mock_credentials do
@@ -52,10 +52,10 @@ describe "<%= method.name %>" do
 <%- end -%>
       raise custom_error
     end
-    mock_stub = MockGrpcClientStubV1.new :<%= method.name %>, mock_method
+    mock_stub = <%= test_mock_service_stub_class_name %>.new :<%= method.name %>, mock_method
 
     # Mock auth layer
-    mock_credentials = MockSpeechCredentialsV1.new "<%= method.name %>"
+    mock_credentials = <%= test_mock_credentials_class_name %>.new "<%= method.name %>"
 
     <%= method.service.proto_service_stub_name_full %>.stub :new, mock_stub do
       <%= method.service.credentials_name_full %>.stub :default, mock_credentials do

--- a/gapic-generator/templates/default/service/test/method/_server.erb
+++ b/gapic-generator/templates/default/service/test/method/_server.erb
@@ -8,14 +8,17 @@ describe "<%= method.name %>" do
 <%= indent render(partial: "service/test/method/fields", locals: { method: method }), 4 %>
 
     # Create expected grpc response
+<%- if method.return_type.nil? -%>
     expected_response = {}
-    expected_response = Gapic::Protobuf.coerce expected_response, to: <%= method.return_type %>
+<%- else -%>
+    expected_response = Gapic::Protobuf.coerce {}, to: <%= method.return_type %>
+<%- end -%>
 
     # Mock Grpc layer
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Gapic::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
+<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 4 %>
 <%- end -%>
       OpenStruct.new execute: expected_response
     end
@@ -45,7 +48,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-      assert_equal Gapic::Protobuf.coerce(<%= field.name %>, to: <%= field.type_name_full %>), request.<%= field.name %>
+<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 4 %>
 <%- end -%>
       raise custom_error
     end

--- a/gapic-generator/templates/default/service/test/method/_server.erb
+++ b/gapic-generator/templates/default/service/test/method/_server.erb
@@ -63,7 +63,7 @@ describe "<%= method.name %>" do
 
         # Call method
         err = assert_raises Gapic::GapicError do
-          client.<%= method.name %> <%= method.fields.map(&:name).join ", " %>
+          client.<%= method.name %> <%= method.fields.map(&:as_kwarg).join ", " %>
         end
 
         # Verify the GapicError wrapped the custom error that was raised.

--- a/gapic-generator/templates/default/service/test/method/_server.erb
+++ b/gapic-generator/templates/default/service/test/method/_server.erb
@@ -18,7 +18,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 4 %>
+<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 6 %>
 <%- end -%>
       OpenStruct.new execute: expected_response
     end
@@ -48,7 +48,7 @@ describe "<%= method.name %>" do
     mock_method = proc do |request|
       assert_instance_of <%= method.request_type %>, request
 <%- method.fields.each do |field| -%>
-<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 4 %>
+<%= indent render(partial: "service/test/method/assert_field_equal", locals: { field: field }), 6 %>
 <%- end -%>
       raise custom_error
     end

--- a/gapic-generator/test/gapic/presenters/field_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/field_presenter_test.rb
@@ -31,6 +31,8 @@ class FieldPresenterTest < PresenterTest
     assert_equal "\"hello world\"", fp.default_value
     assert_equal "", fp.type_name
     assert_nil fp.type_name_full
+    assert_equal "name: name", fp.as_kwarg
+    assert_equal "name: x", fp.as_kwarg(value: "x")
   end
 
   def test_typical_garbage_int_fields
@@ -44,6 +46,8 @@ class FieldPresenterTest < PresenterTest
       assert_equal "42", fp.default_value
       assert_equal "", fp.type_name
       assert_nil fp.type_name_full
+      assert_equal "#{field_name}: #{field_name}", fp.as_kwarg
+      assert_equal "#{field_name}: yx", fp.as_kwarg(value: "yx")
     end
   end
 
@@ -57,6 +61,8 @@ class FieldPresenterTest < PresenterTest
     assert_equal "true", fp.default_value
     assert_equal "", fp.type_name
     assert_nil fp.type_name_full
+    assert_equal "bool: bool", fp.as_kwarg
+    assert_equal "bool: 1", fp.as_kwarg(value: 1)
   end
 
   def test_typical_garbage_numeric_fields
@@ -70,6 +76,8 @@ class FieldPresenterTest < PresenterTest
       assert_equal "3.14", fp.default_value
       assert_equal "", fp.type_name
       assert_nil fp.type_name_full
+      assert_equal "#{field_name}: #{field_name}", fp.as_kwarg
+      assert_equal "#{field_name}: true", fp.as_kwarg(value: true)
     end
   end
 
@@ -83,6 +91,8 @@ class FieldPresenterTest < PresenterTest
     assert_equal "\"hello world\"", fp.default_value
     assert_equal "", fp.type_name
     assert_nil fp.type_name_full
+    assert_equal "bytes: bytes", fp.as_kwarg
+    assert_equal "bytes: ", fp.as_kwarg(value: "")
   end
 
   def test_typical_garbage_msg_field
@@ -95,6 +105,8 @@ class FieldPresenterTest < PresenterTest
     assert_equal "{}", fp.default_value
     assert_equal ".endless.trash.forever.GarbageMap", fp.type_name
     assert_equal "So::Much::Trash::GarbageMap", fp.type_name_full
+    assert_equal "msg: msg", fp.as_kwarg
+    assert_equal "msg: 0", fp.as_kwarg(value: 0)
   end
 
   def test_typical_garbage_enum_field
@@ -107,5 +119,7 @@ class FieldPresenterTest < PresenterTest
     assert_equal "Default", fp.default_value
     assert_equal ".endless.trash.forever.GarbageEnum", fp.type_name
     assert_equal "So::Much::Trash::GarbageEnum", fp.type_name_full
+    assert_equal "enum: enum", fp.as_kwarg
+    assert_equal "enum: enum", fp.as_kwarg(value: "enum")
   end
 end

--- a/gapic-generator/test/gapic/presenters/service/garbage_test.rb
+++ b/gapic-generator/test/gapic/presenters/service/garbage_test.rb
@@ -131,6 +131,12 @@ class GarbageServiceTest < PresenterTest
     assert_equal "so/much/trash/garbage_service_operations_test.rb", presenter.test_client_operations_file_path
   end
 
+  def test_mock_names
+    assert_equal "MockGarbageServiceCredentialsForever", presenter.test_mock_credentials_class_name
+    assert_equal "MockGrpcGarbageServiceStubForever", presenter.test_mock_service_stub_class_name
+    assert_equal "CustomTestGarbageServiceErrorForever", presenter.test_mock_error_class_name
+  end
+
   def test_stub_name
     assert_equal "garbage_service_stub", presenter.stub_name
   end

--- a/gapic-generator/test/gapic/presenters/service/showcase_echo_test.rb
+++ b/gapic-generator/test/gapic/presenters/service/showcase_echo_test.rb
@@ -128,6 +128,12 @@ class ShowcaseEchoServiceTest < PresenterTest
     assert_equal "google/showcase/v1beta1/echo_operations_test.rb", presenter.test_client_operations_file_path
   end
 
+  def test_mock_names
+    assert_equal "MockEchoCredentialsV1beta1", presenter.test_mock_credentials_class_name
+    assert_equal "MockGrpcEchoStubV1beta1", presenter.test_mock_service_stub_class_name
+    assert_equal "CustomTestEchoErrorV1beta1", presenter.test_mock_error_class_name
+  end
+
   def test_stub_name
     assert_equal "echo_stub", presenter.stub_name
   end

--- a/gapic-generator/test/gapic/presenters/service/showcase_identity_test.rb
+++ b/gapic-generator/test/gapic/presenters/service/showcase_identity_test.rb
@@ -131,6 +131,12 @@ class ShowcaseIdentityServiceTest < PresenterTest
     assert_equal "google/showcase/v1beta1/identity_operations_test.rb", presenter.test_client_operations_file_path
   end
 
+  def test_mock_names
+    assert_equal "MockIdentityCredentialsV1beta1", presenter.test_mock_credentials_class_name
+    assert_equal "MockGrpcIdentityStubV1beta1", presenter.test_mock_service_stub_class_name
+    assert_equal "CustomTestIdentityErrorV1beta1", presenter.test_mock_error_class_name
+  end
+
   def test_stub_name
     assert_equal "identity_stub", presenter.stub_name
   end

--- a/gapic-generator/test/gapic/presenters/service/showcase_messaging_test.rb
+++ b/gapic-generator/test/gapic/presenters/service/showcase_messaging_test.rb
@@ -131,6 +131,12 @@ class ShowcaseMessagingServiceTest < PresenterTest
     assert_equal "google/showcase/v1beta1/messaging_operations_test.rb", presenter.test_client_operations_file_path
   end
 
+  def test_mock_names
+    assert_equal "MockMessagingCredentialsV1beta1", presenter.test_mock_credentials_class_name
+    assert_equal "MockGrpcMessagingStubV1beta1", presenter.test_mock_service_stub_class_name
+    assert_equal "CustomTestMessagingErrorV1beta1", presenter.test_mock_error_class_name
+  end
+
   def test_stub_name
     assert_equal "messaging_stub", presenter.stub_name
   end

--- a/gapic-generator/test/gapic/presenters/service/showcase_testing_test.rb
+++ b/gapic-generator/test/gapic/presenters/service/showcase_testing_test.rb
@@ -131,6 +131,12 @@ class ShowcaseTestingServiceTest < PresenterTest
     assert_equal "google/showcase/v1beta1/testing_operations_test.rb", presenter.test_client_operations_file_path
   end
 
+  def test_mock_names
+    assert_equal "MockTestingCredentialsV1beta1", presenter.test_mock_credentials_class_name
+    assert_equal "MockGrpcTestingStubV1beta1", presenter.test_mock_service_stub_class_name
+    assert_equal "CustomTestTestingErrorV1beta1", presenter.test_mock_error_class_name
+  end
+
   def test_stub_name
     assert_equal "testing_stub", presenter.stub_name
   end

--- a/gapic-generator/test/gapic/presenters/service/speech_test.rb
+++ b/gapic-generator/test/gapic/presenters/service/speech_test.rb
@@ -128,6 +128,12 @@ class SpeechServiceTest < PresenterTest
     assert_equal "google/cloud/speech/v1/speech_operations_test.rb", presenter.test_client_operations_file_path
   end
 
+  def test_mock_names
+    assert_equal "MockSpeechCredentialsV1", presenter.test_mock_credentials_class_name
+    assert_equal "MockGrpcSpeechStubV1", presenter.test_mock_service_stub_class_name
+    assert_equal "CustomTestSpeechErrorV1", presenter.test_mock_error_class_name
+  end
+
   def test_stub_name
     assert_equal "speech_stub", presenter.stub_name
   end

--- a/gapic-generator/test/gapic/presenters/service/vision_image_annotator_test.rb
+++ b/gapic-generator/test/gapic/presenters/service/vision_image_annotator_test.rb
@@ -128,6 +128,12 @@ class VisionImageAnnotatorServiceTest < PresenterTest
     assert_equal "google/cloud/vision/v1/image_annotator_operations_test.rb", presenter.test_client_operations_file_path
   end
 
+  def test_mock_names
+    assert_equal "MockImageAnnotatorCredentialsV1", presenter.test_mock_credentials_class_name
+    assert_equal "MockGrpcImageAnnotatorStubV1", presenter.test_mock_service_stub_class_name
+    assert_equal "CustomTestImageAnnotatorErrorV1", presenter.test_mock_error_class_name
+  end
+
   def test_stub_name
     assert_equal "image_annotator_stub", presenter.stub_name
   end

--- a/gapic-generator/test/gapic/presenters/service/vision_product_search_test.rb
+++ b/gapic-generator/test/gapic/presenters/service/vision_product_search_test.rb
@@ -128,6 +128,12 @@ class VisionProductSearchServiceTest < PresenterTest
     assert_equal "google/cloud/vision/v1/product_search_operations_test.rb", presenter.test_client_operations_file_path
   end
 
+  def test_mock_names
+    assert_equal "MockProductSearchCredentialsV1", presenter.test_mock_credentials_class_name
+    assert_equal "MockGrpcProductSearchStubV1", presenter.test_mock_service_stub_class_name
+    assert_equal "CustomTestProductSearchErrorV1", presenter.test_mock_error_class_name
+  end
+
   def test_stub_name
     assert_equal "product_search_stub", presenter.stub_name
   end

--- a/shared/Rakefile
+++ b/shared/Rakefile
@@ -14,6 +14,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+protos = {
+  speech:    [
+    "google/cloud/speech/v1/cloud_speech.proto"
+  ],
+  vision:    [
+    "google/cloud/vision/v1/geometry.proto",
+    "google/cloud/vision/v1/image_annotator.proto",
+    "google/cloud/vision/v1/product_search.proto",
+    "google/cloud/vision/v1/product_search_service.proto",
+    "google/cloud/vision/v1/text_annotation.proto",
+    "google/cloud/vision/v1/web_detection.proto"
+  ],
+  showcase:  [
+    "google/showcase/v1beta1/echo.proto",
+    "google/showcase/v1beta1/identity.proto",
+    "google/showcase/v1beta1/messaging.proto",
+    "google/showcase/v1beta1/testing.proto"
+  ],
+  garbage:   [
+    "garbage/garbage.proto"
+  ],
+  googleads: [
+    "google/ads/googleads/v1/services/campaign_service.proto"
+  ]
+}
+
 desc "Generate the binary input files"
 task :gen do
   Rake::Task["gen:speech"].invoke
@@ -23,57 +49,24 @@ task :gen do
   Rake::Task["gen:googleads"].invoke
 end
 
-# rubocop:disable Metrics/BlockLength
 namespace :gen do
-  desc "Generate the binary input files for speech"
-  task :speech do
-    speech_protos = [
-      "google/cloud/speech/v1/cloud_speech.proto"
-    ]
-    generate_input_file "speech", speech_protos
-  end
-
-  desc "Generate the binary input files for vision"
-  task :vision do
-    vision_protos = [
-      "google/cloud/vision/v1/geometry.proto",
-      "google/cloud/vision/v1/image_annotator.proto",
-      "google/cloud/vision/v1/product_search.proto",
-      "google/cloud/vision/v1/product_search_service.proto",
-      "google/cloud/vision/v1/text_annotation.proto",
-      "google/cloud/vision/v1/web_detection.proto"
-    ]
-    generate_input_file "vision", vision_protos
-  end
-
-  desc "Generate the binary input files for showcase"
-  task :showcase do
-    showcase_protos = [
-      "google/showcase/v1beta1/echo.proto",
-      "google/showcase/v1beta1/identity.proto",
-      "google/showcase/v1beta1/messaging.proto",
-      "google/showcase/v1beta1/testing.proto"
-    ]
-    generate_input_file "showcase", showcase_protos
-  end
-
-  desc "Generate the binary input files for garbage"
-  task :garbage do
-    garbage_protos = [
-      "garbage/garbage.proto"
-    ]
-    generate_input_file "garbage", garbage_protos
-  end
-
-  desc "Generate the binary input files for Google Ads"
-  task :googleads do
-    googleads_protos = [
-      "google/ads/googleads/v1/services/campaign_service.proto"
-    ]
-    generate_input_file "googleads", googleads_protos
+  protos.each do |name, input|
+    desc "Generate the binary input files for #{name}"
+    task name.to_sym do
+      generate_input_file name, input
+    end
   end
 end
-# rubocop:enable Metrics/BlockLength
+
+# TODO: enable me as part of the CI build!
+namespace :validate do
+  protos.each do |name, input|
+    desc "Validate the #{name} library (run unit tests)"
+    task name.to_sym do
+      install_and_run_unit_tests input
+    end
+  end
+end
 
 require "rake/testtask"
 desc "Run functional tests for all custom protos"
@@ -136,5 +129,37 @@ def generate_input_file service, protos
     ].join " "
 
     `#{protoc_cmd}`
+  end
+end
+
+def generate_library_for_test protos
+  require "tmpdir"
+
+  Dir.mktmpdir do |client_lib|
+    protoc_cmd = [
+      "grpc_tools_ruby_protoc",
+      "--proto_path=api-common-protos/",
+      "--proto_path=googleapis/",
+      "--proto_path=protos/",
+      "--ruby_out=#{client_lib}/lib",
+      "--grpc_out=#{client_lib}/lib",
+      "--ruby_gapic_out=#{client_lib}",
+      "--ruby_gapic_opt=configuration=../shared/config/showcase.yml",
+      (protos.join " ").to_s
+    ].join " "
+    puts protoc_cmd.to_s if ENV["VERBOSE"]
+    protoc_cmd_output = `#{protoc_cmd}`
+    puts protoc_cmd_output if ENV["VERBOSE"]
+    yield client_lib
+  end
+end
+
+def install_and_run_unit_tests protos
+  generate_library_for_test protos do |dir|
+    Bundler.with_clean_env do
+      Dir.chdir dir do
+        `bundle install && bundle exec rake test`
+      end
+    end
   end
 end

--- a/shared/Rakefile
+++ b/shared/Rakefile
@@ -63,7 +63,7 @@ namespace :validate do
   protos.each do |name, input|
     desc "Validate the #{name} library (run unit tests)"
     task name.to_sym do
-      install_and_run_unit_tests input
+      install_and_run_unit_tests name, input
     end
   end
 end
@@ -154,11 +154,16 @@ def generate_library_for_test protos
   end
 end
 
-def install_and_run_unit_tests protos
+def install_and_run_unit_tests name, protos
+  require "open3"
+
   generate_library_for_test protos do |dir|
     Bundler.with_clean_env do
       Dir.chdir dir do
-        `bundle install && bundle exec rake test`
+        puts "Validating #{name}..."
+        stdout, stderr, status = Open3.capture3 "bundle install && bundle exec rake test"
+        puts stdout
+        puts stderr unless status.success?
       end
     end
   end

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -105,7 +105,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
           client = Google::Showcase::V1beta1::Echo::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -149,7 +149,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
           client = Google::Showcase::V1beta1::Echo::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert response.error?
@@ -185,7 +185,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_operations name, filter, page_size, page_token
+            client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -230,7 +230,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
           client = Google::Showcase::V1beta1::Echo::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -268,7 +268,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
           client = Google::Showcase::V1beta1::Echo::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert response.error?
@@ -298,7 +298,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_operation name
+            client.get_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -336,13 +336,13 @@ describe Google::Showcase::V1beta1::Echo::Operations do
           client = Google::Showcase::V1beta1::Echo::Operations.new
 
           # Call method
-          response = client.delete_operation name
+          response = client.delete_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_operation name do |resp, operation|
+          client.delete_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -372,7 +372,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_operation name
+            client.delete_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -410,13 +410,13 @@ describe Google::Showcase::V1beta1::Echo::Operations do
           client = Google::Showcase::V1beta1::Echo::Operations.new
 
           # Call method
-          response = client.cancel_operation name
+          response = client.cancel_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.cancel_operation name do |resp, operation|
+          client.cancel_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -446,7 +446,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.cancel_operation name
+            client.cancel_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -76,8 +76,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -89,10 +88,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -133,10 +132,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -168,10 +167,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -205,8 +204,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -218,7 +216,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -256,7 +254,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -285,7 +283,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -319,13 +317,12 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -360,7 +357,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -394,13 +391,12 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -435,7 +431,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -88,10 +88,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -132,10 +132,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -167,10 +167,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -216,7 +216,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -254,7 +254,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -283,7 +283,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -322,7 +322,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -357,7 +357,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -396,7 +396,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -431,7 +431,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -20,9 +20,10 @@ require "google/showcase/v1beta1/echo_pb"
 require "google/showcase/v1beta1/echo_services_pb"
 require "google/showcase/v1beta1/echo"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestEchoErrorV1beta1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcEchoStubV1beta1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -65,7 +66,7 @@ end
 describe Google::Showcase::V1beta1::Echo::Operations do
   describe "list_operations" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#list_operations."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#list_operations."
     end
 
     it "invokes list_operations without error" do
@@ -76,12 +77,12 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::ListOperationsResponse)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:     "operations/list_operations_test",
+        done:     true,
         response: result
       )
 
@@ -94,10 +95,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockEchoCredentialsV1beta1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -124,8 +125,8 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         message: "Operation error for Google::Showcase::V1beta1::Echo::Operations#list_operations."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:  "operations/list_operations_test",
+        done:  true,
         error: operation_error
       )
 
@@ -138,10 +139,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockEchoCredentialsV1beta1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -173,10 +174,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockEchoCredentialsV1beta1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -196,7 +197,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
   describe "get_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#get_operation."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#get_operation."
     end
 
     it "invokes get_operation without error" do
@@ -204,12 +205,12 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:     "operations/get_operation_test",
+        done:     true,
         response: result
       )
 
@@ -219,10 +220,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -246,8 +247,8 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         message: "Operation error for Google::Showcase::V1beta1::Echo::Operations#get_operation."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:  "operations/get_operation_test",
+        done:  true,
         error: operation_error
       )
 
@@ -257,10 +258,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -286,10 +287,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -309,7 +310,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
   describe "delete_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#delete_operation."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#delete_operation."
     end
 
     it "invokes delete_operation without error" do
@@ -317,7 +318,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -325,10 +326,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -360,10 +361,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -383,7 +384,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
   describe "cancel_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#cancel_operation."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#cancel_operation."
     end
 
     it "invokes cancel_operation without error" do
@@ -391,7 +392,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -399,10 +400,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -434,10 +435,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -454,5 +455,4 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       end
     end
   end
-
 end

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -74,14 +74,13 @@ describe Google::Showcase::V1beta1::Echo::Client do
       error = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::EchoRequest, request
-        assert_equal Gapic::Protobuf.coerce(content, to: ), request.content
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal content, request.content
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :echo, mock_method
@@ -117,8 +116,8 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::EchoRequest, request
-        assert_equal Gapic::Protobuf.coerce(content, to: ), request.content
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal content, request.content
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :echo, mock_method
@@ -153,13 +152,12 @@ describe Google::Showcase::V1beta1::Echo::Client do
       error = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ExpandRequest, request
-        assert_equal Gapic::Protobuf.coerce(content, to: ), request.content
+        assert_equal content, request.content
         assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
@@ -190,7 +188,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ExpandRequest, request
-        assert_equal Gapic::Protobuf.coerce(content, to: ), request.content
+        assert_equal content, request.content
         assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
@@ -225,8 +223,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -288,8 +285,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -354,15 +350,14 @@ describe Google::Showcase::V1beta1::Echo::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::PagedExpandResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::PagedExpandResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::PagedExpandRequest, request
-        assert_equal Gapic::Protobuf.coerce(content, to: ), request.content
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal content, request.content
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
@@ -399,9 +394,9 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::PagedExpandRequest, request
-        assert_equal Gapic::Protobuf.coerce(content, to: ), request.content
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal content, request.content
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
@@ -438,8 +433,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       success = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -451,10 +445,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::WaitRequest, request
-        assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
-        assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
+      assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+      assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -495,10 +489,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::WaitRequest, request
-        assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
-        assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
+      assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+      assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -530,10 +524,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::WaitRequest, request
-        assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
-        assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
+      assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+      assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -569,15 +563,14 @@ describe Google::Showcase::V1beta1::Echo::Client do
       success = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::BlockResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::BlockResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::BlockRequest, request
-        assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
+      assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :block, mock_method
@@ -614,9 +607,9 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::BlockRequest, request
-        assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
+      assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :block, mock_method

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -79,8 +79,8 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::EchoRequest, request
-      assert_equal content, request.content
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal content, request.content
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :echo, mock_method
@@ -116,8 +116,8 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::EchoRequest, request
-      assert_equal content, request.content
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal content, request.content
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :echo, mock_method
@@ -355,9 +355,9 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::PagedExpandRequest, request
-      assert_equal content, request.content
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal content, request.content
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
@@ -394,9 +394,9 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::PagedExpandRequest, request
-      assert_equal content, request.content
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal content, request.content
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
@@ -445,10 +445,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::WaitRequest, request
-      assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
-      assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
+        assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+        assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -489,10 +489,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::WaitRequest, request
-      assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
-      assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
+        assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+        assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -524,10 +524,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::WaitRequest, request
-      assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
-      assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
+        assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+        assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -568,9 +568,9 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::BlockRequest, request
-      assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
+        assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :block, mock_method
@@ -607,9 +607,9 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::BlockRequest, request
-      assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
+        assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :block, mock_method

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -94,13 +94,13 @@ describe Google::Showcase::V1beta1::Echo::Client do
           client = Google::Showcase::V1beta1::Echo::Client.new
 
           # Call method
-          response = client.echo content, error
+          response = client.echo content: content, error: error
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.echo content, error do |resp, operation|
+          client.echo content: content, error: error do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -132,7 +132,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.echo content, error
+            client.echo content: content, error: error
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -204,7 +204,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.expand content, error
+            client.expand content: content, error: error
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -371,13 +371,13 @@ describe Google::Showcase::V1beta1::Echo::Client do
           client = Google::Showcase::V1beta1::Echo::Client.new
 
           # Call method
-          response = client.paged_expand content, page_size, page_token
+          response = client.paged_expand content: content, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.paged_expand content, page_size, page_token do |resp, operation|
+          client.paged_expand content: content, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -411,7 +411,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.paged_expand content, page_size, page_token
+            client.paged_expand content: content, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -462,7 +462,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
           client = Google::Showcase::V1beta1::Echo::Client.new
 
           # Call method
-          response = client.wait end_time, ttl, error, success
+          response = client.wait end_time: end_time, ttl: ttl, error: error, success: success
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -506,7 +506,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
           client = Google::Showcase::V1beta1::Echo::Client.new
 
           # Call method
-          response = client.wait end_time, ttl, error, success
+          response = client.wait end_time: end_time, ttl: ttl, error: error, success: success
 
           # Verify the response
           assert response.error?
@@ -542,7 +542,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.wait end_time, ttl, error, success
+            client.wait end_time: end_time, ttl: ttl, error: error, success: success
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -584,13 +584,13 @@ describe Google::Showcase::V1beta1::Echo::Client do
           client = Google::Showcase::V1beta1::Echo::Client.new
 
           # Call method
-          response = client.block response_delay, error, success
+          response = client.block response_delay: response_delay, error: error, success: success
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.block response_delay, error, success do |resp, operation|
+          client.block response_delay: response_delay, error: error, success: success do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -624,7 +624,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.block response_delay, error, success
+            client.block response_delay: response_delay, error: error, success: success
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -20,9 +20,10 @@ require "google/showcase/v1beta1/echo_pb"
 require "google/showcase/v1beta1/echo_services_pb"
 require "google/showcase/v1beta1/echo"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestEchoErrorV1beta1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcEchoStubV1beta1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -65,7 +66,7 @@ end
 describe Google::Showcase::V1beta1::Echo::Client do
   describe "echo" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#echo."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#echo."
     end
 
     it "invokes echo without error" do
@@ -74,7 +75,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       error = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::EchoResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -83,10 +84,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :echo, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :echo, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "echo"
+      mock_credentials = MockEchoCredentialsV1beta1.new "echo"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -120,10 +121,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :echo, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :echo, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "echo"
+      mock_credentials = MockEchoCredentialsV1beta1.new "echo"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -143,7 +144,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
   describe "expand" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#expand."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#expand."
     end
 
     it "invokes expand without error" do
@@ -152,7 +153,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       error = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::EchoResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -161,10 +162,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :expand, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :expand, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "expand"
+      mock_credentials = MockEchoCredentialsV1beta1.new "expand"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -192,10 +193,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :expand, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :expand, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "expand"
+      mock_credentials = MockEchoCredentialsV1beta1.new "expand"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -215,7 +216,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
   describe "collect" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#collect."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#collect."
     end
 
     it "invokes collect without error" do
@@ -223,17 +224,17 @@ describe Google::Showcase::V1beta1::Echo::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::EchoResponse)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
         OpenStruct.new execute: [expected_response]
       end
-      mock_stub = MockGrpcClientStubV1.new :collect, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :collect, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "collect"
+      mock_credentials = MockEchoCredentialsV1beta1.new "collect"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -254,10 +255,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
       # Mock Grpc layer
       mock_method = proc { raise custom_error }
-      mock_stub = MockGrpcClientStubV1.new :collect, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :collect, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "collect"
+      mock_credentials = MockEchoCredentialsV1beta1.new "collect"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -277,7 +278,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
   describe "chat" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#chat."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#chat."
     end
 
     it "invokes chat without error" do
@@ -285,17 +286,17 @@ describe Google::Showcase::V1beta1::Echo::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::EchoResponse)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
         OpenStruct.new execute: [expected_response]
       end
-      mock_stub = MockGrpcClientStubV1.new :chat, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :chat, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "chat"
+      mock_credentials = MockEchoCredentialsV1beta1.new "chat"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -317,10 +318,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
       # Mock Grpc layer
       mock_method = proc { raise custom_error }
-      mock_stub = MockGrpcClientStubV1.new :chat, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :chat, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "chat"
+      mock_credentials = MockEchoCredentialsV1beta1.new "chat"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -340,7 +341,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
   describe "paged_expand" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#paged_expand."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#paged_expand."
     end
 
     it "invokes paged_expand without error" do
@@ -350,7 +351,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::PagedExpandResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::PagedExpandResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -360,10 +361,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :paged_expand, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "paged_expand"
+      mock_credentials = MockEchoCredentialsV1beta1.new "paged_expand"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -399,10 +400,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :paged_expand, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "paged_expand"
+      mock_credentials = MockEchoCredentialsV1beta1.new "paged_expand"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -422,7 +423,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
   describe "wait" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#wait."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#wait."
     end
 
     it "invokes wait without error" do
@@ -433,12 +434,12 @@ describe Google::Showcase::V1beta1::Echo::Client do
       success = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/wait_test",
-        done: true,
+        name:     "operations/wait_test",
+        done:     true,
         response: result
       )
 
@@ -451,10 +452,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :wait, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :wait, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "wait"
+      mock_credentials = MockEchoCredentialsV1beta1.new "wait"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -481,8 +482,8 @@ describe Google::Showcase::V1beta1::Echo::Client do
         message: "Operation error for Google::Showcase::V1beta1::Echo::Client#wait."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/wait_test",
-        done: true,
+        name:  "operations/wait_test",
+        done:  true,
         error: operation_error
       )
 
@@ -495,10 +496,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :wait, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :wait, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "wait"
+      mock_credentials = MockEchoCredentialsV1beta1.new "wait"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -530,10 +531,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :wait, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :wait, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "wait"
+      mock_credentials = MockEchoCredentialsV1beta1.new "wait"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -553,7 +554,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
   describe "block" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#block."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#block."
     end
 
     it "invokes block without error" do
@@ -563,7 +564,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       success = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::BlockResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::BlockResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -573,10 +574,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :block, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :block, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "block"
+      mock_credentials = MockEchoCredentialsV1beta1.new "block"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -612,10 +613,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :block, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :block, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "block"
+      mock_credentials = MockEchoCredentialsV1beta1.new "block"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -20,9 +20,10 @@ require "google/showcase/v1beta1/identity_pb"
 require "google/showcase/v1beta1/identity_services_pb"
 require "google/showcase/v1beta1/identity"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestIdentityErrorV1beta1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcIdentityStubV1beta1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -65,7 +66,7 @@ end
 describe Google::Showcase::V1beta1::Identity::Client do
   describe "create_user" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#create_user."
+      CustomTestIdentityErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#create_user."
     end
 
     it "invokes create_user without error" do
@@ -73,7 +74,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       user = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::User
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::User)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -81,10 +82,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :create_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "create_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -116,10 +117,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :create_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "create_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -139,7 +140,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
   describe "get_user" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#get_user."
+      CustomTestIdentityErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#get_user."
     end
 
     it "invokes get_user without error" do
@@ -147,7 +148,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::User
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::User)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -155,10 +156,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :get_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "get_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -190,10 +191,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :get_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "get_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -213,7 +214,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
   describe "update_user" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#update_user."
+      CustomTestIdentityErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#update_user."
     end
 
     it "invokes update_user without error" do
@@ -222,7 +223,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::User
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::User)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -231,10 +232,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :update_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "update_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -268,10 +269,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :update_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "update_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -291,7 +292,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
   describe "delete_user" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#delete_user."
+      CustomTestIdentityErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#delete_user."
     end
 
     it "invokes delete_user without error" do
@@ -299,7 +300,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -307,10 +308,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :delete_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "delete_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -342,10 +343,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :delete_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "delete_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -365,7 +366,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
   describe "list_users" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#list_users."
+      CustomTestIdentityErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#list_users."
     end
 
     it "invokes list_users without error" do
@@ -374,7 +375,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListUsersResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::ListUsersResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -383,10 +384,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_users, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :list_users, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_users"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "list_users"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -420,10 +421,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_users, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :list_users, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_users"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "list_users"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -73,13 +73,12 @@ describe Google::Showcase::V1beta1::Identity::Client do
       user = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::User
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::User
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
@@ -114,7 +113,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
@@ -148,13 +147,12 @@ describe Google::Showcase::V1beta1::Identity::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::User
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::User
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
@@ -189,7 +187,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
@@ -224,14 +222,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::User
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::User
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
@@ -267,8 +264,8 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
@@ -302,13 +299,12 @@ describe Google::Showcase::V1beta1::Identity::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
@@ -343,7 +339,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
@@ -378,14 +374,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::ListUsersResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListUsersResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListUsersRequest, request
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_users, mock_method
@@ -421,8 +416,8 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListUsersRequest, request
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_users, mock_method

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -78,7 +78,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateUserRequest, request
-      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
@@ -113,7 +113,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateUserRequest, request
-      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
@@ -152,7 +152,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetUserRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
@@ -187,7 +187,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetUserRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
@@ -227,8 +227,8 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateUserRequest, request
-      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
@@ -264,8 +264,8 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateUserRequest, request
-      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
@@ -304,7 +304,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteUserRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
@@ -339,7 +339,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteUserRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
@@ -379,8 +379,8 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListUsersRequest, request
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_users, mock_method
@@ -416,8 +416,8 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListUsersRequest, request
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_users, mock_method

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -92,13 +92,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
           client = Google::Showcase::V1beta1::Identity::Client.new
 
           # Call method
-          response = client.create_user user
+          response = client.create_user user: user
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_user user do |resp, operation|
+          client.create_user user: user do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -128,7 +128,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_user user
+            client.create_user user: user
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -166,13 +166,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
           client = Google::Showcase::V1beta1::Identity::Client.new
 
           # Call method
-          response = client.get_user name
+          response = client.get_user name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_user name do |resp, operation|
+          client.get_user name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -202,7 +202,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_user name
+            client.get_user name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -242,13 +242,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
           client = Google::Showcase::V1beta1::Identity::Client.new
 
           # Call method
-          response = client.update_user user, update_mask
+          response = client.update_user user: user, update_mask: update_mask
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.update_user user, update_mask do |resp, operation|
+          client.update_user user: user, update_mask: update_mask do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -280,7 +280,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.update_user user, update_mask
+            client.update_user user: user, update_mask: update_mask
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -318,13 +318,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
           client = Google::Showcase::V1beta1::Identity::Client.new
 
           # Call method
-          response = client.delete_user name
+          response = client.delete_user name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_user name do |resp, operation|
+          client.delete_user name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -354,7 +354,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_user name
+            client.delete_user name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -394,13 +394,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
           client = Google::Showcase::V1beta1::Identity::Client.new
 
           # Call method
-          response = client.list_users page_size, page_token
+          response = client.list_users page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_users page_size, page_token do |resp, operation|
+          client.list_users page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -432,7 +432,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_users page_size, page_token
+            client.list_users page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -88,10 +88,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -132,10 +132,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -167,10 +167,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -216,7 +216,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -254,7 +254,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -283,7 +283,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -322,7 +322,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -357,7 +357,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -396,7 +396,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -431,7 +431,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -20,9 +20,10 @@ require "google/showcase/v1beta1/messaging_pb"
 require "google/showcase/v1beta1/messaging_services_pb"
 require "google/showcase/v1beta1/messaging"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestMessagingErrorV1beta1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcMessagingStubV1beta1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -65,7 +66,7 @@ end
 describe Google::Showcase::V1beta1::Messaging::Operations do
   describe "list_operations" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#list_operations."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#list_operations."
     end
 
     it "invokes list_operations without error" do
@@ -76,12 +77,12 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::ListOperationsResponse)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:     "operations/list_operations_test",
+        done:     true,
         response: result
       )
 
@@ -94,10 +95,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -124,8 +125,8 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         message: "Operation error for Google::Showcase::V1beta1::Messaging::Operations#list_operations."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:  "operations/list_operations_test",
+        done:  true,
         error: operation_error
       )
 
@@ -138,10 +139,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -173,10 +174,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -196,7 +197,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
   describe "get_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#get_operation."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#get_operation."
     end
 
     it "invokes get_operation without error" do
@@ -204,12 +205,12 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:     "operations/get_operation_test",
+        done:     true,
         response: result
       )
 
@@ -219,10 +220,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -246,8 +247,8 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         message: "Operation error for Google::Showcase::V1beta1::Messaging::Operations#get_operation."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:  "operations/get_operation_test",
+        done:  true,
         error: operation_error
       )
 
@@ -257,10 +258,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -286,10 +287,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -309,7 +310,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
   describe "delete_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#delete_operation."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#delete_operation."
     end
 
     it "invokes delete_operation without error" do
@@ -317,7 +318,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -325,10 +326,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -360,10 +361,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -383,7 +384,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
   describe "cancel_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#cancel_operation."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#cancel_operation."
     end
 
     it "invokes cancel_operation without error" do
@@ -391,7 +392,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -399,10 +400,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -434,10 +435,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -454,5 +455,4 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       end
     end
   end
-
 end

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -76,8 +76,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -89,10 +88,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -133,10 +132,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -168,10 +167,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -205,8 +204,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -218,7 +216,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -256,7 +254,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -285,7 +283,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -319,13 +317,12 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -360,7 +357,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -394,13 +391,12 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -435,7 +431,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -105,7 +105,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
           client = Google::Showcase::V1beta1::Messaging::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -149,7 +149,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
           client = Google::Showcase::V1beta1::Messaging::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert response.error?
@@ -185,7 +185,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_operations name, filter, page_size, page_token
+            client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -230,7 +230,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
           client = Google::Showcase::V1beta1::Messaging::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -268,7 +268,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
           client = Google::Showcase::V1beta1::Messaging::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert response.error?
@@ -298,7 +298,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_operation name
+            client.get_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -336,13 +336,13 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
           client = Google::Showcase::V1beta1::Messaging::Operations.new
 
           # Call method
-          response = client.delete_operation name
+          response = client.delete_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_operation name do |resp, operation|
+          client.delete_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -372,7 +372,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_operation name
+            client.delete_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -410,13 +410,13 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
           client = Google::Showcase::V1beta1::Messaging::Operations.new
 
           # Call method
-          response = client.cancel_operation name
+          response = client.cancel_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.cancel_operation name do |resp, operation|
+          client.cancel_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -446,7 +446,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.cancel_operation name
+            client.cancel_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -78,7 +78,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateRoomRequest, request
-      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
@@ -113,7 +113,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateRoomRequest, request
-      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
@@ -152,7 +152,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetRoomRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
@@ -187,7 +187,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetRoomRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
@@ -227,8 +227,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateRoomRequest, request
-      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
@@ -264,8 +264,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateRoomRequest, request
-      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
@@ -304,7 +304,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteRoomRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
@@ -339,7 +339,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteRoomRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
@@ -379,8 +379,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListRoomsRequest, request
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
@@ -416,8 +416,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListRoomsRequest, request
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
@@ -457,8 +457,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateBlurbRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
@@ -494,8 +494,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateBlurbRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
@@ -534,7 +534,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetBlurbRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
@@ -569,7 +569,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetBlurbRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
@@ -609,8 +609,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateBlurbRequest, request
-      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
@@ -646,8 +646,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateBlurbRequest, request
-      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
@@ -686,7 +686,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteBlurbRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
@@ -721,7 +721,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteBlurbRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
@@ -762,9 +762,9 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListBlurbsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
@@ -801,9 +801,9 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListBlurbsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
@@ -852,10 +852,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::SearchBlurbsRequest, request
-      assert_equal query, request.query
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal query, request.query
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -896,10 +896,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::SearchBlurbsRequest, request
-      assert_equal query, request.query
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal query, request.query
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -931,10 +931,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::SearchBlurbsRequest, request
-      assert_equal query, request.query
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal query, request.query
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -92,13 +92,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.create_room room
+          response = client.create_room room: room
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_room room do |resp, operation|
+          client.create_room room: room do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -128,7 +128,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_room room
+            client.create_room room: room
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -166,13 +166,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.get_room name
+          response = client.get_room name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_room name do |resp, operation|
+          client.get_room name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -202,7 +202,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_room name
+            client.get_room name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -242,13 +242,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.update_room room, update_mask
+          response = client.update_room room: room, update_mask: update_mask
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.update_room room, update_mask do |resp, operation|
+          client.update_room room: room, update_mask: update_mask do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -280,7 +280,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.update_room room, update_mask
+            client.update_room room: room, update_mask: update_mask
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -318,13 +318,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.delete_room name
+          response = client.delete_room name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_room name do |resp, operation|
+          client.delete_room name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -354,7 +354,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_room name
+            client.delete_room name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -394,13 +394,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.list_rooms page_size, page_token
+          response = client.list_rooms page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_rooms page_size, page_token do |resp, operation|
+          client.list_rooms page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -432,7 +432,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_rooms page_size, page_token
+            client.list_rooms page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -472,13 +472,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.create_blurb parent, blurb
+          response = client.create_blurb parent: parent, blurb: blurb
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_blurb parent, blurb do |resp, operation|
+          client.create_blurb parent: parent, blurb: blurb do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -510,7 +510,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_blurb parent, blurb
+            client.create_blurb parent: parent, blurb: blurb
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -548,13 +548,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.get_blurb name
+          response = client.get_blurb name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_blurb name do |resp, operation|
+          client.get_blurb name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -584,7 +584,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_blurb name
+            client.get_blurb name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -624,13 +624,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.update_blurb blurb, update_mask
+          response = client.update_blurb blurb: blurb, update_mask: update_mask
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.update_blurb blurb, update_mask do |resp, operation|
+          client.update_blurb blurb: blurb, update_mask: update_mask do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -662,7 +662,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.update_blurb blurb, update_mask
+            client.update_blurb blurb: blurb, update_mask: update_mask
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -700,13 +700,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.delete_blurb name
+          response = client.delete_blurb name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_blurb name do |resp, operation|
+          client.delete_blurb name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -736,7 +736,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_blurb name
+            client.delete_blurb name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -778,13 +778,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.list_blurbs parent, page_size, page_token
+          response = client.list_blurbs parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_blurbs parent, page_size, page_token do |resp, operation|
+          client.list_blurbs parent: parent, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -818,7 +818,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_blurbs parent, page_size, page_token
+            client.list_blurbs parent: parent, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -869,7 +869,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.search_blurbs query, parent, page_size, page_token
+          response = client.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -913,7 +913,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.search_blurbs query, parent, page_size, page_token
+          response = client.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert response.error?
@@ -949,7 +949,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.search_blurbs query, parent, page_size, page_token
+            client.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1021,7 +1021,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.stream_blurbs name, expire_time
+            client.stream_blurbs name: name, expire_time: expire_time
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -20,9 +20,10 @@ require "google/showcase/v1beta1/messaging_pb"
 require "google/showcase/v1beta1/messaging_services_pb"
 require "google/showcase/v1beta1/messaging"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestMessagingErrorV1beta1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcMessagingStubV1beta1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -65,7 +66,7 @@ end
 describe Google::Showcase::V1beta1::Messaging::Client do
   describe "create_room" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#create_room."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#create_room."
     end
 
     it "invokes create_room without error" do
@@ -73,7 +74,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       room = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Room
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Room)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -81,10 +82,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :create_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "create_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -116,10 +117,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :create_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "create_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -139,7 +140,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "get_room" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#get_room."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#get_room."
     end
 
     it "invokes get_room without error" do
@@ -147,7 +148,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Room
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Room)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -155,10 +156,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -190,10 +191,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -213,7 +214,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "update_room" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#update_room."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#update_room."
     end
 
     it "invokes update_room without error" do
@@ -222,7 +223,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Room
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Room)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -231,10 +232,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :update_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "update_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -268,10 +269,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :update_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "update_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -291,7 +292,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "delete_room" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#delete_room."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#delete_room."
     end
 
     it "invokes delete_room without error" do
@@ -299,7 +300,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -307,10 +308,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :delete_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "delete_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -342,10 +343,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :delete_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "delete_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -365,7 +366,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "list_rooms" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#list_rooms."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#list_rooms."
     end
 
     it "invokes list_rooms without error" do
@@ -374,7 +375,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListRoomsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::ListRoomsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -383,10 +384,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_rooms, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_rooms"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_rooms"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -420,10 +421,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_rooms, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_rooms"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_rooms"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -443,7 +444,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "create_blurb" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#create_blurb."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#create_blurb."
     end
 
     it "invokes create_blurb without error" do
@@ -452,7 +453,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       blurb = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Blurb
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Blurb)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -461,10 +462,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :create_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "create_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -498,10 +499,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :create_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "create_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -521,7 +522,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "get_blurb" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#get_blurb."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#get_blurb."
     end
 
     it "invokes get_blurb without error" do
@@ -529,7 +530,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Blurb
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Blurb)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -537,10 +538,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -572,10 +573,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -595,7 +596,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "update_blurb" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#update_blurb."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#update_blurb."
     end
 
     it "invokes update_blurb without error" do
@@ -604,7 +605,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Blurb
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Blurb)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -613,10 +614,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :update_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "update_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -650,10 +651,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :update_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "update_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -673,7 +674,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "delete_blurb" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#delete_blurb."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#delete_blurb."
     end
 
     it "invokes delete_blurb without error" do
@@ -681,7 +682,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -689,10 +690,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :delete_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "delete_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -724,10 +725,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :delete_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "delete_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -747,7 +748,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "list_blurbs" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#list_blurbs."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#list_blurbs."
     end
 
     it "invokes list_blurbs without error" do
@@ -757,7 +758,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::ListBlurbsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -767,10 +768,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -806,10 +807,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -829,7 +830,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "search_blurbs" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#search_blurbs."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#search_blurbs."
     end
 
     it "invokes search_blurbs without error" do
@@ -840,12 +841,12 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/search_blurbs_test",
-        done: true,
+        name:     "operations/search_blurbs_test",
+        done:     true,
         response: result
       )
 
@@ -858,10 +859,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :search_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "search_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "search_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -888,8 +889,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         message: "Operation error for Google::Showcase::V1beta1::Messaging::Client#search_blurbs."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/search_blurbs_test",
-        done: true,
+        name:  "operations/search_blurbs_test",
+        done:  true,
         error: operation_error
       )
 
@@ -902,10 +903,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :search_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "search_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "search_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -937,10 +938,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :search_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "search_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "search_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -960,7 +961,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "stream_blurbs" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#stream_blurbs."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#stream_blurbs."
     end
 
     it "invokes stream_blurbs without error" do
@@ -969,7 +970,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       expire_time = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::StreamBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::StreamBlurbsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -978,10 +979,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :stream_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :stream_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "stream_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "stream_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -1009,10 +1010,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :stream_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :stream_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "stream_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "stream_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -1032,7 +1033,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "send_blurbs" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#send_blurbs."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#send_blurbs."
     end
 
     it "invokes send_blurbs without error" do
@@ -1040,17 +1041,17 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::SendBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::SendBlurbsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
         OpenStruct.new execute: [expected_response]
       end
-      mock_stub = MockGrpcClientStubV1.new :send_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :send_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "send_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "send_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -1071,10 +1072,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
       # Mock Grpc layer
       mock_method = proc { raise custom_error }
-      mock_stub = MockGrpcClientStubV1.new :send_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :send_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "send_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "send_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -1094,7 +1095,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "connect" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#connect."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#connect."
     end
 
     it "invokes connect without error" do
@@ -1102,17 +1103,17 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::StreamBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::StreamBlurbsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
         OpenStruct.new execute: [expected_response]
       end
-      mock_stub = MockGrpcClientStubV1.new :connect, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :connect, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "connect"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "connect"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -1134,10 +1135,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
       # Mock Grpc layer
       mock_method = proc { raise custom_error }
-      mock_stub = MockGrpcClientStubV1.new :connect, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :connect, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "connect"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "connect"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -73,13 +73,12 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       room = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Room
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Room
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
@@ -114,7 +113,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
@@ -148,13 +147,12 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Room
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Room
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
@@ -189,7 +187,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
@@ -224,14 +222,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Room
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Room
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
@@ -267,8 +264,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
@@ -302,13 +299,12 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
@@ -343,7 +339,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
@@ -378,14 +374,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::ListRoomsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListRoomsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListRoomsRequest, request
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
@@ -421,8 +416,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListRoomsRequest, request
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
@@ -457,14 +452,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       blurb = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Blurb
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Blurb
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
@@ -500,8 +494,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
@@ -535,13 +529,12 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Blurb
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Blurb
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
@@ -576,7 +569,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
@@ -611,14 +604,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Blurb
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Blurb
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
@@ -654,8 +646,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
@@ -689,13 +681,12 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
@@ -730,7 +721,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
@@ -766,15 +757,14 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::ListBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
@@ -811,9 +801,9 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
@@ -850,8 +840,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -863,10 +852,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::SearchBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(query, to: ), request.query
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal query, request.query
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -907,10 +896,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::SearchBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(query, to: ), request.query
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal query, request.query
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -942,10 +931,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::SearchBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(query, to: ), request.query
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal query, request.query
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -980,13 +969,12 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       expire_time = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::StreamBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::StreamBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::StreamBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+        assert_equal name, request.name
         assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         OpenStruct.new execute: expected_response
       end
@@ -1017,7 +1005,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::StreamBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+        assert_equal name, request.name
         assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         raise custom_error
       end
@@ -1052,8 +1040,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::SendBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::SendBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -1115,8 +1102,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::StreamBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::StreamBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -20,9 +20,10 @@ require "google/showcase/v1beta1/testing_pb"
 require "google/showcase/v1beta1/testing_services_pb"
 require "google/showcase/v1beta1/testing"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestTestingErrorV1beta1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcTestingStubV1beta1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -65,7 +66,7 @@ end
 describe Google::Showcase::V1beta1::Testing::Client do
   describe "create_session" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#create_session."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#create_session."
     end
 
     it "invokes create_session without error" do
@@ -73,7 +74,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       session = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Session
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Session)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -81,10 +82,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :create_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "create_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -116,10 +117,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :create_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "create_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -139,7 +140,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "get_session" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#get_session."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#get_session."
     end
 
     it "invokes get_session without error" do
@@ -147,7 +148,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Session
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Session)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -155,10 +156,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :get_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "get_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -190,10 +191,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :get_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "get_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -213,7 +214,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "list_sessions" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#list_sessions."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#list_sessions."
     end
 
     it "invokes list_sessions without error" do
@@ -222,7 +223,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListSessionsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::ListSessionsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -231,10 +232,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :list_sessions, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_sessions"
+      mock_credentials = MockTestingCredentialsV1beta1.new "list_sessions"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -268,10 +269,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :list_sessions, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_sessions"
+      mock_credentials = MockTestingCredentialsV1beta1.new "list_sessions"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -291,7 +292,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "delete_session" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#delete_session."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#delete_session."
     end
 
     it "invokes delete_session without error" do
@@ -299,7 +300,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -307,10 +308,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :delete_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "delete_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -342,10 +343,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :delete_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "delete_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -365,7 +366,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "report_session" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#report_session."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#report_session."
     end
 
     it "invokes report_session without error" do
@@ -373,7 +374,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ReportSessionResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::ReportSessionResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -381,10 +382,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :report_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "report_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "report_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -416,10 +417,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :report_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "report_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "report_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -439,7 +440,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "list_tests" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#list_tests."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#list_tests."
     end
 
     it "invokes list_tests without error" do
@@ -449,7 +450,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListTestsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::ListTestsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -459,10 +460,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :list_tests, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_tests"
+      mock_credentials = MockTestingCredentialsV1beta1.new "list_tests"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -498,10 +499,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :list_tests, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_tests"
+      mock_credentials = MockTestingCredentialsV1beta1.new "list_tests"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -521,7 +522,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "delete_test" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#delete_test."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#delete_test."
     end
 
     it "invokes delete_test without error" do
@@ -529,7 +530,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -537,10 +538,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :delete_test, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_test"
+      mock_credentials = MockTestingCredentialsV1beta1.new "delete_test"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -572,10 +573,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :delete_test, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_test"
+      mock_credentials = MockTestingCredentialsV1beta1.new "delete_test"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -595,7 +596,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "verify_test" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#verify_test."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#verify_test."
     end
 
     it "invokes verify_test without error" do
@@ -605,7 +606,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       answers = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::VerifyTestResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::VerifyTestResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -615,10 +616,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal answers, request.answers
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :verify_test, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "verify_test"
+      mock_credentials = MockTestingCredentialsV1beta1.new "verify_test"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -654,10 +655,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal answers, request.answers
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :verify_test, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "verify_test"
+      mock_credentials = MockTestingCredentialsV1beta1.new "verify_test"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -92,13 +92,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.create_session session
+          response = client.create_session session: session
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_session session do |resp, operation|
+          client.create_session session: session do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -128,7 +128,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_session session
+            client.create_session session: session
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -166,13 +166,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.get_session name
+          response = client.get_session name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_session name do |resp, operation|
+          client.get_session name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -202,7 +202,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_session name
+            client.get_session name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -242,13 +242,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.list_sessions page_size, page_token
+          response = client.list_sessions page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_sessions page_size, page_token do |resp, operation|
+          client.list_sessions page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -280,7 +280,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_sessions page_size, page_token
+            client.list_sessions page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -318,13 +318,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.delete_session name
+          response = client.delete_session name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_session name do |resp, operation|
+          client.delete_session name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -354,7 +354,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_session name
+            client.delete_session name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -392,13 +392,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.report_session name
+          response = client.report_session name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.report_session name do |resp, operation|
+          client.report_session name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -428,7 +428,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.report_session name
+            client.report_session name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -470,13 +470,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.list_tests parent, page_size, page_token
+          response = client.list_tests parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_tests parent, page_size, page_token do |resp, operation|
+          client.list_tests parent: parent, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -510,7 +510,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_tests parent, page_size, page_token
+            client.list_tests parent: parent, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -548,13 +548,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.delete_test name
+          response = client.delete_test name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_test name do |resp, operation|
+          client.delete_test name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -584,7 +584,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_test name
+            client.delete_test name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -626,13 +626,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.verify_test name, answer, answers
+          response = client.verify_test name: name, answer: answer, answers: answers
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.verify_test name, answer, answers do |resp, operation|
+          client.verify_test name: name, answer: answer, answers: answers do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -666,7 +666,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.verify_test name, answer, answers
+            client.verify_test name: name, answer: answer, answers: answers
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -73,13 +73,12 @@ describe Google::Showcase::V1beta1::Testing::Client do
       session = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Session
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Session
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
+      assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
@@ -114,7 +113,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
+      assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
@@ -148,13 +147,12 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Session
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Session
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
@@ -189,7 +187,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
@@ -224,14 +222,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::ListSessionsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListSessionsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListSessionsRequest, request
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
@@ -267,8 +264,8 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListSessionsRequest, request
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
@@ -302,13 +299,12 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
@@ -343,7 +339,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
@@ -377,13 +373,12 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::ReportSessionResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ReportSessionResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ReportSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
@@ -418,7 +413,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ReportSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
@@ -454,15 +449,14 @@ describe Google::Showcase::V1beta1::Testing::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::ListTestsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListTestsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListTestsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
@@ -499,9 +493,9 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListTestsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
@@ -535,13 +529,12 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteTestRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
@@ -576,7 +569,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteTestRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
@@ -612,15 +605,14 @@ describe Google::Showcase::V1beta1::Testing::Client do
       answers = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::VerifyTestResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::VerifyTestResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::VerifyTestRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(answer, to: ), request.answer
-        assert_equal Gapic::Protobuf.coerce(answers, to: ), request.answers
+      assert_equal name, request.name
+      assert_equal answer, request.answer
+      assert_equal answers, request.answers
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method
@@ -657,9 +649,9 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::VerifyTestRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(answer, to: ), request.answer
-        assert_equal Gapic::Protobuf.coerce(answers, to: ), request.answers
+      assert_equal name, request.name
+      assert_equal answer, request.answer
+      assert_equal answers, request.answers
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -78,7 +78,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateSessionRequest, request
-      assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
+        assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
@@ -113,7 +113,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateSessionRequest, request
-      assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
+        assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
@@ -152,7 +152,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetSessionRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
@@ -187,7 +187,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetSessionRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
@@ -227,8 +227,8 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListSessionsRequest, request
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
@@ -264,8 +264,8 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListSessionsRequest, request
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
@@ -304,7 +304,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteSessionRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
@@ -339,7 +339,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteSessionRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
@@ -378,7 +378,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ReportSessionRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
@@ -413,7 +413,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ReportSessionRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
@@ -454,9 +454,9 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListTestsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
@@ -493,9 +493,9 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListTestsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
@@ -534,7 +534,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteTestRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
@@ -569,7 +569,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteTestRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
@@ -610,9 +610,9 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::VerifyTestRequest, request
-      assert_equal name, request.name
-      assert_equal answer, request.answer
-      assert_equal answers, request.answers
+        assert_equal name, request.name
+        assert_equal answer, request.answer
+        assert_equal answers, request.answers
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method
@@ -649,9 +649,9 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::VerifyTestRequest, request
-      assert_equal name, request.name
-      assert_equal answer, request.answer
-      assert_equal answers, request.answers
+        assert_equal name, request.name
+        assert_equal answer, request.answer
+        assert_equal answers, request.answers
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method

--- a/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -88,10 +88,10 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -132,10 +132,10 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -167,10 +167,10 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -216,7 +216,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -254,7 +254,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -283,7 +283,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -322,7 +322,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -357,7 +357,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -396,7 +396,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -431,7 +431,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -105,7 +105,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
           client = Google::Cloud::Speech::V1::Speech::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -149,7 +149,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
           client = Google::Cloud::Speech::V1::Speech::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert response.error?
@@ -185,7 +185,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_operations name, filter, page_size, page_token
+            client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -230,7 +230,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
           client = Google::Cloud::Speech::V1::Speech::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -268,7 +268,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
           client = Google::Cloud::Speech::V1::Speech::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert response.error?
@@ -298,7 +298,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_operation name
+            client.get_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -336,13 +336,13 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
           client = Google::Cloud::Speech::V1::Speech::Operations.new
 
           # Call method
-          response = client.delete_operation name
+          response = client.delete_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_operation name do |resp, operation|
+          client.delete_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -372,7 +372,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_operation name
+            client.delete_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -410,13 +410,13 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
           client = Google::Cloud::Speech::V1::Speech::Operations.new
 
           # Call method
-          response = client.cancel_operation name
+          response = client.cancel_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.cancel_operation name do |resp, operation|
+          client.cancel_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -446,7 +446,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.cancel_operation name
+            client.cancel_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -76,8 +76,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -89,10 +88,10 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -133,10 +132,10 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -168,10 +167,10 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -205,8 +204,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -218,7 +216,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -256,7 +254,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -285,7 +283,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -319,13 +317,12 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -360,7 +357,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -394,13 +391,12 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -435,7 +431,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -20,9 +20,10 @@ require "google/cloud/speech/v1/cloud_speech_pb"
 require "google/cloud/speech/v1/cloud_speech_services_pb"
 require "google/cloud/speech/v1/speech"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestSpeechErrorV1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcSpeechStubV1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -65,7 +66,7 @@ end
 describe Google::Cloud::Speech::V1::Speech::Operations do
   describe "list_operations" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#list_operations."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#list_operations."
     end
 
     it "invokes list_operations without error" do
@@ -76,12 +77,12 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::ListOperationsResponse)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:     "operations/list_operations_test",
+        done:     true,
         response: result
       )
 
@@ -94,7 +95,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :list_operations, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "list_operations"
@@ -124,8 +125,8 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         message: "Operation error for Google::Cloud::Speech::V1::Speech::Operations#list_operations."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:  "operations/list_operations_test",
+        done:  true,
         error: operation_error
       )
 
@@ -138,7 +139,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :list_operations, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "list_operations"
@@ -173,7 +174,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :list_operations, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "list_operations"
@@ -196,7 +197,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
   describe "get_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#get_operation."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#get_operation."
     end
 
     it "invokes get_operation without error" do
@@ -204,12 +205,12 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:     "operations/get_operation_test",
+        done:     true,
         response: result
       )
 
@@ -219,7 +220,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :get_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "get_operation"
@@ -246,8 +247,8 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         message: "Operation error for Google::Cloud::Speech::V1::Speech::Operations#get_operation."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:  "operations/get_operation_test",
+        done:  true,
         error: operation_error
       )
 
@@ -257,7 +258,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :get_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "get_operation"
@@ -286,7 +287,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :get_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "get_operation"
@@ -309,7 +310,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
   describe "delete_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#delete_operation."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#delete_operation."
     end
 
     it "invokes delete_operation without error" do
@@ -317,7 +318,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -325,7 +326,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :delete_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
@@ -360,7 +361,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :delete_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
@@ -383,7 +384,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
   describe "cancel_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#cancel_operation."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#cancel_operation."
     end
 
     it "invokes cancel_operation without error" do
@@ -391,7 +392,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -399,7 +400,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :cancel_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
@@ -434,7 +435,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :cancel_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
@@ -454,5 +455,4 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       end
     end
   end
-
 end

--- a/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
@@ -20,9 +20,10 @@ require "google/cloud/speech/v1/cloud_speech_pb"
 require "google/cloud/speech/v1/cloud_speech_services_pb"
 require "google/cloud/speech/v1/speech"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestSpeechErrorV1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcSpeechStubV1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -65,7 +66,7 @@ end
 describe Google::Cloud::Speech::V1::Speech::Client do
   describe "recognize" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Client#recognize."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Client#recognize."
     end
 
     it "invokes recognize without error" do
@@ -74,7 +75,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       audio = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Speech::V1::RecognizeResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Speech::V1::RecognizeResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -83,7 +84,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "recognize"
@@ -120,7 +121,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "recognize"
@@ -143,7 +144,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
   describe "long_running_recognize" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Client#long_running_recognize."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Client#long_running_recognize."
     end
 
     it "invokes long_running_recognize without error" do
@@ -152,12 +153,12 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       audio = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/long_running_recognize_test",
-        done: true,
+        name:     "operations/long_running_recognize_test",
+        done:     true,
         response: result
       )
 
@@ -168,7 +169,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :long_running_recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "long_running_recognize"
@@ -196,8 +197,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         message: "Operation error for Google::Cloud::Speech::V1::Speech::Client#long_running_recognize."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/long_running_recognize_test",
-        done: true,
+        name:  "operations/long_running_recognize_test",
+        done:  true,
         error: operation_error
       )
 
@@ -208,7 +209,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :long_running_recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "long_running_recognize"
@@ -239,7 +240,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :long_running_recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "long_running_recognize"
@@ -262,7 +263,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
   describe "streaming_recognize" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Client#streaming_recognize."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Client#streaming_recognize."
     end
 
     it "invokes streaming_recognize without error" do
@@ -270,14 +271,14 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Speech::V1::StreamingRecognizeResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Speech::V1::StreamingRecognizeResponse)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
         OpenStruct.new execute: [expected_response]
       end
-      mock_stub = MockGrpcClientStubV1.new :streaming_recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :streaming_recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "streaming_recognize"
@@ -302,7 +303,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
       # Mock Grpc layer
       mock_method = proc { raise custom_error }
-      mock_stub = MockGrpcClientStubV1.new :streaming_recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :streaming_recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "streaming_recognize"

--- a/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
@@ -94,13 +94,13 @@ describe Google::Cloud::Speech::V1::Speech::Client do
           client = Google::Cloud::Speech::V1::Speech::Client.new
 
           # Call method
-          response = client.recognize config, audio
+          response = client.recognize config: config, audio: audio
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.recognize config, audio do |resp, operation|
+          client.recognize config: config, audio: audio do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -132,7 +132,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.recognize config, audio
+            client.recognize config: config, audio: audio
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -179,7 +179,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
           client = Google::Cloud::Speech::V1::Speech::Client.new
 
           # Call method
-          response = client.long_running_recognize config, audio
+          response = client.long_running_recognize config: config, audio: audio
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -219,7 +219,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
           client = Google::Cloud::Speech::V1::Speech::Client.new
 
           # Call method
-          response = client.long_running_recognize config, audio
+          response = client.long_running_recognize config: config, audio: audio
 
           # Verify the response
           assert response.error?
@@ -251,7 +251,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.long_running_recognize config, audio
+            client.long_running_recognize config: config, audio: audio
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
@@ -79,8 +79,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::RecognizeRequest, request
-      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
@@ -116,8 +116,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::RecognizeRequest, request
-      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
@@ -164,8 +164,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -204,8 +204,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -235,8 +235,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method

--- a/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
@@ -74,14 +74,13 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       audio = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Speech::V1::RecognizeResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Speech::V1::RecognizeResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::RecognizeRequest, request
-        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
@@ -117,8 +116,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::RecognizeRequest, request
-        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
@@ -153,21 +152,20 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       audio = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name:     "operations/long_running_recognize_test",
-        done:     true,
+        name: "operations/long_running_recognize_test",
+        done: true,
         response: result
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -198,16 +196,16 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         message: "Operation error for Google::Cloud::Speech::V1::Speech::Client#long_running_recognize."
       )
       operation = Google::Longrunning::Operation.new(
-        name:  "operations/long_running_recognize_test",
-        done:  true,
+        name: "operations/long_running_recognize_test",
+        done: true,
         error: operation_error
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -237,8 +235,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -272,8 +270,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Speech::V1::StreamingRecognizeResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Speech::V1::StreamingRecognizeResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -76,8 +76,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -89,10 +88,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -133,10 +132,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -168,10 +167,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -205,8 +204,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -218,7 +216,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -256,7 +254,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -285,7 +283,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -319,13 +317,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -360,7 +357,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -394,13 +391,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -435,7 +431,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -20,9 +20,10 @@ require "google/cloud/vision/v1/image_annotator_pb"
 require "google/cloud/vision/v1/image_annotator_services_pb"
 require "google/cloud/vision/v1/image_annotator"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestImageAnnotatorErrorV1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcImageAnnotatorStubV1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -65,7 +66,7 @@ end
 describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
   describe "list_operations" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#list_operations."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#list_operations."
     end
 
     it "invokes list_operations without error" do
@@ -76,12 +77,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::ListOperationsResponse)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:     "operations/list_operations_test",
+        done:     true,
         response: result
       )
 
@@ -94,10 +95,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -124,8 +125,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         message: "Operation error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#list_operations."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:  "operations/list_operations_test",
+        done:  true,
         error: operation_error
       )
 
@@ -138,10 +139,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -173,10 +174,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -196,7 +197,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
   describe "get_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#get_operation."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#get_operation."
     end
 
     it "invokes get_operation without error" do
@@ -204,12 +205,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:     "operations/get_operation_test",
+        done:     true,
         response: result
       )
 
@@ -219,10 +220,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -246,8 +247,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         message: "Operation error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#get_operation."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:  "operations/get_operation_test",
+        done:  true,
         error: operation_error
       )
 
@@ -257,10 +258,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -286,10 +287,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -309,7 +310,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
   describe "delete_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#delete_operation."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#delete_operation."
     end
 
     it "invokes delete_operation without error" do
@@ -317,7 +318,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -325,10 +326,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -360,10 +361,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -383,7 +384,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
   describe "cancel_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#cancel_operation."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#cancel_operation."
     end
 
     it "invokes cancel_operation without error" do
@@ -391,7 +392,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -399,10 +400,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -434,10 +435,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -454,5 +455,4 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       end
     end
   end
-
 end

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -105,7 +105,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -149,7 +149,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert response.error?
@@ -185,7 +185,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_operations name, filter, page_size, page_token
+            client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -230,7 +230,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -268,7 +268,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert response.error?
@@ -298,7 +298,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_operation name
+            client.get_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -336,13 +336,13 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Operations.new
 
           # Call method
-          response = client.delete_operation name
+          response = client.delete_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_operation name do |resp, operation|
+          client.delete_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -372,7 +372,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_operation name
+            client.delete_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -410,13 +410,13 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Operations.new
 
           # Call method
-          response = client.cancel_operation name
+          response = client.cancel_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.cancel_operation name do |resp, operation|
+          client.cancel_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -446,7 +446,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.cancel_operation name
+            client.cancel_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -88,10 +88,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -132,10 +132,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -167,10 +167,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -216,7 +216,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -254,7 +254,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -283,7 +283,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -322,7 +322,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -357,7 +357,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -396,7 +396,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -431,7 +431,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -94,13 +94,13 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
           # Call method
-          response = client.batch_annotate_images requests, parent
+          response = client.batch_annotate_images requests: requests, parent: parent
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.batch_annotate_images requests, parent do |resp, operation|
+          client.batch_annotate_images requests: requests, parent: parent do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -132,7 +132,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.batch_annotate_images requests, parent
+            client.batch_annotate_images requests: requests, parent: parent
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -172,13 +172,13 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
           # Call method
-          response = client.batch_annotate_files requests, parent
+          response = client.batch_annotate_files requests: requests, parent: parent
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.batch_annotate_files requests, parent do |resp, operation|
+          client.batch_annotate_files requests: requests, parent: parent do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -210,7 +210,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.batch_annotate_files requests, parent
+            client.batch_annotate_files requests: requests, parent: parent
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -259,7 +259,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
           # Call method
-          response = client.async_batch_annotate_images requests, output_config, parent
+          response = client.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -301,7 +301,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
           # Call method
-          response = client.async_batch_annotate_images requests, output_config, parent
+          response = client.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent
 
           # Verify the response
           assert response.error?
@@ -335,7 +335,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.async_batch_annotate_images requests, output_config, parent
+            client.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -382,7 +382,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
           # Call method
-          response = client.async_batch_annotate_files requests, parent
+          response = client.async_batch_annotate_files requests: requests, parent: parent
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -422,7 +422,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
           # Call method
-          response = client.async_batch_annotate_files requests, parent
+          response = client.async_batch_annotate_files requests: requests, parent: parent
 
           # Verify the response
           assert response.error?
@@ -454,7 +454,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.async_batch_annotate_files requests, parent
+            client.async_batch_annotate_files requests: requests, parent: parent
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -20,9 +20,10 @@ require "google/cloud/vision/v1/image_annotator_pb"
 require "google/cloud/vision/v1/image_annotator_services_pb"
 require "google/cloud/vision/v1/image_annotator"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestImageAnnotatorErrorV1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcImageAnnotatorStubV1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -65,7 +66,7 @@ end
 describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
   describe "batch_annotate_images" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_images."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_images."
     end
 
     it "invokes batch_annotate_images without error" do
@@ -74,7 +75,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::BatchAnnotateImagesResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::BatchAnnotateImagesResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -83,10 +84,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :batch_annotate_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "batch_annotate_images"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "batch_annotate_images"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -120,10 +121,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :batch_annotate_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "batch_annotate_images"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "batch_annotate_images"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -143,7 +144,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
   describe "batch_annotate_files" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_files."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_files."
     end
 
     it "invokes batch_annotate_files without error" do
@@ -152,7 +153,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::BatchAnnotateFilesResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::BatchAnnotateFilesResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -161,10 +162,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :batch_annotate_files, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :batch_annotate_files, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "batch_annotate_files"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "batch_annotate_files"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -198,10 +199,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :batch_annotate_files, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :batch_annotate_files, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "batch_annotate_files"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "batch_annotate_files"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -221,7 +222,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
   describe "async_batch_annotate_images" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_images."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_images."
     end
 
     it "invokes async_batch_annotate_images without error" do
@@ -231,12 +232,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/async_batch_annotate_images_test",
-        done: true,
+        name:     "operations/async_batch_annotate_images_test",
+        done:     true,
         response: result
       )
 
@@ -248,10 +249,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :async_batch_annotate_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "async_batch_annotate_images"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "async_batch_annotate_images"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -277,8 +278,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         message: "Operation error for Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_images."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/async_batch_annotate_images_test",
-        done: true,
+        name:  "operations/async_batch_annotate_images_test",
+        done:  true,
         error: operation_error
       )
 
@@ -290,10 +291,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :async_batch_annotate_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "async_batch_annotate_images"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "async_batch_annotate_images"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -323,10 +324,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :async_batch_annotate_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "async_batch_annotate_images"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "async_batch_annotate_images"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -346,7 +347,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
   describe "async_batch_annotate_files" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_files."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_files."
     end
 
     it "invokes async_batch_annotate_files without error" do
@@ -355,12 +356,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/async_batch_annotate_files_test",
-        done: true,
+        name:     "operations/async_batch_annotate_files_test",
+        done:     true,
         response: result
       )
 
@@ -371,10 +372,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :async_batch_annotate_files, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "async_batch_annotate_files"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "async_batch_annotate_files"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -399,8 +400,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         message: "Operation error for Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_files."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/async_batch_annotate_files_test",
-        done: true,
+        name:  "operations/async_batch_annotate_files_test",
+        done:  true,
         error: operation_error
       )
 
@@ -411,10 +412,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :async_batch_annotate_files, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "async_batch_annotate_files"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "async_batch_annotate_files"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -442,10 +443,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :async_batch_annotate_files, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "async_batch_annotate_files"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "async_batch_annotate_files"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -74,14 +74,13 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::BatchAnnotateImagesResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::BatchAnnotateImagesResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+      assert_equal parent, request.parent
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
@@ -117,8 +116,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+      assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
@@ -153,14 +152,13 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::BatchAnnotateFilesResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::BatchAnnotateFilesResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateFilesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
+      assert_equal parent, request.parent
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_files, mock_method
@@ -196,8 +194,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateFilesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
+      assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_files, mock_method
@@ -233,8 +231,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -246,9 +243,9 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+      assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
+      assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
@@ -288,9 +285,9 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+      assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
+      assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
@@ -321,9 +318,9 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+      assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
+      assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
@@ -358,8 +355,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -371,8 +367,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+      assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
@@ -411,8 +407,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+      assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
@@ -442,8 +438,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+      assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -79,8 +79,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateImagesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal parent, request.parent
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
@@ -116,8 +116,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateImagesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
@@ -157,8 +157,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateFilesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
+        assert_equal parent, request.parent
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_files, mock_method
@@ -194,8 +194,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateFilesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
+        assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_files, mock_method
@@ -243,9 +243,9 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-      assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
+        assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
@@ -285,9 +285,9 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-      assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
+        assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
@@ -318,9 +318,9 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-      assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
+        assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
@@ -367,8 +367,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+        assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
@@ -407,8 +407,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+        assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
@@ -438,8 +438,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+        assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -105,7 +105,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
           client = Google::Cloud::Vision::V1::ProductSearch::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -149,7 +149,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
           client = Google::Cloud::Vision::V1::ProductSearch::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert response.error?
@@ -185,7 +185,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_operations name, filter, page_size, page_token
+            client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -230,7 +230,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
           client = Google::Cloud::Vision::V1::ProductSearch::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -268,7 +268,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
           client = Google::Cloud::Vision::V1::ProductSearch::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert response.error?
@@ -298,7 +298,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_operation name
+            client.get_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -336,13 +336,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
           client = Google::Cloud::Vision::V1::ProductSearch::Operations.new
 
           # Call method
-          response = client.delete_operation name
+          response = client.delete_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_operation name do |resp, operation|
+          client.delete_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -372,7 +372,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_operation name
+            client.delete_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -410,13 +410,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
           client = Google::Cloud::Vision::V1::ProductSearch::Operations.new
 
           # Call method
-          response = client.cancel_operation name
+          response = client.cancel_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.cancel_operation name do |resp, operation|
+          client.cancel_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -446,7 +446,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.cancel_operation name
+            client.cancel_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -20,9 +20,10 @@ require "google/cloud/vision/v1/product_search_service_pb"
 require "google/cloud/vision/v1/product_search_service_services_pb"
 require "google/cloud/vision/v1/product_search"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestProductSearchErrorV1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcProductSearchStubV1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -65,7 +66,7 @@ end
 describe Google::Cloud::Vision::V1::ProductSearch::Operations do
   describe "list_operations" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#list_operations."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#list_operations."
     end
 
     it "invokes list_operations without error" do
@@ -76,12 +77,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::ListOperationsResponse)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:     "operations/list_operations_test",
+        done:     true,
         response: result
       )
 
@@ -94,10 +95,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -124,8 +125,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         message: "Operation error for Google::Cloud::Vision::V1::ProductSearch::Operations#list_operations."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:  "operations/list_operations_test",
+        done:  true,
         error: operation_error
       )
 
@@ -138,10 +139,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -173,10 +174,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -196,7 +197,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
   describe "get_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#get_operation."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#get_operation."
     end
 
     it "invokes get_operation without error" do
@@ -204,12 +205,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:     "operations/get_operation_test",
+        done:     true,
         response: result
       )
 
@@ -219,10 +220,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -246,8 +247,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         message: "Operation error for Google::Cloud::Vision::V1::ProductSearch::Operations#get_operation."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:  "operations/get_operation_test",
+        done:  true,
         error: operation_error
       )
 
@@ -257,10 +258,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -286,10 +287,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -309,7 +310,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
   describe "delete_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#delete_operation."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#delete_operation."
     end
 
     it "invokes delete_operation without error" do
@@ -317,7 +318,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -325,10 +326,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -360,10 +361,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -383,7 +384,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
   describe "cancel_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#cancel_operation."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#cancel_operation."
     end
 
     it "invokes cancel_operation without error" do
@@ -391,7 +392,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -399,10 +400,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -434,10 +435,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -454,5 +455,4 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       end
     end
   end
-
 end

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -76,8 +76,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -89,10 +88,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -133,10 +132,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -168,10 +167,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -205,8 +204,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -218,7 +216,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -256,7 +254,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -285,7 +283,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -319,13 +317,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -360,7 +357,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -394,13 +391,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -435,7 +431,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -88,10 +88,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -132,10 +132,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -167,10 +167,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -216,7 +216,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -254,7 +254,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -283,7 +283,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -322,7 +322,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -357,7 +357,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -396,7 +396,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -431,7 +431,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
@@ -20,9 +20,10 @@ require "google/cloud/vision/v1/product_search_service_pb"
 require "google/cloud/vision/v1/product_search_service_services_pb"
 require "google/cloud/vision/v1/product_search"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestProductSearchErrorV1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcProductSearchStubV1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -65,7 +66,7 @@ end
 describe Google::Cloud::Vision::V1::ProductSearch::Client do
   describe "create_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#create_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#create_product_set."
     end
 
     it "invokes create_product_set without error" do
@@ -75,7 +76,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product_set_id = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ProductSet
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ProductSet)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -85,10 +86,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product_set_id, request.product_set_id
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :create_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "create_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -124,10 +125,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product_set_id, request.product_set_id
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :create_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "create_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -147,7 +148,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "list_product_sets" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_product_sets."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_product_sets."
     end
 
     it "invokes list_product_sets without error" do
@@ -157,7 +158,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListProductSetsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ListProductSetsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -167,10 +168,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_product_sets, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_product_sets"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_product_sets"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -206,10 +207,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_product_sets, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_product_sets"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_product_sets"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -229,7 +230,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "get_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#get_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#get_product_set."
     end
 
     it "invokes get_product_set without error" do
@@ -237,7 +238,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ProductSet
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ProductSet)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -245,10 +246,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -280,10 +281,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -303,7 +304,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "update_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#update_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#update_product_set."
     end
 
     it "invokes update_product_set without error" do
@@ -312,7 +313,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ProductSet
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ProductSet)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -321,10 +322,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :update_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "update_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -358,10 +359,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :update_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "update_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -381,7 +382,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "delete_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#delete_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#delete_product_set."
     end
 
     it "invokes delete_product_set without error" do
@@ -389,7 +390,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -397,10 +398,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -432,10 +433,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -455,7 +456,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "create_product" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#create_product."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#create_product."
     end
 
     it "invokes create_product without error" do
@@ -465,7 +466,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product_id = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::Product
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::Product)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -475,10 +476,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product_id, request.product_id
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :create_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "create_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -514,10 +515,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product_id, request.product_id
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :create_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "create_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -537,7 +538,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "list_products" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_products."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_products."
     end
 
     it "invokes list_products without error" do
@@ -547,7 +548,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListProductsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ListProductsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -557,10 +558,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_products, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_products"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_products"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -596,10 +597,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_products, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_products"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_products"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -619,7 +620,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "get_product" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#get_product."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#get_product."
     end
 
     it "invokes get_product without error" do
@@ -627,7 +628,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::Product
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::Product)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -635,10 +636,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -670,10 +671,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -693,7 +694,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "update_product" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#update_product."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#update_product."
     end
 
     it "invokes update_product without error" do
@@ -702,7 +703,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::Product
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::Product)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -711,10 +712,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :update_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "update_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -748,10 +749,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :update_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "update_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -771,7 +772,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "delete_product" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#delete_product."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#delete_product."
     end
 
     it "invokes delete_product without error" do
@@ -779,7 +780,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -787,10 +788,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -822,10 +823,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -845,7 +846,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "create_reference_image" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#create_reference_image."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#create_reference_image."
     end
 
     it "invokes create_reference_image without error" do
@@ -855,7 +856,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       reference_image_id = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ReferenceImage
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ReferenceImage)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -865,10 +866,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal reference_image_id, request.reference_image_id
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :create_reference_image, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_reference_image"
+      mock_credentials = MockProductSearchCredentialsV1.new "create_reference_image"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -904,10 +905,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal reference_image_id, request.reference_image_id
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :create_reference_image, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_reference_image"
+      mock_credentials = MockProductSearchCredentialsV1.new "create_reference_image"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -927,7 +928,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "delete_reference_image" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#delete_reference_image."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#delete_reference_image."
     end
 
     it "invokes delete_reference_image without error" do
@@ -935,7 +936,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -943,10 +944,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_reference_image, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_reference_image"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_reference_image"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -978,10 +979,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_reference_image, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_reference_image"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_reference_image"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1001,7 +1002,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "list_reference_images" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_reference_images."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_reference_images."
     end
 
     it "invokes list_reference_images without error" do
@@ -1011,7 +1012,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListReferenceImagesResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ListReferenceImagesResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1021,10 +1022,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_reference_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_reference_images"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_reference_images"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1060,10 +1061,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_reference_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_reference_images"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_reference_images"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1083,7 +1084,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "get_reference_image" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#get_reference_image."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#get_reference_image."
     end
 
     it "invokes get_reference_image without error" do
@@ -1091,7 +1092,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ReferenceImage
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ReferenceImage)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1099,10 +1100,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_reference_image, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_reference_image"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_reference_image"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1134,10 +1135,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_reference_image, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_reference_image"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_reference_image"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1157,7 +1158,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "add_product_to_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#add_product_to_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#add_product_to_product_set."
     end
 
     it "invokes add_product_to_product_set without error" do
@@ -1166,7 +1167,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1175,10 +1176,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product, request.product
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :add_product_to_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "add_product_to_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "add_product_to_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1212,10 +1213,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product, request.product
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :add_product_to_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "add_product_to_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "add_product_to_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1235,7 +1236,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "remove_product_from_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#remove_product_from_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#remove_product_from_product_set."
     end
 
     it "invokes remove_product_from_product_set without error" do
@@ -1244,7 +1245,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1253,10 +1254,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product, request.product
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :remove_product_from_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "remove_product_from_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "remove_product_from_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1290,10 +1291,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product, request.product
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :remove_product_from_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "remove_product_from_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "remove_product_from_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1313,7 +1314,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "list_products_in_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_products_in_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_products_in_product_set."
     end
 
     it "invokes list_products_in_product_set without error" do
@@ -1323,7 +1324,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListProductsInProductSetResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ListProductsInProductSetResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1333,10 +1334,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_products_in_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_products_in_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_products_in_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1372,10 +1373,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_products_in_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_products_in_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_products_in_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1395,7 +1396,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "import_product_sets" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#import_product_sets."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#import_product_sets."
     end
 
     it "invokes import_product_sets without error" do
@@ -1404,12 +1405,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       input_config = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/import_product_sets_test",
-        done: true,
+        name:     "operations/import_product_sets_test",
+        done:     true,
         response: result
       )
 
@@ -1420,10 +1421,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :import_product_sets, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "import_product_sets"
+      mock_credentials = MockProductSearchCredentialsV1.new "import_product_sets"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1448,8 +1449,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         message: "Operation error for Google::Cloud::Vision::V1::ProductSearch::Client#import_product_sets."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/import_product_sets_test",
-        done: true,
+        name:  "operations/import_product_sets_test",
+        done:  true,
         error: operation_error
       )
 
@@ -1460,10 +1461,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :import_product_sets, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "import_product_sets"
+      mock_credentials = MockProductSearchCredentialsV1.new "import_product_sets"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1491,10 +1492,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :import_product_sets, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "import_product_sets"
+      mock_credentials = MockProductSearchCredentialsV1.new "import_product_sets"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1514,7 +1515,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "purge_products" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#purge_products."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#purge_products."
     end
 
     it "invokes purge_products without error" do
@@ -1525,12 +1526,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       force = true
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/purge_products_test",
-        done: true,
+        name:     "operations/purge_products_test",
+        done:     true,
         response: result
       )
 
@@ -1543,10 +1544,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal force, request.force
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :purge_products, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "purge_products"
+      mock_credentials = MockProductSearchCredentialsV1.new "purge_products"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1573,8 +1574,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         message: "Operation error for Google::Cloud::Vision::V1::ProductSearch::Client#purge_products."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/purge_products_test",
-        done: true,
+        name:  "operations/purge_products_test",
+        done:  true,
         error: operation_error
       )
 
@@ -1587,10 +1588,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal force, request.force
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :purge_products, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "purge_products"
+      mock_credentials = MockProductSearchCredentialsV1.new "purge_products"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1622,10 +1623,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal force, request.force
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :purge_products, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "purge_products"
+      mock_credentials = MockProductSearchCredentialsV1.new "purge_products"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
@@ -96,13 +96,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.create_product_set parent, product_set, product_set_id
+          response = client.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_product_set parent, product_set, product_set_id do |resp, operation|
+          client.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -136,7 +136,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_product_set parent, product_set, product_set_id
+            client.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -178,13 +178,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.list_product_sets parent, page_size, page_token
+          response = client.list_product_sets parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_product_sets parent, page_size, page_token do |resp, operation|
+          client.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -218,7 +218,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_product_sets parent, page_size, page_token
+            client.list_product_sets parent: parent, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -256,13 +256,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.get_product_set name
+          response = client.get_product_set name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_product_set name do |resp, operation|
+          client.get_product_set name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -292,7 +292,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_product_set name
+            client.get_product_set name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -332,13 +332,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.update_product_set product_set, update_mask
+          response = client.update_product_set product_set: product_set, update_mask: update_mask
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.update_product_set product_set, update_mask do |resp, operation|
+          client.update_product_set product_set: product_set, update_mask: update_mask do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -370,7 +370,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.update_product_set product_set, update_mask
+            client.update_product_set product_set: product_set, update_mask: update_mask
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -408,13 +408,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.delete_product_set name
+          response = client.delete_product_set name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_product_set name do |resp, operation|
+          client.delete_product_set name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -444,7 +444,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_product_set name
+            client.delete_product_set name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -486,13 +486,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.create_product parent, product, product_id
+          response = client.create_product parent: parent, product: product, product_id: product_id
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_product parent, product, product_id do |resp, operation|
+          client.create_product parent: parent, product: product, product_id: product_id do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -526,7 +526,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_product parent, product, product_id
+            client.create_product parent: parent, product: product, product_id: product_id
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -568,13 +568,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.list_products parent, page_size, page_token
+          response = client.list_products parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_products parent, page_size, page_token do |resp, operation|
+          client.list_products parent: parent, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -608,7 +608,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_products parent, page_size, page_token
+            client.list_products parent: parent, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -646,13 +646,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.get_product name
+          response = client.get_product name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_product name do |resp, operation|
+          client.get_product name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -682,7 +682,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_product name
+            client.get_product name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -722,13 +722,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.update_product product, update_mask
+          response = client.update_product product: product, update_mask: update_mask
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.update_product product, update_mask do |resp, operation|
+          client.update_product product: product, update_mask: update_mask do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -760,7 +760,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.update_product product, update_mask
+            client.update_product product: product, update_mask: update_mask
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -798,13 +798,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.delete_product name
+          response = client.delete_product name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_product name do |resp, operation|
+          client.delete_product name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -834,7 +834,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_product name
+            client.delete_product name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -876,13 +876,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.create_reference_image parent, reference_image, reference_image_id
+          response = client.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_reference_image parent, reference_image, reference_image_id do |resp, operation|
+          client.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -916,7 +916,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_reference_image parent, reference_image, reference_image_id
+            client.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -954,13 +954,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.delete_reference_image name
+          response = client.delete_reference_image name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_reference_image name do |resp, operation|
+          client.delete_reference_image name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -990,7 +990,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_reference_image name
+            client.delete_reference_image name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1032,13 +1032,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.list_reference_images parent, page_size, page_token
+          response = client.list_reference_images parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_reference_images parent, page_size, page_token do |resp, operation|
+          client.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -1072,7 +1072,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_reference_images parent, page_size, page_token
+            client.list_reference_images parent: parent, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1110,13 +1110,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.get_reference_image name
+          response = client.get_reference_image name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_reference_image name do |resp, operation|
+          client.get_reference_image name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -1146,7 +1146,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_reference_image name
+            client.get_reference_image name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1186,13 +1186,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.add_product_to_product_set name, product
+          response = client.add_product_to_product_set name: name, product: product
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.add_product_to_product_set name, product do |resp, operation|
+          client.add_product_to_product_set name: name, product: product do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -1224,7 +1224,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.add_product_to_product_set name, product
+            client.add_product_to_product_set name: name, product: product
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1264,13 +1264,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.remove_product_from_product_set name, product
+          response = client.remove_product_from_product_set name: name, product: product
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.remove_product_from_product_set name, product do |resp, operation|
+          client.remove_product_from_product_set name: name, product: product do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -1302,7 +1302,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.remove_product_from_product_set name, product
+            client.remove_product_from_product_set name: name, product: product
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1344,13 +1344,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.list_products_in_product_set name, page_size, page_token
+          response = client.list_products_in_product_set name: name, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_products_in_product_set name, page_size, page_token do |resp, operation|
+          client.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -1384,7 +1384,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_products_in_product_set name, page_size, page_token
+            client.list_products_in_product_set name: name, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1431,7 +1431,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.import_product_sets parent, input_config
+          response = client.import_product_sets parent: parent, input_config: input_config
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -1471,7 +1471,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.import_product_sets parent, input_config
+          response = client.import_product_sets parent: parent, input_config: input_config
 
           # Verify the response
           assert response.error?
@@ -1503,7 +1503,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.import_product_sets parent, input_config
+            client.import_product_sets parent: parent, input_config: input_config
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1554,7 +1554,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.purge_products product_set_purge_config, delete_orphan_products, parent, force
+          response = client.purge_products product_set_purge_config: product_set_purge_config, delete_orphan_products: delete_orphan_products, parent: parent, force: force
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -1598,7 +1598,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.purge_products product_set_purge_config, delete_orphan_products, parent, force
+          response = client.purge_products product_set_purge_config: product_set_purge_config, delete_orphan_products: delete_orphan_products, parent: parent, force: force
 
           # Verify the response
           assert response.error?
@@ -1634,7 +1634,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.purge_products product_set_purge_config, delete_orphan_products, parent, force
+            client.purge_products product_set_purge_config: product_set_purge_config, delete_orphan_products: delete_orphan_products, parent: parent, force: force
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
@@ -80,9 +80,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductSetRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-      assert_equal product_set_id, request.product_set_id
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal product_set_id, request.product_set_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
@@ -119,9 +119,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductSetRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-      assert_equal product_set_id, request.product_set_id
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal product_set_id, request.product_set_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
@@ -162,9 +162,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductSetsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
@@ -201,9 +201,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductSetsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
@@ -242,7 +242,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductSetRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
@@ -277,7 +277,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductSetRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
@@ -317,8 +317,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductSetRequest, request
-      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
@@ -354,8 +354,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductSetRequest, request
-      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
@@ -394,7 +394,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductSetRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
@@ -429,7 +429,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductSetRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
@@ -470,9 +470,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-      assert_equal product_id, request.product_id
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal product_id, request.product_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
@@ -509,9 +509,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-      assert_equal product_id, request.product_id
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal product_id, request.product_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
@@ -552,9 +552,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
@@ -591,9 +591,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
@@ -632,7 +632,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
@@ -667,7 +667,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
@@ -707,8 +707,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductRequest, request
-      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
@@ -744,8 +744,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductRequest, request
-      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
@@ -784,7 +784,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
@@ -819,7 +819,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
@@ -860,9 +860,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateReferenceImageRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
-      assert_equal reference_image_id, request.reference_image_id
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
+        assert_equal reference_image_id, request.reference_image_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
@@ -899,9 +899,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateReferenceImageRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
-      assert_equal reference_image_id, request.reference_image_id
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
+        assert_equal reference_image_id, request.reference_image_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
@@ -940,7 +940,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteReferenceImageRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
@@ -975,7 +975,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteReferenceImageRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
@@ -1016,9 +1016,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListReferenceImagesRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
@@ -1055,9 +1055,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListReferenceImagesRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
@@ -1096,7 +1096,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetReferenceImageRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
@@ -1131,7 +1131,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetReferenceImageRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
@@ -1171,8 +1171,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AddProductToProductSetRequest, request
-      assert_equal name, request.name
-      assert_equal product, request.product
+        assert_equal name, request.name
+        assert_equal product, request.product
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
@@ -1208,8 +1208,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AddProductToProductSetRequest, request
-      assert_equal name, request.name
-      assert_equal product, request.product
+        assert_equal name, request.name
+        assert_equal product, request.product
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
@@ -1249,8 +1249,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest, request
-      assert_equal name, request.name
-      assert_equal product, request.product
+        assert_equal name, request.name
+        assert_equal product, request.product
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
@@ -1286,8 +1286,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest, request
-      assert_equal name, request.name
-      assert_equal product, request.product
+        assert_equal name, request.name
+        assert_equal product, request.product
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
@@ -1328,9 +1328,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsInProductSetRequest, request
-      assert_equal name, request.name
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
@@ -1367,9 +1367,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsInProductSetRequest, request
-      assert_equal name, request.name
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
@@ -1416,8 +1416,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1456,8 +1456,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1487,8 +1487,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1537,10 +1537,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::PurgeProductsRequest, request
-      assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
-      assert_equal delete_orphan_products, request.delete_orphan_products
-      assert_equal parent, request.parent
-      assert_equal force, request.force
+        assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
+        assert_equal delete_orphan_products, request.delete_orphan_products
+        assert_equal parent, request.parent
+        assert_equal force, request.force
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
@@ -1581,10 +1581,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::PurgeProductsRequest, request
-      assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
-      assert_equal delete_orphan_products, request.delete_orphan_products
-      assert_equal parent, request.parent
-      assert_equal force, request.force
+        assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
+        assert_equal delete_orphan_products, request.delete_orphan_products
+        assert_equal parent, request.parent
+        assert_equal force, request.force
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
@@ -1616,10 +1616,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::PurgeProductsRequest, request
-      assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
-      assert_equal delete_orphan_products, request.delete_orphan_products
-      assert_equal parent, request.parent
-      assert_equal force, request.force
+        assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
+        assert_equal delete_orphan_products, request.delete_orphan_products
+        assert_equal parent, request.parent
+        assert_equal force, request.force
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
@@ -75,15 +75,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product_set_id = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ProductSet
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ProductSet
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Gapic::Protobuf.coerce(product_set_id, to: ), request.product_set_id
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+      assert_equal product_set_id, request.product_set_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
@@ -120,9 +119,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Gapic::Protobuf.coerce(product_set_id, to: ), request.product_set_id
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+      assert_equal product_set_id, request.product_set_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
@@ -158,15 +157,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListProductSetsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListProductSetsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductSetsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
@@ -203,9 +201,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductSetsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
@@ -239,13 +237,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ProductSet
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ProductSet
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
@@ -280,7 +277,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
@@ -315,14 +312,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ProductSet
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ProductSet
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
@@ -358,8 +354,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
@@ -393,13 +389,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
@@ -434,7 +429,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
@@ -470,15 +465,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product_id = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::Product
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::Product
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Gapic::Protobuf.coerce(product_id, to: ), request.product_id
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+      assert_equal product_id, request.product_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
@@ -515,9 +509,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Gapic::Protobuf.coerce(product_id, to: ), request.product_id
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+      assert_equal product_id, request.product_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
@@ -553,15 +547,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListProductsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListProductsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
@@ -598,9 +591,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
@@ -634,13 +627,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::Product
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::Product
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
@@ -675,7 +667,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
@@ -710,14 +702,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::Product
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::Product
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
@@ -753,8 +744,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
@@ -788,13 +779,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
@@ -829,7 +819,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
@@ -865,15 +855,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       reference_image_id = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ReferenceImage
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ReferenceImage
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateReferenceImageRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
-        assert_equal Gapic::Protobuf.coerce(reference_image_id, to: ), request.reference_image_id
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
+      assert_equal reference_image_id, request.reference_image_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
@@ -910,9 +899,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateReferenceImageRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
-        assert_equal Gapic::Protobuf.coerce(reference_image_id, to: ), request.reference_image_id
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
+      assert_equal reference_image_id, request.reference_image_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
@@ -946,13 +935,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteReferenceImageRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
@@ -987,7 +975,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteReferenceImageRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
@@ -1023,15 +1011,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListReferenceImagesResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListReferenceImagesResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListReferenceImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
@@ -1068,9 +1055,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListReferenceImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
@@ -1104,13 +1091,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ReferenceImage
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ReferenceImage
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetReferenceImageRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
@@ -1145,7 +1131,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetReferenceImageRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
@@ -1180,14 +1166,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AddProductToProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(product, to: ), request.product
+      assert_equal name, request.name
+      assert_equal product, request.product
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
@@ -1223,8 +1208,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AddProductToProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(product, to: ), request.product
+      assert_equal name, request.name
+      assert_equal product, request.product
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
@@ -1259,14 +1244,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(product, to: ), request.product
+      assert_equal name, request.name
+      assert_equal product, request.product
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
@@ -1302,8 +1286,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(product, to: ), request.product
+      assert_equal name, request.name
+      assert_equal product, request.product
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
@@ -1339,15 +1323,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListProductsInProductSetResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListProductsInProductSetResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsInProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
@@ -1384,9 +1367,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsInProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
@@ -1421,8 +1404,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       input_config = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -1434,8 +1416,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1474,8 +1456,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1505,8 +1487,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1543,8 +1525,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       force = true
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -1556,10 +1537,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::PurgeProductsRequest, request
-        assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
-        assert_equal Gapic::Protobuf.coerce(delete_orphan_products, to: ), request.delete_orphan_products
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(force, to: ), request.force
+      assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
+      assert_equal delete_orphan_products, request.delete_orphan_products
+      assert_equal parent, request.parent
+      assert_equal force, request.force
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
@@ -1600,10 +1581,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::PurgeProductsRequest, request
-        assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
-        assert_equal Gapic::Protobuf.coerce(delete_orphan_products, to: ), request.delete_orphan_products
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(force, to: ), request.force
+      assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
+      assert_equal delete_orphan_products, request.delete_orphan_products
+      assert_equal parent, request.parent
+      assert_equal force, request.force
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
@@ -1635,10 +1616,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::PurgeProductsRequest, request
-        assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
-        assert_equal Gapic::Protobuf.coerce(delete_orphan_products, to: ), request.delete_orphan_products
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(force, to: ), request.force
+      assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
+      assert_equal delete_orphan_products, request.delete_orphan_products
+      assert_equal parent, request.parent
+      assert_equal force, request.force
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method

--- a/shared/output/gapic/templates/showcase/proto_docs/google/showcase/v1beta1/messaging.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/showcase/v1beta1/messaging.rb
@@ -139,7 +139,7 @@ module Google
       # @!attribute [r] create_time
       #   @return [Google::Protobuf::Timestamp]
       #     The timestamp at which the blurb was created.
-      # @!attribute [rw] update_time
+      # @!attribute [r] update_time
       #   @return [Google::Protobuf::Timestamp]
       #     The latest timestamp at which the blurb was updated.
       class Blurb

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -96,10 +96,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -140,10 +140,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -175,10 +175,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -224,7 +224,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -262,7 +262,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -291,7 +291,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -330,7 +330,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -365,7 +365,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -404,7 +404,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -439,7 +439,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -28,9 +28,10 @@ require "google/showcase/v1beta1/echo_pb"
 require "google/showcase/v1beta1/echo_services_pb"
 require "google/showcase/v1beta1/echo"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestEchoErrorV1beta1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcEchoStubV1beta1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -73,7 +74,7 @@ end
 describe Google::Showcase::V1beta1::Echo::Operations do
   describe "list_operations" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#list_operations."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#list_operations."
     end
 
     it "invokes list_operations without error" do
@@ -84,12 +85,12 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::ListOperationsResponse)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:     "operations/list_operations_test",
+        done:     true,
         response: result
       )
 
@@ -102,10 +103,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockEchoCredentialsV1beta1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -132,8 +133,8 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         message: "Operation error for Google::Showcase::V1beta1::Echo::Operations#list_operations."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:  "operations/list_operations_test",
+        done:  true,
         error: operation_error
       )
 
@@ -146,10 +147,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockEchoCredentialsV1beta1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -181,10 +182,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockEchoCredentialsV1beta1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -204,7 +205,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
   describe "get_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#get_operation."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#get_operation."
     end
 
     it "invokes get_operation without error" do
@@ -212,12 +213,12 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:     "operations/get_operation_test",
+        done:     true,
         response: result
       )
 
@@ -227,10 +228,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -254,8 +255,8 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         message: "Operation error for Google::Showcase::V1beta1::Echo::Operations#get_operation."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:  "operations/get_operation_test",
+        done:  true,
         error: operation_error
       )
 
@@ -265,10 +266,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -294,10 +295,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -317,7 +318,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
   describe "delete_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#delete_operation."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#delete_operation."
     end
 
     it "invokes delete_operation without error" do
@@ -325,7 +326,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -333,10 +334,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -368,10 +369,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -391,7 +392,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
   describe "cancel_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#cancel_operation."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Operations#cancel_operation."
     end
 
     it "invokes cancel_operation without error" do
@@ -399,7 +400,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -407,10 +408,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -442,10 +443,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockEchoCredentialsV1beta1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -462,5 +463,4 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       end
     end
   end
-
 end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -113,7 +113,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
           client = Google::Showcase::V1beta1::Echo::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -157,7 +157,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
           client = Google::Showcase::V1beta1::Echo::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert response.error?
@@ -193,7 +193,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_operations name, filter, page_size, page_token
+            client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -238,7 +238,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
           client = Google::Showcase::V1beta1::Echo::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -276,7 +276,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
           client = Google::Showcase::V1beta1::Echo::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert response.error?
@@ -306,7 +306,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_operation name
+            client.get_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -344,13 +344,13 @@ describe Google::Showcase::V1beta1::Echo::Operations do
           client = Google::Showcase::V1beta1::Echo::Operations.new
 
           # Call method
-          response = client.delete_operation name
+          response = client.delete_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_operation name do |resp, operation|
+          client.delete_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -380,7 +380,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_operation name
+            client.delete_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -418,13 +418,13 @@ describe Google::Showcase::V1beta1::Echo::Operations do
           client = Google::Showcase::V1beta1::Echo::Operations.new
 
           # Call method
-          response = client.cancel_operation name
+          response = client.cancel_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.cancel_operation name do |resp, operation|
+          client.cancel_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -454,7 +454,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.cancel_operation name
+            client.cancel_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -84,8 +84,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -97,10 +96,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -141,10 +140,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -176,10 +175,10 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -213,8 +212,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -226,7 +224,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -264,7 +262,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -293,7 +291,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -327,13 +325,12 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -368,7 +365,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -402,13 +399,12 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -443,7 +439,7 @@ describe Google::Showcase::V1beta1::Echo::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -28,9 +28,10 @@ require "google/showcase/v1beta1/echo_pb"
 require "google/showcase/v1beta1/echo_services_pb"
 require "google/showcase/v1beta1/echo"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestEchoErrorV1beta1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcEchoStubV1beta1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -73,7 +74,7 @@ end
 describe Google::Showcase::V1beta1::Echo::Client do
   describe "echo" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#echo."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#echo."
     end
 
     it "invokes echo without error" do
@@ -82,7 +83,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       error = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::EchoResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -91,10 +92,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :echo, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :echo, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "echo"
+      mock_credentials = MockEchoCredentialsV1beta1.new "echo"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -128,10 +129,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :echo, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :echo, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "echo"
+      mock_credentials = MockEchoCredentialsV1beta1.new "echo"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -151,7 +152,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
   describe "expand" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#expand."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#expand."
     end
 
     it "invokes expand without error" do
@@ -160,7 +161,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       error = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::EchoResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -169,10 +170,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :expand, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :expand, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "expand"
+      mock_credentials = MockEchoCredentialsV1beta1.new "expand"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -200,10 +201,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :expand, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :expand, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "expand"
+      mock_credentials = MockEchoCredentialsV1beta1.new "expand"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -223,7 +224,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
   describe "collect" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#collect."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#collect."
     end
 
     it "invokes collect without error" do
@@ -231,17 +232,17 @@ describe Google::Showcase::V1beta1::Echo::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::EchoResponse)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
         OpenStruct.new execute: [expected_response]
       end
-      mock_stub = MockGrpcClientStubV1.new :collect, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :collect, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "collect"
+      mock_credentials = MockEchoCredentialsV1beta1.new "collect"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -262,10 +263,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
       # Mock Grpc layer
       mock_method = proc { raise custom_error }
-      mock_stub = MockGrpcClientStubV1.new :collect, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :collect, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "collect"
+      mock_credentials = MockEchoCredentialsV1beta1.new "collect"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -285,7 +286,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
   describe "chat" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#chat."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#chat."
     end
 
     it "invokes chat without error" do
@@ -293,17 +294,17 @@ describe Google::Showcase::V1beta1::Echo::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::EchoResponse)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
         OpenStruct.new execute: [expected_response]
       end
-      mock_stub = MockGrpcClientStubV1.new :chat, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :chat, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "chat"
+      mock_credentials = MockEchoCredentialsV1beta1.new "chat"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -325,10 +326,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
       # Mock Grpc layer
       mock_method = proc { raise custom_error }
-      mock_stub = MockGrpcClientStubV1.new :chat, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :chat, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "chat"
+      mock_credentials = MockEchoCredentialsV1beta1.new "chat"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -348,7 +349,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
   describe "paged_expand" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#paged_expand."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#paged_expand."
     end
 
     it "invokes paged_expand without error" do
@@ -358,7 +359,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::PagedExpandResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::PagedExpandResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -368,10 +369,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :paged_expand, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "paged_expand"
+      mock_credentials = MockEchoCredentialsV1beta1.new "paged_expand"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -407,10 +408,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :paged_expand, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "paged_expand"
+      mock_credentials = MockEchoCredentialsV1beta1.new "paged_expand"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -430,7 +431,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
   describe "wait" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#wait."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#wait."
     end
 
     it "invokes wait without error" do
@@ -441,12 +442,12 @@ describe Google::Showcase::V1beta1::Echo::Client do
       success = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/wait_test",
-        done: true,
+        name:     "operations/wait_test",
+        done:     true,
         response: result
       )
 
@@ -459,10 +460,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :wait, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :wait, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "wait"
+      mock_credentials = MockEchoCredentialsV1beta1.new "wait"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -489,8 +490,8 @@ describe Google::Showcase::V1beta1::Echo::Client do
         message: "Operation error for Google::Showcase::V1beta1::Echo::Client#wait."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/wait_test",
-        done: true,
+        name:  "operations/wait_test",
+        done:  true,
         error: operation_error
       )
 
@@ -503,10 +504,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :wait, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :wait, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "wait"
+      mock_credentials = MockEchoCredentialsV1beta1.new "wait"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -538,10 +539,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :wait, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :wait, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "wait"
+      mock_credentials = MockEchoCredentialsV1beta1.new "wait"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -561,7 +562,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
   describe "block" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#block."
+      CustomTestEchoErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Echo::Client#block."
     end
 
     it "invokes block without error" do
@@ -571,7 +572,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       success = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::BlockResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::BlockResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -581,10 +582,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :block, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :block, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "block"
+      mock_credentials = MockEchoCredentialsV1beta1.new "block"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do
@@ -620,10 +621,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
         assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :block, mock_method
+      mock_stub = MockGrpcEchoStubV1beta1.new :block, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "block"
+      mock_credentials = MockEchoCredentialsV1beta1.new "block"
 
       Google::Showcase::V1beta1::Echo::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Echo::Credentials.stub :default, mock_credentials do

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -165,8 +165,8 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ExpandRequest, request
-      assert_equal content, request.content
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal content, request.content
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :expand, mock_method
@@ -196,8 +196,8 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ExpandRequest, request
-      assert_equal content, request.content
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal content, request.content
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :expand, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -102,13 +102,13 @@ describe Google::Showcase::V1beta1::Echo::Client do
           client = Google::Showcase::V1beta1::Echo::Client.new
 
           # Call method
-          response = client.echo content, error
+          response = client.echo content: content, error: error
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.echo content, error do |resp, operation|
+          client.echo content: content, error: error do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -140,7 +140,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.echo content, error
+            client.echo content: content, error: error
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -212,7 +212,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.expand content, error
+            client.expand content: content, error: error
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -379,13 +379,13 @@ describe Google::Showcase::V1beta1::Echo::Client do
           client = Google::Showcase::V1beta1::Echo::Client.new
 
           # Call method
-          response = client.paged_expand content, page_size, page_token
+          response = client.paged_expand content: content, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.paged_expand content, page_size, page_token do |resp, operation|
+          client.paged_expand content: content, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -419,7 +419,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.paged_expand content, page_size, page_token
+            client.paged_expand content: content, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -470,7 +470,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
           client = Google::Showcase::V1beta1::Echo::Client.new
 
           # Call method
-          response = client.wait end_time, ttl, error, success
+          response = client.wait end_time: end_time, ttl: ttl, error: error, success: success
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -514,7 +514,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
           client = Google::Showcase::V1beta1::Echo::Client.new
 
           # Call method
-          response = client.wait end_time, ttl, error, success
+          response = client.wait end_time: end_time, ttl: ttl, error: error, success: success
 
           # Verify the response
           assert response.error?
@@ -550,7 +550,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.wait end_time, ttl, error, success
+            client.wait end_time: end_time, ttl: ttl, error: error, success: success
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -592,13 +592,13 @@ describe Google::Showcase::V1beta1::Echo::Client do
           client = Google::Showcase::V1beta1::Echo::Client.new
 
           # Call method
-          response = client.block response_delay, error, success
+          response = client.block response_delay: response_delay, error: error, success: success
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.block response_delay, error, success do |resp, operation|
+          client.block response_delay: response_delay, error: error, success: success do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -632,7 +632,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.block response_delay, error, success
+            client.block response_delay: response_delay, error: error, success: success
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -87,8 +87,8 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::EchoRequest, request
-      assert_equal content, request.content
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal content, request.content
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :echo, mock_method
@@ -124,8 +124,8 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::EchoRequest, request
-      assert_equal content, request.content
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal content, request.content
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :echo, mock_method
@@ -363,9 +363,9 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::PagedExpandRequest, request
-      assert_equal content, request.content
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal content, request.content
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
@@ -402,9 +402,9 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::PagedExpandRequest, request
-      assert_equal content, request.content
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal content, request.content
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
@@ -453,10 +453,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::WaitRequest, request
-      assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
-      assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
+        assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+        assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -497,10 +497,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::WaitRequest, request
-      assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
-      assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
+        assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+        assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -532,10 +532,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::WaitRequest, request
-      assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
-      assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
+        assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+        assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -576,9 +576,9 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::BlockRequest, request
-      assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
+        assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :block, mock_method
@@ -615,9 +615,9 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::BlockRequest, request
-      assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
-      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
+        assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
+        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :block, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -82,14 +82,13 @@ describe Google::Showcase::V1beta1::Echo::Client do
       error = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::EchoRequest, request
-        assert_equal Gapic::Protobuf.coerce(content, to: ), request.content
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal content, request.content
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :echo, mock_method
@@ -125,8 +124,8 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::EchoRequest, request
-        assert_equal Gapic::Protobuf.coerce(content, to: ), request.content
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal content, request.content
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :echo, mock_method
@@ -161,14 +160,13 @@ describe Google::Showcase::V1beta1::Echo::Client do
       error = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ExpandRequest, request
-        assert_equal Gapic::Protobuf.coerce(content, to: ), request.content
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal content, request.content
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :expand, mock_method
@@ -198,8 +196,8 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ExpandRequest, request
-        assert_equal Gapic::Protobuf.coerce(content, to: ), request.content
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal content, request.content
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :expand, mock_method
@@ -233,8 +231,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -296,8 +293,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::EchoResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::EchoResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -362,15 +358,14 @@ describe Google::Showcase::V1beta1::Echo::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::PagedExpandResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::PagedExpandResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::PagedExpandRequest, request
-        assert_equal Gapic::Protobuf.coerce(content, to: ), request.content
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal content, request.content
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
@@ -407,9 +402,9 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::PagedExpandRequest, request
-        assert_equal Gapic::Protobuf.coerce(content, to: ), request.content
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal content, request.content
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :paged_expand, mock_method
@@ -446,8 +441,7 @@ describe Google::Showcase::V1beta1::Echo::Client do
       success = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -459,10 +453,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::WaitRequest, request
-        assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
-        assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
+      assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+      assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -503,10 +497,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::WaitRequest, request
-        assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
-        assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
+      assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+      assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -538,10 +532,10 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::WaitRequest, request
-        assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
-        assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
+      assert_equal Gapic::Protobuf.coerce(end_time, to: Google::Protobuf::Timestamp), request.end_time
+      assert_equal Gapic::Protobuf.coerce(ttl, to: Google::Protobuf::Duration), request.ttl
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::WaitResponse), request.success
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :wait, mock_method
@@ -577,15 +571,14 @@ describe Google::Showcase::V1beta1::Echo::Client do
       success = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::BlockResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::BlockResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::BlockRequest, request
-        assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
+      assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :block, mock_method
@@ -622,9 +615,9 @@ describe Google::Showcase::V1beta1::Echo::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::BlockRequest, request
-        assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
-        assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
-        assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
+      assert_equal Gapic::Protobuf.coerce(response_delay, to: Google::Protobuf::Duration), request.response_delay
+      assert_equal Gapic::Protobuf.coerce(error, to: Google::Rpc::Status), request.error
+      assert_equal Gapic::Protobuf.coerce(success, to: Google::Showcase::V1beta1::BlockResponse), request.success
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :block, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -100,13 +100,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
           client = Google::Showcase::V1beta1::Identity::Client.new
 
           # Call method
-          response = client.create_user user
+          response = client.create_user user: user
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_user user do |resp, operation|
+          client.create_user user: user do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -136,7 +136,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_user user
+            client.create_user user: user
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -174,13 +174,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
           client = Google::Showcase::V1beta1::Identity::Client.new
 
           # Call method
-          response = client.get_user name
+          response = client.get_user name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_user name do |resp, operation|
+          client.get_user name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -210,7 +210,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_user name
+            client.get_user name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -250,13 +250,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
           client = Google::Showcase::V1beta1::Identity::Client.new
 
           # Call method
-          response = client.update_user user, update_mask
+          response = client.update_user user: user, update_mask: update_mask
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.update_user user, update_mask do |resp, operation|
+          client.update_user user: user, update_mask: update_mask do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -288,7 +288,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.update_user user, update_mask
+            client.update_user user: user, update_mask: update_mask
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -326,13 +326,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
           client = Google::Showcase::V1beta1::Identity::Client.new
 
           # Call method
-          response = client.delete_user name
+          response = client.delete_user name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_user name do |resp, operation|
+          client.delete_user name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -362,7 +362,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_user name
+            client.delete_user name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -402,13 +402,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
           client = Google::Showcase::V1beta1::Identity::Client.new
 
           # Call method
-          response = client.list_users page_size, page_token
+          response = client.list_users page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_users page_size, page_token do |resp, operation|
+          client.list_users page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -440,7 +440,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_users page_size, page_token
+            client.list_users page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -86,7 +86,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateUserRequest, request
-      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
@@ -121,7 +121,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateUserRequest, request
-      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
@@ -160,7 +160,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetUserRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
@@ -195,7 +195,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetUserRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
@@ -235,8 +235,8 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateUserRequest, request
-      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
@@ -272,8 +272,8 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateUserRequest, request
-      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
@@ -312,7 +312,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteUserRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
@@ -347,7 +347,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteUserRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
@@ -387,8 +387,8 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListUsersRequest, request
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_users, mock_method
@@ -424,8 +424,8 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListUsersRequest, request
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_users, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -28,9 +28,10 @@ require "google/showcase/v1beta1/identity_pb"
 require "google/showcase/v1beta1/identity_services_pb"
 require "google/showcase/v1beta1/identity"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestIdentityErrorV1beta1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcIdentityStubV1beta1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -73,7 +74,7 @@ end
 describe Google::Showcase::V1beta1::Identity::Client do
   describe "create_user" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#create_user."
+      CustomTestIdentityErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#create_user."
     end
 
     it "invokes create_user without error" do
@@ -81,7 +82,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       user = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::User
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::User)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -89,10 +90,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :create_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "create_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -124,10 +125,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :create_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "create_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -147,7 +148,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
   describe "get_user" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#get_user."
+      CustomTestIdentityErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#get_user."
     end
 
     it "invokes get_user without error" do
@@ -155,7 +156,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::User
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::User)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -163,10 +164,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :get_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "get_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -198,10 +199,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :get_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "get_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -221,7 +222,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
   describe "update_user" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#update_user."
+      CustomTestIdentityErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#update_user."
     end
 
     it "invokes update_user without error" do
@@ -230,7 +231,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::User
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::User)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -239,10 +240,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :update_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "update_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -276,10 +277,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :update_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "update_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -299,7 +300,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
   describe "delete_user" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#delete_user."
+      CustomTestIdentityErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#delete_user."
     end
 
     it "invokes delete_user without error" do
@@ -307,7 +308,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -315,10 +316,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :delete_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "delete_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -350,10 +351,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :delete_user, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_user"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "delete_user"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -373,7 +374,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
 
   describe "list_users" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#list_users."
+      CustomTestIdentityErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Identity::Client#list_users."
     end
 
     it "invokes list_users without error" do
@@ -382,7 +383,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListUsersResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::ListUsersResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -391,10 +392,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_users, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :list_users, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_users"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "list_users"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do
@@ -428,10 +429,10 @@ describe Google::Showcase::V1beta1::Identity::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_users, mock_method
+      mock_stub = MockGrpcIdentityStubV1beta1.new :list_users, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_users"
+      mock_credentials = MockIdentityCredentialsV1beta1.new "list_users"
 
       Google::Showcase::V1beta1::Identity::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Identity::Credentials.stub :default, mock_credentials do

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -81,13 +81,12 @@ describe Google::Showcase::V1beta1::Identity::Client do
       user = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::User
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::User
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
@@ -122,7 +121,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_user, mock_method
@@ -156,13 +155,12 @@ describe Google::Showcase::V1beta1::Identity::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::User
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::User
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
@@ -197,7 +195,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_user, mock_method
@@ -232,14 +230,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::User
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::User
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
@@ -275,8 +272,8 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(user, to: Google::Showcase::V1beta1::User), request.user
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_user, mock_method
@@ -310,13 +307,12 @@ describe Google::Showcase::V1beta1::Identity::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
@@ -351,7 +347,7 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteUserRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_user, mock_method
@@ -386,14 +382,13 @@ describe Google::Showcase::V1beta1::Identity::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::ListUsersResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListUsersResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListUsersRequest, request
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_users, mock_method
@@ -429,8 +424,8 @@ describe Google::Showcase::V1beta1::Identity::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListUsersRequest, request
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_users, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -28,9 +28,10 @@ require "google/showcase/v1beta1/messaging_pb"
 require "google/showcase/v1beta1/messaging_services_pb"
 require "google/showcase/v1beta1/messaging"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestMessagingErrorV1beta1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcMessagingStubV1beta1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -73,7 +74,7 @@ end
 describe Google::Showcase::V1beta1::Messaging::Operations do
   describe "list_operations" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#list_operations."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#list_operations."
     end
 
     it "invokes list_operations without error" do
@@ -84,12 +85,12 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::ListOperationsResponse)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:     "operations/list_operations_test",
+        done:     true,
         response: result
       )
 
@@ -102,10 +103,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -132,8 +133,8 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         message: "Operation error for Google::Showcase::V1beta1::Messaging::Operations#list_operations."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:  "operations/list_operations_test",
+        done:  true,
         error: operation_error
       )
 
@@ -146,10 +147,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -181,10 +182,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -204,7 +205,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
   describe "get_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#get_operation."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#get_operation."
     end
 
     it "invokes get_operation without error" do
@@ -212,12 +213,12 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:     "operations/get_operation_test",
+        done:     true,
         response: result
       )
 
@@ -227,10 +228,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -254,8 +255,8 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         message: "Operation error for Google::Showcase::V1beta1::Messaging::Operations#get_operation."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:  "operations/get_operation_test",
+        done:  true,
         error: operation_error
       )
 
@@ -265,10 +266,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -294,10 +295,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -317,7 +318,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
   describe "delete_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#delete_operation."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#delete_operation."
     end
 
     it "invokes delete_operation without error" do
@@ -325,7 +326,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -333,10 +334,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -368,10 +369,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -391,7 +392,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
   describe "cancel_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#cancel_operation."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Operations#cancel_operation."
     end
 
     it "invokes cancel_operation without error" do
@@ -399,7 +400,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -407,10 +408,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -442,10 +443,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -462,5 +463,4 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       end
     end
   end
-
 end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -113,7 +113,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
           client = Google::Showcase::V1beta1::Messaging::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -157,7 +157,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
           client = Google::Showcase::V1beta1::Messaging::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert response.error?
@@ -193,7 +193,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_operations name, filter, page_size, page_token
+            client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -238,7 +238,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
           client = Google::Showcase::V1beta1::Messaging::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -276,7 +276,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
           client = Google::Showcase::V1beta1::Messaging::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert response.error?
@@ -306,7 +306,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_operation name
+            client.get_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -344,13 +344,13 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
           client = Google::Showcase::V1beta1::Messaging::Operations.new
 
           # Call method
-          response = client.delete_operation name
+          response = client.delete_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_operation name do |resp, operation|
+          client.delete_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -380,7 +380,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_operation name
+            client.delete_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -418,13 +418,13 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
           client = Google::Showcase::V1beta1::Messaging::Operations.new
 
           # Call method
-          response = client.cancel_operation name
+          response = client.cancel_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.cancel_operation name do |resp, operation|
+          client.cancel_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -454,7 +454,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.cancel_operation name
+            client.cancel_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -84,8 +84,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -97,10 +96,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -141,10 +140,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -176,10 +175,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -213,8 +212,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -226,7 +224,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -264,7 +262,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -293,7 +291,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -327,13 +325,12 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -368,7 +365,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -402,13 +399,12 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -443,7 +439,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -96,10 +96,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -140,10 +140,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -175,10 +175,10 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -224,7 +224,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -262,7 +262,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -291,7 +291,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -330,7 +330,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -365,7 +365,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -404,7 +404,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -439,7 +439,7 @@ describe Google::Showcase::V1beta1::Messaging::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -81,13 +81,12 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       room = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Room
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Room
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
@@ -122,7 +121,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
@@ -156,13 +155,12 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Room
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Room
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
@@ -197,7 +195,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
@@ -232,14 +230,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Room
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Room
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
@@ -275,8 +272,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
@@ -310,13 +307,12 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
@@ -351,7 +347,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteRoomRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
@@ -386,14 +382,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::ListRoomsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListRoomsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListRoomsRequest, request
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
@@ -429,8 +424,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListRoomsRequest, request
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
@@ -465,14 +460,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       blurb = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Blurb
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Blurb
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
@@ -508,8 +502,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
@@ -543,13 +537,12 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Blurb
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Blurb
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
@@ -584,7 +577,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
@@ -619,14 +612,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Blurb
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Blurb
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
@@ -662,8 +654,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
@@ -697,13 +689,12 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
@@ -738,7 +729,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteBlurbRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
@@ -774,15 +765,14 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::ListBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
@@ -819,9 +809,9 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
@@ -858,8 +848,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -871,10 +860,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::SearchBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(query, to: ), request.query
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal query, request.query
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -915,10 +904,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::SearchBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(query, to: ), request.query
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal query, request.query
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -950,10 +939,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::SearchBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(query, to: ), request.query
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal query, request.query
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -988,14 +977,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       expire_time = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::StreamBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::StreamBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::StreamBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
+      assert_equal name, request.name
+      assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :stream_blurbs, mock_method
@@ -1025,8 +1013,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::StreamBlurbsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
+      assert_equal name, request.name
+      assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :stream_blurbs, mock_method
@@ -1060,8 +1048,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::SendBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::SendBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -1123,8 +1110,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::StreamBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::StreamBlurbsResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -982,8 +982,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::StreamBlurbsRequest, request
-      assert_equal name, request.name
-      assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
+        assert_equal name, request.name
+        assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :stream_blurbs, mock_method
@@ -1013,8 +1013,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::StreamBlurbsRequest, request
-      assert_equal name, request.name
-      assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
+        assert_equal name, request.name
+        assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :stream_blurbs, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -28,9 +28,10 @@ require "google/showcase/v1beta1/messaging_pb"
 require "google/showcase/v1beta1/messaging_services_pb"
 require "google/showcase/v1beta1/messaging"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestMessagingErrorV1beta1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcMessagingStubV1beta1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -73,7 +74,7 @@ end
 describe Google::Showcase::V1beta1::Messaging::Client do
   describe "create_room" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#create_room."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#create_room."
     end
 
     it "invokes create_room without error" do
@@ -81,7 +82,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       room = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Room
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Room)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -89,10 +90,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :create_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "create_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -124,10 +125,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :create_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "create_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -147,7 +148,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "get_room" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#get_room."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#get_room."
     end
 
     it "invokes get_room without error" do
@@ -155,7 +156,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Room
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Room)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -163,10 +164,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -198,10 +199,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -221,7 +222,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "update_room" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#update_room."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#update_room."
     end
 
     it "invokes update_room without error" do
@@ -230,7 +231,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Room
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Room)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -239,10 +240,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :update_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "update_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -276,10 +277,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :update_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "update_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -299,7 +300,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "delete_room" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#delete_room."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#delete_room."
     end
 
     it "invokes delete_room without error" do
@@ -307,7 +308,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -315,10 +316,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :delete_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "delete_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -350,10 +351,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :delete_room, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_room"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "delete_room"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -373,7 +374,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "list_rooms" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#list_rooms."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#list_rooms."
     end
 
     it "invokes list_rooms without error" do
@@ -382,7 +383,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListRoomsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::ListRoomsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -391,10 +392,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_rooms, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_rooms"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_rooms"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -428,10 +429,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_rooms, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_rooms"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_rooms"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -451,7 +452,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "create_blurb" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#create_blurb."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#create_blurb."
     end
 
     it "invokes create_blurb without error" do
@@ -460,7 +461,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       blurb = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Blurb
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Blurb)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -469,10 +470,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :create_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "create_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -506,10 +507,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :create_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "create_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -529,7 +530,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "get_blurb" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#get_blurb."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#get_blurb."
     end
 
     it "invokes get_blurb without error" do
@@ -537,7 +538,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Blurb
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Blurb)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -545,10 +546,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -580,10 +581,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :get_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "get_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -603,7 +604,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "update_blurb" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#update_blurb."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#update_blurb."
     end
 
     it "invokes update_blurb without error" do
@@ -612,7 +613,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Blurb
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Blurb)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -621,10 +622,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :update_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "update_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -658,10 +659,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :update_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "update_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -681,7 +682,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "delete_blurb" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#delete_blurb."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#delete_blurb."
     end
 
     it "invokes delete_blurb without error" do
@@ -689,7 +690,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -697,10 +698,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :delete_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "delete_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -732,10 +733,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :delete_blurb, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_blurb"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "delete_blurb"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -755,7 +756,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "list_blurbs" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#list_blurbs."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#list_blurbs."
     end
 
     it "invokes list_blurbs without error" do
@@ -765,7 +766,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::ListBlurbsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -775,10 +776,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -814,10 +815,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :list_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "list_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -837,7 +838,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "search_blurbs" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#search_blurbs."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#search_blurbs."
     end
 
     it "invokes search_blurbs without error" do
@@ -848,12 +849,12 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/search_blurbs_test",
-        done: true,
+        name:     "operations/search_blurbs_test",
+        done:     true,
         response: result
       )
 
@@ -866,10 +867,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :search_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "search_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "search_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -896,8 +897,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         message: "Operation error for Google::Showcase::V1beta1::Messaging::Client#search_blurbs."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/search_blurbs_test",
-        done: true,
+        name:  "operations/search_blurbs_test",
+        done:  true,
         error: operation_error
       )
 
@@ -910,10 +911,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :search_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "search_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "search_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -945,10 +946,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :search_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "search_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "search_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -968,7 +969,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "stream_blurbs" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#stream_blurbs."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#stream_blurbs."
     end
 
     it "invokes stream_blurbs without error" do
@@ -977,7 +978,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       expire_time = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::StreamBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::StreamBlurbsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -986,10 +987,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :stream_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :stream_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "stream_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "stream_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -1017,10 +1018,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
         assert_equal Gapic::Protobuf.coerce(expire_time, to: Google::Protobuf::Timestamp), request.expire_time
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :stream_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :stream_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "stream_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "stream_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -1040,7 +1041,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "send_blurbs" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#send_blurbs."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#send_blurbs."
     end
 
     it "invokes send_blurbs without error" do
@@ -1048,17 +1049,17 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::SendBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::SendBlurbsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
         OpenStruct.new execute: [expected_response]
       end
-      mock_stub = MockGrpcClientStubV1.new :send_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :send_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "send_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "send_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -1079,10 +1080,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
       # Mock Grpc layer
       mock_method = proc { raise custom_error }
-      mock_stub = MockGrpcClientStubV1.new :send_blurbs, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :send_blurbs, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "send_blurbs"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "send_blurbs"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -1102,7 +1103,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
   describe "connect" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#connect."
+      CustomTestMessagingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Messaging::Client#connect."
     end
 
     it "invokes connect without error" do
@@ -1110,17 +1111,17 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::StreamBlurbsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::StreamBlurbsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
         OpenStruct.new execute: [expected_response]
       end
-      mock_stub = MockGrpcClientStubV1.new :connect, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :connect, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "connect"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "connect"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do
@@ -1142,10 +1143,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
       # Mock Grpc layer
       mock_method = proc { raise custom_error }
-      mock_stub = MockGrpcClientStubV1.new :connect, mock_method
+      mock_stub = MockGrpcMessagingStubV1beta1.new :connect, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "connect"
+      mock_credentials = MockMessagingCredentialsV1beta1.new "connect"
 
       Google::Showcase::V1beta1::Messaging::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Messaging::Credentials.stub :default, mock_credentials do

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -86,7 +86,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateRoomRequest, request
-      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
@@ -121,7 +121,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateRoomRequest, request
-      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_room, mock_method
@@ -160,7 +160,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetRoomRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
@@ -195,7 +195,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetRoomRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_room, mock_method
@@ -235,8 +235,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateRoomRequest, request
-      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
@@ -272,8 +272,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateRoomRequest, request
-      assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(room, to: Google::Showcase::V1beta1::Room), request.room
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_room, mock_method
@@ -312,7 +312,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteRoomRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
@@ -347,7 +347,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteRoomRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_room, mock_method
@@ -387,8 +387,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListRoomsRequest, request
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
@@ -424,8 +424,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListRoomsRequest, request
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_rooms, mock_method
@@ -465,8 +465,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateBlurbRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
@@ -502,8 +502,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateBlurbRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_blurb, mock_method
@@ -542,7 +542,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetBlurbRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
@@ -577,7 +577,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetBlurbRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_blurb, mock_method
@@ -617,8 +617,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateBlurbRequest, request
-      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
@@ -654,8 +654,8 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::UpdateBlurbRequest, request
-      assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(blurb, to: Google::Showcase::V1beta1::Blurb), request.blurb
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_blurb, mock_method
@@ -694,7 +694,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteBlurbRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
@@ -729,7 +729,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteBlurbRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_blurb, mock_method
@@ -770,9 +770,9 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListBlurbsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
@@ -809,9 +809,9 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListBlurbsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_blurbs, mock_method
@@ -860,10 +860,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::SearchBlurbsRequest, request
-      assert_equal query, request.query
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal query, request.query
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -904,10 +904,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::SearchBlurbsRequest, request
-      assert_equal query, request.query
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal query, request.query
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method
@@ -939,10 +939,10 @@ describe Google::Showcase::V1beta1::Messaging::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::SearchBlurbsRequest, request
-      assert_equal query, request.query
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal query, request.query
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :search_blurbs, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -100,13 +100,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.create_room room
+          response = client.create_room room: room
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_room room do |resp, operation|
+          client.create_room room: room do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -136,7 +136,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_room room
+            client.create_room room: room
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -174,13 +174,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.get_room name
+          response = client.get_room name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_room name do |resp, operation|
+          client.get_room name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -210,7 +210,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_room name
+            client.get_room name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -250,13 +250,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.update_room room, update_mask
+          response = client.update_room room: room, update_mask: update_mask
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.update_room room, update_mask do |resp, operation|
+          client.update_room room: room, update_mask: update_mask do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -288,7 +288,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.update_room room, update_mask
+            client.update_room room: room, update_mask: update_mask
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -326,13 +326,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.delete_room name
+          response = client.delete_room name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_room name do |resp, operation|
+          client.delete_room name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -362,7 +362,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_room name
+            client.delete_room name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -402,13 +402,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.list_rooms page_size, page_token
+          response = client.list_rooms page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_rooms page_size, page_token do |resp, operation|
+          client.list_rooms page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -440,7 +440,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_rooms page_size, page_token
+            client.list_rooms page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -480,13 +480,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.create_blurb parent, blurb
+          response = client.create_blurb parent: parent, blurb: blurb
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_blurb parent, blurb do |resp, operation|
+          client.create_blurb parent: parent, blurb: blurb do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -518,7 +518,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_blurb parent, blurb
+            client.create_blurb parent: parent, blurb: blurb
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -556,13 +556,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.get_blurb name
+          response = client.get_blurb name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_blurb name do |resp, operation|
+          client.get_blurb name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -592,7 +592,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_blurb name
+            client.get_blurb name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -632,13 +632,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.update_blurb blurb, update_mask
+          response = client.update_blurb blurb: blurb, update_mask: update_mask
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.update_blurb blurb, update_mask do |resp, operation|
+          client.update_blurb blurb: blurb, update_mask: update_mask do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -670,7 +670,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.update_blurb blurb, update_mask
+            client.update_blurb blurb: blurb, update_mask: update_mask
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -708,13 +708,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.delete_blurb name
+          response = client.delete_blurb name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_blurb name do |resp, operation|
+          client.delete_blurb name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -744,7 +744,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_blurb name
+            client.delete_blurb name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -786,13 +786,13 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.list_blurbs parent, page_size, page_token
+          response = client.list_blurbs parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_blurbs parent, page_size, page_token do |resp, operation|
+          client.list_blurbs parent: parent, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -826,7 +826,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_blurbs parent, page_size, page_token
+            client.list_blurbs parent: parent, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -877,7 +877,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.search_blurbs query, parent, page_size, page_token
+          response = client.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -921,7 +921,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
           client = Google::Showcase::V1beta1::Messaging::Client.new
 
           # Call method
-          response = client.search_blurbs query, parent, page_size, page_token
+          response = client.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert response.error?
@@ -957,7 +957,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.search_blurbs query, parent, page_size, page_token
+            client.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1029,7 +1029,7 @@ describe Google::Showcase::V1beta1::Messaging::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.stream_blurbs name, expire_time
+            client.stream_blurbs name: name, expire_time: expire_time
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -100,13 +100,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.create_session session
+          response = client.create_session session: session
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_session session do |resp, operation|
+          client.create_session session: session do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -136,7 +136,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_session session
+            client.create_session session: session
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -174,13 +174,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.get_session name
+          response = client.get_session name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_session name do |resp, operation|
+          client.get_session name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -210,7 +210,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_session name
+            client.get_session name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -250,13 +250,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.list_sessions page_size, page_token
+          response = client.list_sessions page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_sessions page_size, page_token do |resp, operation|
+          client.list_sessions page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -288,7 +288,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_sessions page_size, page_token
+            client.list_sessions page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -326,13 +326,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.delete_session name
+          response = client.delete_session name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_session name do |resp, operation|
+          client.delete_session name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -362,7 +362,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_session name
+            client.delete_session name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -400,13 +400,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.report_session name
+          response = client.report_session name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.report_session name do |resp, operation|
+          client.report_session name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -436,7 +436,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.report_session name
+            client.report_session name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -478,13 +478,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.list_tests parent, page_size, page_token
+          response = client.list_tests parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_tests parent, page_size, page_token do |resp, operation|
+          client.list_tests parent: parent, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -518,7 +518,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_tests parent, page_size, page_token
+            client.list_tests parent: parent, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -556,13 +556,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.delete_test name
+          response = client.delete_test name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_test name do |resp, operation|
+          client.delete_test name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -592,7 +592,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_test name
+            client.delete_test name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -634,13 +634,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
           client = Google::Showcase::V1beta1::Testing::Client.new
 
           # Call method
-          response = client.verify_test name, answer, answers
+          response = client.verify_test name: name, answer: answer, answers: answers
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.verify_test name, answer, answers do |resp, operation|
+          client.verify_test name: name, answer: answer, answers: answers do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -674,7 +674,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.verify_test name, answer, answers
+            client.verify_test name: name, answer: answer, answers: answers
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -28,9 +28,10 @@ require "google/showcase/v1beta1/testing_pb"
 require "google/showcase/v1beta1/testing_services_pb"
 require "google/showcase/v1beta1/testing"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestTestingErrorV1beta1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcTestingStubV1beta1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -73,7 +74,7 @@ end
 describe Google::Showcase::V1beta1::Testing::Client do
   describe "create_session" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#create_session."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#create_session."
     end
 
     it "invokes create_session without error" do
@@ -81,7 +82,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       session = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Session
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Session)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -89,10 +90,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :create_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "create_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -124,10 +125,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :create_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "create_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -147,7 +148,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "get_session" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#get_session."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#get_session."
     end
 
     it "invokes get_session without error" do
@@ -155,7 +156,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Session
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::Session)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -163,10 +164,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :get_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "get_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -198,10 +199,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :get_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "get_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -221,7 +222,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "list_sessions" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#list_sessions."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#list_sessions."
     end
 
     it "invokes list_sessions without error" do
@@ -230,7 +231,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListSessionsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::ListSessionsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -239,10 +240,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :list_sessions, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_sessions"
+      mock_credentials = MockTestingCredentialsV1beta1.new "list_sessions"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -276,10 +277,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :list_sessions, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_sessions"
+      mock_credentials = MockTestingCredentialsV1beta1.new "list_sessions"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -299,7 +300,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "delete_session" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#delete_session."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#delete_session."
     end
 
     it "invokes delete_session without error" do
@@ -307,7 +308,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -315,10 +316,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :delete_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "delete_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -350,10 +351,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :delete_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "delete_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -373,7 +374,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "report_session" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#report_session."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#report_session."
     end
 
     it "invokes report_session without error" do
@@ -381,7 +382,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ReportSessionResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::ReportSessionResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -389,10 +390,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :report_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "report_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "report_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -424,10 +425,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :report_session, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "report_session"
+      mock_credentials = MockTestingCredentialsV1beta1.new "report_session"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -447,7 +448,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "list_tests" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#list_tests."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#list_tests."
     end
 
     it "invokes list_tests without error" do
@@ -457,7 +458,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListTestsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::ListTestsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -467,10 +468,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :list_tests, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_tests"
+      mock_credentials = MockTestingCredentialsV1beta1.new "list_tests"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -506,10 +507,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :list_tests, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_tests"
+      mock_credentials = MockTestingCredentialsV1beta1.new "list_tests"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -529,7 +530,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "delete_test" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#delete_test."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#delete_test."
     end
 
     it "invokes delete_test without error" do
@@ -537,7 +538,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -545,10 +546,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :delete_test, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_test"
+      mock_credentials = MockTestingCredentialsV1beta1.new "delete_test"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -580,10 +581,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :delete_test, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_test"
+      mock_credentials = MockTestingCredentialsV1beta1.new "delete_test"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -603,7 +604,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
 
   describe "verify_test" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#verify_test."
+      CustomTestTestingErrorV1beta1.new "Custom test error for Google::Showcase::V1beta1::Testing::Client#verify_test."
     end
 
     it "invokes verify_test without error" do
@@ -613,7 +614,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       answers = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::VerifyTestResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Showcase::V1beta1::VerifyTestResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -623,10 +624,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal answers, request.answers
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :verify_test, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "verify_test"
+      mock_credentials = MockTestingCredentialsV1beta1.new "verify_test"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do
@@ -662,10 +663,10 @@ describe Google::Showcase::V1beta1::Testing::Client do
         assert_equal answers, request.answers
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method
+      mock_stub = MockGrpcTestingStubV1beta1.new :verify_test, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "verify_test"
+      mock_credentials = MockTestingCredentialsV1beta1.new "verify_test"
 
       Google::Showcase::V1beta1::Testing::Stub.stub :new, mock_stub do
         Google::Showcase::V1beta1::Testing::Credentials.stub :default, mock_credentials do

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -86,7 +86,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateSessionRequest, request
-      assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
+        assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
@@ -121,7 +121,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateSessionRequest, request
-      assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
+        assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
@@ -160,7 +160,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetSessionRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
@@ -195,7 +195,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetSessionRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
@@ -235,8 +235,8 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListSessionsRequest, request
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
@@ -272,8 +272,8 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListSessionsRequest, request
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
@@ -312,7 +312,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteSessionRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
@@ -347,7 +347,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteSessionRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
@@ -386,7 +386,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ReportSessionRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
@@ -421,7 +421,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ReportSessionRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
@@ -462,9 +462,9 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListTestsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
@@ -501,9 +501,9 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListTestsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
@@ -542,7 +542,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteTestRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
@@ -577,7 +577,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteTestRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
@@ -618,9 +618,9 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::VerifyTestRequest, request
-      assert_equal name, request.name
-      assert_equal answer, request.answer
-      assert_equal answers, request.answers
+        assert_equal name, request.name
+        assert_equal answer, request.answer
+        assert_equal answers, request.answers
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method
@@ -657,9 +657,9 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::VerifyTestRequest, request
-      assert_equal name, request.name
-      assert_equal answer, request.answer
-      assert_equal answers, request.answers
+        assert_equal name, request.name
+        assert_equal answer, request.answer
+        assert_equal answers, request.answers
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -81,13 +81,12 @@ describe Google::Showcase::V1beta1::Testing::Client do
       session = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Session
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Session
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
+      assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
@@ -122,7 +121,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::CreateSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
+      assert_equal Gapic::Protobuf.coerce(session, to: Google::Showcase::V1beta1::Session), request.session
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_session, mock_method
@@ -156,13 +155,12 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::Session
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::Session
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
@@ -197,7 +195,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::GetSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_session, mock_method
@@ -232,14 +230,13 @@ describe Google::Showcase::V1beta1::Testing::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::ListSessionsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListSessionsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListSessionsRequest, request
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
@@ -275,8 +272,8 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListSessionsRequest, request
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_sessions, mock_method
@@ -310,13 +307,12 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
@@ -351,7 +347,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_session, mock_method
@@ -385,13 +381,12 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::ReportSessionResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ReportSessionResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ReportSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
@@ -426,7 +421,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ReportSessionRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :report_session, mock_method
@@ -462,15 +457,14 @@ describe Google::Showcase::V1beta1::Testing::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::ListTestsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::ListTestsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListTestsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
@@ -507,9 +501,9 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::ListTestsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_tests, mock_method
@@ -543,13 +537,12 @@ describe Google::Showcase::V1beta1::Testing::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteTestRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
@@ -584,7 +577,7 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::DeleteTestRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_test, mock_method
@@ -620,15 +613,14 @@ describe Google::Showcase::V1beta1::Testing::Client do
       answers = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Showcase::V1beta1::VerifyTestResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Showcase::V1beta1::VerifyTestResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::VerifyTestRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(answer, to: ), request.answer
-        assert_equal Gapic::Protobuf.coerce(answers, to: ), request.answers
+      assert_equal name, request.name
+      assert_equal answer, request.answer
+      assert_equal answers, request.answers
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method
@@ -665,9 +657,9 @@ describe Google::Showcase::V1beta1::Testing::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Showcase::V1beta1::VerifyTestRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(answer, to: ), request.answer
-        assert_equal Gapic::Protobuf.coerce(answers, to: ), request.answers
+      assert_equal name, request.name
+      assert_equal answer, request.answer
+      assert_equal answers, request.answers
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :verify_test, mock_method

--- a/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -96,10 +96,10 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -140,10 +140,10 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -175,10 +175,10 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -224,7 +224,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -262,7 +262,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -291,7 +291,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -330,7 +330,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -365,7 +365,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -404,7 +404,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -439,7 +439,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -84,8 +84,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -97,10 +96,10 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -141,10 +140,10 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -176,10 +175,10 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -213,8 +212,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -226,7 +224,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -264,7 +262,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -293,7 +291,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -327,13 +325,12 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -368,7 +365,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -402,13 +399,12 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -443,7 +439,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -113,7 +113,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
           client = Google::Cloud::Speech::V1::Speech::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -157,7 +157,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
           client = Google::Cloud::Speech::V1::Speech::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert response.error?
@@ -193,7 +193,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_operations name, filter, page_size, page_token
+            client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -238,7 +238,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
           client = Google::Cloud::Speech::V1::Speech::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -276,7 +276,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
           client = Google::Cloud::Speech::V1::Speech::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert response.error?
@@ -306,7 +306,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_operation name
+            client.get_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -344,13 +344,13 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
           client = Google::Cloud::Speech::V1::Speech::Operations.new
 
           # Call method
-          response = client.delete_operation name
+          response = client.delete_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_operation name do |resp, operation|
+          client.delete_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -380,7 +380,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_operation name
+            client.delete_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -418,13 +418,13 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
           client = Google::Cloud::Speech::V1::Speech::Operations.new
 
           # Call method
-          response = client.cancel_operation name
+          response = client.cancel_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.cancel_operation name do |resp, operation|
+          client.cancel_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -454,7 +454,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.cancel_operation name
+            client.cancel_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -28,9 +28,10 @@ require "google/cloud/speech/v1/cloud_speech_pb"
 require "google/cloud/speech/v1/cloud_speech_services_pb"
 require "google/cloud/speech/v1/speech"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestSpeechErrorV1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcSpeechStubV1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -73,7 +74,7 @@ end
 describe Google::Cloud::Speech::V1::Speech::Operations do
   describe "list_operations" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#list_operations."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#list_operations."
     end
 
     it "invokes list_operations without error" do
@@ -84,12 +85,12 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::ListOperationsResponse)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:     "operations/list_operations_test",
+        done:     true,
         response: result
       )
 
@@ -102,7 +103,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :list_operations, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "list_operations"
@@ -132,8 +133,8 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         message: "Operation error for Google::Cloud::Speech::V1::Speech::Operations#list_operations."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:  "operations/list_operations_test",
+        done:  true,
         error: operation_error
       )
 
@@ -146,7 +147,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :list_operations, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "list_operations"
@@ -181,7 +182,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :list_operations, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "list_operations"
@@ -204,7 +205,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
   describe "get_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#get_operation."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#get_operation."
     end
 
     it "invokes get_operation without error" do
@@ -212,12 +213,12 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:     "operations/get_operation_test",
+        done:     true,
         response: result
       )
 
@@ -227,7 +228,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :get_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "get_operation"
@@ -254,8 +255,8 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         message: "Operation error for Google::Cloud::Speech::V1::Speech::Operations#get_operation."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:  "operations/get_operation_test",
+        done:  true,
         error: operation_error
       )
 
@@ -265,7 +266,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :get_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "get_operation"
@@ -294,7 +295,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :get_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "get_operation"
@@ -317,7 +318,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
   describe "delete_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#delete_operation."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#delete_operation."
     end
 
     it "invokes delete_operation without error" do
@@ -325,7 +326,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -333,7 +334,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :delete_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
@@ -368,7 +369,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :delete_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
@@ -391,7 +392,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
 
   describe "cancel_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#cancel_operation."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Operations#cancel_operation."
     end
 
     it "invokes cancel_operation without error" do
@@ -399,7 +400,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -407,7 +408,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :cancel_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
@@ -442,7 +443,7 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :cancel_operation, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
@@ -462,5 +463,4 @@ describe Google::Cloud::Speech::V1::Speech::Operations do
       end
     end
   end
-
 end

--- a/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_test.rb
@@ -28,9 +28,10 @@ require "google/cloud/speech/v1/cloud_speech_pb"
 require "google/cloud/speech/v1/cloud_speech_services_pb"
 require "google/cloud/speech/v1/speech"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestSpeechErrorV1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcSpeechStubV1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -73,7 +74,7 @@ end
 describe Google::Cloud::Speech::V1::Speech::Client do
   describe "recognize" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Client#recognize."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Client#recognize."
     end
 
     it "invokes recognize without error" do
@@ -82,7 +83,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       audio = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Speech::V1::RecognizeResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Speech::V1::RecognizeResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -91,7 +92,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "recognize"
@@ -128,7 +129,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "recognize"
@@ -151,7 +152,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
   describe "long_running_recognize" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Client#long_running_recognize."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Client#long_running_recognize."
     end
 
     it "invokes long_running_recognize without error" do
@@ -160,12 +161,12 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       audio = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/long_running_recognize_test",
-        done: true,
+        name:     "operations/long_running_recognize_test",
+        done:     true,
         response: result
       )
 
@@ -176,7 +177,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :long_running_recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "long_running_recognize"
@@ -204,8 +205,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         message: "Operation error for Google::Cloud::Speech::V1::Speech::Client#long_running_recognize."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/long_running_recognize_test",
-        done: true,
+        name:  "operations/long_running_recognize_test",
+        done:  true,
         error: operation_error
       )
 
@@ -216,7 +217,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :long_running_recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "long_running_recognize"
@@ -247,7 +248,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :long_running_recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "long_running_recognize"
@@ -270,7 +271,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
   describe "streaming_recognize" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Client#streaming_recognize."
+      CustomTestSpeechErrorV1.new "Custom test error for Google::Cloud::Speech::V1::Speech::Client#streaming_recognize."
     end
 
     it "invokes streaming_recognize without error" do
@@ -278,14 +279,14 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Speech::V1::StreamingRecognizeResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Speech::V1::StreamingRecognizeResponse)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
         OpenStruct.new execute: [expected_response]
       end
-      mock_stub = MockGrpcClientStubV1.new :streaming_recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :streaming_recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "streaming_recognize"
@@ -310,7 +311,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
       # Mock Grpc layer
       mock_method = proc { raise custom_error }
-      mock_stub = MockGrpcClientStubV1.new :streaming_recognize, mock_method
+      mock_stub = MockGrpcSpeechStubV1.new :streaming_recognize, mock_method
 
       # Mock auth layer
       mock_credentials = MockSpeechCredentialsV1.new "streaming_recognize"

--- a/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_test.rb
@@ -87,8 +87,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::RecognizeRequest, request
-      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
@@ -124,8 +124,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::RecognizeRequest, request
-      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
@@ -172,8 +172,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -212,8 +212,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -243,8 +243,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method

--- a/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_test.rb
@@ -102,13 +102,13 @@ describe Google::Cloud::Speech::V1::Speech::Client do
           client = Google::Cloud::Speech::V1::Speech::Client.new
 
           # Call method
-          response = client.recognize config, audio
+          response = client.recognize config: config, audio: audio
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.recognize config, audio do |resp, operation|
+          client.recognize config: config, audio: audio do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -140,7 +140,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.recognize config, audio
+            client.recognize config: config, audio: audio
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -187,7 +187,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
           client = Google::Cloud::Speech::V1::Speech::Client.new
 
           # Call method
-          response = client.long_running_recognize config, audio
+          response = client.long_running_recognize config: config, audio: audio
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -227,7 +227,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
           client = Google::Cloud::Speech::V1::Speech::Client.new
 
           # Call method
-          response = client.long_running_recognize config, audio
+          response = client.long_running_recognize config: config, audio: audio
 
           # Verify the response
           assert response.error?
@@ -259,7 +259,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.long_running_recognize config, audio
+            client.long_running_recognize config: config, audio: audio
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_test.rb
@@ -82,14 +82,13 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       audio = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Speech::V1::RecognizeResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Speech::V1::RecognizeResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::RecognizeRequest, request
-        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
@@ -125,8 +124,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::RecognizeRequest, request
-        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :recognize, mock_method
@@ -161,21 +160,20 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       audio = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name:     "operations/long_running_recognize_test",
-        done:     true,
+        name: "operations/long_running_recognize_test",
+        done: true,
         response: result
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -206,16 +204,16 @@ describe Google::Cloud::Speech::V1::Speech::Client do
         message: "Operation error for Google::Cloud::Speech::V1::Speech::Client#long_running_recognize."
       )
       operation = Google::Longrunning::Operation.new(
-        name:  "operations/long_running_recognize_test",
-        done:  true,
+        name: "operations/long_running_recognize_test",
+        done: true,
         error: operation_error
       )
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -245,8 +243,8 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Speech::V1::LongRunningRecognizeRequest, request
-        assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
-        assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
+      assert_equal Gapic::Protobuf.coerce(config, to: Google::Cloud::Speech::V1::RecognitionConfig), request.config
+      assert_equal Gapic::Protobuf.coerce(audio, to: Google::Cloud::Speech::V1::RecognitionAudio), request.audio
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :long_running_recognize, mock_method
@@ -280,8 +278,7 @@ describe Google::Cloud::Speech::V1::Speech::Client do
       request = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Speech::V1::StreamingRecognizeResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Speech::V1::StreamingRecognizeResponse
 
       # Mock Grpc layer
       mock_method = proc do |requests|

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -113,7 +113,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -157,7 +157,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert response.error?
@@ -193,7 +193,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_operations name, filter, page_size, page_token
+            client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -238,7 +238,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -276,7 +276,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert response.error?
@@ -306,7 +306,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_operation name
+            client.get_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -344,13 +344,13 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Operations.new
 
           # Call method
-          response = client.delete_operation name
+          response = client.delete_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_operation name do |resp, operation|
+          client.delete_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -380,7 +380,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_operation name
+            client.delete_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -418,13 +418,13 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Operations.new
 
           # Call method
-          response = client.cancel_operation name
+          response = client.cancel_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.cancel_operation name do |resp, operation|
+          client.cancel_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -454,7 +454,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.cancel_operation name
+            client.cancel_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -84,8 +84,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -97,10 +96,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -141,10 +140,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -176,10 +175,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -213,8 +212,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -226,7 +224,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -264,7 +262,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -293,7 +291,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -327,13 +325,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -368,7 +365,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -402,13 +399,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -443,7 +439,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -96,10 +96,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -140,10 +140,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -175,10 +175,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -224,7 +224,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -262,7 +262,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -291,7 +291,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -330,7 +330,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -365,7 +365,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -404,7 +404,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -439,7 +439,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -28,9 +28,10 @@ require "google/cloud/vision/v1/image_annotator_pb"
 require "google/cloud/vision/v1/image_annotator_services_pb"
 require "google/cloud/vision/v1/image_annotator"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestImageAnnotatorErrorV1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcImageAnnotatorStubV1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -73,7 +74,7 @@ end
 describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
   describe "list_operations" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#list_operations."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#list_operations."
     end
 
     it "invokes list_operations without error" do
@@ -84,12 +85,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::ListOperationsResponse)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:     "operations/list_operations_test",
+        done:     true,
         response: result
       )
 
@@ -102,10 +103,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -132,8 +133,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         message: "Operation error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#list_operations."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:  "operations/list_operations_test",
+        done:  true,
         error: operation_error
       )
 
@@ -146,10 +147,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -181,10 +182,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -204,7 +205,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
   describe "get_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#get_operation."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#get_operation."
     end
 
     it "invokes get_operation without error" do
@@ -212,12 +213,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:     "operations/get_operation_test",
+        done:     true,
         response: result
       )
 
@@ -227,10 +228,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -254,8 +255,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         message: "Operation error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#get_operation."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:  "operations/get_operation_test",
+        done:  true,
         error: operation_error
       )
 
@@ -265,10 +266,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -294,10 +295,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -317,7 +318,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
   describe "delete_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#delete_operation."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#delete_operation."
     end
 
     it "invokes delete_operation without error" do
@@ -325,7 +326,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -333,10 +334,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -368,10 +369,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -391,7 +392,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
 
   describe "cancel_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#cancel_operation."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Operations#cancel_operation."
     end
 
     it "invokes cancel_operation without error" do
@@ -399,7 +400,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -407,10 +408,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -442,10 +443,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -462,5 +463,4 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Operations do
       end
     end
   end
-
 end

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -87,8 +87,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateImagesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal parent, request.parent
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
@@ -124,8 +124,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateImagesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
@@ -165,8 +165,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateFilesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
+        assert_equal parent, request.parent
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_files, mock_method
@@ -202,8 +202,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateFilesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
+        assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_files, mock_method
@@ -251,9 +251,9 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-      assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
+        assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
@@ -293,9 +293,9 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-      assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
+        assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
@@ -326,9 +326,9 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-      assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+        assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
+        assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
@@ -375,8 +375,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+        assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
@@ -415,8 +415,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+        assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
@@ -446,8 +446,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
-      assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+        assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -102,13 +102,13 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
           # Call method
-          response = client.batch_annotate_images requests, parent
+          response = client.batch_annotate_images requests: requests, parent: parent
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.batch_annotate_images requests, parent do |resp, operation|
+          client.batch_annotate_images requests: requests, parent: parent do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -140,7 +140,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.batch_annotate_images requests, parent
+            client.batch_annotate_images requests: requests, parent: parent
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -180,13 +180,13 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
           # Call method
-          response = client.batch_annotate_files requests, parent
+          response = client.batch_annotate_files requests: requests, parent: parent
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.batch_annotate_files requests, parent do |resp, operation|
+          client.batch_annotate_files requests: requests, parent: parent do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -218,7 +218,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.batch_annotate_files requests, parent
+            client.batch_annotate_files requests: requests, parent: parent
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -267,7 +267,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
           # Call method
-          response = client.async_batch_annotate_images requests, output_config, parent
+          response = client.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -309,7 +309,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
           # Call method
-          response = client.async_batch_annotate_images requests, output_config, parent
+          response = client.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent
 
           # Verify the response
           assert response.error?
@@ -343,7 +343,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.async_batch_annotate_images requests, output_config, parent
+            client.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -390,7 +390,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
           # Call method
-          response = client.async_batch_annotate_files requests, parent
+          response = client.async_batch_annotate_files requests: requests, parent: parent
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -430,7 +430,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
           client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
           # Call method
-          response = client.async_batch_annotate_files requests, parent
+          response = client.async_batch_annotate_files requests: requests, parent: parent
 
           # Verify the response
           assert response.error?
@@ -462,7 +462,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.async_batch_annotate_files requests, parent
+            client.async_batch_annotate_files requests: requests, parent: parent
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -28,9 +28,10 @@ require "google/cloud/vision/v1/image_annotator_pb"
 require "google/cloud/vision/v1/image_annotator_services_pb"
 require "google/cloud/vision/v1/image_annotator"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestImageAnnotatorErrorV1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcImageAnnotatorStubV1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -73,7 +74,7 @@ end
 describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
   describe "batch_annotate_images" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_images."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_images."
     end
 
     it "invokes batch_annotate_images without error" do
@@ -82,7 +83,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::BatchAnnotateImagesResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::BatchAnnotateImagesResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -91,10 +92,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :batch_annotate_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "batch_annotate_images"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "batch_annotate_images"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -128,10 +129,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :batch_annotate_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "batch_annotate_images"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "batch_annotate_images"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -151,7 +152,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
   describe "batch_annotate_files" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_files."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_files."
     end
 
     it "invokes batch_annotate_files without error" do
@@ -160,7 +161,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::BatchAnnotateFilesResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::BatchAnnotateFilesResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -169,10 +170,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :batch_annotate_files, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :batch_annotate_files, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "batch_annotate_files"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "batch_annotate_files"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -206,10 +207,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :batch_annotate_files, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :batch_annotate_files, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "batch_annotate_files"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "batch_annotate_files"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -229,7 +230,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
   describe "async_batch_annotate_images" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_images."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_images."
     end
 
     it "invokes async_batch_annotate_images without error" do
@@ -239,12 +240,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/async_batch_annotate_images_test",
-        done: true,
+        name:     "operations/async_batch_annotate_images_test",
+        done:     true,
         response: result
       )
 
@@ -256,10 +257,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :async_batch_annotate_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "async_batch_annotate_images"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "async_batch_annotate_images"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -285,8 +286,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         message: "Operation error for Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_images."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/async_batch_annotate_images_test",
-        done: true,
+        name:  "operations/async_batch_annotate_images_test",
+        done:  true,
         error: operation_error
       )
 
@@ -298,10 +299,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :async_batch_annotate_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "async_batch_annotate_images"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "async_batch_annotate_images"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -331,10 +332,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :async_batch_annotate_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "async_batch_annotate_images"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "async_batch_annotate_images"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -354,7 +355,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
 
   describe "async_batch_annotate_files" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_files."
+      CustomTestImageAnnotatorErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_files."
     end
 
     it "invokes async_batch_annotate_files without error" do
@@ -363,12 +364,12 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/async_batch_annotate_files_test",
-        done: true,
+        name:     "operations/async_batch_annotate_files_test",
+        done:     true,
         response: result
       )
 
@@ -379,10 +380,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :async_batch_annotate_files, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "async_batch_annotate_files"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "async_batch_annotate_files"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -407,8 +408,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         message: "Operation error for Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_files."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/async_batch_annotate_files_test",
-        done: true,
+        name:  "operations/async_batch_annotate_files_test",
+        done:  true,
         error: operation_error
       )
 
@@ -419,10 +420,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :async_batch_annotate_files, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "async_batch_annotate_files"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "async_batch_annotate_files"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do
@@ -450,10 +451,10 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
         assert_equal parent, request.parent
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
+      mock_stub = MockGrpcImageAnnotatorStubV1.new :async_batch_annotate_files, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "async_batch_annotate_files"
+      mock_credentials = MockImageAnnotatorCredentialsV1.new "async_batch_annotate_files"
 
       Google::Cloud::Vision::V1::ImageAnnotator::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ImageAnnotator::Credentials.stub :default, mock_credentials do

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -82,14 +82,13 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::BatchAnnotateImagesResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::BatchAnnotateImagesResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+      assert_equal parent, request.parent
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
@@ -125,8 +124,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+      assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_images, mock_method
@@ -161,14 +160,13 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::BatchAnnotateFilesResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::BatchAnnotateFilesResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateFilesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
+      assert_equal parent, request.parent
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_files, mock_method
@@ -204,8 +202,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::BatchAnnotateFilesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateFileRequest), request.requests
+      assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :batch_annotate_files, mock_method
@@ -241,8 +239,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -254,9 +251,9 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+      assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
+      assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
@@ -296,9 +293,9 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+      assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
+      assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
@@ -329,9 +326,9 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AnnotateImageRequest), request.requests
+      assert_equal Gapic::Protobuf.coerce(output_config, to: Google::Cloud::Vision::V1::OutputConfig), request.output_config
+      assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_images, mock_method
@@ -366,8 +363,7 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       parent = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -379,8 +375,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+      assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
@@ -419,8 +415,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+      assert_equal parent, request.parent
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method
@@ -450,8 +446,8 @@ describe Google::Cloud::Vision::V1::ImageAnnotator::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, request
-        assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
+      assert_equal Gapic::Protobuf.coerce(requests, to: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest), request.requests
+      assert_equal parent, request.parent
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :async_batch_annotate_files, mock_method

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -84,8 +84,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -97,10 +96,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -141,10 +140,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -176,10 +175,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(filter, to: ), request.filter
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal filter, request.filter
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -213,8 +212,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -226,7 +224,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -264,7 +262,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -293,7 +291,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -327,13 +325,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -368,7 +365,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -402,13 +399,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -443,7 +439,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -96,10 +96,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -140,10 +140,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -175,10 +175,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::ListOperationsRequest, request
-      assert_equal name, request.name
-      assert_equal filter, request.filter
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal filter, request.filter
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
@@ -224,7 +224,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -262,7 +262,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -291,7 +291,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::GetOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
@@ -330,7 +330,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -365,7 +365,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::DeleteOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
@@ -404,7 +404,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
@@ -439,7 +439,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Longrunning::CancelOperationRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -28,9 +28,10 @@ require "google/cloud/vision/v1/product_search_service_pb"
 require "google/cloud/vision/v1/product_search_service_services_pb"
 require "google/cloud/vision/v1/product_search"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestProductSearchErrorV1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcProductSearchStubV1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -73,7 +74,7 @@ end
 describe Google::Cloud::Vision::V1::ProductSearch::Operations do
   describe "list_operations" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#list_operations."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#list_operations."
     end
 
     it "invokes list_operations without error" do
@@ -84,12 +85,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::ListOperationsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::ListOperationsResponse)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:     "operations/list_operations_test",
+        done:     true,
         response: result
       )
 
@@ -102,10 +103,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -132,8 +133,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         message: "Operation error for Google::Cloud::Vision::V1::ProductSearch::Operations#list_operations."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/list_operations_test",
-        done: true,
+        name:  "operations/list_operations_test",
+        done:  true,
         error: operation_error
       )
 
@@ -146,10 +147,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -181,10 +182,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_operations, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_operations, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_operations"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_operations"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -204,7 +205,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
   describe "get_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#get_operation."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#get_operation."
     end
 
     it "invokes get_operation without error" do
@@ -212,12 +213,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:     "operations/get_operation_test",
+        done:     true,
         response: result
       )
 
@@ -227,10 +228,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -254,8 +255,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         message: "Operation error for Google::Cloud::Vision::V1::ProductSearch::Operations#get_operation."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/get_operation_test",
-        done: true,
+        name:  "operations/get_operation_test",
+        done:  true,
         error: operation_error
       )
 
@@ -265,10 +266,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -294,10 +295,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -317,7 +318,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
   describe "delete_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#delete_operation."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#delete_operation."
     end
 
     it "invokes delete_operation without error" do
@@ -325,7 +326,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -333,10 +334,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -368,10 +369,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -391,7 +392,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
   describe "cancel_operation" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#cancel_operation."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Operations#cancel_operation."
     end
 
     it "invokes cancel_operation without error" do
@@ -399,7 +400,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -407,10 +408,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -442,10 +443,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :cancel_operation, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :cancel_operation, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "cancel_operation"
+      mock_credentials = MockProductSearchCredentialsV1.new "cancel_operation"
 
       Google::Longrunning::Operations::Stub.stub :new, mock_stub do
         Google::Longrunning::Operations::Credentials.stub :default, mock_credentials do
@@ -462,5 +463,4 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
       end
     end
   end
-
 end

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -113,7 +113,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
           client = Google::Cloud::Vision::V1::ProductSearch::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -157,7 +157,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
           client = Google::Cloud::Vision::V1::ProductSearch::Operations.new
 
           # Call method
-          response = client.list_operations name, filter, page_size, page_token
+          response = client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert response.error?
@@ -193,7 +193,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_operations name, filter, page_size, page_token
+            client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -238,7 +238,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
           client = Google::Cloud::Vision::V1::ProductSearch::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -276,7 +276,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
           client = Google::Cloud::Vision::V1::ProductSearch::Operations.new
 
           # Call method
-          response = client.get_operation name
+          response = client.get_operation name: name
 
           # Verify the response
           assert response.error?
@@ -306,7 +306,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_operation name
+            client.get_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -344,13 +344,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
           client = Google::Cloud::Vision::V1::ProductSearch::Operations.new
 
           # Call method
-          response = client.delete_operation name
+          response = client.delete_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_operation name do |resp, operation|
+          client.delete_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -380,7 +380,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_operation name
+            client.delete_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -418,13 +418,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
           client = Google::Cloud::Vision::V1::ProductSearch::Operations.new
 
           # Call method
-          response = client.cancel_operation name
+          response = client.cancel_operation name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.cancel_operation name do |resp, operation|
+          client.cancel_operation name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -454,7 +454,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Operations do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.cancel_operation name
+            client.cancel_operation name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_test.rb
@@ -104,13 +104,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.create_product_set parent, product_set, product_set_id
+          response = client.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_product_set parent, product_set, product_set_id do |resp, operation|
+          client.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -144,7 +144,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_product_set parent, product_set, product_set_id
+            client.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -186,13 +186,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.list_product_sets parent, page_size, page_token
+          response = client.list_product_sets parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_product_sets parent, page_size, page_token do |resp, operation|
+          client.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -226,7 +226,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_product_sets parent, page_size, page_token
+            client.list_product_sets parent: parent, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -264,13 +264,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.get_product_set name
+          response = client.get_product_set name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_product_set name do |resp, operation|
+          client.get_product_set name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -300,7 +300,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_product_set name
+            client.get_product_set name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -340,13 +340,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.update_product_set product_set, update_mask
+          response = client.update_product_set product_set: product_set, update_mask: update_mask
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.update_product_set product_set, update_mask do |resp, operation|
+          client.update_product_set product_set: product_set, update_mask: update_mask do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -378,7 +378,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.update_product_set product_set, update_mask
+            client.update_product_set product_set: product_set, update_mask: update_mask
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -416,13 +416,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.delete_product_set name
+          response = client.delete_product_set name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_product_set name do |resp, operation|
+          client.delete_product_set name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -452,7 +452,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_product_set name
+            client.delete_product_set name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -494,13 +494,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.create_product parent, product, product_id
+          response = client.create_product parent: parent, product: product, product_id: product_id
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_product parent, product, product_id do |resp, operation|
+          client.create_product parent: parent, product: product, product_id: product_id do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -534,7 +534,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_product parent, product, product_id
+            client.create_product parent: parent, product: product, product_id: product_id
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -576,13 +576,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.list_products parent, page_size, page_token
+          response = client.list_products parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_products parent, page_size, page_token do |resp, operation|
+          client.list_products parent: parent, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -616,7 +616,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_products parent, page_size, page_token
+            client.list_products parent: parent, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -654,13 +654,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.get_product name
+          response = client.get_product name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_product name do |resp, operation|
+          client.get_product name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -690,7 +690,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_product name
+            client.get_product name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -730,13 +730,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.update_product product, update_mask
+          response = client.update_product product: product, update_mask: update_mask
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.update_product product, update_mask do |resp, operation|
+          client.update_product product: product, update_mask: update_mask do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -768,7 +768,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.update_product product, update_mask
+            client.update_product product: product, update_mask: update_mask
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -806,13 +806,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.delete_product name
+          response = client.delete_product name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_product name do |resp, operation|
+          client.delete_product name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -842,7 +842,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_product name
+            client.delete_product name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -884,13 +884,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.create_reference_image parent, reference_image, reference_image_id
+          response = client.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.create_reference_image parent, reference_image, reference_image_id do |resp, operation|
+          client.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -924,7 +924,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.create_reference_image parent, reference_image, reference_image_id
+            client.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -962,13 +962,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.delete_reference_image name
+          response = client.delete_reference_image name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.delete_reference_image name do |resp, operation|
+          client.delete_reference_image name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -998,7 +998,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.delete_reference_image name
+            client.delete_reference_image name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1040,13 +1040,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.list_reference_images parent, page_size, page_token
+          response = client.list_reference_images parent: parent, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_reference_images parent, page_size, page_token do |resp, operation|
+          client.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -1080,7 +1080,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_reference_images parent, page_size, page_token
+            client.list_reference_images parent: parent, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1118,13 +1118,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.get_reference_image name
+          response = client.get_reference_image name: name
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.get_reference_image name do |resp, operation|
+          client.get_reference_image name: name do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -1154,7 +1154,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.get_reference_image name
+            client.get_reference_image name: name
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1194,13 +1194,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.add_product_to_product_set name, product
+          response = client.add_product_to_product_set name: name, product: product
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.add_product_to_product_set name, product do |resp, operation|
+          client.add_product_to_product_set name: name, product: product do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -1232,7 +1232,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.add_product_to_product_set name, product
+            client.add_product_to_product_set name: name, product: product
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1272,13 +1272,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.remove_product_from_product_set name, product
+          response = client.remove_product_from_product_set name: name, product: product
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.remove_product_from_product_set name, product do |resp, operation|
+          client.remove_product_from_product_set name: name, product: product do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -1310,7 +1310,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.remove_product_from_product_set name, product
+            client.remove_product_from_product_set name: name, product: product
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1352,13 +1352,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.list_products_in_product_set name, page_size, page_token
+          response = client.list_products_in_product_set name: name, page_size: page_size, page_token: page_token
 
           # Verify the response
           assert_equal expected_response, response
 
           # Call method with block
-          client.list_products_in_product_set name, page_size, page_token do |resp, operation|
+          client.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |resp, operation|
             # Verify the response
             assert_equal expected_response, resp
             refute_nil operation
@@ -1392,7 +1392,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.list_products_in_product_set name, page_size, page_token
+            client.list_products_in_product_set name: name, page_size: page_size, page_token: page_token
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1439,7 +1439,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.import_product_sets parent, input_config
+          response = client.import_product_sets parent: parent, input_config: input_config
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -1479,7 +1479,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.import_product_sets parent, input_config
+          response = client.import_product_sets parent: parent, input_config: input_config
 
           # Verify the response
           assert response.error?
@@ -1511,7 +1511,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.import_product_sets parent, input_config
+            client.import_product_sets parent: parent, input_config: input_config
           end
 
           # Verify the GapicError wrapped the custom error that was raised.
@@ -1562,7 +1562,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.purge_products product_set_purge_config, delete_orphan_products, parent, force
+          response = client.purge_products product_set_purge_config: product_set_purge_config, delete_orphan_products: delete_orphan_products, parent: parent, force: force
 
           # Verify the response
           assert_equal expected_response, response.response
@@ -1606,7 +1606,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
           client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
           # Call method
-          response = client.purge_products product_set_purge_config, delete_orphan_products, parent, force
+          response = client.purge_products product_set_purge_config: product_set_purge_config, delete_orphan_products: delete_orphan_products, parent: parent, force: force
 
           # Verify the response
           assert response.error?
@@ -1642,7 +1642,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
           # Call method
           err = assert_raises Gapic::GapicError do
-            client.purge_products product_set_purge_config, delete_orphan_products, parent, force
+            client.purge_products product_set_purge_config: product_set_purge_config, delete_orphan_products: delete_orphan_products, parent: parent, force: force
           end
 
           # Verify the GapicError wrapped the custom error that was raised.

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_test.rb
@@ -28,9 +28,10 @@ require "google/cloud/vision/v1/product_search_service_pb"
 require "google/cloud/vision/v1/product_search_service_services_pb"
 require "google/cloud/vision/v1/product_search"
 
-class CustomTestErrorV1 < StandardError; end
+class CustomTestProductSearchErrorV1 < StandardError; end
+
 # Mock for the GRPC::ClientStub class.
-class MockGrpcClientStubV1
+class MockGrpcProductSearchStubV1
   # @param expected_symbol [Symbol] the symbol of the grpc method to be mocked.
   # @param mock_method [Proc] The method that is being mocked.
   def initialize expected_symbol, mock_method
@@ -73,7 +74,7 @@ end
 describe Google::Cloud::Vision::V1::ProductSearch::Client do
   describe "create_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#create_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#create_product_set."
     end
 
     it "invokes create_product_set without error" do
@@ -83,7 +84,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product_set_id = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ProductSet
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ProductSet)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -93,10 +94,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product_set_id, request.product_set_id
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :create_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "create_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -132,10 +133,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product_set_id, request.product_set_id
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :create_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "create_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -155,7 +156,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "list_product_sets" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_product_sets."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_product_sets."
     end
 
     it "invokes list_product_sets without error" do
@@ -165,7 +166,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListProductSetsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ListProductSetsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -175,10 +176,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_product_sets, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_product_sets"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_product_sets"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -214,10 +215,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_product_sets, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_product_sets"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_product_sets"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -237,7 +238,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "get_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#get_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#get_product_set."
     end
 
     it "invokes get_product_set without error" do
@@ -245,7 +246,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ProductSet
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ProductSet)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -253,10 +254,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -288,10 +289,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -311,7 +312,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "update_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#update_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#update_product_set."
     end
 
     it "invokes update_product_set without error" do
@@ -320,7 +321,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ProductSet
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ProductSet)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -329,10 +330,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :update_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "update_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -366,10 +367,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :update_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "update_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -389,7 +390,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "delete_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#delete_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#delete_product_set."
     end
 
     it "invokes delete_product_set without error" do
@@ -397,7 +398,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -405,10 +406,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -440,10 +441,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -463,7 +464,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "create_product" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#create_product."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#create_product."
     end
 
     it "invokes create_product without error" do
@@ -473,7 +474,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product_id = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::Product
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::Product)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -483,10 +484,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product_id, request.product_id
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :create_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "create_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -522,10 +523,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product_id, request.product_id
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :create_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "create_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -545,7 +546,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "list_products" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_products."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_products."
     end
 
     it "invokes list_products without error" do
@@ -555,7 +556,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListProductsResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ListProductsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -565,10 +566,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_products, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_products"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_products"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -604,10 +605,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_products, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_products"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_products"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -627,7 +628,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "get_product" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#get_product."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#get_product."
     end
 
     it "invokes get_product without error" do
@@ -635,7 +636,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::Product
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::Product)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -643,10 +644,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -678,10 +679,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -701,7 +702,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "update_product" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#update_product."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#update_product."
     end
 
     it "invokes update_product without error" do
@@ -710,7 +711,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::Product
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::Product)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -719,10 +720,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :update_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "update_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -756,10 +757,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :update_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "update_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "update_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -779,7 +780,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "delete_product" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#delete_product."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#delete_product."
     end
 
     it "invokes delete_product without error" do
@@ -787,7 +788,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -795,10 +796,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -830,10 +831,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_product, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_product"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_product"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -853,7 +854,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "create_reference_image" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#create_reference_image."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#create_reference_image."
     end
 
     it "invokes create_reference_image without error" do
@@ -863,7 +864,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       reference_image_id = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ReferenceImage
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ReferenceImage)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -873,10 +874,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal reference_image_id, request.reference_image_id
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :create_reference_image, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_reference_image"
+      mock_credentials = MockProductSearchCredentialsV1.new "create_reference_image"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -912,10 +913,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal reference_image_id, request.reference_image_id
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :create_reference_image, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "create_reference_image"
+      mock_credentials = MockProductSearchCredentialsV1.new "create_reference_image"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -935,7 +936,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "delete_reference_image" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#delete_reference_image."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#delete_reference_image."
     end
 
     it "invokes delete_reference_image without error" do
@@ -943,7 +944,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -951,10 +952,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_reference_image, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_reference_image"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_reference_image"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -986,10 +987,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :delete_reference_image, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "delete_reference_image"
+      mock_credentials = MockProductSearchCredentialsV1.new "delete_reference_image"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1009,7 +1010,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "list_reference_images" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_reference_images."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_reference_images."
     end
 
     it "invokes list_reference_images without error" do
@@ -1019,7 +1020,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListReferenceImagesResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ListReferenceImagesResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1029,10 +1030,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_reference_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_reference_images"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_reference_images"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1068,10 +1069,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_reference_images, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_reference_images"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_reference_images"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1091,7 +1092,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "get_reference_image" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#get_reference_image."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#get_reference_image."
     end
 
     it "invokes get_reference_image without error" do
@@ -1099,7 +1100,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ReferenceImage
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ReferenceImage)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1107,10 +1108,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_reference_image, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_reference_image"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_reference_image"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1142,10 +1143,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal name, request.name
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :get_reference_image, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "get_reference_image"
+      mock_credentials = MockProductSearchCredentialsV1.new "get_reference_image"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1165,7 +1166,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "add_product_to_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#add_product_to_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#add_product_to_product_set."
     end
 
     it "invokes add_product_to_product_set without error" do
@@ -1174,7 +1175,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1183,10 +1184,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product, request.product
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :add_product_to_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "add_product_to_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "add_product_to_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1220,10 +1221,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product, request.product
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :add_product_to_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "add_product_to_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "add_product_to_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1243,7 +1244,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "remove_product_from_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#remove_product_from_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#remove_product_from_product_set."
     end
 
     it "invokes remove_product_from_product_set without error" do
@@ -1252,7 +1253,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Protobuf::Empty)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1261,10 +1262,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product, request.product
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :remove_product_from_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "remove_product_from_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "remove_product_from_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1298,10 +1299,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal product, request.product
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :remove_product_from_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "remove_product_from_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "remove_product_from_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1321,7 +1322,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "list_products_in_product_set" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_products_in_product_set."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#list_products_in_product_set."
     end
 
     it "invokes list_products_in_product_set without error" do
@@ -1331,7 +1332,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListProductsInProductSetResponse
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Cloud::Vision::V1::ListProductsInProductSetResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1341,10 +1342,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
-      mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_products_in_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_products_in_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_products_in_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1380,10 +1381,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal page_token, request.page_token
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :list_products_in_product_set, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "list_products_in_product_set"
+      mock_credentials = MockProductSearchCredentialsV1.new "list_products_in_product_set"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1403,7 +1404,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "import_product_sets" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#import_product_sets."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#import_product_sets."
     end
 
     it "invokes import_product_sets without error" do
@@ -1412,12 +1413,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       input_config = {}
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/import_product_sets_test",
-        done: true,
+        name:     "operations/import_product_sets_test",
+        done:     true,
         response: result
       )
 
@@ -1428,10 +1429,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :import_product_sets, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "import_product_sets"
+      mock_credentials = MockProductSearchCredentialsV1.new "import_product_sets"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1456,8 +1457,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         message: "Operation error for Google::Cloud::Vision::V1::ProductSearch::Client#import_product_sets."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/import_product_sets_test",
-        done: true,
+        name:  "operations/import_product_sets_test",
+        done:  true,
         error: operation_error
       )
 
@@ -1468,10 +1469,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :import_product_sets, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "import_product_sets"
+      mock_credentials = MockProductSearchCredentialsV1.new "import_product_sets"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1499,10 +1500,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :import_product_sets, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "import_product_sets"
+      mock_credentials = MockProductSearchCredentialsV1.new "import_product_sets"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1522,7 +1523,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
 
   describe "purge_products" do
     let :custom_error do
-      CustomTestErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#purge_products."
+      CustomTestProductSearchErrorV1.new "Custom test error for Google::Cloud::Vision::V1::ProductSearch::Client#purge_products."
     end
 
     it "invokes purge_products without error" do
@@ -1533,12 +1534,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       force = true
 
       # Create expected grpc response
-      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce({}, to: Google::Longrunning::Operation)
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
-        name: "operations/purge_products_test",
-        done: true,
+        name:     "operations/purge_products_test",
+        done:     true,
         response: result
       )
 
@@ -1551,10 +1552,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal force, request.force
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :purge_products, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "purge_products"
+      mock_credentials = MockProductSearchCredentialsV1.new "purge_products"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1581,8 +1582,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         message: "Operation error for Google::Cloud::Vision::V1::ProductSearch::Client#purge_products."
       )
       operation = Google::Longrunning::Operation.new(
-        name: "operations/purge_products_test",
-        done: true,
+        name:  "operations/purge_products_test",
+        done:  true,
         error: operation_error
       )
 
@@ -1595,10 +1596,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal force, request.force
         OpenStruct.new execute: operation
       end
-      mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :purge_products, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "purge_products"
+      mock_credentials = MockProductSearchCredentialsV1.new "purge_products"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do
@@ -1630,10 +1631,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
         assert_equal force, request.force
         raise custom_error
       end
-      mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
+      mock_stub = MockGrpcProductSearchStubV1.new :purge_products, mock_method
 
       # Mock auth layer
-      mock_credentials = MockSpeechCredentialsV1.new "purge_products"
+      mock_credentials = MockProductSearchCredentialsV1.new "purge_products"
 
       Google::Cloud::Vision::V1::ProductSearch::Stub.stub :new, mock_stub do
         Google::Cloud::Vision::V1::ProductSearch::Credentials.stub :default, mock_credentials do

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_test.rb
@@ -83,15 +83,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product_set_id = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ProductSet
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ProductSet
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Gapic::Protobuf.coerce(product_set_id, to: ), request.product_set_id
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+      assert_equal product_set_id, request.product_set_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
@@ -128,9 +127,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Gapic::Protobuf.coerce(product_set_id, to: ), request.product_set_id
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+      assert_equal product_set_id, request.product_set_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
@@ -166,15 +165,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListProductSetsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListProductSetsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductSetsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
@@ -211,9 +209,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductSetsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
@@ -247,13 +245,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ProductSet
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ProductSet
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
@@ -288,7 +285,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
@@ -323,14 +320,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ProductSet
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ProductSet
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
@@ -366,8 +362,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
@@ -401,13 +397,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
@@ -442,7 +437,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
@@ -478,15 +473,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product_id = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::Product
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::Product
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Gapic::Protobuf.coerce(product_id, to: ), request.product_id
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+      assert_equal product_id, request.product_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
@@ -523,9 +517,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Gapic::Protobuf.coerce(product_id, to: ), request.product_id
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+      assert_equal product_id, request.product_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
@@ -561,15 +555,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListProductsResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListProductsResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
@@ -606,9 +599,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
@@ -642,13 +635,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::Product
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::Product
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
@@ -683,7 +675,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
@@ -718,14 +710,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       update_mask = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::Product
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::Product
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
@@ -761,8 +752,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
@@ -796,13 +787,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
@@ -837,7 +827,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
@@ -873,15 +863,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       reference_image_id = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ReferenceImage
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ReferenceImage
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateReferenceImageRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
-        assert_equal Gapic::Protobuf.coerce(reference_image_id, to: ), request.reference_image_id
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
+      assert_equal reference_image_id, request.reference_image_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
@@ -918,9 +907,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateReferenceImageRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
-        assert_equal Gapic::Protobuf.coerce(reference_image_id, to: ), request.reference_image_id
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
+      assert_equal reference_image_id, request.reference_image_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
@@ -954,13 +943,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteReferenceImageRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
@@ -995,7 +983,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteReferenceImageRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
@@ -1031,15 +1019,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListReferenceImagesResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListReferenceImagesResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListReferenceImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
@@ -1076,9 +1063,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListReferenceImagesRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal parent, request.parent
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
@@ -1112,13 +1099,12 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       name = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ReferenceImage
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ReferenceImage
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetReferenceImageRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
@@ -1153,7 +1139,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetReferenceImageRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
+      assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
@@ -1188,14 +1174,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AddProductToProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(product, to: ), request.product
+      assert_equal name, request.name
+      assert_equal product, request.product
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
@@ -1231,8 +1216,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AddProductToProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(product, to: ), request.product
+      assert_equal name, request.name
+      assert_equal product, request.product
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
@@ -1267,14 +1252,13 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       product = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Protobuf::Empty
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Protobuf::Empty
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(product, to: ), request.product
+      assert_equal name, request.name
+      assert_equal product, request.product
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
@@ -1310,8 +1294,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(product, to: ), request.product
+      assert_equal name, request.name
+      assert_equal product, request.product
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
@@ -1347,15 +1331,14 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       page_token = "hello world"
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Cloud::Vision::V1::ListProductsInProductSetResponse
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Cloud::Vision::V1::ListProductsInProductSetResponse
 
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsInProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
@@ -1392,9 +1375,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsInProductSetRequest, request
-        assert_equal Gapic::Protobuf.coerce(name, to: ), request.name
-        assert_equal Gapic::Protobuf.coerce(page_size, to: ), request.page_size
-        assert_equal Gapic::Protobuf.coerce(page_token, to: ), request.page_token
+      assert_equal name, request.name
+      assert_equal page_size, request.page_size
+      assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
@@ -1429,8 +1412,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       input_config = {}
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -1442,8 +1424,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1482,8 +1464,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1513,8 +1495,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+      assert_equal parent, request.parent
+      assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1551,8 +1533,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       force = true
 
       # Create expected grpc response
-      expected_response = {}
-      expected_response = Gapic::Protobuf.coerce expected_response, to: Google::Longrunning::Operation
+      expected_response = Gapic::Protobuf.coerce {}, to: Google::Longrunning::Operation
       result = Google::Protobuf::Any.new
       result.pack expected_response
       operation = Google::Longrunning::Operation.new(
@@ -1564,10 +1545,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::PurgeProductsRequest, request
-        assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
-        assert_equal Gapic::Protobuf.coerce(delete_orphan_products, to: ), request.delete_orphan_products
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(force, to: ), request.force
+      assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
+      assert_equal delete_orphan_products, request.delete_orphan_products
+      assert_equal parent, request.parent
+      assert_equal force, request.force
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
@@ -1608,10 +1589,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::PurgeProductsRequest, request
-        assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
-        assert_equal Gapic::Protobuf.coerce(delete_orphan_products, to: ), request.delete_orphan_products
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(force, to: ), request.force
+      assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
+      assert_equal delete_orphan_products, request.delete_orphan_products
+      assert_equal parent, request.parent
+      assert_equal force, request.force
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
@@ -1643,10 +1624,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::PurgeProductsRequest, request
-        assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
-        assert_equal Gapic::Protobuf.coerce(delete_orphan_products, to: ), request.delete_orphan_products
-        assert_equal Gapic::Protobuf.coerce(parent, to: ), request.parent
-        assert_equal Gapic::Protobuf.coerce(force, to: ), request.force
+      assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
+      assert_equal delete_orphan_products, request.delete_orphan_products
+      assert_equal parent, request.parent
+      assert_equal force, request.force
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_test.rb
@@ -88,9 +88,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductSetRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-      assert_equal product_set_id, request.product_set_id
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal product_set_id, request.product_set_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
@@ -127,9 +127,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductSetRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-      assert_equal product_set_id, request.product_set_id
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal product_set_id, request.product_set_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_product_set, mock_method
@@ -170,9 +170,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductSetsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
@@ -209,9 +209,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductSetsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_product_sets, mock_method
@@ -250,7 +250,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductSetRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
@@ -285,7 +285,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductSetRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_product_set, mock_method
@@ -325,8 +325,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductSetRequest, request
-      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
@@ -362,8 +362,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductSetRequest, request
-      assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(product_set, to: Google::Cloud::Vision::V1::ProductSet), request.product_set
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_product_set, mock_method
@@ -402,7 +402,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductSetRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
@@ -437,7 +437,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductSetRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product_set, mock_method
@@ -478,9 +478,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-      assert_equal product_id, request.product_id
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal product_id, request.product_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
@@ -517,9 +517,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateProductRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-      assert_equal product_id, request.product_id
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal product_id, request.product_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_product, mock_method
@@ -560,9 +560,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
@@ -599,9 +599,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_products, mock_method
@@ -640,7 +640,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
@@ -675,7 +675,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetProductRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_product, mock_method
@@ -715,8 +715,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductRequest, request
-      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
@@ -752,8 +752,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::UpdateProductRequest, request
-      assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
-      assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
+        assert_equal Gapic::Protobuf.coerce(product, to: Google::Cloud::Vision::V1::Product), request.product
+        assert_equal Gapic::Protobuf.coerce(update_mask, to: Google::Protobuf::FieldMask), request.update_mask
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :update_product, mock_method
@@ -792,7 +792,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
@@ -827,7 +827,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteProductRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_product, mock_method
@@ -868,9 +868,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateReferenceImageRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
-      assert_equal reference_image_id, request.reference_image_id
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
+        assert_equal reference_image_id, request.reference_image_id
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
@@ -907,9 +907,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::CreateReferenceImageRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
-      assert_equal reference_image_id, request.reference_image_id
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(reference_image, to: Google::Cloud::Vision::V1::ReferenceImage), request.reference_image
+        assert_equal reference_image_id, request.reference_image_id
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :create_reference_image, mock_method
@@ -948,7 +948,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteReferenceImageRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
@@ -983,7 +983,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::DeleteReferenceImageRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :delete_reference_image, mock_method
@@ -1024,9 +1024,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListReferenceImagesRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
@@ -1063,9 +1063,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListReferenceImagesRequest, request
-      assert_equal parent, request.parent
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal parent, request.parent
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_reference_images, mock_method
@@ -1104,7 +1104,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetReferenceImageRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
@@ -1139,7 +1139,7 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::GetReferenceImageRequest, request
-      assert_equal name, request.name
+        assert_equal name, request.name
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :get_reference_image, mock_method
@@ -1179,8 +1179,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AddProductToProductSetRequest, request
-      assert_equal name, request.name
-      assert_equal product, request.product
+        assert_equal name, request.name
+        assert_equal product, request.product
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
@@ -1216,8 +1216,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::AddProductToProductSetRequest, request
-      assert_equal name, request.name
-      assert_equal product, request.product
+        assert_equal name, request.name
+        assert_equal product, request.product
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :add_product_to_product_set, mock_method
@@ -1257,8 +1257,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest, request
-      assert_equal name, request.name
-      assert_equal product, request.product
+        assert_equal name, request.name
+        assert_equal product, request.product
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
@@ -1294,8 +1294,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest, request
-      assert_equal name, request.name
-      assert_equal product, request.product
+        assert_equal name, request.name
+        assert_equal product, request.product
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :remove_product_from_product_set, mock_method
@@ -1336,9 +1336,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsInProductSetRequest, request
-      assert_equal name, request.name
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         OpenStruct.new execute: expected_response
       end
       mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
@@ -1375,9 +1375,9 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ListProductsInProductSetRequest, request
-      assert_equal name, request.name
-      assert_equal page_size, request.page_size
-      assert_equal page_token, request.page_token
+        assert_equal name, request.name
+        assert_equal page_size, request.page_size
+        assert_equal page_token, request.page_token
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :list_products_in_product_set, mock_method
@@ -1424,8 +1424,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1464,8 +1464,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1495,8 +1495,8 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::ImportProductSetsRequest, request
-      assert_equal parent, request.parent
-      assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
+        assert_equal parent, request.parent
+        assert_equal Gapic::Protobuf.coerce(input_config, to: Google::Cloud::Vision::V1::ImportProductSetsInputConfig), request.input_config
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :import_product_sets, mock_method
@@ -1545,10 +1545,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::PurgeProductsRequest, request
-      assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
-      assert_equal delete_orphan_products, request.delete_orphan_products
-      assert_equal parent, request.parent
-      assert_equal force, request.force
+        assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
+        assert_equal delete_orphan_products, request.delete_orphan_products
+        assert_equal parent, request.parent
+        assert_equal force, request.force
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
@@ -1589,10 +1589,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::PurgeProductsRequest, request
-      assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
-      assert_equal delete_orphan_products, request.delete_orphan_products
-      assert_equal parent, request.parent
-      assert_equal force, request.force
+        assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
+        assert_equal delete_orphan_products, request.delete_orphan_products
+        assert_equal parent, request.parent
+        assert_equal force, request.force
         OpenStruct.new execute: operation
       end
       mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method
@@ -1624,10 +1624,10 @@ describe Google::Cloud::Vision::V1::ProductSearch::Client do
       # Mock Grpc layer
       mock_method = proc do |request|
         assert_instance_of Google::Cloud::Vision::V1::PurgeProductsRequest, request
-      assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
-      assert_equal delete_orphan_products, request.delete_orphan_products
-      assert_equal parent, request.parent
-      assert_equal force, request.force
+        assert_equal Gapic::Protobuf.coerce(product_set_purge_config, to: Google::Cloud::Vision::V1::ProductSetPurgeConfig), request.product_set_purge_config
+        assert_equal delete_orphan_products, request.delete_orphan_products
+        assert_equal parent, request.parent
+        assert_equal force, request.force
         raise custom_error
       end
       mock_stub = MockGrpcClientStubV1.new :purge_products, mock_method


### PR DESCRIPTION
Fixes #220 by skipping the `coerce` step for non-message types in unit tests and adds the local mock/error class names to the `service_presenter`.

Adds a rake `validate` task in the `shared` gem to install and run the generated unit test for each library included in the baselines. Note, that the `validate` task must currently be invoked manually and isn't yet part of the CI task because it will fail (see #221). This is getting big so I suggest we tackle that in a followup.