### PR TITLE
Add operation to PagedEnumerable::Page

### DIFF
--- a/gapic-common/lib/gapic/paged_enumerable.rb
+++ b/gapic-common/lib/gapic/paged_enumerable.rb
@@ -53,7 +53,7 @@ module Gapic
     # @param method_name [Symbol] The RPC method name.
     # @param request [Object] The request object.
     # @param response [Object] The response object.
-    # @param operation [GRPC::ActiveCall::Operation] the current RPC operation.
+    # @param operation [GRPC::ActiveCall::Operation] the RPC operation for the response.
     # @param options [Gapic::CallOptions] The options for making the RPC call.
     # @param format_resource [Proc] A Proc object to format the resource object. The Proc should accept response as an
     #   argument, and return a formatted resource object. Optional.
@@ -195,9 +195,9 @@ module Gapic
     # resource elements.
     #
     # @attribute [r] response
-    #   @return [Object] the actual response object.
+    #   @return [Object] the response object for the page.
     # @attribute [r] operation
-    #   @return [GRPC::ActiveCall::Operation] the current RPC operation.
+    #   @return [GRPC::ActiveCall::Operation] the RPC operation for the page.
     class Page
       include Enumerable
       attr_reader :response, :operation
@@ -206,7 +206,7 @@ module Gapic
       # @private
       # @param response [Object] The response object for the page.
       # @param resource_field [String] The name of the field in response which holds the resources.
-      # @param operation [GRPC::ActiveCall::Operation] the current RPC operation.
+      # @param operation [GRPC::ActiveCall::Operation] the RPC operation for the page.
       # @param format_resource [Proc] A Proc object to format the resource object. The Proc should accept response as an
       #   argument, and return a formatted resource object. Optional.
       #

--- a/gapic-common/test/gapic/paged_enumerable/enum_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/enum_test.rb
@@ -35,7 +35,7 @@ describe Gapic::PagedEnumerable, :enumerable do
     )
     options = Gapic::CallOptions.new
     paged_enum = Gapic::PagedEnumerable.new(
-      gax_stub, :method_name, request, response, options
+      gax_stub, :method_name, request, response, :fake_operation, options
     )
 
     assert_equal %w[foo bar baz bif], paged_enum.each.map(&:name)
@@ -61,9 +61,39 @@ describe Gapic::PagedEnumerable, :enumerable do
     )
     options = Gapic::CallOptions.new
     paged_enum = Gapic::PagedEnumerable.new(
-      gax_stub, :method_name, request, response, options
+      gax_stub, :method_name, request, response, :fake_operation, options
     )
 
-    assert_equal [2, 2], paged_enum.each_page.map(&:count)
+    assert_equal [["foo", "bar"], ["baz", "bif"]], paged_enum.each_page.map { |page| page.map(&:name) }
+  end
+
+  it "enumerates all pages with operations" do
+    api_responses = [
+      Gapic::Examples::GoodPagedResponse.new(
+        users: [
+          Gapic::Examples::User.new(name: "baz"),
+          Gapic::Examples::User.new(name: "bif")
+        ]
+      )
+    ]
+    gax_stub = FakeGapicStub.new(*api_responses)
+    request = Gapic::Examples::GoodPagedRequest.new
+    response = Gapic::Examples::GoodPagedResponse.new(
+      users:           [
+        Gapic::Examples::User.new(name: "foo"),
+        Gapic::Examples::User.new(name: "bar")
+      ],
+      next_page_token: "next"
+    )
+    options = Gapic::CallOptions.new
+    paged_enum = Gapic::PagedEnumerable.new(
+      gax_stub, :method_name, request, response, :fake_operation, options
+    )
+
+    act_res_w_ops = paged_enum.each_page.map do |page|
+      [page.map(&:name), page.operation]
+    end
+    exp_res_w_ops = [[["foo", "bar"], :fake_operation], [["baz", "bif"], :fake_operation_1]]
+    assert_equal exp_res_w_ops, act_res_w_ops
   end
 end

