### PR TITLE
Expose operation to paged RPC calls on all pages

### DIFF
--- a/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
+++ b/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
@@ -135,7 +135,7 @@ module Gapic
             Thread.new { operation.execute }
           else
             response = operation.execute
-            response = format_response.call response if format_response
+            response = format_response.call response, operation if format_response
             operation_callback&.call response, operation
             response
           end
@@ -156,7 +156,7 @@ module Gapic
         return unless stream_callback
         return stream_callback unless format_response
 
-        proc { |response| stream_callback.call format_response.call response }
+        proc { |response| stream_callback.call format_response.call(response, nil) }
       end
 
       def calculate_deadline options

--- a/gapic-common/test/gapic/grpc/rpc_call/rpc_call_test.rb
+++ b/gapic-common/test/gapic/grpc/rpc_call/rpc_call_test.rb
@@ -41,7 +41,7 @@ class RpcCallTest < Minitest::Test
       OperationStub.new { 2 + request }
     end
 
-    format_response = ->(response) { response.to_s }
+    format_response = ->(response, _) { response.to_s }
     rpc_call = Gapic::ServiceStub::RpcCall.new api_meth_stub
 
     assert_equal 5, rpc_call.call(3)
@@ -73,7 +73,7 @@ class RpcCallTest < Minitest::Test
       OperationStub.new { 2 + request + adder }
     end
 
-    format_response = ->(response) { response.to_s }
+    format_response = ->(response, _) { response.to_s }
     increment_addr = ->(*args) { adder = 5 }
     rpc_call = Gapic::ServiceStub::RpcCall.new api_meth_stub
 
@@ -112,7 +112,7 @@ class RpcCallTest < Minitest::Test
     end
 
     collect_response = ->(response) { all_responses << response }
-    format_response = ->(response) { response.to_s }
+    format_response = ->(response, _) { response.to_s }
     rpc_call = Gapic::ServiceStub::RpcCall.new api_meth_stub
 
     rpc_call.call([:foo, :bar, :baz].to_enum, stream_callback: collect_response)
@@ -152,7 +152,7 @@ class RpcCallTest < Minitest::Test
       OperationStub.new { requests.each(&block) }
     end
 
-    format_responses = ->(responses) { responses.lazy.map(&:to_s) }
+    format_responses = ->(responses, _) { responses.lazy.map(&:to_s) }
     rpc_call = Gapic::ServiceStub::RpcCall.new api_meth_stub
 
     responses = rpc_call.call [:foo, :bar, :baz].to_enum

--- a/gapic-common/test/gapic/paged_enumerable/enum_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/enum_test.rb
@@ -35,7 +35,7 @@ describe Gapic::PagedEnumerable, :enumerable do
     )
     options = Gapic::CallOptions.new
     paged_enum = Gapic::PagedEnumerable.new(
-      gax_stub, :method_name, request, response, options
+      gax_stub, :method_name, request, response, {}, options
     )
 
     assert_equal %w[foo bar baz bif], paged_enum.each.map(&:name)
@@ -61,7 +61,7 @@ describe Gapic::PagedEnumerable, :enumerable do
     )
     options = Gapic::CallOptions.new
     paged_enum = Gapic::PagedEnumerable.new(
-      gax_stub, :method_name, request, response, options
+      gax_stub, :method_name, request, response, {}, options
     )
 
     assert_equal [2, 2], paged_enum.each_page.map(&:count)

--- a/gapic-common/test/gapic/paged_enumerable/enum_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/enum_test.rb
@@ -66,4 +66,34 @@ describe Gapic::PagedEnumerable, :enumerable do
 
     assert_equal [2, 2], paged_enum.each_page.map(&:count)
   end
+
+  it "enumerates all pages with operations" do
+    api_responses = [
+      Gapic::Examples::GoodPagedResponse.new(
+        users: [
+          Gapic::Examples::User.new(name: "baz"),
+          Gapic::Examples::User.new(name: "bif")
+        ]
+      )
+    ]
+    gax_stub = FakeGapicStub.new(*api_responses)
+    request = Gapic::Examples::GoodPagedRequest.new
+    response = Gapic::Examples::GoodPagedResponse.new(
+      users:           [
+        Gapic::Examples::User.new(name: "foo"),
+        Gapic::Examples::User.new(name: "bar")
+      ],
+      next_page_token: "next"
+    )
+    options = Gapic::CallOptions.new
+    paged_enum = Gapic::PagedEnumerable.new(
+      gax_stub, :method_name, request, response, { initial: true }, options
+    )
+
+    operations = []
+    paged_enum.each_page_with_operation do |_, operation|
+      operations << operation
+    end
+    assert_equal [{ initial: true }, { count: 1 }], operations
+  end
 end

