### PR TITLE
Simplify RPC calls by removing named procs

### DIFF
--- a/gapic-common/lib/gapic/grpc/service_stub.rb
+++ b/gapic-common/lib/gapic/grpc/service_stub.rb
@@ -131,7 +131,7 @@ module Gapic
     #   response = echo_stub.call_rpc :echo, request
     #                                 options: options
     #
-    # @example Accessing the request and RPC operation using a block:
+    # @example Accessing the response and RPC operation using a block:
     #   require "google/showcase/v1beta1/echo_pb"
     #   require "google/showcase/v1beta1/echo_services_pb"
     #   require "gapic"

--- a/gapic-common/lib/gapic/grpc/service_stub.rb
+++ b/gapic-common/lib/gapic/grpc/service_stub.rb
@@ -84,19 +84,12 @@ module Gapic
     # @param options [Gapic::CallOptions, Hash] The options for making the RPC call. A Hash can be provided to
     #   customize the options object, using keys that match the arguments for {Gapic::CallOptions.new}. This object
     #   should only be used once.
-    # @param format_response [Proc] A Proc object to format the response object. The Proc should accept response as
-    #   an argument, and return a formatted response object. Optional.
     #
-    #   If `stream_callback` is also provided, the response argument will be an Enumerable of the responses.
-    #   Returning a lazy enumerable that adds the desired formatting is recommended.
-    # @param operation_callback [Proc] A Proc object to provide a callback of the response and operation objects.
-    #   The response will be formatted with `format_response` if that is also provided. Optional.
-    # @param stream_callback [Proc] A Proc object to provide a callback for every streamed response received. The
-    #   Proc will be called with the response object. Should only be used on Bidi and Server streaming RPC calls.
-    #   Optional.
+    # @yield [response, operation] Access the response along with the RPC operation.
+    # @yieldparam response [Object] The response object.
+    # @yieldparam operation [GRPC::ActiveCall::Operation] The RPC operation for the response.
     #
-    # @return [Object, Thread] The response object. Or, when `stream_callback` is provided, a thread running the
-    #   callback for every streamed response is returned.
+    # @return [Object] The response object.
     #
     # @example
     #   require "google/showcase/v1beta1/echo_pb"
@@ -138,7 +131,7 @@ module Gapic
     #   response = echo_stub.call_rpc :echo, request
     #                                 options: options
     #
-    # @example Formatting the response in the call:
+    # @example Accessing the request and RPC operation using a block:
     #   require "google/showcase/v1beta1/echo_pb"
     #   require "google/showcase/v1beta1/echo_services_pb"
     #   require "gapic"
@@ -153,21 +146,13 @@ module Gapic
     #   )
     #
     #   request = Google::Showcase::V1beta1::EchoRequest.new
-    #   content_upcaser = proc do |response|
-    #     format_response = response.dup
-    #     format_response.content.upcase!
-    #     format_response
+    #   echo_stub.call_rpc :echo, request do |response, operation|
+    #     operation.trailing_metadata
     #   end
-    #   response = echo_stub.call_rpc :echo, request,
-    #                                 format_response: content_upcaser
     #
-    def call_rpc method_name, request, options: nil, format_response: nil, operation_callback: nil,
-                 stream_callback: nil
+    def call_rpc method_name, request, options: nil, &block
       rpc_call = RpcCall.new @grpc_stub.method method_name
-      rpc_call.call request, options:            options,
-                             format_response:    format_response,
-                             operation_callback: operation_callback,
-                             stream_callback:    stream_callback
+      rpc_call.call request, options: options, &block
     end
   end
 end

--- a/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
+++ b/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
@@ -91,7 +91,7 @@ module Gapic
       #   )
       #   response = echo_call.call request, options: options
       #
-      # @example Accessing the request and RPC operation using a block:
+      # @example Accessing the response and RPC operation using a block:
       #   require "google/showcase/v1beta1/echo_pb"
       #   require "google/showcase/v1beta1/echo_services_pb"
       #   require "gapic"

--- a/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
+++ b/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
@@ -43,19 +43,12 @@ module Gapic
       # @param options [Gapic::CallOptions, Hash] The options for making the RPC call. A Hash can be provided to
       #   customize the options object, using keys that match the arguments for {Gapic::CallOptions.new}. This object
       #   should only be used once.
-      # @param format_response [Proc] A Proc object to format the response object. The Proc should accept response as
-      #   an argument, and return a formatted response object. Optional.
       #
-      #   If `stream_callback` is also provided, the response argument will be an Enumerable of the responses.
-      #   Returning a lazy enumerable that adds the desired formatting is recommended.
-      # @param operation_callback [Proc] A Proc object to provide a callback of the response and operation objects.
-      #   The response will be formatted with `format_response` if that is also provided. Optional.
-      # @param stream_callback [Proc] A Proc object to provide a callback for every streamed response received. The
-      #   Proc will be called with the response object. Should only be used on Bidi and Server streaming RPC calls.
-      #   Optional.
+      # @yield [response, operation] Access the response along with the RPC operation.
+      # @yieldparam response [Object] The response object.
+      # @yieldparam operation [GRPC::ActiveCall::Operation] The RPC operation for the response.
       #
-      # @return [Object, Thread] The response object. Or, when `stream_callback` is provided, a thread running the
-      #   callback for every streamed response is returned.
+      # @return [Object] The response object.
       #
       # @example
       #   require "google/showcase/v1beta1/echo_pb"
@@ -98,7 +91,7 @@ module Gapic
       #   )
       #   response = echo_call.call request, options: options
       #
-      # @example Formatting the response in the call:
+      # @example Accessing the request and RPC operation using a block:
       #   require "google/showcase/v1beta1/echo_pb"
       #   require "google/showcase/v1beta1/echo_services_pb"
       #   require "gapic"
@@ -114,31 +107,21 @@ module Gapic
       #   echo_call = Gapic::ServiceStub::RpcCall.new echo_stub.method :echo
       #
       #   request = Google::Showcase::V1beta1::EchoRequest.new
-      #   content_upcaser = proc do |response|
-      #     format_response = response.dup
-      #     format_response.content.upcase!
-      #     format_response
+      #   echo_call.call request do |response, operation|
+      #     operation.trailing_metadata
       #   end
-      #   response = echo_call.call request, format_response: content_upcaser
       #
-      def call request, options: nil, format_response: nil, operation_callback: nil, stream_callback: nil
+      def call request, options: nil
         # Converts hash and nil to an options object
         options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
-        stream_proc = compose_stream_proc stream_callback: stream_callback, format_response: format_response
         deadline = calculate_deadline options
         metadata = options.metadata
 
         begin
-          operation = stub_method.call request, deadline: deadline, metadata: metadata, return_op: true, &stream_proc
-
-          if stream_proc
-            Thread.new { operation.execute }
-          else
-            response = operation.execute
-            response = format_response.call response if format_response
-            operation_callback&.call response, operation
-            response
-          end
+          operation = stub_method.call request, deadline: deadline, metadata: metadata, return_op: true
+          response = operation.execute
+          yield response, operation if block_given?
+          response
         rescue StandardError => error
           if check_retry? deadline
             retry if options.retry_policy.call error