--- a/gapic-common/test/gapic/paged_enumerable/format_resource_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/format_resource_test.rb
@@ -36,7 +36,7 @@ describe Gapic::PagedEnumerable, :format_resource do
     options = Gapic::CallOptions.new
     upcase_resource = ->(user) { user.name.upcase }
     paged_enum = Gapic::PagedEnumerable.new(
-      gax_stub, :method_name, request, response, options, format_resource: upcase_resource
+      gax_stub, :method_name, request, response, :fake_operation, options, format_resource: upcase_resource
     )
 
     assert_equal ["FOO", "BAR", "BAZ", "BIF"], paged_enum.each.to_a
@@ -63,7 +63,7 @@ describe Gapic::PagedEnumerable, :format_resource do
     options = Gapic::CallOptions.new
     upcase_resource = ->(user) { user.name.upcase }
     paged_enum = Gapic::PagedEnumerable.new(
-      gax_stub, :method_name, request, response, options, format_resource: upcase_resource
+      gax_stub, :method_name, request, response, :fake_operation, options, format_resource: upcase_resource
     )
 
     page_proc = ->(page) { page.each.to_a }

--- a/gapic-common/test/gapic/paged_enumerable/invalid_request_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/invalid_request_test.rb
@@ -22,7 +22,7 @@ class PagedEnumerableInvalidRequestTest < Minitest::Test
 
     error = assert_raises ArgumentError do
       Gapic::PagedEnumerable.new(
-        Object.new, :method_name, request, response, options
+        Object.new, :method_name, request, response, :fake_operation, options
       )
     end
     exp_msg = "#{request.class} must have a page_token field (String)"
@@ -36,7 +36,7 @@ class PagedEnumerableInvalidRequestTest < Minitest::Test
 
     error = assert_raises ArgumentError do
       Gapic::PagedEnumerable.new(
-        Object.new, :method_name, request, response, options
+        Object.new, :method_name, request, response, :fake_operation, options
       )
     end
     exp_msg = "#{request.class} must have a page_size field (Integer)"

--- a/gapic-common/test/gapic/paged_enumerable/invalid_response_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/invalid_response_test.rb
@@ -22,7 +22,7 @@ class PagedEnumerableInvalidResponseTest < Minitest::Test
 
     error = assert_raises ArgumentError do
       Gapic::PagedEnumerable.new(
-        Object.new, :method_name, request, response, options
+        Object.new, :method_name, request, response, :fake_operation, options
       )
     end
     exp_msg = "#{response.class} must have one repeated field"
@@ -36,7 +36,7 @@ class PagedEnumerableInvalidResponseTest < Minitest::Test
 
     error = assert_raises ArgumentError do
       Gapic::PagedEnumerable.new(
-        Object.new, :method_name, request, response, options
+        Object.new, :method_name, request, response, :fake_operation, options
       )
     end
     exp_msg = "#{response.class} must have one repeated field"
@@ -50,7 +50,7 @@ class PagedEnumerableInvalidResponseTest < Minitest::Test
 
     error = assert_raises ArgumentError do
       Gapic::PagedEnumerable.new(
-        Object.new, :method_name, request, response, options
+        Object.new, :method_name, request, response, :fake_operation, options
       )
     end
     exp_msg = "#{response.class} must have a next_page_token field (String)"
@@ -66,7 +66,7 @@ class PagedEnumerableInvalidResponseTest < Minitest::Test
 
     error = assert_raises ArgumentError do
       Gapic::PagedEnumerable.new(
-        Object.new, :method_name, request, response, options
+        Object.new, :method_name, request, response, :fake_operation, options
       )
     end
     exp_msg = "#{response.class} must have one primary repeated field " \

