### PR TITLE
Add missing test requires

### DIFF
--- a/gapic-common/test/gapic/call_options/retry_policy/call_test.rb
+++ b/gapic-common/test/gapic/call_options/retry_policy/call_test.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "test_helper"
+require "gapic/grpc"
 
 class RetryPolicyCallTest < Minitest::Test
   def test_wont_retry_when_unconfigured

--- a/gapic-common/test/gapic/call_options/retry_policy/settings_test.rb
+++ b/gapic-common/test/gapic/call_options/retry_policy/settings_test.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "test_helper"
+require "gapic/grpc"
 
 class RetryPolicySettingsTest < Minitest::Test
   def test_defaults

--- a/gapic-common/test/gapic/call_options/settings_test.rb
+++ b/gapic-common/test/gapic/call_options/settings_test.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "test_helper"
+require "gapic/grpc"
 
 class OptionsSettingsTest < Minitest::Test
   def test_defaults

--- a/gapic-common/test/gapic/error_test.rb
+++ b/gapic-common/test/gapic/error_test.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "test_helper"
+require "gapic/grpc"
 
 describe Gapic::GapicError do
   describe "without cause" do

--- a/gapic-common/test/gapic/gax_error/status_details_test.rb
+++ b/gapic-common/test/gapic/gax_error/status_details_test.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "test_helper"
+require "gapic/grpc"
 require "google/rpc/error_details_pb"
 require "google/protobuf/timestamp_pb"
 

--- a/gapic-common/test/gapic/grpc/rpc_call/raise_test.rb
+++ b/gapic-common/test/gapic/grpc/rpc_call/raise_test.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "test_helper"
+require "gapic/grpc"
 
 class RpcCallRaiseTest < Minitest::Test
   def test_traps_exception

--- a/gapic-common/test/gapic/grpc/rpc_call/retry/raise_test.rb
+++ b/gapic-common/test/gapic/grpc/rpc_call/retry/raise_test.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "test_helper"
+require "gapic/grpc"
 
 class RpcCallRetryRaiseTest < Minitest::Test
   def test_no_retry_without_codes

--- a/gapic-common/test/gapic/grpc/rpc_call/retry/retry_test.rb
+++ b/gapic-common/test/gapic/grpc/rpc_call/retry/retry_test.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "test_helper"
+require "gapic/grpc"
 
 class RpcCallRetryTest < Minitest::Test
   def default_sleep_counts

--- a/gapic-common/test/gapic/grpc/rpc_call/rpc_call_test.rb
+++ b/gapic-common/test/gapic/grpc/rpc_call/rpc_call_test.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "test_helper"
+require "gapic/grpc"
 
 class RpcCallTest < Minitest::Test
   def test_call


### PR DESCRIPTION
These tests complete when running in one job, but they are missing
needed requires when running in isolation, e.g. autotest.