@@ -151,13 +134,6 @@ module Gapic
       end
 
       private
-
-      def compose_stream_proc stream_callback: nil, format_response: nil
-        return unless stream_callback
-        return stream_callback unless format_response
-
-        proc { |response| stream_callback.call format_response.call response }
-      end
 
       def calculate_deadline options
         Time.now + options.timeout

--- a/gapic-common/test/gapic/paged_enumerable/format_resource_test.rb
+++ b/gapic-common/test/gapic/paged_enumerable/format_resource_test.rb
@@ -15,7 +15,7 @@
 require "test_helper"
 
 describe Gapic::PagedEnumerable, :format_resource do
-  it "enumerates all resources and formats them" do
+  it "enumerates all resources" do
     api_responses = [
       Gapic::Examples::GoodPagedResponse.new(
         users: [
@@ -36,10 +36,10 @@ describe Gapic::PagedEnumerable, :format_resource do
     options = Gapic::CallOptions.new
     upcase_resource = ->(user) { user.name.upcase }
     paged_enum = Gapic::PagedEnumerable.new(
-      gax_stub, :method_name, request, response, :fake_operation, options, format_resource: upcase_resource
+      gax_stub, :method_name, request, response, :fake_operation, options
     )
 
-    assert_equal ["FOO", "BAR", "BAZ", "BIF"], paged_enum.each.to_a
+    assert_equal ["FOO", "BAR", "BAZ", "BIF"], paged_enum.each.map { |user| user.name.upcase }
   end
 
   it "enumerates all pages and formats the resources" do

--- a/gapic-common/test/test_helper.rb
+++ b/gapic-common/test/test_helper.rb
@@ -46,12 +46,11 @@ class FakeGapicStub
     @count = 0
   end
 
-  def call_rpc *_, **keyword_args
+  def call_rpc *args
     result = @responses.shift
     @count += 1
     fake_operation = "fake_operation_#{@count}".to_sym
-    operation_callback = keyword_args[:operation_callback]
-    operation_callback&.call result, fake_operation
+    yield result, fake_operation if block_given?
     result
   end
 end

--- a/gapic-generator/templates/default/service/client/method/_def.erb
+++ b/gapic-generator/templates/default/service/client/method/_def.erb
@@ -11,7 +11,7 @@
 # @raise [Gapic::GapicError] if the RPC is aborted.
 #
 <%= render partial: "service/client/method/docs/samples", locals: { method: method } -%>
-def <%= method.name %> request, options = nil, &block
+def <%= method.name %> request, options = nil
 <%= indent render(partial: "service/client/method/def/request", locals: { method: method }), 2 %>
 
 <%= indent render(partial: "service/client/method/def/options_defaults", locals: { method: method }), 2 %>

--- a/gapic-generator/templates/default/service/client/method/def/_response_normal.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_response_normal.erb
@@ -1,5 +1,8 @@
 <%- assert_locals method -%>
-<%- if method.lro? -%>
-wrap_gax_operation = ->(response) { Gapic::Operation.new(response, <%= method.service.lro_client_ivar %>) }
-<%- end -%>
-@<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options, operation_callback: block<%- if method.lro? -%>, format_response: wrap_gax_operation<%- end -%>
+@<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options do |response, operation|
+  <%- if method.lro? -%>
+  response = Gapic::Operation.new response, <%= method.service.lro_client_ivar %>
+  <%- end -%>
+  yield response, operation if block_given?
+  return response
+end

--- a/gapic-generator/templates/default/service/client/method/def/_response_paged.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_response_paged.erb
@@ -1,11 +1,9 @@
 <%- assert_locals method -%>
-<%- if method.lro? -%>
-wrap_gax_operation = ->(response) { Gapic::Operation.new(response, <%= method.service.lro_client_ivar %>) }
-<%- end -%>
-paged_response = nil
-paged_operation_callback = ->(response, operation) do
-  paged_response = Gapic::PagedEnumerable.new @<%= method.service.stub_name %>, :<%= method.name %>, request, response, operation, options<%- if method.lro? -%>, format_resource: wrap_gax_operation<%- end -%>
-  block.call paged_response, operation if block
+@<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options do |response, operation|
+  <%- if method.lro? -%>
+  wrap_gax_operation = ->(response) { Gapic::Operation.new(response, <%= method.service.lro_client_ivar %>) }
+  <%- end -%>
+  response = Gapic::PagedEnumerable.new @<%= method.service.stub_name %>, :<%= method.name %>, request, response, operation, options<%- if method.lro? -%>, format_resource: wrap_gax_operation<%- end -%>
+  yield response, operation if block_given?
+  return response
 end
-@<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options, operation_callback: paged_operation_callback
-paged_response

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
@@ -126,7 +126,7 @@ module Google
               #
               # @raise [Google::Ads::GoogleAdsError] if the RPC is aborted.
               #
-              def get_campaign request, options = nil, &block
+              def get_campaign request, options = nil
                 raise ArgumentError, "request must be provided" if request.nil?
 
                 request = Gapic::Protobuf.coerce request, to: Google::Ads::GoogleAds::V1::Services::GetCampaignRequest
@@ -154,7 +154,10 @@ module Google
                 options.apply_defaults metadata:     @config.metadata,
                                        retry_policy: @config.retry_policy
 
-                @campaign_service_stub.call_rpc :get_campaign, request, options: options, operation_callback: block
+                @campaign_service_stub.call_rpc :get_campaign, request, options: options do |response, operation|
+                  yield response, operation if block_given?
+                  return response
+                end
                 # rescue Gapic::GapicError => gax_error
                 #  raise Doogle::Ads::GoogleAds::Error.new gax_error.message
               end
@@ -191,7 +194,7 @@ module Google
               #
               # @raise [Google::Ads::GoogleAdsError] if the RPC is aborted.
               #
-              def mutate_campaigns request, options = nil, &block
+              def mutate_campaigns request, options = nil
                 raise ArgumentError, "request must be provided" if request.nil?
 
                 request = Gapic::Protobuf.coerce request, to: Google::Ads::GoogleAds::V1::Services::MutateCampaignsRequest
@@ -219,7 +222,10 @@ module Google
                 options.apply_defaults metadata:     @config.metadata,
                                        retry_policy: @config.retry_policy
 
-                @campaign_service_stub.call_rpc :mutate_campaigns, request, options: options, operation_callback: block
+                @campaign_service_stub.call_rpc :mutate_campaigns, request, options: options do |response, operation|
+                  yield response, operation if block_given?
+                  return response
+                end
                 # rescue Gapic::GapicError => gax_error
                 #  raise Doogle::Ads::GoogleAds::Error.new gax_error.message
               end

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -129,7 +129,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def echo request, options = nil, &block
+          def echo request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::EchoRequest
@@ -151,7 +151,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @echo_stub.call_rpc :echo, request, options: options, operation_callback: block
+            @echo_stub.call_rpc :echo, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -180,7 +183,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def expand request, options = nil, &block
+          def expand request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ExpandRequest
@@ -202,7 +205,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @echo_stub.call_rpc :expand, request, options: options, operation_callback: block
+            @echo_stub.call_rpc :expand, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -223,7 +229,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def collect request, options = nil, &block
+          def collect request, options = nil
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -253,7 +259,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @echo_stub.call_rpc :collect, request, options: options, operation_callback: block
+            @echo_stub.call_rpc :collect, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -274,7 +283,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def chat request, options = nil, &block
+          def chat request, options = nil
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -304,7 +313,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @echo_stub.call_rpc :chat, request, options: options, operation_callback: block
+            @echo_stub.call_rpc :chat, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -335,7 +347,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def paged_expand request, options = nil, &block
+          def paged_expand request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::PagedExpandRequest
@@ -357,13 +369,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, operation, options
-              yield paged_response, operation if block
+            @echo_stub.call_rpc :paged_expand, request, options: options do |response, operation|
+              response = Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, operation, options
+              yield response, operation if block_given?
+              return response
             end
-            @echo_stub.call_rpc :paged_expand, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -397,7 +407,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def wait request, options = nil, &block
+          def wait request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::WaitRequest
@@ -419,8 +429,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            @echo_stub.call_rpc :wait, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @echo_stub.call_rpc :wait, request, options: options do |response, operation|
+              response = Gapic::Operation.new response, @operations_client
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -454,7 +467,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def block request, options = nil, &block
+          def block request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::BlockRequest
@@ -476,7 +489,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @echo_stub.call_rpc :block, request, options: options, operation_callback: block
+            @echo_stub.call_rpc :block, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           class Configuration

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -134,7 +134,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_operations request, options = nil, &block
+          def list_operations request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
@@ -162,14 +162,12 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
-              yield paged_response, operation if block
+            @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
+              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+              yield response, operation if block_given?
+              return response
             end
-            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -198,7 +196,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def get_operation request, options = nil, &block
+          def get_operation request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
@@ -226,8 +224,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
+              response = Gapic::Operation.new response, @operations_client
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -258,7 +259,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_operation request, options = nil, &block
+          def delete_operation request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
@@ -286,7 +287,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
+            @operations_stub.call_rpc :delete_operation, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -329,7 +333,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def cancel_operation request, options = nil, &block
+          def cancel_operation request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
@@ -357,7 +361,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
+            @operations_stub.call_rpc :cancel_operation, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           class Configuration

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -126,7 +126,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def create_user request, options = nil, &block
+          def create_user request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::CreateUserRequest
@@ -148,7 +148,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @identity_stub.call_rpc :create_user, request, options: options, operation_callback: block
+            @identity_stub.call_rpc :create_user, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -173,7 +176,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def get_user request, options = nil, &block
+          def get_user request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::GetUserRequest
@@ -201,7 +204,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @identity_stub.call_rpc :get_user, request, options: options, operation_callback: block
+            @identity_stub.call_rpc :get_user, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -229,7 +235,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def update_user request, options = nil, &block
+          def update_user request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::UpdateUserRequest
@@ -257,7 +263,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @identity_stub.call_rpc :update_user, request, options: options, operation_callback: block
+            @identity_stub.call_rpc :update_user, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -282,7 +291,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_user request, options = nil, &block
+          def delete_user request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteUserRequest
@@ -310,7 +319,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @identity_stub.call_rpc :delete_user, request, options: options, operation_callback: block
+            @identity_stub.call_rpc :delete_user, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -340,7 +352,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_users request, options = nil, &block
+          def list_users request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListUsersRequest
@@ -362,13 +374,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, operation, options
-              yield paged_response, operation if block
+            @identity_stub.call_rpc :list_users, request, options: options do |response, operation|
+              response = Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, operation, options
+              yield response, operation if block_given?
+              return response
             end
-            @identity_stub.call_rpc :list_users, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           class Configuration

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -130,7 +130,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def create_room request, options = nil, &block
+          def create_room request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::CreateRoomRequest
@@ -152,7 +152,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :create_room, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :create_room, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -177,7 +180,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def get_room request, options = nil, &block
+          def get_room request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::GetRoomRequest
@@ -205,7 +208,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :get_room, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :get_room, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -233,7 +239,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def update_room request, options = nil, &block
+          def update_room request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::UpdateRoomRequest
@@ -261,7 +267,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :update_room, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :update_room, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -286,7 +295,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_room request, options = nil, &block
+          def delete_room request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteRoomRequest
@@ -314,7 +323,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :delete_room, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :delete_room, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -344,7 +356,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_rooms request, options = nil, &block
+          def list_rooms request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListRoomsRequest
@@ -366,13 +378,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, operation, options
-              yield paged_response, operation if block
+            @messaging_stub.call_rpc :list_rooms, request, options: options do |response, operation|
+              response = Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, operation, options
+              yield response, operation if block_given?
+              return response
             end
-            @messaging_stub.call_rpc :list_rooms, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -404,7 +414,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def create_blurb request, options = nil, &block
+          def create_blurb request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::CreateBlurbRequest
@@ -432,7 +442,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :create_blurb, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :create_blurb, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -457,7 +470,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def get_blurb request, options = nil, &block
+          def get_blurb request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::GetBlurbRequest
@@ -485,7 +498,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :get_blurb, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :get_blurb, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -513,7 +529,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def update_blurb request, options = nil, &block
+          def update_blurb request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::UpdateBlurbRequest
@@ -541,7 +557,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :update_blurb, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :update_blurb, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -566,7 +585,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_blurb request, options = nil, &block
+          def delete_blurb request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteBlurbRequest
@@ -594,7 +613,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :delete_blurb, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :delete_blurb, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -629,7 +651,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_blurbs request, options = nil, &block
+          def list_blurbs request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListBlurbsRequest
@@ -657,13 +679,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, operation, options
-              yield paged_response, operation if block
+            @messaging_stub.call_rpc :list_blurbs, request, options: options do |response, operation|
+              response = Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, operation, options
+              yield response, operation if block_given?
+              return response
             end
-            @messaging_stub.call_rpc :list_blurbs, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -705,7 +725,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def search_blurbs request, options = nil, &block
+          def search_blurbs request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::SearchBlurbsRequest
@@ -733,8 +753,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            @messaging_stub.call_rpc :search_blurbs, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @messaging_stub.call_rpc :search_blurbs, request, options: options do |response, operation|
+              response = Gapic::Operation.new response, @operations_client
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -763,7 +786,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def stream_blurbs request, options = nil, &block
+          def stream_blurbs request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::StreamBlurbsRequest
@@ -791,7 +814,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :stream_blurbs, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :stream_blurbs, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -811,7 +837,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def send_blurbs request, options = nil, &block
+          def send_blurbs request, options = nil
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -847,7 +873,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :send_blurbs, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :send_blurbs, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -869,7 +898,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def connect request, options = nil, &block
+          def connect request, options = nil
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -899,7 +928,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :connect, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :connect, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           class Configuration

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -134,7 +134,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_operations request, options = nil, &block
+          def list_operations request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
@@ -162,14 +162,12 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
-              yield paged_response, operation if block
+            @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
+              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+              yield response, operation if block_given?
+              return response
             end
-            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -198,7 +196,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def get_operation request, options = nil, &block
+          def get_operation request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
@@ -226,8 +224,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
+              response = Gapic::Operation.new response, @operations_client
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -258,7 +259,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_operation request, options = nil, &block
+          def delete_operation request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
@@ -286,7 +287,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
+            @operations_stub.call_rpc :delete_operation, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -329,7 +333,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def cancel_operation request, options = nil, &block
+          def cancel_operation request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
@@ -357,7 +361,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
+            @operations_stub.call_rpc :cancel_operation, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           class Configuration

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -128,7 +128,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def create_session request, options = nil, &block
+          def create_session request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::CreateSessionRequest
@@ -150,7 +150,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @testing_stub.call_rpc :create_session, request, options: options, operation_callback: block
+            @testing_stub.call_rpc :create_session, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -175,7 +178,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def get_session request, options = nil, &block
+          def get_session request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::GetSessionRequest
@@ -203,7 +206,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @testing_stub.call_rpc :get_session, request, options: options, operation_callback: block
+            @testing_stub.call_rpc :get_session, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -230,7 +236,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_sessions request, options = nil, &block
+          def list_sessions request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListSessionsRequest
@@ -252,13 +258,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, operation, options
-              yield paged_response, operation if block
+            @testing_stub.call_rpc :list_sessions, request, options: options do |response, operation|
+              response = Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, operation, options
+              yield response, operation if block_given?
+              return response
             end
-            @testing_stub.call_rpc :list_sessions, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -283,7 +287,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_session request, options = nil, &block
+          def delete_session request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteSessionRequest
@@ -311,7 +315,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @testing_stub.call_rpc :delete_session, request, options: options, operation_callback: block
+            @testing_stub.call_rpc :delete_session, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -340,7 +347,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def report_session request, options = nil, &block
+          def report_session request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ReportSessionRequest
@@ -368,7 +375,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @testing_stub.call_rpc :report_session, request, options: options, operation_callback: block
+            @testing_stub.call_rpc :report_session, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -397,7 +407,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_tests request, options = nil, &block
+          def list_tests request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListTestsRequest
@@ -425,13 +435,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, operation, options
-              yield paged_response, operation if block
+            @testing_stub.call_rpc :list_tests, request, options: options do |response, operation|
+              response = Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, operation, options
+              yield response, operation if block_given?
+              return response
             end
-            @testing_stub.call_rpc :list_tests, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -466,7 +474,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_test request, options = nil, &block
+          def delete_test request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteTestRequest
@@ -494,7 +502,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @testing_stub.call_rpc :delete_test, request, options: options, operation_callback: block
+            @testing_stub.call_rpc :delete_test, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -529,7 +540,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def verify_test request, options = nil, &block
+          def verify_test request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::VerifyTestRequest
@@ -557,7 +568,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @testing_stub.call_rpc :verify_test, request, options: options, operation_callback: block
+            @testing_stub.call_rpc :verify_test, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           class Configuration

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -161,7 +161,7 @@ module Google
             #     puts "Transcript: #{alternative.transcript}"
             #   end
             #
-            def recognize request, options = nil, &block
+            def recognize request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Speech::V1::RecognizeRequest
@@ -183,7 +183,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @speech_stub.call_rpc :recognize, request, options: options, operation_callback: block
+              @speech_stub.call_rpc :recognize, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -252,7 +255,7 @@ module Google
             #     puts "End time: #{word.end_time.seconds} seconds #{word.end_time.nanos} nanos"
             #   end
             #
-            def long_running_recognize request, options = nil, &block
+            def long_running_recognize request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Speech::V1::LongRunningRecognizeRequest
@@ -274,8 +277,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @speech_stub.call_rpc :long_running_recognize, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @speech_stub.call_rpc :long_running_recognize, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -295,7 +301,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def streaming_recognize request, options = nil, &block
+            def streaming_recognize request, options = nil
               unless request.is_a? Enumerable
                 if request.respond_to? :to_enum
                   request = request.to_enum
@@ -325,7 +331,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @speech_stub.call_rpc :streaming_recognize, request, options: options, operation_callback: block
+              @speech_stub.call_rpc :streaming_recognize, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             class Configuration

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -135,7 +135,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_operations request, options = nil, &block
+            def list_operations request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
@@ -163,14 +163,12 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
-                yield paged_response, operation if block
+              @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
+                wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                yield response, operation if block_given?
+                return response
               end
-              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -199,7 +197,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def get_operation request, options = nil, &block
+            def get_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
@@ -227,8 +225,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -259,7 +260,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def delete_operation request, options = nil, &block
+            def delete_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
@@ -287,7 +288,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
+              @operations_stub.call_rpc :delete_operation, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -330,7 +334,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def cancel_operation request, options = nil, &block
+            def cancel_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
@@ -358,7 +362,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
+              @operations_stub.call_rpc :cancel_operation, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             class Configuration

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -141,7 +141,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def batch_annotate_images request, options = nil, &block
+            def batch_annotate_images request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
@@ -163,7 +163,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @image_annotator_stub.call_rpc :batch_annotate_images, request, options: options, operation_callback: block
+              @image_annotator_stub.call_rpc :batch_annotate_images, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -214,7 +217,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def batch_annotate_files request, options = nil, &block
+            def batch_annotate_files request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::BatchAnnotateFilesRequest
@@ -236,7 +239,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @image_annotator_stub.call_rpc :batch_annotate_files, request, options: options, operation_callback: block
+              @image_annotator_stub.call_rpc :batch_annotate_files, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -292,7 +298,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def async_batch_annotate_images request, options = nil, &block
+            def async_batch_annotate_images request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest
@@ -314,8 +320,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @image_annotator_stub.call_rpc :async_batch_annotate_images, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @image_annotator_stub.call_rpc :async_batch_annotate_images, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -363,7 +372,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def async_batch_annotate_files request, options = nil, &block
+            def async_batch_annotate_files request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
@@ -385,8 +394,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @image_annotator_stub.call_rpc :async_batch_annotate_files, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @image_annotator_stub.call_rpc :async_batch_annotate_files, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             class Configuration

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -135,7 +135,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_operations request, options = nil, &block
+            def list_operations request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
@@ -163,14 +163,12 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
-                yield paged_response, operation if block
+              @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
+                wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                yield response, operation if block_given?
+                return response
               end
-              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -199,7 +197,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def get_operation request, options = nil, &block
+            def get_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
@@ -227,8 +225,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -259,7 +260,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def delete_operation request, options = nil, &block
+            def delete_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
@@ -287,7 +288,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
+              @operations_stub.call_rpc :delete_operation, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -330,7 +334,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def cancel_operation request, options = nil, &block
+            def cancel_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
@@ -358,7 +362,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
+              @operations_stub.call_rpc :cancel_operation, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             class Configuration

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -147,7 +147,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def create_product_set request, options = nil, &block
+            def create_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductSetRequest
@@ -175,7 +175,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :create_product_set, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :create_product_set, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -216,7 +219,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_product_sets request, options = nil, &block
+            def list_product_sets request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductSetsRequest
@@ -244,13 +247,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, operation, options
-                yield paged_response, operation if block
+              @product_search_stub.call_rpc :list_product_sets, request, options: options do |response, operation|
+                response = Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, operation, options
+                yield response, operation if block_given?
+                return response
               end
-              @product_search_stub.call_rpc :list_product_sets, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -286,7 +287,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def get_product_set request, options = nil, &block
+            def get_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductSetRequest
@@ -314,7 +315,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :get_product_set, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :get_product_set, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -358,7 +362,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def update_product_set request, options = nil, &block
+            def update_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductSetRequest
@@ -386,7 +390,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :update_product_set, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :update_product_set, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -420,7 +427,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def delete_product_set request, options = nil, &block
+            def delete_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductSetRequest
@@ -448,7 +455,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :delete_product_set, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :delete_product_set, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -497,7 +507,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def create_product request, options = nil, &block
+            def create_product request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductRequest
@@ -525,7 +535,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :create_product, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :create_product, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -565,7 +578,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_products request, options = nil, &block
+            def list_products request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsRequest
@@ -593,13 +606,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, operation, options
-                yield paged_response, operation if block
+              @product_search_stub.call_rpc :list_products, request, options: options do |response, operation|
+                response = Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, operation, options
+                yield response, operation if block_given?
+                return response
               end
-              @product_search_stub.call_rpc :list_products, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -635,7 +646,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def get_product request, options = nil, &block
+            def get_product request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductRequest
@@ -663,7 +674,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :get_product, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :get_product, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -723,7 +737,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def update_product request, options = nil, &block
+            def update_product request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductRequest
@@ -751,7 +765,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :update_product, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :update_product, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -787,7 +804,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def delete_product request, options = nil, &block
+            def delete_product request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductRequest
@@ -815,7 +832,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :delete_product, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :delete_product, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -887,7 +907,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def create_reference_image request, options = nil, &block
+            def create_reference_image request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateReferenceImageRequest
@@ -915,7 +935,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :create_reference_image, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :create_reference_image, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -956,7 +979,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def delete_reference_image request, options = nil, &block
+            def delete_reference_image request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteReferenceImageRequest
@@ -984,7 +1007,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :delete_reference_image, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :delete_reference_image, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -1031,7 +1057,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_reference_images request, options = nil, &block
+            def list_reference_images request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListReferenceImagesRequest
@@ -1059,13 +1085,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, operation, options
-                yield paged_response, operation if block
+              @product_search_stub.call_rpc :list_reference_images, request, options: options do |response, operation|
+                response = Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, operation, options
+                yield response, operation if block_given?
+                return response
               end
-              @product_search_stub.call_rpc :list_reference_images, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -1102,7 +1126,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def get_reference_image request, options = nil, &block
+            def get_reference_image request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetReferenceImageRequest
@@ -1130,7 +1154,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :get_reference_image, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :get_reference_image, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -1177,7 +1204,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def add_product_to_product_set request, options = nil, &block
+            def add_product_to_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AddProductToProductSetRequest
@@ -1205,7 +1232,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :add_product_to_product_set, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :add_product_to_product_set, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -1238,7 +1268,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def remove_product_from_product_set request, options = nil, &block
+            def remove_product_from_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
@@ -1266,7 +1296,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :remove_product_from_product_set, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :remove_product_from_product_set, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -1310,7 +1343,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_products_in_product_set request, options = nil, &block
+            def list_products_in_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsInProductSetRequest
@@ -1338,13 +1371,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, operation, options
-                yield paged_response, operation if block
+              @product_search_stub.call_rpc :list_products_in_product_set, request, options: options do |response, operation|
+                response = Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, operation, options
+                yield response, operation if block_given?
+                return response
               end
-              @product_search_stub.call_rpc :list_products_in_product_set, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -1393,7 +1424,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def import_product_sets request, options = nil, &block
+            def import_product_sets request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ImportProductSetsRequest
@@ -1421,8 +1452,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @product_search_stub.call_rpc :import_product_sets, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @product_search_stub.call_rpc :import_product_sets, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -1503,7 +1537,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def purge_products request, options = nil, &block
+            def purge_products request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::PurgeProductsRequest
@@ -1531,8 +1565,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @product_search_stub.call_rpc :purge_products, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @product_search_stub.call_rpc :purge_products, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             class Configuration

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -135,7 +135,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_operations request, options = nil, &block
+            def list_operations request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
@@ -163,14 +163,12 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
-                yield paged_response, operation if block
+              @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
+                wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                yield response, operation if block_given?
+                return response
               end
-              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -199,7 +197,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def get_operation request, options = nil, &block
+            def get_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
@@ -227,8 +225,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -259,7 +260,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def delete_operation request, options = nil, &block
+            def delete_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
@@ -287,7 +288,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
+              @operations_stub.call_rpc :delete_operation, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -330,7 +334,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def cancel_operation request, options = nil, &block
+            def cancel_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
@@ -358,7 +362,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
+              @operations_stub.call_rpc :cancel_operation, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             class Configuration

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -136,7 +136,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def echo request, options = nil, &block
+          def echo request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::EchoRequest
@@ -158,7 +158,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @echo_stub.call_rpc :echo, request, options: options, operation_callback: block
+            @echo_stub.call_rpc :echo, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -187,7 +190,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def expand request, options = nil, &block
+          def expand request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ExpandRequest
@@ -209,7 +212,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @echo_stub.call_rpc :expand, request, options: options, operation_callback: block
+            @echo_stub.call_rpc :expand, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -230,7 +236,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def collect request, options = nil, &block
+          def collect request, options = nil
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -260,7 +266,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @echo_stub.call_rpc :collect, request, options: options, operation_callback: block
+            @echo_stub.call_rpc :collect, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -281,7 +290,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def chat request, options = nil, &block
+          def chat request, options = nil
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -311,7 +320,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @echo_stub.call_rpc :chat, request, options: options, operation_callback: block
+            @echo_stub.call_rpc :chat, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -342,7 +354,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def paged_expand request, options = nil, &block
+          def paged_expand request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::PagedExpandRequest
@@ -364,13 +376,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, operation, options
-              yield paged_response, operation if block
+            @echo_stub.call_rpc :paged_expand, request, options: options do |response, operation|
+              response = Gapic::PagedEnumerable.new @echo_stub, :paged_expand, request, response, operation, options
+              yield response, operation if block_given?
+              return response
             end
-            @echo_stub.call_rpc :paged_expand, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -404,7 +414,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def wait request, options = nil, &block
+          def wait request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::WaitRequest
@@ -426,8 +436,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            @echo_stub.call_rpc :wait, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @echo_stub.call_rpc :wait, request, options: options do |response, operation|
+              response = Gapic::Operation.new response, @operations_client
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -461,7 +474,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def block request, options = nil, &block
+          def block request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::BlockRequest
@@ -483,7 +496,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @echo_stub.call_rpc :block, request, options: options, operation_callback: block
+            @echo_stub.call_rpc :block, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           class Configuration

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -142,7 +142,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_operations request, options = nil, &block
+          def list_operations request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
@@ -170,14 +170,12 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
-              yield paged_response, operation if block
+            @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
+              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+              yield response, operation if block_given?
+              return response
             end
-            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -206,7 +204,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def get_operation request, options = nil, &block
+          def get_operation request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
@@ -234,8 +232,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
+              response = Gapic::Operation.new response, @operations_client
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -266,7 +267,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_operation request, options = nil, &block
+          def delete_operation request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
@@ -294,7 +295,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
+            @operations_stub.call_rpc :delete_operation, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -337,7 +341,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def cancel_operation request, options = nil, &block
+          def cancel_operation request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
@@ -365,7 +369,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
+            @operations_stub.call_rpc :cancel_operation, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           class Configuration

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -133,7 +133,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def create_user request, options = nil, &block
+          def create_user request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::CreateUserRequest
@@ -155,7 +155,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @identity_stub.call_rpc :create_user, request, options: options, operation_callback: block
+            @identity_stub.call_rpc :create_user, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -180,7 +183,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def get_user request, options = nil, &block
+          def get_user request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::GetUserRequest
@@ -208,7 +211,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @identity_stub.call_rpc :get_user, request, options: options, operation_callback: block
+            @identity_stub.call_rpc :get_user, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -236,7 +242,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def update_user request, options = nil, &block
+          def update_user request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::UpdateUserRequest
@@ -264,7 +270,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @identity_stub.call_rpc :update_user, request, options: options, operation_callback: block
+            @identity_stub.call_rpc :update_user, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -289,7 +298,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_user request, options = nil, &block
+          def delete_user request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteUserRequest
@@ -317,7 +326,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @identity_stub.call_rpc :delete_user, request, options: options, operation_callback: block
+            @identity_stub.call_rpc :delete_user, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -347,7 +359,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_users request, options = nil, &block
+          def list_users request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListUsersRequest
@@ -369,13 +381,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, operation, options
-              yield paged_response, operation if block
+            @identity_stub.call_rpc :list_users, request, options: options do |response, operation|
+              response = Gapic::PagedEnumerable.new @identity_stub, :list_users, request, response, operation, options
+              yield response, operation if block_given?
+              return response
             end
-            @identity_stub.call_rpc :list_users, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           class Configuration

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -137,7 +137,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def create_room request, options = nil, &block
+          def create_room request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::CreateRoomRequest
@@ -159,7 +159,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :create_room, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :create_room, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -184,7 +187,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def get_room request, options = nil, &block
+          def get_room request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::GetRoomRequest
@@ -212,7 +215,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :get_room, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :get_room, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -240,7 +246,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def update_room request, options = nil, &block
+          def update_room request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::UpdateRoomRequest
@@ -268,7 +274,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :update_room, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :update_room, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -293,7 +302,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_room request, options = nil, &block
+          def delete_room request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteRoomRequest
@@ -321,7 +330,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :delete_room, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :delete_room, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -351,7 +363,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_rooms request, options = nil, &block
+          def list_rooms request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListRoomsRequest
@@ -373,13 +385,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, operation, options
-              yield paged_response, operation if block
+            @messaging_stub.call_rpc :list_rooms, request, options: options do |response, operation|
+              response = Gapic::PagedEnumerable.new @messaging_stub, :list_rooms, request, response, operation, options
+              yield response, operation if block_given?
+              return response
             end
-            @messaging_stub.call_rpc :list_rooms, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -411,7 +421,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def create_blurb request, options = nil, &block
+          def create_blurb request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::CreateBlurbRequest
@@ -439,7 +449,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :create_blurb, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :create_blurb, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -464,7 +477,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def get_blurb request, options = nil, &block
+          def get_blurb request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::GetBlurbRequest
@@ -492,7 +505,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :get_blurb, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :get_blurb, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -520,7 +536,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def update_blurb request, options = nil, &block
+          def update_blurb request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::UpdateBlurbRequest
@@ -548,7 +564,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :update_blurb, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :update_blurb, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -573,7 +592,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_blurb request, options = nil, &block
+          def delete_blurb request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteBlurbRequest
@@ -601,7 +620,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :delete_blurb, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :delete_blurb, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -636,7 +658,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_blurbs request, options = nil, &block
+          def list_blurbs request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListBlurbsRequest
@@ -664,13 +686,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, operation, options
-              yield paged_response, operation if block
+            @messaging_stub.call_rpc :list_blurbs, request, options: options do |response, operation|
+              response = Gapic::PagedEnumerable.new @messaging_stub, :list_blurbs, request, response, operation, options
+              yield response, operation if block_given?
+              return response
             end
-            @messaging_stub.call_rpc :list_blurbs, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -712,7 +732,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def search_blurbs request, options = nil, &block
+          def search_blurbs request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::SearchBlurbsRequest
@@ -740,8 +760,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            @messaging_stub.call_rpc :search_blurbs, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @messaging_stub.call_rpc :search_blurbs, request, options: options do |response, operation|
+              response = Gapic::Operation.new response, @operations_client
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -770,7 +793,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def stream_blurbs request, options = nil, &block
+          def stream_blurbs request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::StreamBlurbsRequest
@@ -798,7 +821,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :stream_blurbs, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :stream_blurbs, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -818,7 +844,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def send_blurbs request, options = nil, &block
+          def send_blurbs request, options = nil
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -854,7 +880,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :send_blurbs, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :send_blurbs, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -876,7 +905,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def connect request, options = nil, &block
+          def connect request, options = nil
             unless request.is_a? Enumerable
               if request.respond_to? :to_enum
                 request = request.to_enum
@@ -906,7 +935,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @messaging_stub.call_rpc :connect, request, options: options, operation_callback: block
+            @messaging_stub.call_rpc :connect, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           class Configuration

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -142,7 +142,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_operations request, options = nil, &block
+          def list_operations request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
@@ -170,14 +170,12 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
-              yield paged_response, operation if block
+            @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
+              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+              yield response, operation if block_given?
+              return response
             end
-            @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -206,7 +204,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def get_operation request, options = nil, &block
+          def get_operation request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
@@ -234,8 +232,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-            @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+            @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
+              response = Gapic::Operation.new response, @operations_client
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -266,7 +267,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_operation request, options = nil, &block
+          def delete_operation request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
@@ -294,7 +295,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
+            @operations_stub.call_rpc :delete_operation, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -337,7 +341,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def cancel_operation request, options = nil, &block
+          def cancel_operation request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
@@ -365,7 +369,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
+            @operations_stub.call_rpc :cancel_operation, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           class Configuration

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -135,7 +135,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def create_session request, options = nil, &block
+          def create_session request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::CreateSessionRequest
@@ -157,7 +157,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @testing_stub.call_rpc :create_session, request, options: options, operation_callback: block
+            @testing_stub.call_rpc :create_session, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -182,7 +185,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def get_session request, options = nil, &block
+          def get_session request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::GetSessionRequest
@@ -210,7 +213,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @testing_stub.call_rpc :get_session, request, options: options, operation_callback: block
+            @testing_stub.call_rpc :get_session, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -237,7 +243,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_sessions request, options = nil, &block
+          def list_sessions request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListSessionsRequest
@@ -259,13 +265,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, operation, options
-              yield paged_response, operation if block
+            @testing_stub.call_rpc :list_sessions, request, options: options do |response, operation|
+              response = Gapic::PagedEnumerable.new @testing_stub, :list_sessions, request, response, operation, options
+              yield response, operation if block_given?
+              return response
             end
-            @testing_stub.call_rpc :list_sessions, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -290,7 +294,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_session request, options = nil, &block
+          def delete_session request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteSessionRequest
@@ -318,7 +322,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @testing_stub.call_rpc :delete_session, request, options: options, operation_callback: block
+            @testing_stub.call_rpc :delete_session, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -347,7 +354,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def report_session request, options = nil, &block
+          def report_session request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ReportSessionRequest
@@ -375,7 +382,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @testing_stub.call_rpc :report_session, request, options: options, operation_callback: block
+            @testing_stub.call_rpc :report_session, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -404,7 +414,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def list_tests request, options = nil, &block
+          def list_tests request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListTestsRequest
@@ -432,13 +442,11 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            paged_response = nil
-            paged_operation_callback = lambda do |response, operation|
-              paged_response = Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, operation, options
-              yield paged_response, operation if block
+            @testing_stub.call_rpc :list_tests, request, options: options do |response, operation|
+              response = Gapic::PagedEnumerable.new @testing_stub, :list_tests, request, response, operation, options
+              yield response, operation if block_given?
+              return response
             end
-            @testing_stub.call_rpc :list_tests, request, options: options, operation_callback: paged_operation_callback
-            paged_response
           end
 
           ##
@@ -473,7 +481,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def delete_test request, options = nil, &block
+          def delete_test request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteTestRequest
@@ -501,7 +509,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @testing_stub.call_rpc :delete_test, request, options: options, operation_callback: block
+            @testing_stub.call_rpc :delete_test, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           ##
@@ -536,7 +547,7 @@ module Google
           #
           # @raise [Gapic::GapicError] if the RPC is aborted.
           #
-          def verify_test request, options = nil, &block
+          def verify_test request, options = nil
             raise ArgumentError, "request must be provided" if request.nil?
 
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::VerifyTestRequest
@@ -564,7 +575,10 @@ module Google
             options.apply_defaults metadata:     @config.metadata,
                                    retry_policy: @config.retry_policy
 
-            @testing_stub.call_rpc :verify_test, request, options: options, operation_callback: block
+            @testing_stub.call_rpc :verify_test, request, options: options do |response, operation|
+              yield response, operation if block_given?
+              return response
+            end
           end
 
           class Configuration

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -168,7 +168,7 @@ module Google
             #     puts "Transcript: #{alternative.transcript}"
             #   end
             #
-            def recognize request, options = nil, &block
+            def recognize request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Speech::V1::RecognizeRequest
@@ -190,7 +190,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @speech_stub.call_rpc :recognize, request, options: options, operation_callback: block
+              @speech_stub.call_rpc :recognize, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -259,7 +262,7 @@ module Google
             #     puts "End time: #{word.end_time.seconds} seconds #{word.end_time.nanos} nanos"
             #   end
             #
-            def long_running_recognize request, options = nil, &block
+            def long_running_recognize request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Speech::V1::LongRunningRecognizeRequest
@@ -281,8 +284,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @speech_stub.call_rpc :long_running_recognize, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @speech_stub.call_rpc :long_running_recognize, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -302,7 +308,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def streaming_recognize request, options = nil, &block
+            def streaming_recognize request, options = nil
               unless request.is_a? Enumerable
                 if request.respond_to? :to_enum
                   request = request.to_enum
@@ -332,7 +338,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @speech_stub.call_rpc :streaming_recognize, request, options: options, operation_callback: block
+              @speech_stub.call_rpc :streaming_recognize, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             class Configuration

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -143,7 +143,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_operations request, options = nil, &block
+            def list_operations request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
@@ -171,14 +171,12 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
-                yield paged_response, operation if block
+              @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
+                wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                yield response, operation if block_given?
+                return response
               end
-              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -207,7 +205,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def get_operation request, options = nil, &block
+            def get_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
@@ -235,8 +233,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -267,7 +268,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def delete_operation request, options = nil, &block
+            def delete_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
@@ -295,7 +296,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
+              @operations_stub.call_rpc :delete_operation, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -338,7 +342,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def cancel_operation request, options = nil, &block
+            def cancel_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
@@ -366,7 +370,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
+              @operations_stub.call_rpc :cancel_operation, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             class Configuration

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -148,7 +148,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def batch_annotate_images request, options = nil, &block
+            def batch_annotate_images request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
@@ -170,7 +170,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @image_annotator_stub.call_rpc :batch_annotate_images, request, options: options, operation_callback: block
+              @image_annotator_stub.call_rpc :batch_annotate_images, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -221,7 +224,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def batch_annotate_files request, options = nil, &block
+            def batch_annotate_files request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::BatchAnnotateFilesRequest
@@ -243,7 +246,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @image_annotator_stub.call_rpc :batch_annotate_files, request, options: options, operation_callback: block
+              @image_annotator_stub.call_rpc :batch_annotate_files, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -299,7 +305,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def async_batch_annotate_images request, options = nil, &block
+            def async_batch_annotate_images request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest
@@ -321,8 +327,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @image_annotator_stub.call_rpc :async_batch_annotate_images, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @image_annotator_stub.call_rpc :async_batch_annotate_images, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -370,7 +379,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def async_batch_annotate_files request, options = nil, &block
+            def async_batch_annotate_files request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
@@ -392,8 +401,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @image_annotator_stub.call_rpc :async_batch_annotate_files, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @image_annotator_stub.call_rpc :async_batch_annotate_files, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             class Configuration

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -143,7 +143,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_operations request, options = nil, &block
+            def list_operations request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
@@ -171,14 +171,12 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
-                yield paged_response, operation if block
+              @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
+                wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                yield response, operation if block_given?
+                return response
               end
-              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -207,7 +205,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def get_operation request, options = nil, &block
+            def get_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
@@ -235,8 +233,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -267,7 +268,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def delete_operation request, options = nil, &block
+            def delete_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
@@ -295,7 +296,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
+              @operations_stub.call_rpc :delete_operation, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -338,7 +342,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def cancel_operation request, options = nil, &block
+            def cancel_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
@@ -366,7 +370,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
+              @operations_stub.call_rpc :cancel_operation, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             class Configuration

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -154,7 +154,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def create_product_set request, options = nil, &block
+            def create_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductSetRequest
@@ -182,7 +182,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :create_product_set, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :create_product_set, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -223,7 +226,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_product_sets request, options = nil, &block
+            def list_product_sets request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductSetsRequest
@@ -251,13 +254,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, operation, options
-                yield paged_response, operation if block
+              @product_search_stub.call_rpc :list_product_sets, request, options: options do |response, operation|
+                response = Gapic::PagedEnumerable.new @product_search_stub, :list_product_sets, request, response, operation, options
+                yield response, operation if block_given?
+                return response
               end
-              @product_search_stub.call_rpc :list_product_sets, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -293,7 +294,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def get_product_set request, options = nil, &block
+            def get_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductSetRequest
@@ -321,7 +322,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :get_product_set, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :get_product_set, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -365,7 +369,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def update_product_set request, options = nil, &block
+            def update_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductSetRequest
@@ -393,7 +397,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :update_product_set, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :update_product_set, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -427,7 +434,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def delete_product_set request, options = nil, &block
+            def delete_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductSetRequest
@@ -455,7 +462,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :delete_product_set, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :delete_product_set, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -504,7 +514,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def create_product request, options = nil, &block
+            def create_product request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductRequest
@@ -532,7 +542,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :create_product, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :create_product, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -572,7 +585,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_products request, options = nil, &block
+            def list_products request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsRequest
@@ -600,13 +613,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, operation, options
-                yield paged_response, operation if block
+              @product_search_stub.call_rpc :list_products, request, options: options do |response, operation|
+                response = Gapic::PagedEnumerable.new @product_search_stub, :list_products, request, response, operation, options
+                yield response, operation if block_given?
+                return response
               end
-              @product_search_stub.call_rpc :list_products, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -642,7 +653,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def get_product request, options = nil, &block
+            def get_product request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductRequest
@@ -670,7 +681,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :get_product, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :get_product, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -730,7 +744,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def update_product request, options = nil, &block
+            def update_product request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductRequest
@@ -758,7 +772,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :update_product, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :update_product, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -794,7 +811,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def delete_product request, options = nil, &block
+            def delete_product request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductRequest
@@ -822,7 +839,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :delete_product, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :delete_product, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -894,7 +914,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def create_reference_image request, options = nil, &block
+            def create_reference_image request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateReferenceImageRequest
@@ -922,7 +942,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :create_reference_image, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :create_reference_image, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -963,7 +986,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def delete_reference_image request, options = nil, &block
+            def delete_reference_image request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteReferenceImageRequest
@@ -991,7 +1014,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :delete_reference_image, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :delete_reference_image, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -1038,7 +1064,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_reference_images request, options = nil, &block
+            def list_reference_images request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListReferenceImagesRequest
@@ -1066,13 +1092,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, operation, options
-                yield paged_response, operation if block
+              @product_search_stub.call_rpc :list_reference_images, request, options: options do |response, operation|
+                response = Gapic::PagedEnumerable.new @product_search_stub, :list_reference_images, request, response, operation, options
+                yield response, operation if block_given?
+                return response
               end
-              @product_search_stub.call_rpc :list_reference_images, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -1109,7 +1133,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def get_reference_image request, options = nil, &block
+            def get_reference_image request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetReferenceImageRequest
@@ -1137,7 +1161,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :get_reference_image, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :get_reference_image, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -1184,7 +1211,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def add_product_to_product_set request, options = nil, &block
+            def add_product_to_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AddProductToProductSetRequest
@@ -1212,7 +1239,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :add_product_to_product_set, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :add_product_to_product_set, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -1245,7 +1275,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def remove_product_from_product_set request, options = nil, &block
+            def remove_product_from_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
@@ -1273,7 +1303,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @product_search_stub.call_rpc :remove_product_from_product_set, request, options: options, operation_callback: block
+              @product_search_stub.call_rpc :remove_product_from_product_set, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -1317,7 +1350,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_products_in_product_set request, options = nil, &block
+            def list_products_in_product_set request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsInProductSetRequest
@@ -1345,13 +1378,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, operation, options
-                yield paged_response, operation if block
+              @product_search_stub.call_rpc :list_products_in_product_set, request, options: options do |response, operation|
+                response = Gapic::PagedEnumerable.new @product_search_stub, :list_products_in_product_set, request, response, operation, options
+                yield response, operation if block_given?
+                return response
               end
-              @product_search_stub.call_rpc :list_products_in_product_set, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -1400,7 +1431,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def import_product_sets request, options = nil, &block
+            def import_product_sets request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ImportProductSetsRequest
@@ -1428,8 +1459,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @product_search_stub.call_rpc :import_product_sets, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @product_search_stub.call_rpc :import_product_sets, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -1510,7 +1544,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def purge_products request, options = nil, &block
+            def purge_products request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::PurgeProductsRequest
@@ -1538,8 +1572,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @product_search_stub.call_rpc :purge_products, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @product_search_stub.call_rpc :purge_products, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             class Configuration

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -143,7 +143,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def list_operations request, options = nil, &block
+            def list_operations request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
@@ -171,14 +171,12 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              paged_response = nil
-              paged_operation_callback = lambda do |response, operation|
-                paged_response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
-                yield paged_response, operation if block
+              @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
+                wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
+                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                yield response, operation if block_given?
+                return response
               end
-              @operations_stub.call_rpc :list_operations, request, options: options, operation_callback: paged_operation_callback
-              paged_response
             end
 
             ##
@@ -207,7 +205,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def get_operation request, options = nil, &block
+            def get_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
@@ -235,8 +233,11 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              @operations_stub.call_rpc :get_operation, request, options: options, operation_callback: block, format_response: wrap_gax_operation
+              @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
+                response = Gapic::Operation.new response, @operations_client
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -267,7 +268,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def delete_operation request, options = nil, &block
+            def delete_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
@@ -295,7 +296,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @operations_stub.call_rpc :delete_operation, request, options: options, operation_callback: block
+              @operations_stub.call_rpc :delete_operation, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             ##
@@ -338,7 +342,7 @@ module Google
             #
             # @raise [Gapic::GapicError] if the RPC is aborted.
             #
-            def cancel_operation request, options = nil, &block
+            def cancel_operation request, options = nil
               raise ArgumentError, "request must be provided" if request.nil?
 
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
@@ -366,7 +370,10 @@ module Google
               options.apply_defaults metadata:     @config.metadata,
                                      retry_policy: @config.retry_policy
 
-              @operations_stub.call_rpc :cancel_operation, request, options: options, operation_callback: block
+              @operations_stub.call_rpc :cancel_operation, request, options: options do |response, operation|
+                yield response, operation if block_given?
+                return response
+              end
             end
 
             class Configuration


### PR DESCRIPTION
Remove named proc objects from RPC calls and move that logic to client methods. This greatly simplifies the RPC code, and does not add significant complexity to the client methods.