--- a/gapic-common/test/gapic/paged_enumerable/format_resource_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/format_resource_test.rb
@@ -34,9 +34,9 @@ describe Gapic::PagedEnumerable, :format_resource do
       next_page_token: "next"
     )
     options = Gapic::CallOptions.new
-    upcase_resource = ->(user) { user.name.upcase }
+    upcase_resource = ->(user, _) { user.name.upcase }
     paged_enum = Gapic::PagedEnumerable.new(
-      gax_stub, :method_name, request, response, options, format_resource: upcase_resource
+      gax_stub, :method_name, request, response, {}, options, format_resource: upcase_resource
     )
 
     assert_equal ["FOO", "BAR", "BAZ", "BIF"], paged_enum.each.to_a
@@ -61,9 +61,9 @@ describe Gapic::PagedEnumerable, :format_resource do
       next_page_token: "next"
     )
     options = Gapic::CallOptions.new
-    upcase_resource = ->(str) { str.upcase }
+    upcase_resource = ->(str, _) { str.upcase }
     paged_enum = Gapic::PagedEnumerable.new(
-      gax_stub, :method_name, request, response, options, format_resource: upcase_resource
+      gax_stub, :method_name, request, response, {}, options, format_resource: upcase_resource
     )
 
     page_proc = ->(page) { page.each.map(&:name) }

--- a/gapic-common/test/gapic/paged_enumerable/format_resource_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/format_resource_test.rb
@@ -34,7 +34,7 @@ describe Gapic::PagedEnumerable, :format_resource do
       next_page_token: "next"
     )
     options = Gapic::CallOptions.new
-    upcase_resource = ->(user, _) { user.name.upcase }
+    upcase_resource = ->(user) { user.name.upcase }
     paged_enum = Gapic::PagedEnumerable.new(
       gax_stub, :method_name, request, response, {}, options, format_resource: upcase_resource
     )
@@ -61,12 +61,12 @@ describe Gapic::PagedEnumerable, :format_resource do
       next_page_token: "next"
     )
     options = Gapic::CallOptions.new
-    upcase_resource = ->(str, _) { str.upcase }
+    upcase_resource = ->(user) { user.name.upcase }
     paged_enum = Gapic::PagedEnumerable.new(
       gax_stub, :method_name, request, response, {}, options, format_resource: upcase_resource
     )
 
-    page_proc = ->(page) { page.each.map(&:name) }
-    assert_equal [["foo", "bar"], ["baz", "bif"]], paged_enum.each_page.map(&page_proc)
+    page_proc = ->(page) { page.to_a }
+    assert_equal [["FOO", "BAR"], ["BAZ", "BIF"]], paged_enum.each_page.map(&page_proc)
   end
 end

--- a/gapic-common/test/gapic/paged_enumerable/invalid_request_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/invalid_request_test.rb
@@ -22,7 +22,7 @@ class PagedEnumerableInvalidRequestTest < Minitest::Test
 
     error = assert_raises ArgumentError do
       Gapic::PagedEnumerable.new(
-        Object.new, :method_name, request, response, options
+        Object.new, :method_name, request, response, {}, options
       )
     end
     exp_msg = "#{request.class} must have a page_token field (String)"
@@ -36,7 +36,7 @@ class PagedEnumerableInvalidRequestTest < Minitest::Test
 
     error = assert_raises ArgumentError do
       Gapic::PagedEnumerable.new(
-        Object.new, :method_name, request, response, options
+        Object.new, :method_name, request, response, {}, options
       )
     end
     exp_msg = "#{request.class} must have a page_size field (Integer)"

--- a/gapic-common/test/gapic/paged_enumerable/invalid_response_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/invalid_response_test.rb
@@ -22,7 +22,7 @@ class PagedEnumerableInvalidResponseTest < Minitest::Test
 
     error = assert_raises ArgumentError do
       Gapic::PagedEnumerable.new(
-        Object.new, :method_name, request, response, options
+        Object.new, :method_name, request, response, {}, options
       )
     end
     exp_msg = "#{response.class} must have one repeated field"
@@ -36,7 +36,7 @@ class PagedEnumerableInvalidResponseTest < Minitest::Test
 
     error = assert_raises ArgumentError do
       Gapic::PagedEnumerable.new(
-        Object.new, :method_name, request, response, options
+        Object.new, :method_name, request, response, {}, options
       )
     end
     exp_msg = "#{response.class} must have one repeated field"
