### PR TITLE
Allow call options timeout to be nil or negative

### DIFF
--- a/gapic-common/lib/gapic/call_options.rb
+++ b/gapic-common/lib/gapic/call_options.rb
@@ -18,13 +18,15 @@ module Gapic
   ##
   # Encapsulates the overridable settings for a particular RPC call.
   #
+  # @!attribute [r] timeout
+  #   @return [Numeric, nil]
   # @!attribute [r] metadata
   #   @return [Hash]
   # @!attribute [r] retry_policy
   #   @return [RetryPolicy, Object]
   #
   class CallOptions
-    attr_reader :metadata, :retry_policy
+    attr_reader :timeout, :metadata, :retry_policy
 
     ##
     # Create a new Options object instance.
@@ -45,14 +47,6 @@ module Gapic
       @timeout = timeout # allow to be nil so it can be overridden
       @metadata = metadata.to_h # Ensure always hash, even for nil
       @retry_policy = retry_policy
-    end
-
-    ##
-    # client-side timeout for RPC calls
-    #
-    # @return [Numeric]
-    def timeout
-      @timeout || 300
     end
 
     ##

--- a/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
+++ b/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
@@ -136,10 +136,14 @@ module Gapic
       private
 
       def calculate_deadline options
+        return if options.timeout.nil?
+
         Time.now + options.timeout
       end
 
       def check_retry? deadline
+        return true if deadline.nil?
+
         deadline > Time.now
       end
 

--- a/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
+++ b/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
@@ -137,6 +137,7 @@ module Gapic
 
       def calculate_deadline options
         return if options.timeout.nil?
+        return if options.timeout.negative?
 
         Time.now + options.timeout
       end

--- a/gapic-common/test/gapic/call_options/settings_test.rb
+++ b/gapic-common/test/gapic/call_options/settings_test.rb
@@ -18,7 +18,7 @@ class OptionsSettingsTest < Minitest::Test
   def test_defaults
     options = Gapic::CallOptions.new
 
-    assert_equal 300, options.timeout
+    assert_nil options.timeout
     assert_equal({}, options.metadata)
     assert_equal [], options.retry_policy.retry_codes
     assert_equal 1, options.retry_policy.initial_delay

--- a/gapic-common/test/gapic/grpc/rpc_call/raise_test.rb
+++ b/gapic-common/test/gapic/grpc/rpc_call/raise_test.rb
@@ -57,7 +57,7 @@ class RpcCallRaiseTest < Minitest::Test
     rpc_call = Gapic::ServiceStub::RpcCall.new api_meth_stub
 
     exc = assert_raises Gapic::GapicError do
-      rpc_call.call Object.new
+      rpc_call.call Object.new, options: { timeout: 300 }
     end
     assert_kind_of GRPC::BadStatus, exc.cause
 
@@ -79,7 +79,7 @@ class RpcCallRaiseTest < Minitest::Test
     rpc_call = Gapic::ServiceStub::RpcCall.new api_meth_stub
 
     assert_raises FakeCodeError do
-      rpc_call.call Object.new
+      rpc_call.call Object.new, options: { timeout: 300 }
     end
     assert_kind_of Time, deadline_arg
     assert_equal 1, call_count

--- a/gapic-common/test/gapic/grpc/rpc_call/retry/raise_test.rb
+++ b/gapic-common/test/gapic/grpc/rpc_call/retry/raise_test.rb
@@ -86,6 +86,7 @@ class RpcCallRetryRaiseTest < Minitest::Test
     sleep_proc = ->(count) { sleep_mock.sleep count }
 
     options = Gapic::CallOptions.new(
+      timeout: 300,
       retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
     )
 

--- a/gapic-common/test/gapic/grpc/rpc_call/retry/retry_test.rb
+++ b/gapic-common/test/gapic/grpc/rpc_call/retry/retry_test.rb
@@ -47,6 +47,7 @@ class RpcCallRetryTest < Minitest::Test
 
     rpc_call = Gapic::ServiceStub::RpcCall.new api_meth_stub
     options = Gapic::CallOptions.new(
+      timeout: 300,
       retry_policy: { retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE] }
     )
 

--- a/gapic-common/test/gapic/grpc/rpc_call/rpc_call_test.rb
+++ b/gapic-common/test/gapic/grpc/rpc_call/rpc_call_test.rb
@@ -26,12 +26,36 @@ class RpcCallTest < Minitest::Test
     rpc_call = Gapic::ServiceStub::RpcCall.new api_meth_stub
 
     assert_equal 42, rpc_call.call(Object.new)
-    assert_kind_of Time, deadline_arg
+    assert_nil deadline_arg
 
     new_deadline = Time.now + 20
+    options = Gapic::CallOptions.new timeout: nil
+
+    assert_equal 42, rpc_call.call(Object.new, options: options)
+    assert_nil deadline_arg
+  end
+
+  def test_call_with_timeout
+    deadline_arg = nil
+
+    api_meth_stub = proc do |deadline: nil, **_kwargs|
+      deadline_arg = deadline
+      OperationStub.new { 42 }
+    end
+
+    options = Gapic::CallOptions.new timeout: 300
+    rpc_call = Gapic::ServiceStub::RpcCall.new api_meth_stub
+
+    assert_equal 42, rpc_call.call(Object.new, options: options)
+    refute_nil deadline_arg
+    assert_kind_of Time, deadline_arg
+    new_deadline = Time.now + 300
+    assert_in_delta new_deadline, deadline_arg, 0.9
+
     options = Gapic::CallOptions.new timeout: 20
 
     assert_equal 42, rpc_call.call(Object.new, options: options)
+    new_deadline = Time.now + 20
     assert_in_delta new_deadline, deadline_arg, 0.9
   end
 

--- a/gapic-common/test/gapic/grpc/rpc_call/rpc_call_test.rb
+++ b/gapic-common/test/gapic/grpc/rpc_call/rpc_call_test.rb
@@ -35,6 +35,26 @@ class RpcCallTest < Minitest::Test
     assert_nil deadline_arg
   end
 
+  def test_call_with_negative_timeout
+    deadline_arg = nil
+
+    api_meth_stub = proc do |deadline: nil, **_kwargs|
+      deadline_arg = deadline
+      OperationStub.new { 42 }
+    end
+
+    rpc_call = Gapic::ServiceStub::RpcCall.new api_meth_stub
+
+    assert_equal 42, rpc_call.call(Object.new)
+    assert_nil deadline_arg
+
+    new_deadline = Time.now + 20
+    options = Gapic::CallOptions.new timeout: -1
+
+    assert_equal 42, rpc_call.call(Object.new, options: options)
+    assert_nil deadline_arg
+  end
+
   def test_call_with_timeout
     deadline_arg = nil
 


### PR DESCRIPTION
When timeout is nil or negative the RPC call will not specify a call deadline.
This is important for streaming calls that do not want a deadline.