### PR TITLE
Refactor PagedEnumerable format_resource

### DIFF
--- a/gapic-common/test/gapic/paged_enumerable/format_resource_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/format_resource_test.rb
@@ -61,12 +61,12 @@ describe Gapic::PagedEnumerable, :format_resource do
       next_page_token: "next"
     )
     options = Gapic::CallOptions.new
-    upcase_resource = ->(str) { str.upcase }
+    upcase_resource = ->(user) { user.name.upcase }
     paged_enum = Gapic::PagedEnumerable.new(
       gax_stub, :method_name, request, response, options, format_resource: upcase_resource
     )
 
-    page_proc = ->(page) { page.each.map(&:name) }
-    assert_equal [["foo", "bar"], ["baz", "bif"]], paged_enum.each_page.map(&page_proc)
+    page_proc = ->(page) { page.each.to_a }
+    assert_equal [["FOO", "BAR"], ["BAZ", "BIF"]], paged_enum.each_page.map(&page_proc)
   end
 end


### PR DESCRIPTION
Refactor the responsibility for applying a resource format from the PagedEnumerable to the PagedEnumerable's Page object. Fixes an issue where the formatting wasn't applied when accessing the paged resource from a Page object.

Extracted from #228.