--- a/gapic-common/test/gapic/paged_enumerable/valid_request_response_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/valid_request_response_test.rb
@@ -35,7 +35,7 @@ class PagedEnumerableValidRequestResponseTest < Minitest::Test
     )
     options = Gapic::CallOptions.new
     paged_enum = Gapic::PagedEnumerable.new(
-      gax_stub, :method_name, request, response, options
+      gax_stub, :method_name, request, response, :fake_operation, options
     )
 
     assert_equal %w[foo bar baz bif], paged_enum.map(&:name)
@@ -61,7 +61,7 @@ class PagedEnumerableValidRequestResponseTest < Minitest::Test
     )
     options = Gapic::CallOptions.new
     paged_enum = Gapic::PagedEnumerable.new(
-      gax_stub, :method_name, request, response, options
+      gax_stub, :method_name, request, response, :fake_operation, options
     )
 
     assert_equal %w[foo bar baz bif], paged_enum.map(&:name)

--- a/gapic-common/test/test_helper.rb
+++ b/gapic-common/test/test_helper.rb
@@ -43,8 +43,15 @@ end
 class FakeGapicStub
   def initialize *responses
     @responses = responses
+    @count = 0
   end
-  def call_rpc *args
-    @responses.shift
+
+  def call_rpc *_, **keyword_args
+    result = @responses.shift
+    @count += 1
+    fake_operation = "fake_operation_#{@count}".to_sym
+    operation_callback = keyword_args[:operation_callback]
+    operation_callback&.call result, fake_operation
+    result
   end
 end

--- a/gapic-generator/templates/default/service/client/method/def/_response.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_response.erb
@@ -1,19 +1,6 @@
 <%- assert_locals method -%>
-<%- if method.lro? -%>
-wrap_gax_operation = ->(response) { Gapic::Operation.new(response, <%= method.service.lro_client_ivar %>) }
-<%- end -%>
 <%- if method.paged? -%>
-<%- if method.lro? -%>
-wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new(@<%= method.service.stub_name %>, :<%= method.name %>, request, response, options, format_resource: wrap_gax_operation) }
+<%= render partial: "service/client/method/def/response_paged", locals: { method: method } -%>
 <%- else -%>
-wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new(@<%= method.service.stub_name %>, :<%= method.name %>, request, response, options) }
-<%- end -%>
-<%- end -%>
-
-<%- if method.paged? -%>
-@<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options, operation_callback: block, format_response: wrap_paged_enum
-<%- elsif method.lro? -%>
-@<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options, operation_callback: block, format_response: wrap_gax_operation
-<%- else -%>
-@<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options, operation_callback: block
+<%= render partial: "service/client/method/def/response_normal", locals: { method: method } -%>
 <%- end -%>

--- a/gapic-generator/templates/default/service/client/method/def/_response_normal.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_response_normal.erb
@@ -1,0 +1,5 @@
+<%- assert_locals method -%>
+<%- if method.lro? -%>
+wrap_gax_operation = ->(response) { Gapic::Operation.new(response, <%= method.service.lro_client_ivar %>) }
+<%- end -%>
+@<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options, operation_callback: block<%- if method.lro? -%>, format_response: wrap_gax_operation<%- end -%>

--- a/gapic-generator/templates/default/service/client/method/def/_response_paged.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_response_paged.erb
@@ -1,0 +1,11 @@
+<%- assert_locals method -%>
+<%- if method.lro? -%>
+wrap_gax_operation = ->(response) { Gapic::Operation.new(response, <%= method.service.lro_client_ivar %>) }
+<%- end -%>
+paged_response = nil
+paged_operation_callback = ->(response, operation) do
+  paged_response = Gapic::PagedEnumerable.new @<%= method.service.stub_name %>, :<%= method.name %>, request, response, operation, options<%- if method.lro? -%>, format_resource: wrap_gax_operation<%- end -%>
+  block.call paged_response, operation if block
+end
+@<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options, operation_callback: paged_operation_callback
+paged_response

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -357,9 +357,13 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, options }
-
-            @echo_stub.call_rpc :paged_expand, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, operation, options
+              yield paged_response, operation if block
+            end
+            @echo_stub.call_rpc :paged_expand, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##
@@ -416,7 +420,6 @@ module Google
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
             @echo_stub.call_rpc :wait, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -163,9 +163,13 @@ module Google
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
-
-            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+              yield paged_response, operation if block
+            end
+            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##
@@ -223,7 +227,6 @@ module Google
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
             @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -362,9 +362,13 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, options }
