### PR TITLE
Dynamically traverse Cloud namespace for configure

### DIFF
--- a/gapic-generator-cloud/templates/cloud/service/client/_requires.erb
+++ b/gapic-generator-cloud/templates/cloud/service/client/_requires.erb
@@ -1,3 +1,2 @@
 <%- assert_locals service -%>
-require "<%= service.gem.name.gsub "-", "/" %>"
 require "google/cloud/errors"

--- a/gapic-generator-cloud/templates/cloud/service/client/_self_configure.erb
+++ b/gapic-generator-cloud/templates/cloud/service/client/_self_configure.erb
@@ -1,6 +1,12 @@
 <%- assert_locals service -%>
 @configure ||= begin
-  parent_config = <%= service.gem.namespace %>.configure
+  namespace = <%= service.namespace.split("::").inspect %>
+  parent_config = while namespace.any?
+                    parent_name = namespace.join "::"
+                    parent_const = const_get parent_name
+                    break parent_const.configure if parent_const&.respond_to? :configure
+                    namespace.pop
+                  end
   <%= service.client_name %>::Configuration.new parent_config
 end
 yield @configure if block_given?

--- a/shared/output/cloud/language/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language/lib/google/cloud/language/v1/language_service/client.rb
@@ -20,7 +20,6 @@ require "gapic/common"
 require "gapic/config"
 require "gapic/config/method"
 
-require "google/cloud/language"
 require "google/cloud/errors"
 require "google/cloud/language/version"
 require "google/cloud/language/v1/language_service_pb"
@@ -47,7 +46,13 @@ module Google
             #
             def self.configure
               @configure ||= begin
-                parent_config = Google::Cloud::Language.configure
+                namespace = ["Google", "Cloud", "Language", "V1"]
+                parent_config = while namespace.any?
+                                  parent_name = namespace.join "::"
+                                  parent_const = const_get parent_name
+                                  break parent_const.configure if parent_const&.respond_to? :configure
+                                  namespace.pop
+                                end
                 Client::Configuration.new parent_config
               end
               yield @configure if block_given?

--- a/shared/output/cloud/language/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/cloud/language/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -20,7 +20,6 @@ require "gapic/common"
 require "gapic/config"
 require "gapic/config/method"
 
-require "google/cloud/language"
 require "google/cloud/errors"
 require "google/cloud/language/version"
 require "google/cloud/language/v1beta1/language_service_pb"
@@ -47,7 +46,13 @@ module Google
             #
             def self.configure
               @configure ||= begin
-                parent_config = Google::Cloud::Language.configure
+                namespace = ["Google", "Cloud", "Language", "V1beta1"]
+                parent_config = while namespace.any?
+                                  parent_name = namespace.join "::"
+                                  parent_const = const_get parent_name
+                                  break parent_const.configure if parent_const&.respond_to? :configure
+                                  namespace.pop
+                                end
                 Client::Configuration.new parent_config
               end
               yield @configure if block_given?

--- a/shared/output/cloud/language/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -20,7 +20,6 @@ require "gapic/common"
 require "gapic/config"
 require "gapic/config/method"
 
-require "google/cloud/language"
 require "google/cloud/errors"
 require "google/cloud/language/version"
 require "google/cloud/language/v1beta2/language_service_pb"
@@ -47,7 +46,13 @@ module Google
             #
             def self.configure
               @configure ||= begin
-                parent_config = Google::Cloud::Language.configure
+                namespace = ["Google", "Cloud", "Language", "V1beta2"]
+                parent_config = while namespace.any?
+                                  parent_name = namespace.join "::"
+                                  parent_const = const_get parent_name
+                                  break parent_const.configure if parent_const&.respond_to? :configure
+                                  namespace.pop
+                                end
                 Client::Configuration.new parent_config
               end
               yield @configure if block_given?

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -20,7 +20,6 @@ require "gapic/common"
 require "gapic/config"
 require "gapic/config/method"
 
-require "google/showcase"
 require "google/cloud/errors"
 require "google/showcase/version"
 require "google/showcase/v1beta1/echo_pb"
@@ -47,7 +46,13 @@ module Google
           #
           def self.configure
             @configure ||= begin
-              parent_config = Google::Showcase.configure
+              namespace = ["Google", "Showcase", "V1beta1"]
+              parent_config = while namespace.any?
+                                parent_name = namespace.join "::"
+                                parent_const = const_get parent_name
+                                break parent_const.configure if parent_const&.respond_to? :configure
+                                namespace.pop
+                              end
               Client::Configuration.new parent_config
             end
             yield @configure if block_given?

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -20,7 +20,6 @@ require "gapic/common"
 require "gapic/config"
 require "gapic/config/method"
 
-require "google/showcase"
 require "google/cloud/errors"
 require "google/showcase/version"
 require "google/showcase/v1beta1/identity_pb"