@@ -50,7 +50,7 @@ class PagedEnumerableInvalidResponseTest < Minitest::Test
 
     error = assert_raises ArgumentError do
       Gapic::PagedEnumerable.new(
-        Object.new, :method_name, request, response, options
+        Object.new, :method_name, request, response, {}, options
       )
     end
     exp_msg = "#{response.class} must have a next_page_token field (String)"
@@ -66,7 +66,7 @@ class PagedEnumerableInvalidResponseTest < Minitest::Test
 
     error = assert_raises ArgumentError do
       Gapic::PagedEnumerable.new(
-        Object.new, :method_name, request, response, options
+        Object.new, :method_name, request, response, {}, options
       )
     end
     exp_msg = "#{response.class} must have one primary repeated field " \

--- a/gapic-common/test/gapic/paged_enumerable/valid_request_response_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/valid_request_response_test.rb
@@ -35,7 +35,7 @@ class PagedEnumerableValidRequestResponseTest < Minitest::Test
     )
     options = Gapic::CallOptions.new
     paged_enum = Gapic::PagedEnumerable.new(
-      gax_stub, :method_name, request, response, options
+      gax_stub, :method_name, request, response, {}, options
     )
 
     assert_equal %w[foo bar baz bif], paged_enum.map(&:name)
@@ -61,7 +61,7 @@ class PagedEnumerableValidRequestResponseTest < Minitest::Test
     )
     options = Gapic::CallOptions.new
     paged_enum = Gapic::PagedEnumerable.new(
-      gax_stub, :method_name, request, response, options
+      gax_stub, :method_name, request, response, {}, options
     )
 
     assert_equal %w[foo bar baz bif], paged_enum.map(&:name)

--- a/gapic-common/test/test_helper.rb
+++ b/gapic-common/test/test_helper.rb
@@ -44,7 +44,11 @@ class FakeGapicStub
   def initialize *responses
     @responses = responses
   end
-  def call_rpc *args
-    @responses.shift
+
+  def call_rpc *_, **keyword_args
+    result = @responses.shift
+    operation_callback = keyword_args[:operation_callback]
+    operation_callback&.call result, {}
+    result
   end
 end

--- a/gapic-common/test/test_helper.rb
+++ b/gapic-common/test/test_helper.rb
@@ -43,12 +43,14 @@ end
 class FakeGapicStub
   def initialize *responses
     @responses = responses
+    @count = 0
   end
 
   def call_rpc *_, **keyword_args
     result = @responses.shift
+    @count += 1
     operation_callback = keyword_args[:operation_callback]
-    operation_callback&.call result, {}
+    operation_callback&.call result, count: @count
     result
   end
 end

--- a/gapic-generator/templates/default/service/client/method/def/_response.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_response.erb
@@ -1,12 +1,12 @@
 <%- assert_locals method -%>
 <%- if method.lro? -%>
-wrap_gax_operation = ->(response) { Gapic::Operation.new(response, <%= method.service.lro_client_ivar %>) }
+wrap_gax_operation = ->(response, operation) { Gapic::Operation.new(response, <%= method.service.lro_client_ivar %>) }
 <%- end -%>
 <%- if method.paged? -%>
 <%- if method.lro? -%>
-wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new(@<%= method.service.stub_name %>, :<%= method.name %>, request, response, options, format_resource: wrap_gax_operation) }
+wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new(@<%= method.service.stub_name %>, :<%= method.name %>, request, response, operation, options, format_resource: wrap_gax_operation) }
 <%- else -%>
-wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new(@<%= method.service.stub_name %>, :<%= method.name %>, request, response, options) }
+wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new(@<%= method.service.stub_name %>, :<%= method.name %>, request, response, operation, options) }
 <%- end -%>
 <%- end -%>
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -357,7 +357,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, options }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, operation, options }
 
             @echo_stub.call_rpc :paged_expand, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
@@ -415,7 +415,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+            wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
             @echo_stub.call_rpc :wait, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -162,8 +162,8 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
+            wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation }
 
             @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
@@ -222,7 +222,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+            wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
             @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -362,7 +362,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, options }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, operation, options }
 
             @identity_stub.call_rpc :list_users, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -366,7 +366,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, options }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, operation, options }
 
             @messaging_stub.call_rpc :list_rooms, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
@@ -653,7 +653,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, options }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, operation, options }
 
             @messaging_stub.call_rpc :list_blurbs, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
@@ -725,7 +725,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+            wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
             @messaging_stub.call_rpc :search_blurbs, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -162,8 +162,8 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
+            wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation }
 
             @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
@@ -222,7 +222,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+            wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
             @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -252,7 +252,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, options }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, operation, options }
 
             @testing_stub.call_rpc :list_sessions, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