-
-            @identity_stub.call_rpc :list_users, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, operation, options
+              yield paged_response, operation if block
+            end
+            @identity_stub.call_rpc :list_users, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           class Configuration

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -366,9 +366,13 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, options }
-
-            @messaging_stub.call_rpc :list_rooms, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, operation, options
+              yield paged_response, operation if block
+            end
+            @messaging_stub.call_rpc :list_rooms, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##
@@ -653,9 +657,13 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, options }
-
-            @messaging_stub.call_rpc :list_blurbs, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, operation, options
+              yield paged_response, operation if block
+            end
+            @messaging_stub.call_rpc :list_blurbs, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##
@@ -726,7 +734,6 @@ module Google
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
             @messaging_stub.call_rpc :search_blurbs, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -163,9 +163,13 @@ module Google
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
-
-            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+              yield paged_response, operation if block
+            end
+            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##
@@ -223,7 +227,6 @@ module Google
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
             @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -252,9 +252,13 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, options }
-
-            @testing_stub.call_rpc :list_sessions, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, operation, options
+              yield paged_response, operation if block
+            end
+            @testing_stub.call_rpc :list_sessions, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##
@@ -421,9 +425,13 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, options }
-
-            @testing_stub.call_rpc :list_tests, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, operation, options
+              yield paged_response, operation if block
+            end
+            @testing_stub.call_rpc :list_tests, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -275,7 +275,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @speech_stub.call_rpc :long_running_recognize, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -164,9 +164,13 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
-
-              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                yield paged_response, operation if block
+              end
+              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -224,7 +228,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -315,7 +315,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @image_annotator_stub.call_rpc :async_batch_annotate_images, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
@@ -387,7 +386,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @image_annotator_stub.call_rpc :async_batch_annotate_files, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -164,9 +164,13 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
-
-              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                yield paged_response, operation if block
+              end
+              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -224,7 +228,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -244,9 +244,13 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, options }
-
-              @product_search_stub.call_rpc :list_product_sets, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, operation, options
+                yield paged_response, operation if block
+              end
+              @product_search_stub.call_rpc :list_product_sets, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -589,9 +593,13 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, options }
-
-              @product_search_stub.call_rpc :list_products, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, operation, options
+                yield paged_response, operation if block
+              end
+              @product_search_stub.call_rpc :list_products, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -1051,9 +1059,13 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, options }
-
-              @product_search_stub.call_rpc :list_reference_images, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, operation, options
+                yield paged_response, operation if block
+              end
+              @product_search_stub.call_rpc :list_reference_images, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -1326,9 +1338,13 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, options }
-
-              @product_search_stub.call_rpc :list_products_in_product_set, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, operation, options
+                yield paged_response, operation if block
+              end
+              @product_search_stub.call_rpc :list_products_in_product_set, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -1406,7 +1422,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @product_search_stub.call_rpc :import_product_sets, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
@@ -1517,7 +1532,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @product_search_stub.call_rpc :purge_products, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -164,9 +164,13 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
-
-              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                yield paged_response, operation if block
+              end
+              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -224,7 +228,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -364,9 +364,13 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, options }
-
-            @echo_stub.call_rpc :paged_expand, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, operation, options
+              yield paged_response, operation if block
+            end
+            @echo_stub.call_rpc :paged_expand, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##
@@ -423,7 +427,6 @@ module Google
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
             @echo_stub.call_rpc :wait, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -171,9 +171,13 @@ module Google
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
-
-            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+              yield paged_response, operation if block
+            end
+            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##
@@ -231,7 +235,6 @@ module Google
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
             @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -369,9 +369,13 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, options }