@@ -49,7 +48,13 @@ module Google
           #
           def self.configure
             @configure ||= begin
-              parent_config = Google::Showcase.configure
+              namespace = ["Google", "Showcase", "V1beta1"]
+              parent_config = while namespace.any?
+                                parent_name = namespace.join "::"
+                                parent_const = const_get parent_name
+                                break parent_const.configure if parent_const&.respond_to? :configure
+                                namespace.pop
+                              end
               Client::Configuration.new parent_config
             end
             yield @configure if block_given?

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -20,7 +20,6 @@ require "gapic/common"
 require "gapic/config"
 require "gapic/config/method"
 
-require "google/showcase"
 require "google/cloud/errors"
 require "google/showcase/version"
 require "google/showcase/v1beta1/messaging_pb"
@@ -50,7 +49,13 @@ module Google
           #
           def self.configure
             @configure ||= begin
-              parent_config = Google::Showcase.configure
+              namespace = ["Google", "Showcase", "V1beta1"]
+              parent_config = while namespace.any?
+                                parent_name = namespace.join "::"
+                                parent_const = const_get parent_name
+                                break parent_const.configure if parent_const&.respond_to? :configure
+                                namespace.pop
+                              end
               Client::Configuration.new parent_config
             end
             yield @configure if block_given?

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -20,7 +20,6 @@ require "gapic/common"
 require "gapic/config"
 require "gapic/config/method"
 
-require "google/showcase"
 require "google/cloud/errors"
 require "google/showcase/version"
 require "google/showcase/v1beta1/testing_pb"
@@ -49,7 +48,13 @@ module Google
           #
           def self.configure
             @configure ||= begin
-              parent_config = Google::Showcase.configure
+              namespace = ["Google", "Showcase", "V1beta1"]
+              parent_config = while namespace.any?
+                                parent_name = namespace.join "::"
+                                parent_const = const_get parent_name
+                                break parent_const.configure if parent_const&.respond_to? :configure
+                                namespace.pop
+                              end
               Client::Configuration.new parent_config
             end
             yield @configure if block_given?

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -20,7 +20,6 @@ require "gapic/common"
 require "gapic/config"
 require "gapic/config/method"
 
-require "google/cloud/speech"
 require "google/cloud/errors"
 require "google/cloud/speech/version"
 require "google/cloud/speech/v1/cloud_speech_pb"
@@ -48,7 +47,13 @@ module Google
             #
             def self.configure
               @configure ||= begin
-                parent_config = Google::Cloud::Speech.configure
+                namespace = ["Google", "Cloud", "Speech", "V1"]
+                parent_config = while namespace.any?
+                                  parent_name = namespace.join "::"
+                                  parent_const = const_get parent_name
+                                  break parent_const.configure if parent_const&.respond_to? :configure
+                                  namespace.pop
+                                end
                 Client::Configuration.new parent_config
               end
               yield @configure if block_given?

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -20,7 +20,6 @@ require "gapic/common"
 require "gapic/config"
 require "gapic/config/method"
 
-require "google/cloud/vision"
 require "google/cloud/errors"
 require "google/cloud/vision/version"
 require "google/cloud/vision/v1/image_annotator_pb"
@@ -48,7 +47,13 @@ module Google
             #
             def self.configure
               @configure ||= begin
-                parent_config = Google::Cloud::Vision.configure
+                namespace = ["Google", "Cloud", "Vision", "V1"]
+                parent_config = while namespace.any?
+                                  parent_name = namespace.join "::"
+                                  parent_const = const_get parent_name
+                                  break parent_const.configure if parent_const&.respond_to? :configure
+                                  namespace.pop
+                                end
                 Client::Configuration.new parent_config
               end
               yield @configure if block_given?

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -20,7 +20,6 @@ require "gapic/common"
 require "gapic/config"
 require "gapic/config/method"
 
-require "google/cloud/vision"
 require "google/cloud/errors"
 require "google/cloud/vision/version"
 require "google/cloud/vision/v1/product_search_service_pb"
@@ -51,7 +50,13 @@ module Google
             #
             def self.configure
               @configure ||= begin
-                parent_config = Google::Cloud::Vision.configure
+                namespace = ["Google", "Cloud", "Vision", "V1"]
+                parent_config = while namespace.any?
+                                  parent_name = namespace.join "::"
+                                  parent_const = const_get parent_name
+                                  break parent_const.configure if parent_const&.respond_to? :configure
+                                  namespace.pop
+                                end
                 Client::Configuration.new parent_config
               end
               yield @configure if block_given?


### PR DESCRIPTION
Instead of adding a require to the client file, check the namespace for a constant that has a configure method. This will come in handy if/when we have service-specific gems, such as google-cloud-spanner-v1. Those gems won't have a dependency on google-cloud-spanner, and so they should not have a require for it, and dynamically find the parent configure object instead.