@@ -421,7 +421,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, options }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, operation, options }
 
             @testing_stub.call_rpc :list_tests, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -239,7 +239,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @speech_stub.call_rpc :long_running_recognize, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -163,8 +163,8 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation }
 
               @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -223,7 +223,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -314,7 +314,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @image_annotator_stub.call_rpc :async_batch_annotate_images, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
@@ -386,7 +386,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @image_annotator_stub.call_rpc :async_batch_annotate_files, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -163,8 +163,8 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation }
 
               @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -223,7 +223,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -244,7 +244,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, options }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, operation, options }
 
               @product_search_stub.call_rpc :list_product_sets, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -589,7 +589,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, options }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, operation, options }
 
               @product_search_stub.call_rpc :list_products, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -1051,7 +1051,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, options }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, operation, options }
 
               @product_search_stub.call_rpc :list_reference_images, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -1326,7 +1326,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, options }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, operation, options }
 
               @product_search_stub.call_rpc :list_products_in_product_set, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -1405,7 +1405,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @product_search_stub.call_rpc :import_product_sets, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
@@ -1516,7 +1516,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @product_search_stub.call_rpc :purge_products, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -163,8 +163,8 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation }
 
               @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -223,7 +223,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -364,7 +364,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, options }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, operation, options }
 
             @echo_stub.call_rpc :paged_expand, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
@@ -422,7 +422,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+            wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
             @echo_stub.call_rpc :wait, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -170,8 +170,8 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
+            wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation }
 
             @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
@@ -230,7 +230,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+            wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
             @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -369,7 +369,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, options }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, operation, options }
 
             @identity_stub.call_rpc :list_users, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -373,7 +373,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, options }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, operation, options }
 
             @messaging_stub.call_rpc :list_rooms, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
@@ -660,7 +660,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, options }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, operation, options }
 
             @messaging_stub.call_rpc :list_blurbs, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
@@ -732,7 +732,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+            wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
             @messaging_stub.call_rpc :search_blurbs, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -170,8 +170,8 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
+            wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation }
 
             @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
@@ -230,7 +230,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+            wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
             @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -259,7 +259,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, options }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, operation, options }
 
             @testing_stub.call_rpc :list_sessions, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end
@@ -428,7 +428,7 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, options }
+            wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, operation, options }
 
             @testing_stub.call_rpc :list_tests, request, options: options, operation_callback: block, format_response: wrap_paged_enum
           end

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -246,7 +246,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @speech_stub.call_rpc :long_running_recognize, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -171,8 +171,8 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation }
 
               @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -231,7 +231,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -321,7 +321,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @image_annotator_stub.call_rpc :async_batch_annotate_images, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
@@ -393,7 +393,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @image_annotator_stub.call_rpc :async_batch_annotate_files, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -171,8 +171,8 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation }
 
               @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -231,7 +231,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -251,7 +251,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, options }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, operation, options }
 
               @product_search_stub.call_rpc :list_product_sets, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -596,7 +596,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, options }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, operation, options }
 
               @product_search_stub.call_rpc :list_products, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -1058,7 +1058,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, options }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, operation, options }
 
               @product_search_stub.call_rpc :list_reference_images, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -1333,7 +1333,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, options }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, operation, options }
 
               @product_search_stub.call_rpc :list_products_in_product_set, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -1412,7 +1412,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @product_search_stub.call_rpc :import_product_sets, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
@@ -1523,7 +1523,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @product_search_stub.call_rpc :purge_products, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -171,8 +171,8 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
+              wrap_paged_enum = ->(response, operation) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation }
 
               @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
             end
@@ -231,7 +231,7 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              wrap_gax_operation = ->(response, _operation) { Gapic::Operation.new response, @operations_client }
 
               @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end

--- a/shared/test/showcase/echo/echo_test.rb
+++ b/shared/test/showcase/echo/echo_test.rb
@@ -28,4 +28,12 @@ class EchoTest < ShowcaseTest
 
     assert_equal "hi there!", response.content
   end
+
+  def test_echo_with_block
+    @client.echo content: "hello again!" do |response, operation|
+      assert_equal "hello again!", response.content
+      assert_instance_of GRPC::ActiveCall::Operation, operation
+      assert_equal({}, operation.trailing_metadata)
+    end
+  end
 end


### PR DESCRIPTION
The underlying gRPC operation should always be available so that the `trailing_metadata` can be accessed by clients. Currently, this is only possible on the first page of a paginated RPC and this change adds an `operation` property to the `Page` class and exposes the `operation` via the `format_response` callback.

Note that the `format_response` callback returns a nil operation for streaming methods - I'm not sure if we want to also pass the operation to this callback each time or document it as-is. Thoughts?

[resolves #227]