-
-            @identity_stub.call_rpc :list_users, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, operation, options
+              yield paged_response, operation if block
+            end
+            @identity_stub.call_rpc :list_users, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           class Configuration

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -373,9 +373,13 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, options }
-
-            @messaging_stub.call_rpc :list_rooms, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, operation, options
+              yield paged_response, operation if block
+            end
+            @messaging_stub.call_rpc :list_rooms, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##
@@ -660,9 +664,13 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, options }
-
-            @messaging_stub.call_rpc :list_blurbs, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, operation, options
+              yield paged_response, operation if block
+            end
+            @messaging_stub.call_rpc :list_blurbs, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##
@@ -733,7 +741,6 @@ module Google
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
             @messaging_stub.call_rpc :search_blurbs, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -171,9 +171,13 @@ module Google
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
-
-            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+              yield paged_response, operation if block
+            end
+            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##
@@ -231,7 +235,6 @@ module Google
                                    retry_policy: @config.retry_policy
 
             wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
             @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
           end
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -259,9 +259,13 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, options }
-
-            @testing_stub.call_rpc :list_sessions, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, operation, options
+              yield paged_response, operation if block
+            end
+            @testing_stub.call_rpc :list_sessions, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##
@@ -428,9 +432,13 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, options }
-
-            @testing_stub.call_rpc :list_tests, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+            paged_response = nil
+            paged_operation_callback = lambda do |response, operation|
+              paged_response = Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, operation, options
+              yield paged_response, operation if block
+            end
+            @testing_stub.call_rpc :list_tests, request, options: options, operation_callback: paged_operation_callback
+            paged_response
           end
 
           ##

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -282,7 +282,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @speech_stub.call_rpc :long_running_recognize, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -172,9 +172,13 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
-
-              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                yield paged_response, operation if block
+              end
+              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -232,7 +236,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -322,7 +322,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @image_annotator_stub.call_rpc :async_batch_annotate_images, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
@@ -394,7 +393,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @image_annotator_stub.call_rpc :async_batch_annotate_files, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -172,9 +172,13 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
-
-              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                yield paged_response, operation if block
+              end
+              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -232,7 +236,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -251,9 +251,13 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, options }
-
-              @product_search_stub.call_rpc :list_product_sets, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, operation, options
+                yield paged_response, operation if block
+              end
+              @product_search_stub.call_rpc :list_product_sets, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -596,9 +600,13 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, options }
-
-              @product_search_stub.call_rpc :list_products, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, operation, options
+                yield paged_response, operation if block
+              end
+              @product_search_stub.call_rpc :list_products, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -1058,9 +1066,13 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, options }
-
-              @product_search_stub.call_rpc :list_reference_images, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, operation, options
+                yield paged_response, operation if block
+              end
+              @product_search_stub.call_rpc :list_reference_images, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -1333,9 +1345,13 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, options }
-
-              @product_search_stub.call_rpc :list_products_in_product_set, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, operation, options
+                yield paged_response, operation if block
+              end
+              @product_search_stub.call_rpc :list_products_in_product_set, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -1413,7 +1429,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @product_search_stub.call_rpc :import_product_sets, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 
@@ -1524,7 +1539,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @product_search_stub.call_rpc :purge_products, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -172,9 +172,13 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              wrap_paged_enum = ->(response) { Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, options, format_resource: wrap_gax_operation }
-
-              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: block, format_response: wrap_paged_enum
+              paged_response = nil
+              paged_operation_callback = lambda do |response, operation|
+                paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                yield paged_response, operation if block
+              end
+              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
+              paged_response
             end
 
             ##
@@ -232,7 +236,6 @@ module Google
                                      retry_policy: @config.retry_policy
 
               wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-
               @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
             end
 


### PR DESCRIPTION
This allows for users to access trailing metadata by enumerating each page of the response at a time. Paged client methods have been updated to create a PagedEnumerable object in the method instead of using a response formatter proc.

Extracted from #228.