### PR TITLE
Escape curly braces documentation

### DIFF
--- a/gapic-generator/lib/gapic/schema/wrappers.rb
+++ b/gapic-generator/lib/gapic/schema/wrappers.rb
@@ -93,6 +93,20 @@ module Gapic
         @docs = docs
       end
 
+      # Gets the cleaned up leading comments documentation
+      def docs_leading_comments
+        return nil if @docs.nil?
+        return nil if @docs.leading_comments.empty?
+
+        @docs
+          .leading_comments
+          .each_line
+          .map { |line| line.start_with?(" ") ? line[1..-1] : line }
+          .join
+          .split("{").join("\\\\\\{") # The only safe way to replace with \ characters...
+          .split("}").join("\\}")
+      end
+
       # @!method path
       #   @return [Array<Integer>]
       #     Identifies which part of the FileDescriptorProto was defined at

--- a/gapic-generator/templates/default/helpers/presenters/enum_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/enum_presenter.rb
@@ -26,16 +26,7 @@ class EnumPresenter
   end
 
   def doc_description
-    return nil if @enum.docs.leading_comments.empty?
-
-    @enum
-      .docs
-      .leading_comments
-      .each_line
-      .map { |line| line.start_with?(" ") ? line[1..-1] : line }
-      .join
-      .split("{").join("\\\\\\{") # The only safe way to replace with \ characters...
-      .split("}").join("\\}")
+    @enum.docs_leading_comments
   end
 
   def values

--- a/gapic-generator/templates/default/helpers/presenters/enum_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/enum_presenter.rb
@@ -34,6 +34,8 @@ class EnumPresenter
       .each_line
       .map { |line| line.start_with?(" ") ? line[1..-1] : line }
       .join
+      .split("{").join("\\\\\\{") # The only safe way to replace with \ characters...
+      .split("}").join("\\}")
   end
 
   def values

--- a/gapic-generator/templates/default/helpers/presenters/enum_value_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/enum_value_presenter.rb
@@ -32,6 +32,8 @@ class EnumValuePresenter
       .each_line
       .map { |line| line.start_with?(" ") ? line[1..-1] : line }
       .join
+      .split("{").join("\\\\\\{") # The only safe way to replace with \ characters...
+      .split("}").join("\\}")
   end
 
   def number

--- a/gapic-generator/templates/default/helpers/presenters/enum_value_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/enum_value_presenter.rb
@@ -24,16 +24,7 @@ class EnumValuePresenter
   end
 
   def doc_description
-    return nil if @value.docs.leading_comments.empty?
-
-    @value
-      .docs
-      .leading_comments
-      .each_line
-      .map { |line| line.start_with?(" ") ? line[1..-1] : line }
-      .join
-      .split("{").join("\\\\\\{") # The only safe way to replace with \ characters...
-      .split("}").join("\\}")
+    @value.docs_leading_comments
   end
 
   def number

--- a/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
@@ -58,17 +58,7 @@ class FieldPresenter
   end
 
   def doc_description
-    return nil if @field.docs.nil?
-    return nil if @field.docs.leading_comments.empty?
-
-    @field
-      .docs
-      .leading_comments
-      .each_line
-      .map { |line| line.start_with?(" ") ? line[1..-1] : line }
-      .join
-      .split("{").join("\\\\\\{") # The only safe way to replace with \ characters...
-      .split("}").join("\\}")
+    @field.docs_leading_comments
   end
 
   def default_value

--- a/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
@@ -67,6 +67,8 @@ class FieldPresenter
       .each_line
       .map { |line| line.start_with?(" ") ? line[1..-1] : line }
       .join
+      .split("{").join("\\\\\\{") # The only safe way to replace with \ characters...
+      .split("}").join("\\}")
   end
 
   def default_value

--- a/gapic-generator/templates/default/helpers/presenters/message_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/message_presenter.rb
@@ -35,17 +35,7 @@ class MessagePresenter
   end
 
   def doc_description
-    return nil if @message.docs.nil?
-    return nil if @message.docs.leading_comments.empty?
-
-    @message
-      .docs
-      .leading_comments
-      .each_line
-      .map { |line| line.start_with?(" ") ? line[1..-1] : line }
-      .join
-      .split("{").join("\\\\\\{") # The only safe way to replace with \ characters...
-      .split("}").join("\\}")
+    @message.docs_leading_comments
   end
 
   def default_value

--- a/gapic-generator/templates/default/helpers/presenters/message_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/message_presenter.rb
@@ -44,6 +44,8 @@ class MessagePresenter
       .each_line
       .map { |line| line.start_with?(" ") ? line[1..-1] : line }
       .join
+      .split("{").join("\\\\\\{") # The only safe way to replace with \ characters...
+      .split("}").join("\\}")
   end
 
   def default_value

--- a/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
@@ -51,16 +51,7 @@ class MethodPresenter
   end
 
   def doc_description
-    return nil if @method.docs.leading_comments.empty?
-
-    @method
-      .docs
-      .leading_comments
-      .each_line
-      .map { |line| line.start_with?(" ") ? line[1..-1] : line }
-      .join
-      .split("{").join("\\\\\\{") # The only safe way to replace with \ characters...
-      .split("}").join("\\}")
+    @method.docs_leading_comments
   end
 
   def doc_response_type

--- a/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/method_presenter.rb
@@ -59,6 +59,8 @@ class MethodPresenter
       .each_line
       .map { |line| line.start_with?(" ") ? line[1..-1] : line }
       .join
+      .split("{").join("\\\\\\{") # The only safe way to replace with \ characters...
+      .split("}").join("\\}")
   end
 
   def doc_response_type

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v1/resources/campaign.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v1/resources/campaign.rb
@@ -28,7 +28,7 @@ module Google
           #     The resource name of the campaign.
           #     Campaign resource names have the form:
           #
-          #     `customers/{customer_id}/campaigns/{campaign_id}`
+          #     `customers/\\\{customer_id\}/campaigns/\\\{campaign_id\}`
           # @!attribute [rw] id
           #   @return [Google::Protobuf::Int64Value]
           #     The ID of the campaign.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v1/services/campaign_service.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v1/services/campaign_service.rb
@@ -71,7 +71,7 @@ module Google
           #     Remove operation: A resource name for the removed campaign is
           #     expected, in this format:
           #
-          #     `customers/{customer_id}/campaigns/{campaign_id}`
+          #     `customers/\\\{customer_id\}/campaigns/\\\{campaign_id\}`
           class CampaignOperation
             include Google::Protobuf::MessageExts
             extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/ads/googleads/proto_docs/google/protobuf/any.rb
+++ b/shared/output/ads/googleads/proto_docs/google/protobuf/any.rb
@@ -31,18 +31,18 @@ module Google
     #     Any any;
     #     any.PackFrom(foo);
     #     ...
-    #     if (any.UnpackTo(&foo)) {
+    #     if (any.UnpackTo(&foo)) \\\{
     #       ...
-    #     }
+    #     \}
     #
     # Example 2: Pack and unpack a message in Java.
     #
     #     Foo foo = ...;
     #     Any any = Any.pack(foo);
     #     ...
-    #     if (any.is(Foo.class)) {
+    #     if (any.is(Foo.class)) \\\{
     #       foo = any.unpack(Foo.class);
-    #     }
+    #     \}
     #
     #  Example 3: Pack and unpack a message in Python.
     #
@@ -56,13 +56,13 @@ module Google
     #
     #  Example 4: Pack and unpack a message in Go
     #
-    #      foo := &pb.Foo{...}
+    #      foo := &pb.Foo\\\{...\}
     #      any, err := ptypes.MarshalAny(foo)
     #      ...
-    #      foo := &pb.Foo{}
-    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #      foo := &pb.Foo\\\{\}
+    #      if err := ptypes.UnmarshalAny(any, foo); err != nil \\\{
     #        ...
-    #      }
+    #      \}
     #
     # The pack methods provided by protobuf library will by default use
     # 'type.googleapis.com/full.type.name' as the type URL and the unpack
@@ -78,26 +78,26 @@ module Google
     # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
-    #     message Person {
+    #     message Person \\\{
     #       string first_name = 1;
     #       string last_name = 2;
-    #     }
+    #     \}
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.profile.Person",
     #       "firstName": <string>,
     #       "lastName": <string>
-    #     }
+    #     \}
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
     # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message [google.protobuf.Duration][]):
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.protobuf.Duration",
     #       "value": "1.212s"
-    #     }
+    #     \}
     # @!attribute [rw] type_url
     #   @return [String]
     #     A URL/resource name that uniquely identifies the type of the serialized

--- a/shared/output/ads/googleads/proto_docs/google/protobuf/field_mask.rb
+++ b/shared/output/ads/googleads/proto_docs/google/protobuf/field_mask.rb
@@ -39,14 +39,14 @@ module Google
     # specified in the mask. For example, if the mask in the previous
     # example is applied to a response message as follows:
     #
-    #     f {
+    #     f \\\{
     #       a : 22
-    #       b {
+    #       b \\\{
     #         d : 1
     #         x : 2
-    #       }
+    #       \}
     #       y : 13
-    #     }
+    #     \}
     #     z: 8
     #
     # The result will not contain specific values for fields x,y and z
@@ -54,12 +54,12 @@ module Google
     # output):
     #
     #
-    #     f {
+    #     f \\\{
     #       a : 22
-    #       b {
+    #       b \\\{
     #         d : 1
-    #       }
-    #     }
+    #       \}
+    #     \}
     #
     # A repeated field is not allowed except at the last position of a
     # paths string.
@@ -97,22 +97,22 @@ module Google
     #
     # For example, given the target message:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 1
     #         x: 2
-    #       }
+    #       \}
     #       c: [1]
-    #     }
+    #     \}
     #
     # And an update message:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 10
-    #       }
+    #       \}
     #       c: [2]
-    #     }
+    #     \}
     #
     # then if the field mask is:
     #
@@ -120,13 +120,13 @@ module Google
     #
     # then the result will be:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 10
     #         x: 2
-    #       }
+    #       \}
     #       c: [1, 2]
-    #     }
+    #     \}
     #
     # An implementation may provide options to override this default behavior for
     # repeated and message fields.
@@ -164,51 +164,51 @@ module Google
     #
     # As an example, consider the following message declarations:
     #
-    #     message Profile {
+    #     message Profile \\\{
     #       User user = 1;
     #       Photo photo = 2;
-    #     }
-    #     message User {
+    #     \}
+    #     message User \\\{
     #       string display_name = 1;
     #       string address = 2;
-    #     }
+    #     \}
     #
     # In proto a field mask for `Profile` may look as such:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "user.display_name"
     #       paths: "photo"
-    #     }
+    #     \}
     #
     # In JSON, the same mask is represented as below:
     #
-    #     {
+    #     \\\{
     #       mask: "user.displayName,photo"
-    #     }
+    #     \}
     #
     # # Field Masks and Oneof Fields
     #
     # Field masks treat fields in oneofs just as regular fields. Consider the
     # following message:
     #
-    #     message SampleMessage {
-    #       oneof test_oneof {
+    #     message SampleMessage \\\{
+    #       oneof test_oneof \\\{
     #         string name = 4;
     #         SubMessage sub_message = 9;
-    #       }
-    #     }
+    #       \}
+    #     \}
     #
     # The field mask can be:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "name"
-    #     }
+    #     \}
     #
     # Or:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "sub_message"
-    #     }
+    #     \}
     #
     # Note that oneof type names ("test_oneof" in this case) cannot be used in
     # paths.

--- a/shared/output/cloud/language/proto_docs/google/protobuf/timestamp.rb
+++ b/shared/output/cloud/language/proto_docs/google/protobuf/timestamp.rb
@@ -79,9 +79,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\\{year\}-\\\{month\}-\\\{day\}T\\\{hour\}:\\\{min\}:\\\{sec\}[.\\\{frac_sec\}]Z"
+    # where \\\{year\} is always expressed using four digits while \\\{month\}, \\\{day\},
+    # \\\{hour\}, \\\{min\}, and \\\{sec\} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required. A proto3 JSON serializer should always use UTC (as indicated by

--- a/shared/output/cloud/showcase/proto_docs/google/api/resource.rb
+++ b/shared/output/cloud/showcase/proto_docs/google/api/resource.rb
@@ -27,110 +27,110 @@ module Google
     #
     # Example:
     #
-    #     message Topic {
+    #     message Topic \\\{
     #       // Indicates this message defines a resource schema.
-    #       // Declares the resource type in the format of {service}/{kind}.
-    #       // For Kubernetes resources, the format is {api group}/{kind}.
-    #       option (google.api.resource) = {
+    #       // Declares the resource type in the format of \\\{service\}/\\\{kind\}.
+    #       // For Kubernetes resources, the format is \\\{api group\}/\\\{kind\}.
+    #       option (google.api.resource) = \\\{
     #         type: "pubsub.googleapis.com/Topic"
-    #         name_descriptor: {
-    #           pattern: "projects/{project}/topics/{topic}"
+    #         name_descriptor: \\\{
+    #           pattern: "projects/\\\{project\}/topics/\\\{topic\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         }
-    #       };
-    #     }
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #    resources:
     #    - type: "pubsub.googleapis.com/Topic"
     #      name_descriptor:
-    #        - pattern: "projects/{project}/topics/{topic}"
+    #        - pattern: "projects/\\\{project\}/topics/\\\{topic\}"
     #          parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #          parent_name_extractor: "projects/{project}"
+    #          parent_name_extractor: "projects/\\\{project\}"
     #
     # Sometimes, resources have multiple patterns, typically because they can
     # live under multiple parents.
     #
     # Example:
     #
-    #     message LogEntry {
-    #       option (google.api.resource) = {
+    #     message LogEntry \\\{
+    #       option (google.api.resource) = \\\{
     #         type: "logging.googleapis.com/LogEntry"
-    #         name_descriptor: {
-    #           pattern: "projects/{project}/logs/{log}"
+    #         name_descriptor: \\\{
+    #           pattern: "projects/\\\{project\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "folders/{folder}/logs/{log}"
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "folders/\\\{folder\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/{folder}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "organizations/{organization}/logs/{log}"
+    #           parent_name_extractor: "folders/\\\{folder\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/{organization}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "billingAccounts/{billing_account}/logs/{log}"
+    #           parent_name_extractor: "organizations/\\\{organization\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/{billing_account}"
-    #         }
-    #       };
-    #     }
+    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'logging.googleapis.com/LogEntry'
     #       name_descriptor:
-    #         - pattern: "projects/{project}/logs/{log}"
+    #         - pattern: "projects/\\\{project\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         - pattern: "folders/{folder}/logs/{log}"
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         - pattern: "folders/\\\{folder\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/{folder}"
-    #         - pattern: "organizations/{organization}/logs/{log}"
+    #           parent_name_extractor: "folders/\\\{folder\}"
+    #         - pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/{organization}"
-    #         - pattern: "billingAccounts/{billing_account}/logs/{log}"
+    #           parent_name_extractor: "organizations/\\\{organization\}"
+    #         - pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/{billing_account}"
+    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
     #
     # For flexible resources, the resource name doesn't contain parent names, but
     # the resource itself has parents for policy evaluation.
     #
     # Example:
     #
-    #     message Shelf {
-    #       option (google.api.resource) = {
+    #     message Shelf \\\{
+    #       option (google.api.resource) = \\\{
     #         type: "library.googleapis.com/Shelf"
-    #         name_descriptor: {
-    #           pattern: "shelves/{shelf}"
+    #         name_descriptor: \\\{
+    #           pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "shelves/{shelf}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #         }
-    #       };
-    #     }
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'library.googleapis.com/Shelf'
     #       name_descriptor:
-    #         - pattern: "shelves/{shelf}"
+    #         - pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         - pattern: "shelves/{shelf}"
+    #         - pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
     # @!attribute [rw] type
     #   @return [String]
     #     The resource type. It must be in the format of
-    #     {service_name}/{resource_type_kind}. The `resource_type_kind` must be
+    #     \\\{service_name\}/\\\{resource_type_kind\}. The `resource_type_kind` must be
     #     singular and must not include version numbers.
     #
     #     Example: `storage.googleapis.com/Bucket`
@@ -147,14 +147,14 @@ module Google
     #     The path pattern must follow the syntax, which aligns with HTTP binding
     #     syntax:
     #
-    #         Template = Segment { "/" Segment } ;
+    #         Template = Segment \\\{ "/" Segment \} ;
     #         Segment = LITERAL | Variable ;
-    #         Variable = "{" LITERAL "}" ;
+    #         Variable = "\\\{" LITERAL "\}" ;
     #
     #     Examples:
     #
-    #         - "projects/{project}/topics/{topic}"
-    #         - "projects/{project}/knowledgeBases/{knowledge_base}"
+    #         - "projects/\\\{project\}/topics/\\\{topic\}"
+    #         - "projects/\\\{project\}/knowledgeBases/\\\{knowledge_base\}"
     #
     #     The components in braces correspond to the IDs for each resource in the
     #     hierarchy. It is expected that, if multiple patterns are provided,
@@ -172,19 +172,19 @@ module Google
     #
     #         // The InspectTemplate message originally only supported resource
     #         // names with organization, and project was added later.
-    #         message InspectTemplate {
-    #           option (google.api.resource) = {
+    #         message InspectTemplate \\\{
+    #           option (google.api.resource) = \\\{
     #             type: "dlp.googleapis.com/InspectTemplate"
     #             pattern:
-    #             "organizations/{organization}/inspectTemplates/{inspect_template}"
-    #             pattern: "projects/{project}/inspectTemplates/{inspect_template}"
+    #             "organizations/\\\{organization\}/inspectTemplates/\\\{inspect_template\}"
+    #             pattern: "projects/\\\{project\}/inspectTemplates/\\\{inspect_template\}"
     #             history: ORIGINALLY_SINGLE_PATTERN
-    #           };
-    #         }
+    #           \};
+    #         \}
     # @!attribute [rw] plural
     #   @return [String]
     #     The plural name used in the resource name, such as 'projects' for
-    #     the name of 'projects/{project}'. It is the same concept of the `plural`
+    #     the name of 'projects/\\\{project\}'. It is the same concept of the `plural`
     #     field in k8s CRD spec
     #     https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
     # @!attribute [rw] singular
@@ -221,11 +221,11 @@ module Google
     #
     #     Example:
     #
-    #         message Subscription {
-    #           string topic = 2 [(google.api.resource_reference) = {
+    #         message Subscription \\\{
+    #           string topic = 2 [(google.api.resource_reference) = \\\{
     #             type: "pubsub.googleapis.com/Topic"
-    #           }];
-    #         }
+    #           \}];
+    #         \}
     # @!attribute [rw] child_type
     #   @return [String]
     #     The resource type of a child collection that the annotated field
@@ -234,11 +234,11 @@ module Google
     #
     #     Example:
     #
-    #       message ListLogEntriesRequest {
-    #         string parent = 1 [(google.api.resource_reference) = {
+    #       message ListLogEntriesRequest \\\{
+    #         string parent = 1 [(google.api.resource_reference) = \\\{
     #           child_type: "logging.googleapis.com/LogEntry"
-    #         };
-    #       }
+    #         \};
+    #       \}
     class ResourceReference
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/showcase/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/cloud/showcase/proto_docs/google/longrunning/operations.rb
@@ -117,12 +117,12 @@ module Google
     # Example:
     #
     #   rpc LongRunningRecognize(LongRunningRecognizeRequest)
-    #       returns (google.longrunning.Operation) {
-    #     option (google.longrunning.operation_info) = {
+    #       returns (google.longrunning.Operation) \\\{
+    #     option (google.longrunning.operation_info) = \\\{
     #       response_type: "LongRunningRecognizeResponse"
     #       metadata_type: "LongRunningRecognizeMetadata"
-    #     };
-    #   }
+    #     \};
+    #   \}
     # @!attribute [rw] response_type
     #   @return [String]
     #     Required. The message name of the primary return type for this

--- a/shared/output/cloud/showcase/proto_docs/google/protobuf/any.rb
+++ b/shared/output/cloud/showcase/proto_docs/google/protobuf/any.rb
@@ -31,18 +31,18 @@ module Google
     #     Any any;
     #     any.PackFrom(foo);
     #     ...
-    #     if (any.UnpackTo(&foo)) {
+    #     if (any.UnpackTo(&foo)) \\\{
     #       ...
-    #     }
+    #     \}
     #
     # Example 2: Pack and unpack a message in Java.
     #
     #     Foo foo = ...;
     #     Any any = Any.pack(foo);
     #     ...
-    #     if (any.is(Foo.class)) {
+    #     if (any.is(Foo.class)) \\\{
     #       foo = any.unpack(Foo.class);
-    #     }
+    #     \}
     #
     #  Example 3: Pack and unpack a message in Python.
     #
@@ -56,13 +56,13 @@ module Google
     #
     #  Example 4: Pack and unpack a message in Go
     #
-    #      foo := &pb.Foo{...}
+    #      foo := &pb.Foo\\\{...\}
     #      any, err := ptypes.MarshalAny(foo)
     #      ...
-    #      foo := &pb.Foo{}
-    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #      foo := &pb.Foo\\\{\}
+    #      if err := ptypes.UnmarshalAny(any, foo); err != nil \\\{
     #        ...
-    #      }
+    #      \}
     #
     # The pack methods provided by protobuf library will by default use
     # 'type.googleapis.com/full.type.name' as the type URL and the unpack
@@ -78,26 +78,26 @@ module Google
     # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
-    #     message Person {
+    #     message Person \\\{
     #       string first_name = 1;
     #       string last_name = 2;
-    #     }
+    #     \}
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.profile.Person",
     #       "firstName": <string>,
     #       "lastName": <string>
-    #     }
+    #     \}
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
     # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message [google.protobuf.Duration][]):
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.protobuf.Duration",
     #       "value": "1.212s"
-    #     }
+    #     \}
     # @!attribute [rw] type_url
     #   @return [String]
     #     A URL/resource name that uniquely identifies the type of the serialized

--- a/shared/output/cloud/showcase/proto_docs/google/protobuf/duration.rb
+++ b/shared/output/cloud/showcase/proto_docs/google/protobuf/duration.rb
@@ -37,13 +37,13 @@ module Google
     #     duration.seconds = end.seconds - start.seconds;
     #     duration.nanos = end.nanos - start.nanos;
     #
-    #     if (duration.seconds < 0 && duration.nanos > 0) {
+    #     if (duration.seconds < 0 && duration.nanos > 0) \\\{
     #       duration.seconds += 1;
     #       duration.nanos -= 1000000000;
-    #     } else if (durations.seconds > 0 && duration.nanos < 0) {
+    #     \} else if (durations.seconds > 0 && duration.nanos < 0) \\\{
     #       duration.seconds -= 1;
     #       duration.nanos += 1000000000;
-    #     }
+    #     \}
     #
     # Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
     #
@@ -54,13 +54,13 @@ module Google
     #     end.seconds = start.seconds + duration.seconds;
     #     end.nanos = start.nanos + duration.nanos;
     #
-    #     if (end.nanos < 0) {
+    #     if (end.nanos < 0) \\\{
     #       end.seconds -= 1;
     #       end.nanos += 1000000000;
-    #     } else if (end.nanos >= 1000000000) {
+    #     \} else if (end.nanos >= 1000000000) \\\{
     #       end.seconds += 1;
     #       end.nanos -= 1000000000;
-    #     }
+    #     \}
     #
     # Example 3: Compute Duration from datetime.timedelta in Python.
     #

--- a/shared/output/cloud/showcase/proto_docs/google/protobuf/empty.rb
+++ b/shared/output/cloud/showcase/proto_docs/google/protobuf/empty.rb
@@ -23,11 +23,11 @@ module Google
     # empty messages in your APIs. A typical example is to use it as the request
     # or the response type of an API method. For instance:
     #
-    #     service Foo {
+    #     service Foo \\\{
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-    #     }
+    #     \}
     #
-    # The JSON representation for `Empty` is empty JSON object `{}`.
+    # The JSON representation for `Empty` is empty JSON object `\\\{\}`.
     class Empty
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/showcase/proto_docs/google/protobuf/field_mask.rb
+++ b/shared/output/cloud/showcase/proto_docs/google/protobuf/field_mask.rb
@@ -39,14 +39,14 @@ module Google
     # specified in the mask. For example, if the mask in the previous
     # example is applied to a response message as follows:
     #
-    #     f {
+    #     f \\\{
     #       a : 22
-    #       b {
+    #       b \\\{
     #         d : 1
     #         x : 2
-    #       }
+    #       \}
     #       y : 13
-    #     }
+    #     \}
     #     z: 8
     #
     # The result will not contain specific values for fields x,y and z
@@ -54,12 +54,12 @@ module Google
     # output):
     #
     #
-    #     f {
+    #     f \\\{
     #       a : 22
-    #       b {
+    #       b \\\{
     #         d : 1
-    #       }
-    #     }
+    #       \}
+    #     \}
     #
     # A repeated field is not allowed except at the last position of a
     # paths string.
@@ -97,22 +97,22 @@ module Google
     #
     # For example, given the target message:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 1
     #         x: 2
-    #       }
+    #       \}
     #       c: [1]
-    #     }
+    #     \}
     #
     # And an update message:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 10
-    #       }
+    #       \}
     #       c: [2]
-    #     }
+    #     \}
     #
     # then if the field mask is:
     #
@@ -120,13 +120,13 @@ module Google
     #
     # then the result will be:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 10
     #         x: 2
-    #       }
+    #       \}
     #       c: [1, 2]
-    #     }
+    #     \}
     #
     # An implementation may provide options to override this default behavior for
     # repeated and message fields.
@@ -164,51 +164,51 @@ module Google
     #
     # As an example, consider the following message declarations:
     #
-    #     message Profile {
+    #     message Profile \\\{
     #       User user = 1;
     #       Photo photo = 2;
-    #     }
-    #     message User {
+    #     \}
+    #     message User \\\{
     #       string display_name = 1;
     #       string address = 2;
-    #     }
+    #     \}
     #
     # In proto a field mask for `Profile` may look as such:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "user.display_name"
     #       paths: "photo"
-    #     }
+    #     \}
     #
     # In JSON, the same mask is represented as below:
     #
-    #     {
+    #     \\\{
     #       mask: "user.displayName,photo"
-    #     }
+    #     \}
     #
     # # Field Masks and Oneof Fields
     #
     # Field masks treat fields in oneofs just as regular fields. Consider the
     # following message:
     #
-    #     message SampleMessage {
-    #       oneof test_oneof {
+    #     message SampleMessage \\\{
+    #       oneof test_oneof \\\{
     #         string name = 4;
     #         SubMessage sub_message = 9;
-    #       }
-    #     }
+    #       \}
+    #     \}
     #
     # The field mask can be:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "name"
-    #     }
+    #     \}
     #
     # Or:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "sub_message"
-    #     }
+    #     \}
     #
     # Note that oneof type names ("test_oneof" in this case) cannot be used in
     # paths.

--- a/shared/output/cloud/showcase/proto_docs/google/protobuf/timestamp.rb
+++ b/shared/output/cloud/showcase/proto_docs/google/protobuf/timestamp.rb
@@ -79,9 +79,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\\{year\}-\\\{month\}-\\\{day\}T\\\{hour\}:\\\{min\}:\\\{sec\}[.\\\{frac_sec\}]Z"
+    # where \\\{year\} is always expressed using four digits while \\\{month\}, \\\{day\},
+    # \\\{hour\}, \\\{min\}, and \\\{sec\} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required. A proto3 JSON serializer should always use UTC (as indicated by

--- a/shared/output/cloud/speech/proto_docs/google/cloud/speech/v1/cloud_speech.rb
+++ b/shared/output/cloud/speech/proto_docs/google/cloud/speech/v1/cloud_speech.rb
@@ -562,27 +562,27 @@ module Google
         # Here's an example of a series of ten `StreamingRecognizeResponse`s that might
         # be returned while processing audio:
         #
-        # 1. results { alternatives { transcript: "tube" } stability: 0.01 }
+        # 1. results \\\{ alternatives \\\{ transcript: "tube" \} stability: 0.01 \}
         #
-        # 2. results { alternatives { transcript: "to be a" } stability: 0.01 }
+        # 2. results \\\{ alternatives \\\{ transcript: "to be a" \} stability: 0.01 \}
         #
-        # 3. results { alternatives { transcript: "to be" } stability: 0.9 }
-        #    results { alternatives { transcript: " or not to be" } stability: 0.01 }
+        # 3. results \\\{ alternatives \\\{ transcript: "to be" \} stability: 0.9 \}
+        #    results \\\{ alternatives \\\{ transcript: " or not to be" \} stability: 0.01 \}
         #
-        # 4. results { alternatives { transcript: "to be or not to be"
-        #                             confidence: 0.92 }
-        #              alternatives { transcript: "to bee or not to bee" }
-        #              is_final: true }
+        # 4. results \\\{ alternatives \\\{ transcript: "to be or not to be"
+        #                             confidence: 0.92 \}
+        #              alternatives \\\{ transcript: "to bee or not to bee" \}
+        #              is_final: true \}
         #
-        # 5. results { alternatives { transcript: " that's" } stability: 0.01 }
+        # 5. results \\\{ alternatives \\\{ transcript: " that's" \} stability: 0.01 \}
         #
-        # 6. results { alternatives { transcript: " that is" } stability: 0.9 }
-        #    results { alternatives { transcript: " the question" } stability: 0.01 }
+        # 6. results \\\{ alternatives \\\{ transcript: " that is" \} stability: 0.9 \}
+        #    results \\\{ alternatives \\\{ transcript: " the question" \} stability: 0.01 \}
         #
-        # 7. results { alternatives { transcript: " that is the question"
-        #                             confidence: 0.98 }
-        #              alternatives { transcript: " that was the question" }
-        #              is_final: true }
+        # 7. results \\\{ alternatives \\\{ transcript: " that is the question"
+        #                             confidence: 0.98 \}
+        #              alternatives \\\{ transcript: " that was the question" \}
+        #              is_final: true \}
         #
         # Notes:
         #

--- a/shared/output/cloud/speech/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/cloud/speech/proto_docs/google/longrunning/operations.rb
@@ -117,12 +117,12 @@ module Google
     # Example:
     #
     #   rpc LongRunningRecognize(LongRunningRecognizeRequest)
-    #       returns (google.longrunning.Operation) {
-    #     option (google.longrunning.operation_info) = {
+    #       returns (google.longrunning.Operation) \\\{
+    #     option (google.longrunning.operation_info) = \\\{
     #       response_type: "LongRunningRecognizeResponse"
     #       metadata_type: "LongRunningRecognizeMetadata"
-    #     };
-    #   }
+    #     \};
+    #   \}
     # @!attribute [rw] response_type
     #   @return [String]
     #     Required. The message name of the primary return type for this

--- a/shared/output/cloud/speech/proto_docs/google/protobuf/any.rb
+++ b/shared/output/cloud/speech/proto_docs/google/protobuf/any.rb
@@ -31,18 +31,18 @@ module Google
     #     Any any;
     #     any.PackFrom(foo);
     #     ...
-    #     if (any.UnpackTo(&foo)) {
+    #     if (any.UnpackTo(&foo)) \\\{
     #       ...
-    #     }
+    #     \}
     #
     # Example 2: Pack and unpack a message in Java.
     #
     #     Foo foo = ...;
     #     Any any = Any.pack(foo);
     #     ...
-    #     if (any.is(Foo.class)) {
+    #     if (any.is(Foo.class)) \\\{
     #       foo = any.unpack(Foo.class);
-    #     }
+    #     \}
     #
     #  Example 3: Pack and unpack a message in Python.
     #
@@ -56,13 +56,13 @@ module Google
     #
     #  Example 4: Pack and unpack a message in Go
     #
-    #      foo := &pb.Foo{...}
+    #      foo := &pb.Foo\\\{...\}
     #      any, err := ptypes.MarshalAny(foo)
     #      ...
-    #      foo := &pb.Foo{}
-    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #      foo := &pb.Foo\\\{\}
+    #      if err := ptypes.UnmarshalAny(any, foo); err != nil \\\{
     #        ...
-    #      }
+    #      \}
     #
     # The pack methods provided by protobuf library will by default use
     # 'type.googleapis.com/full.type.name' as the type URL and the unpack
@@ -78,26 +78,26 @@ module Google
     # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
-    #     message Person {
+    #     message Person \\\{
     #       string first_name = 1;
     #       string last_name = 2;
-    #     }
+    #     \}
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.profile.Person",
     #       "firstName": <string>,
     #       "lastName": <string>
-    #     }
+    #     \}
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
     # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message [google.protobuf.Duration][]):
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.protobuf.Duration",
     #       "value": "1.212s"
-    #     }
+    #     \}
     # @!attribute [rw] type_url
     #   @return [String]
     #     A URL/resource name that uniquely identifies the type of the serialized

--- a/shared/output/cloud/speech/proto_docs/google/protobuf/duration.rb
+++ b/shared/output/cloud/speech/proto_docs/google/protobuf/duration.rb
@@ -37,13 +37,13 @@ module Google
     #     duration.seconds = end.seconds - start.seconds;
     #     duration.nanos = end.nanos - start.nanos;
     #
-    #     if (duration.seconds < 0 && duration.nanos > 0) {
+    #     if (duration.seconds < 0 && duration.nanos > 0) \\\{
     #       duration.seconds += 1;
     #       duration.nanos -= 1000000000;
-    #     } else if (durations.seconds > 0 && duration.nanos < 0) {
+    #     \} else if (durations.seconds > 0 && duration.nanos < 0) \\\{
     #       duration.seconds -= 1;
     #       duration.nanos += 1000000000;
-    #     }
+    #     \}
     #
     # Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
     #
@@ -54,13 +54,13 @@ module Google
     #     end.seconds = start.seconds + duration.seconds;
     #     end.nanos = start.nanos + duration.nanos;
     #
-    #     if (end.nanos < 0) {
+    #     if (end.nanos < 0) \\\{
     #       end.seconds -= 1;
     #       end.nanos += 1000000000;
-    #     } else if (end.nanos >= 1000000000) {
+    #     \} else if (end.nanos >= 1000000000) \\\{
     #       end.seconds += 1;
     #       end.nanos -= 1000000000;
-    #     }
+    #     \}
     #
     # Example 3: Compute Duration from datetime.timedelta in Python.
     #

--- a/shared/output/cloud/speech/proto_docs/google/protobuf/empty.rb
+++ b/shared/output/cloud/speech/proto_docs/google/protobuf/empty.rb
@@ -23,11 +23,11 @@ module Google
     # empty messages in your APIs. A typical example is to use it as the request
     # or the response type of an API method. For instance:
     #
-    #     service Foo {
+    #     service Foo \\\{
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-    #     }
+    #     \}
     #
-    # The JSON representation for `Empty` is empty JSON object `{}`.
+    # The JSON representation for `Empty` is empty JSON object `\\\{\}`.
     class Empty
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/speech/proto_docs/google/protobuf/timestamp.rb
+++ b/shared/output/cloud/speech/proto_docs/google/protobuf/timestamp.rb
@@ -79,9 +79,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\\{year\}-\\\{month\}-\\\{day\}T\\\{hour\}:\\\{min\}:\\\{sec\}[.\\\{frac_sec\}]Z"
+    # where \\\{year\} is always expressed using four digits while \\\{month\}, \\\{day\},
+    # \\\{hour\}, \\\{min\}, and \\\{sec\} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required. A proto3 JSON serializer should always use UTC (as indicated by

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -128,7 +128,7 @@ module Google
             #   @param parent [String]
             #     Optional. Target project and location to make a call.
             #
-            #     Format: `projects/{project-id}/locations/{location-id}`.
+            #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
             #
             #     If no parent is specified, a region will be chosen automatically.
             #
@@ -206,7 +206,7 @@ module Google
             #   @param parent [String]
             #     Optional. Target project and location to make a call.
             #
-            #     Format: `projects/{project-id}/locations/{location-id}`.
+            #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
             #
             #     If no parent is specified, a region will be chosen automatically.
             #
@@ -289,7 +289,7 @@ module Google
             #   @param parent [String]
             #     Optional. Target project and location to make a call.
             #
-            #     Format: `projects/{project-id}/locations/{location-id}`.
+            #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
             #
             #     If no parent is specified, a region will be chosen automatically.
             #
@@ -365,7 +365,7 @@ module Google
             #   @param parent [String]
             #     Optional. Target project and location to make a call.
             #
-            #     Format: `projects/{project-id}/locations/{location-id}`.
+            #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
             #
             #     If no parent is specified, a region will be chosen automatically.
             #

--- a/shared/output/cloud/vision/proto_docs/google/api/resource.rb
+++ b/shared/output/cloud/vision/proto_docs/google/api/resource.rb
@@ -27,110 +27,110 @@ module Google
     #
     # Example:
     #
-    #     message Topic {
+    #     message Topic \\\{
     #       // Indicates this message defines a resource schema.
-    #       // Declares the resource type in the format of {service}/{kind}.
-    #       // For Kubernetes resources, the format is {api group}/{kind}.
-    #       option (google.api.resource) = {
+    #       // Declares the resource type in the format of \\\{service\}/\\\{kind\}.
+    #       // For Kubernetes resources, the format is \\\{api group\}/\\\{kind\}.
+    #       option (google.api.resource) = \\\{
     #         type: "pubsub.googleapis.com/Topic"
-    #         name_descriptor: {
-    #           pattern: "projects/{project}/topics/{topic}"
+    #         name_descriptor: \\\{
+    #           pattern: "projects/\\\{project\}/topics/\\\{topic\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         }
-    #       };
-    #     }
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #    resources:
     #    - type: "pubsub.googleapis.com/Topic"
     #      name_descriptor:
-    #        - pattern: "projects/{project}/topics/{topic}"
+    #        - pattern: "projects/\\\{project\}/topics/\\\{topic\}"
     #          parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #          parent_name_extractor: "projects/{project}"
+    #          parent_name_extractor: "projects/\\\{project\}"
     #
     # Sometimes, resources have multiple patterns, typically because they can
     # live under multiple parents.
     #
     # Example:
     #
-    #     message LogEntry {
-    #       option (google.api.resource) = {
+    #     message LogEntry \\\{
+    #       option (google.api.resource) = \\\{
     #         type: "logging.googleapis.com/LogEntry"
-    #         name_descriptor: {
-    #           pattern: "projects/{project}/logs/{log}"
+    #         name_descriptor: \\\{
+    #           pattern: "projects/\\\{project\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "folders/{folder}/logs/{log}"
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "folders/\\\{folder\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/{folder}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "organizations/{organization}/logs/{log}"
+    #           parent_name_extractor: "folders/\\\{folder\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/{organization}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "billingAccounts/{billing_account}/logs/{log}"
+    #           parent_name_extractor: "organizations/\\\{organization\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/{billing_account}"
-    #         }
-    #       };
-    #     }
+    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'logging.googleapis.com/LogEntry'
     #       name_descriptor:
-    #         - pattern: "projects/{project}/logs/{log}"
+    #         - pattern: "projects/\\\{project\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         - pattern: "folders/{folder}/logs/{log}"
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         - pattern: "folders/\\\{folder\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/{folder}"
-    #         - pattern: "organizations/{organization}/logs/{log}"
+    #           parent_name_extractor: "folders/\\\{folder\}"
+    #         - pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/{organization}"
-    #         - pattern: "billingAccounts/{billing_account}/logs/{log}"
+    #           parent_name_extractor: "organizations/\\\{organization\}"
+    #         - pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/{billing_account}"
+    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
     #
     # For flexible resources, the resource name doesn't contain parent names, but
     # the resource itself has parents for policy evaluation.
     #
     # Example:
     #
-    #     message Shelf {
-    #       option (google.api.resource) = {
+    #     message Shelf \\\{
+    #       option (google.api.resource) = \\\{
     #         type: "library.googleapis.com/Shelf"
-    #         name_descriptor: {
-    #           pattern: "shelves/{shelf}"
+    #         name_descriptor: \\\{
+    #           pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "shelves/{shelf}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #         }
-    #       };
-    #     }
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'library.googleapis.com/Shelf'
     #       name_descriptor:
-    #         - pattern: "shelves/{shelf}"
+    #         - pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         - pattern: "shelves/{shelf}"
+    #         - pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
     # @!attribute [rw] type
     #   @return [String]
     #     The resource type. It must be in the format of
-    #     {service_name}/{resource_type_kind}. The `resource_type_kind` must be
+    #     \\\{service_name\}/\\\{resource_type_kind\}. The `resource_type_kind` must be
     #     singular and must not include version numbers.
     #
     #     Example: `storage.googleapis.com/Bucket`
@@ -147,14 +147,14 @@ module Google
     #     The path pattern must follow the syntax, which aligns with HTTP binding
     #     syntax:
     #
-    #         Template = Segment { "/" Segment } ;
+    #         Template = Segment \\\{ "/" Segment \} ;
     #         Segment = LITERAL | Variable ;
-    #         Variable = "{" LITERAL "}" ;
+    #         Variable = "\\\{" LITERAL "\}" ;
     #
     #     Examples:
     #
-    #         - "projects/{project}/topics/{topic}"
-    #         - "projects/{project}/knowledgeBases/{knowledge_base}"
+    #         - "projects/\\\{project\}/topics/\\\{topic\}"
+    #         - "projects/\\\{project\}/knowledgeBases/\\\{knowledge_base\}"
     #
     #     The components in braces correspond to the IDs for each resource in the
     #     hierarchy. It is expected that, if multiple patterns are provided,
@@ -172,19 +172,19 @@ module Google
     #
     #         // The InspectTemplate message originally only supported resource
     #         // names with organization, and project was added later.
-    #         message InspectTemplate {
-    #           option (google.api.resource) = {
+    #         message InspectTemplate \\\{
+    #           option (google.api.resource) = \\\{
     #             type: "dlp.googleapis.com/InspectTemplate"
     #             pattern:
-    #             "organizations/{organization}/inspectTemplates/{inspect_template}"
-    #             pattern: "projects/{project}/inspectTemplates/{inspect_template}"
+    #             "organizations/\\\{organization\}/inspectTemplates/\\\{inspect_template\}"
+    #             pattern: "projects/\\\{project\}/inspectTemplates/\\\{inspect_template\}"
     #             history: ORIGINALLY_SINGLE_PATTERN
-    #           };
-    #         }
+    #           \};
+    #         \}
     # @!attribute [rw] plural
     #   @return [String]
     #     The plural name used in the resource name, such as 'projects' for
-    #     the name of 'projects/{project}'. It is the same concept of the `plural`
+    #     the name of 'projects/\\\{project\}'. It is the same concept of the `plural`
     #     field in k8s CRD spec
     #     https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
     # @!attribute [rw] singular
@@ -221,11 +221,11 @@ module Google
     #
     #     Example:
     #
-    #         message Subscription {
-    #           string topic = 2 [(google.api.resource_reference) = {
+    #         message Subscription \\\{
+    #           string topic = 2 [(google.api.resource_reference) = \\\{
     #             type: "pubsub.googleapis.com/Topic"
-    #           }];
-    #         }
+    #           \}];
+    #         \}
     # @!attribute [rw] child_type
     #   @return [String]
     #     The resource type of a child collection that the annotated field
@@ -234,11 +234,11 @@ module Google
     #
     #     Example:
     #
-    #       message ListLogEntriesRequest {
-    #         string parent = 1 [(google.api.resource_reference) = {
+    #       message ListLogEntriesRequest \\\{
+    #         string parent = 1 [(google.api.resource_reference) = \\\{
     #           child_type: "logging.googleapis.com/LogEntry"
-    #         };
-    #       }
+    #         \};
+    #       \}
     class ResourceReference
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/vision/proto_docs/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/cloud/vision/proto_docs/google/cloud/vision/v1/image_annotator.rb
@@ -695,7 +695,7 @@ module Google
         #   @return [String]
         #     Optional. Target project and location to make a call.
         #
-        #     Format: `projects/{project-id}/locations/{location-id}`.
+        #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
         #
         #     If no parent is specified, a region will be chosen automatically.
         #
@@ -780,7 +780,7 @@ module Google
         #   @return [String]
         #     Optional. Target project and location to make a call.
         #
-        #     Format: `projects/{project-id}/locations/{location-id}`.
+        #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
         #
         #     If no parent is specified, a region will be chosen automatically.
         #
@@ -843,7 +843,7 @@ module Google
         #   @return [String]
         #     Optional. Target project and location to make a call.
         #
-        #     Format: `projects/{project-id}/locations/{location-id}`.
+        #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
         #
         #     If no parent is specified, a region will be chosen automatically.
         #
@@ -876,7 +876,7 @@ module Google
         #   @return [String]
         #     Optional. Target project and location to make a call.
         #
-        #     Format: `projects/{project-id}/locations/{location-id}`.
+        #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
         #
         #     If no parent is specified, a region will be chosen automatically.
         #

--- a/shared/output/cloud/vision/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/cloud/vision/proto_docs/google/longrunning/operations.rb
@@ -117,12 +117,12 @@ module Google
     # Example:
     #
     #   rpc LongRunningRecognize(LongRunningRecognizeRequest)
-    #       returns (google.longrunning.Operation) {
-    #     option (google.longrunning.operation_info) = {
+    #       returns (google.longrunning.Operation) \\\{
+    #     option (google.longrunning.operation_info) = \\\{
     #       response_type: "LongRunningRecognizeResponse"
     #       metadata_type: "LongRunningRecognizeMetadata"
-    #     };
-    #   }
+    #     \};
+    #   \}
     # @!attribute [rw] response_type
     #   @return [String]
     #     Required. The message name of the primary return type for this

--- a/shared/output/cloud/vision/proto_docs/google/protobuf/any.rb
+++ b/shared/output/cloud/vision/proto_docs/google/protobuf/any.rb
@@ -31,18 +31,18 @@ module Google
     #     Any any;
     #     any.PackFrom(foo);
     #     ...
-    #     if (any.UnpackTo(&foo)) {
+    #     if (any.UnpackTo(&foo)) \\\{
     #       ...
-    #     }
+    #     \}
     #
     # Example 2: Pack and unpack a message in Java.
     #
     #     Foo foo = ...;
     #     Any any = Any.pack(foo);
     #     ...
-    #     if (any.is(Foo.class)) {
+    #     if (any.is(Foo.class)) \\\{
     #       foo = any.unpack(Foo.class);
-    #     }
+    #     \}
     #
     #  Example 3: Pack and unpack a message in Python.
     #
@@ -56,13 +56,13 @@ module Google
     #
     #  Example 4: Pack and unpack a message in Go
     #
-    #      foo := &pb.Foo{...}
+    #      foo := &pb.Foo\\\{...\}
     #      any, err := ptypes.MarshalAny(foo)
     #      ...
-    #      foo := &pb.Foo{}
-    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #      foo := &pb.Foo\\\{\}
+    #      if err := ptypes.UnmarshalAny(any, foo); err != nil \\\{
     #        ...
-    #      }
+    #      \}
     #
     # The pack methods provided by protobuf library will by default use
     # 'type.googleapis.com/full.type.name' as the type URL and the unpack
@@ -78,26 +78,26 @@ module Google
     # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
-    #     message Person {
+    #     message Person \\\{
     #       string first_name = 1;
     #       string last_name = 2;
-    #     }
+    #     \}
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.profile.Person",
     #       "firstName": <string>,
     #       "lastName": <string>
-    #     }
+    #     \}
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
     # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message [google.protobuf.Duration][]):
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.protobuf.Duration",
     #       "value": "1.212s"
-    #     }
+    #     \}
     # @!attribute [rw] type_url
     #   @return [String]
     #     A URL/resource name that uniquely identifies the type of the serialized

--- a/shared/output/cloud/vision/proto_docs/google/protobuf/empty.rb
+++ b/shared/output/cloud/vision/proto_docs/google/protobuf/empty.rb
@@ -23,11 +23,11 @@ module Google
     # empty messages in your APIs. A typical example is to use it as the request
     # or the response type of an API method. For instance:
     #
-    #     service Foo {
+    #     service Foo \\\{
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-    #     }
+    #     \}
     #
-    # The JSON representation for `Empty` is empty JSON object `{}`.
+    # The JSON representation for `Empty` is empty JSON object `\\\{\}`.
     class Empty
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/vision/proto_docs/google/protobuf/field_mask.rb
+++ b/shared/output/cloud/vision/proto_docs/google/protobuf/field_mask.rb
@@ -39,14 +39,14 @@ module Google
     # specified in the mask. For example, if the mask in the previous
     # example is applied to a response message as follows:
     #
-    #     f {
+    #     f \\\{
     #       a : 22
-    #       b {
+    #       b \\\{
     #         d : 1
     #         x : 2
-    #       }
+    #       \}
     #       y : 13
-    #     }
+    #     \}
     #     z: 8
     #
     # The result will not contain specific values for fields x,y and z
@@ -54,12 +54,12 @@ module Google
     # output):
     #
     #
-    #     f {
+    #     f \\\{
     #       a : 22
-    #       b {
+    #       b \\\{
     #         d : 1
-    #       }
-    #     }
+    #       \}
+    #     \}
     #
     # A repeated field is not allowed except at the last position of a
     # paths string.
@@ -97,22 +97,22 @@ module Google
     #
     # For example, given the target message:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 1
     #         x: 2
-    #       }
+    #       \}
     #       c: [1]
-    #     }
+    #     \}
     #
     # And an update message:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 10
-    #       }
+    #       \}
     #       c: [2]
-    #     }
+    #     \}
     #
     # then if the field mask is:
     #
@@ -120,13 +120,13 @@ module Google
     #
     # then the result will be:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 10
     #         x: 2
-    #       }
+    #       \}
     #       c: [1, 2]
-    #     }
+    #     \}
     #
     # An implementation may provide options to override this default behavior for
     # repeated and message fields.
@@ -164,51 +164,51 @@ module Google
     #
     # As an example, consider the following message declarations:
     #
-    #     message Profile {
+    #     message Profile \\\{
     #       User user = 1;
     #       Photo photo = 2;
-    #     }
-    #     message User {
+    #     \}
+    #     message User \\\{
     #       string display_name = 1;
     #       string address = 2;
-    #     }
+    #     \}
     #
     # In proto a field mask for `Profile` may look as such:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "user.display_name"
     #       paths: "photo"
-    #     }
+    #     \}
     #
     # In JSON, the same mask is represented as below:
     #
-    #     {
+    #     \\\{
     #       mask: "user.displayName,photo"
-    #     }
+    #     \}
     #
     # # Field Masks and Oneof Fields
     #
     # Field masks treat fields in oneofs just as regular fields. Consider the
     # following message:
     #
-    #     message SampleMessage {
-    #       oneof test_oneof {
+    #     message SampleMessage \\\{
+    #       oneof test_oneof \\\{
     #         string name = 4;
     #         SubMessage sub_message = 9;
-    #       }
-    #     }
+    #       \}
+    #     \}
     #
     # The field mask can be:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "name"
-    #     }
+    #     \}
     #
     # Or:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "sub_message"
-    #     }
+    #     \}
     #
     # Note that oneof type names ("test_oneof" in this case) cannot be used in
     # paths.

--- a/shared/output/cloud/vision/proto_docs/google/protobuf/timestamp.rb
+++ b/shared/output/cloud/vision/proto_docs/google/protobuf/timestamp.rb
@@ -79,9 +79,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\\{year\}-\\\{month\}-\\\{day\}T\\\{hour\}:\\\{min\}:\\\{sec\}[.\\\{frac_sec\}]Z"
+    # where \\\{year\} is always expressed using four digits while \\\{month\}, \\\{day\},
+    # \\\{hour\}, \\\{min\}, and \\\{sec\} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required. A proto3 JSON serializer should always use UTC (as indicated by

--- a/shared/output/cloud/vision/proto_docs/google/type/color.rb
+++ b/shared/output/cloud/vision/proto_docs/google/type/color.rb
@@ -37,7 +37,7 @@ module Google
     #      import com.google.type.Color;
     #
     #      // ...
-    #      public static java.awt.Color fromProto(Color protocolor) {
+    #      public static java.awt.Color fromProto(Color protocolor) \\\{
     #        float alpha = protocolor.hasAlpha()
     #            ? protocolor.getAlpha().getValue()
     #            : 1.0;
@@ -47,9 +47,9 @@ module Google
     #            protocolor.getGreen(),
     #            protocolor.getBlue(),
     #            alpha);
-    #      }
+    #      \}
     #
-    #      public static Color toProto(java.awt.Color color) {
+    #      public static Color toProto(java.awt.Color color) \\\{
     #        float red = (float) color.getRed();
     #        float green = (float) color.getGreen();
     #        float blue = (float) color.getBlue();
@@ -61,54 +61,54 @@ module Google
     #                .setGreen(green / denominator)
     #                .setBlue(blue / denominator);
     #        int alpha = color.getAlpha();
-    #        if (alpha != 255) {
+    #        if (alpha != 255) \\\{
     #          result.setAlpha(
     #              FloatValue
     #                  .newBuilder()
     #                  .setValue(((float) alpha) / denominator)
     #                  .build());
-    #        }
+    #        \}
     #        return resultBuilder.build();
-    #      }
+    #      \}
     #      // ...
     #
     # Example (iOS / Obj-C):
     #
     #      // ...
-    #      static UIColor* fromProto(Color* protocolor) {
+    #      static UIColor* fromProto(Color* protocolor) \\\{
     #         float red = [protocolor red];
     #         float green = [protocolor green];
     #         float blue = [protocolor blue];
     #         FloatValue* alpha_wrapper = [protocolor alpha];
     #         float alpha = 1.0;
-    #         if (alpha_wrapper != nil) {
+    #         if (alpha_wrapper != nil) \\\{
     #           alpha = [alpha_wrapper value];
-    #         }
+    #         \}
     #         return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
-    #      }
+    #      \}
     #
-    #      static Color* toProto(UIColor* color) {
+    #      static Color* toProto(UIColor* color) \\\{
     #          CGFloat red, green, blue, alpha;
-    #          if (![color getRed:&red green:&green blue:&blue alpha:&alpha]) {
+    #          if (![color getRed:&red green:&green blue:&blue alpha:&alpha]) \\\{
     #            return nil;
-    #          }
+    #          \}
     #          Color* result = [[Color alloc] init];
     #          [result setRed:red];
     #          [result setGreen:green];
     #          [result setBlue:blue];
-    #          if (alpha <= 0.9999) {
+    #          if (alpha <= 0.9999) \\\{
     #            [result setAlpha:floatWrapperWithValue(alpha)];
-    #          }
+    #          \}
     #          [result autorelease];
     #          return result;
-    #     }
+    #     \}
     #     // ...
     #
     #  Example (JavaScript):
     #
     #     // ...
     #
-    #     var protoToCssColor = function(rgb_color) {
+    #     var protoToCssColor = function(rgb_color) \\\{
     #        var redFrac = rgb_color.red || 0.0;
     #        var greenFrac = rgb_color.green || 0.0;
     #        var blueFrac = rgb_color.blue || 0.0;
@@ -116,26 +116,26 @@ module Google
     #        var green = Math.floor(greenFrac * 255);
     #        var blue = Math.floor(blueFrac * 255);
     #
-    #        if (!('alpha' in rgb_color)) {
+    #        if (!('alpha' in rgb_color)) \\\{
     #           return rgbToCssColor_(red, green, blue);
-    #        }
+    #        \}
     #
     #        var alphaFrac = rgb_color.alpha.value || 0.0;
     #        var rgbParams = [red, green, blue].join(',');
     #        return ['rgba(', rgbParams, ',', alphaFrac, ')'].join('');
-    #     };
+    #     \};
     #
-    #     var rgbToCssColor_ = function(red, green, blue) {
+    #     var rgbToCssColor_ = function(red, green, blue) \\\{
     #       var rgbNumber = new Number((red << 16) | (green << 8) | blue);
     #       var hexString = rgbNumber.toString(16);
     #       var missingZeros = 6 - hexString.length;
     #       var resultBuilder = ['#'];
-    #       for (var i = 0; i < missingZeros; i++) {
+    #       for (var i = 0; i < missingZeros; i++) \\\{
     #          resultBuilder.push('0');
-    #       }
+    #       \}
     #       resultBuilder.push(hexString);
     #       return resultBuilder.join('');
-    #     };
+    #     \};
     #
     #     // ...
     # @!attribute [rw] red

--- a/shared/output/gapic/templates/garbage/proto_docs/google/api/resource.rb
+++ b/shared/output/gapic/templates/garbage/proto_docs/google/api/resource.rb
@@ -35,110 +35,110 @@ module Google
     #
     # Example:
     #
-    #     message Topic {
+    #     message Topic \\\{
     #       // Indicates this message defines a resource schema.
-    #       // Declares the resource type in the format of {service}/{kind}.
-    #       // For Kubernetes resources, the format is {api group}/{kind}.
-    #       option (google.api.resource) = {
+    #       // Declares the resource type in the format of \\\{service\}/\\\{kind\}.
+    #       // For Kubernetes resources, the format is \\\{api group\}/\\\{kind\}.
+    #       option (google.api.resource) = \\\{
     #         type: "pubsub.googleapis.com/Topic"
-    #         name_descriptor: {
-    #           pattern: "projects/{project}/topics/{topic}"
+    #         name_descriptor: \\\{
+    #           pattern: "projects/\\\{project\}/topics/\\\{topic\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         }
-    #       };
-    #     }
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #    resources:
     #    - type: "pubsub.googleapis.com/Topic"
     #      name_descriptor:
-    #        - pattern: "projects/{project}/topics/{topic}"
+    #        - pattern: "projects/\\\{project\}/topics/\\\{topic\}"
     #          parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #          parent_name_extractor: "projects/{project}"
+    #          parent_name_extractor: "projects/\\\{project\}"
     #
     # Sometimes, resources have multiple patterns, typically because they can
     # live under multiple parents.
     #
     # Example:
     #
-    #     message LogEntry {
-    #       option (google.api.resource) = {
+    #     message LogEntry \\\{
+    #       option (google.api.resource) = \\\{
     #         type: "logging.googleapis.com/LogEntry"
-    #         name_descriptor: {
-    #           pattern: "projects/{project}/logs/{log}"
+    #         name_descriptor: \\\{
+    #           pattern: "projects/\\\{project\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "folders/{folder}/logs/{log}"
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "folders/\\\{folder\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/{folder}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "organizations/{organization}/logs/{log}"
+    #           parent_name_extractor: "folders/\\\{folder\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/{organization}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "billingAccounts/{billing_account}/logs/{log}"
+    #           parent_name_extractor: "organizations/\\\{organization\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/{billing_account}"
-    #         }
-    #       };
-    #     }
+    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'logging.googleapis.com/LogEntry'
     #       name_descriptor:
-    #         - pattern: "projects/{project}/logs/{log}"
+    #         - pattern: "projects/\\\{project\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         - pattern: "folders/{folder}/logs/{log}"
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         - pattern: "folders/\\\{folder\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/{folder}"
-    #         - pattern: "organizations/{organization}/logs/{log}"
+    #           parent_name_extractor: "folders/\\\{folder\}"
+    #         - pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/{organization}"
-    #         - pattern: "billingAccounts/{billing_account}/logs/{log}"
+    #           parent_name_extractor: "organizations/\\\{organization\}"
+    #         - pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/{billing_account}"
+    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
     #
     # For flexible resources, the resource name doesn't contain parent names, but
     # the resource itself has parents for policy evaluation.
     #
     # Example:
     #
-    #     message Shelf {
-    #       option (google.api.resource) = {
+    #     message Shelf \\\{
+    #       option (google.api.resource) = \\\{
     #         type: "library.googleapis.com/Shelf"
-    #         name_descriptor: {
-    #           pattern: "shelves/{shelf}"
+    #         name_descriptor: \\\{
+    #           pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "shelves/{shelf}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #         }
-    #       };
-    #     }
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'library.googleapis.com/Shelf'
     #       name_descriptor:
-    #         - pattern: "shelves/{shelf}"
+    #         - pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         - pattern: "shelves/{shelf}"
+    #         - pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
     # @!attribute [rw] type
     #   @return [String]
     #     The resource type. It must be in the format of
-    #     {service_name}/{resource_type_kind}. The `resource_type_kind` must be
+    #     \\\{service_name\}/\\\{resource_type_kind\}. The `resource_type_kind` must be
     #     singular and must not include version numbers.
     #
     #     Example: `storage.googleapis.com/Bucket`
@@ -155,14 +155,14 @@ module Google
     #     The path pattern must follow the syntax, which aligns with HTTP binding
     #     syntax:
     #
-    #         Template = Segment { "/" Segment } ;
+    #         Template = Segment \\\{ "/" Segment \} ;
     #         Segment = LITERAL | Variable ;
-    #         Variable = "{" LITERAL "}" ;
+    #         Variable = "\\\{" LITERAL "\}" ;
     #
     #     Examples:
     #
-    #         - "projects/{project}/topics/{topic}"
-    #         - "projects/{project}/knowledgeBases/{knowledge_base}"
+    #         - "projects/\\\{project\}/topics/\\\{topic\}"
+    #         - "projects/\\\{project\}/knowledgeBases/\\\{knowledge_base\}"
     #
     #     The components in braces correspond to the IDs for each resource in the
     #     hierarchy. It is expected that, if multiple patterns are provided,
@@ -180,19 +180,19 @@ module Google
     #
     #         // The InspectTemplate message originally only supported resource
     #         // names with organization, and project was added later.
-    #         message InspectTemplate {
-    #           option (google.api.resource) = {
+    #         message InspectTemplate \\\{
+    #           option (google.api.resource) = \\\{
     #             type: "dlp.googleapis.com/InspectTemplate"
     #             pattern:
-    #             "organizations/{organization}/inspectTemplates/{inspect_template}"
-    #             pattern: "projects/{project}/inspectTemplates/{inspect_template}"
+    #             "organizations/\\\{organization\}/inspectTemplates/\\\{inspect_template\}"
+    #             pattern: "projects/\\\{project\}/inspectTemplates/\\\{inspect_template\}"
     #             history: ORIGINALLY_SINGLE_PATTERN
-    #           };
-    #         }
+    #           \};
+    #         \}
     # @!attribute [rw] plural
     #   @return [String]
     #     The plural name used in the resource name, such as 'projects' for
-    #     the name of 'projects/{project}'. It is the same concept of the `plural`
+    #     the name of 'projects/\\\{project\}'. It is the same concept of the `plural`
     #     field in k8s CRD spec
     #     https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
     # @!attribute [rw] singular
@@ -229,11 +229,11 @@ module Google
     #
     #     Example:
     #
-    #         message Subscription {
-    #           string topic = 2 [(google.api.resource_reference) = {
+    #         message Subscription \\\{
+    #           string topic = 2 [(google.api.resource_reference) = \\\{
     #             type: "pubsub.googleapis.com/Topic"
-    #           }];
-    #         }
+    #           \}];
+    #         \}
     # @!attribute [rw] child_type
     #   @return [String]
     #     The resource type of a child collection that the annotated field
@@ -242,11 +242,11 @@ module Google
     #
     #     Example:
     #
-    #       message ListLogEntriesRequest {
-    #         string parent = 1 [(google.api.resource_reference) = {
+    #       message ListLogEntriesRequest \\\{
+    #         string parent = 1 [(google.api.resource_reference) = \\\{
     #           child_type: "logging.googleapis.com/LogEntry"
-    #         };
-    #       }
+    #         \};
+    #       \}
     class ResourceReference
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/gapic/templates/garbage/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/gapic/templates/garbage/proto_docs/google/longrunning/operations.rb
@@ -125,12 +125,12 @@ module Google
     # Example:
     #
     #   rpc LongRunningRecognize(LongRunningRecognizeRequest)
-    #       returns (google.longrunning.Operation) {
-    #     option (google.longrunning.operation_info) = {
+    #       returns (google.longrunning.Operation) \\\{
+    #     option (google.longrunning.operation_info) = \\\{
     #       response_type: "LongRunningRecognizeResponse"
     #       metadata_type: "LongRunningRecognizeMetadata"
-    #     };
-    #   }
+    #     \};
+    #   \}
     # @!attribute [rw] response_type
     #   @return [String]
     #     Required. The message name of the primary return type for this

--- a/shared/output/gapic/templates/garbage/proto_docs/google/protobuf/any.rb
+++ b/shared/output/gapic/templates/garbage/proto_docs/google/protobuf/any.rb
@@ -39,18 +39,18 @@ module Google
     #     Any any;
     #     any.PackFrom(foo);
     #     ...
-    #     if (any.UnpackTo(&foo)) {
+    #     if (any.UnpackTo(&foo)) \\\{
     #       ...
-    #     }
+    #     \}
     #
     # Example 2: Pack and unpack a message in Java.
     #
     #     Foo foo = ...;
     #     Any any = Any.pack(foo);
     #     ...
-    #     if (any.is(Foo.class)) {
+    #     if (any.is(Foo.class)) \\\{
     #       foo = any.unpack(Foo.class);
-    #     }
+    #     \}
     #
     #  Example 3: Pack and unpack a message in Python.
     #
@@ -64,13 +64,13 @@ module Google
     #
     #  Example 4: Pack and unpack a message in Go
     #
-    #      foo := &pb.Foo{...}
+    #      foo := &pb.Foo\\\{...\}
     #      any, err := ptypes.MarshalAny(foo)
     #      ...
-    #      foo := &pb.Foo{}
-    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #      foo := &pb.Foo\\\{\}
+    #      if err := ptypes.UnmarshalAny(any, foo); err != nil \\\{
     #        ...
-    #      }
+    #      \}
     #
     # The pack methods provided by protobuf library will by default use
     # 'type.googleapis.com/full.type.name' as the type URL and the unpack
@@ -86,26 +86,26 @@ module Google
     # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
-    #     message Person {
+    #     message Person \\\{
     #       string first_name = 1;
     #       string last_name = 2;
-    #     }
+    #     \}
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.profile.Person",
     #       "firstName": <string>,
     #       "lastName": <string>
-    #     }
+    #     \}
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
     # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message [google.protobuf.Duration][]):
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.protobuf.Duration",
     #       "value": "1.212s"
-    #     }
+    #     \}
     # @!attribute [rw] type_url
     #   @return [String]
     #     A URL/resource name that uniquely identifies the type of the serialized

--- a/shared/output/gapic/templates/garbage/proto_docs/google/protobuf/duration.rb
+++ b/shared/output/gapic/templates/garbage/proto_docs/google/protobuf/duration.rb
@@ -45,13 +45,13 @@ module Google
     #     duration.seconds = end.seconds - start.seconds;
     #     duration.nanos = end.nanos - start.nanos;
     #
-    #     if (duration.seconds < 0 && duration.nanos > 0) {
+    #     if (duration.seconds < 0 && duration.nanos > 0) \\\{
     #       duration.seconds += 1;
     #       duration.nanos -= 1000000000;
-    #     } else if (durations.seconds > 0 && duration.nanos < 0) {
+    #     \} else if (durations.seconds > 0 && duration.nanos < 0) \\\{
     #       duration.seconds -= 1;
     #       duration.nanos += 1000000000;
-    #     }
+    #     \}
     #
     # Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
     #
@@ -62,13 +62,13 @@ module Google
     #     end.seconds = start.seconds + duration.seconds;
     #     end.nanos = start.nanos + duration.nanos;
     #
-    #     if (end.nanos < 0) {
+    #     if (end.nanos < 0) \\\{
     #       end.seconds -= 1;
     #       end.nanos += 1000000000;
-    #     } else if (end.nanos >= 1000000000) {
+    #     \} else if (end.nanos >= 1000000000) \\\{
     #       end.seconds += 1;
     #       end.nanos -= 1000000000;
-    #     }
+    #     \}
     #
     # Example 3: Compute Duration from datetime.timedelta in Python.
     #

--- a/shared/output/gapic/templates/garbage/proto_docs/google/protobuf/empty.rb
+++ b/shared/output/gapic/templates/garbage/proto_docs/google/protobuf/empty.rb
@@ -31,11 +31,11 @@ module Google
     # empty messages in your APIs. A typical example is to use it as the request
     # or the response type of an API method. For instance:
     #
-    #     service Foo {
+    #     service Foo \\\{
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-    #     }
+    #     \}
     #
-    # The JSON representation for `Empty` is empty JSON object `{}`.
+    # The JSON representation for `Empty` is empty JSON object `\\\{\}`.
     class Empty
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/gapic/templates/garbage/proto_docs/google/protobuf/timestamp.rb
+++ b/shared/output/gapic/templates/garbage/proto_docs/google/protobuf/timestamp.rb
@@ -87,9 +87,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\\{year\}-\\\{month\}-\\\{day\}T\\\{hour\}:\\\{min\}:\\\{sec\}[.\\\{frac_sec\}]Z"
+    # where \\\{year\} is always expressed using four digits while \\\{month\}, \\\{day\},
+    # \\\{hour\}, \\\{min\}, and \\\{sec\} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required. A proto3 JSON serializer should always use UTC (as indicated by

--- a/shared/output/gapic/templates/language/proto_docs/google/protobuf/timestamp.rb
+++ b/shared/output/gapic/templates/language/proto_docs/google/protobuf/timestamp.rb
@@ -87,9 +87,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\\{year\}-\\\{month\}-\\\{day\}T\\\{hour\}:\\\{min\}:\\\{sec\}[.\\\{frac_sec\}]Z"
+    # where \\\{year\} is always expressed using four digits while \\\{month\}, \\\{day\},
+    # \\\{hour\}, \\\{min\}, and \\\{sec\} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required. A proto3 JSON serializer should always use UTC (as indicated by

--- a/shared/output/gapic/templates/showcase/proto_docs/google/api/resource.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/api/resource.rb
@@ -35,110 +35,110 @@ module Google
     #
     # Example:
     #
-    #     message Topic {
+    #     message Topic \\\{
     #       // Indicates this message defines a resource schema.
-    #       // Declares the resource type in the format of {service}/{kind}.
-    #       // For Kubernetes resources, the format is {api group}/{kind}.
-    #       option (google.api.resource) = {
+    #       // Declares the resource type in the format of \\\{service\}/\\\{kind\}.
+    #       // For Kubernetes resources, the format is \\\{api group\}/\\\{kind\}.
+    #       option (google.api.resource) = \\\{
     #         type: "pubsub.googleapis.com/Topic"
-    #         name_descriptor: {
-    #           pattern: "projects/{project}/topics/{topic}"
+    #         name_descriptor: \\\{
+    #           pattern: "projects/\\\{project\}/topics/\\\{topic\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         }
-    #       };
-    #     }
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #    resources:
     #    - type: "pubsub.googleapis.com/Topic"
     #      name_descriptor:
-    #        - pattern: "projects/{project}/topics/{topic}"
+    #        - pattern: "projects/\\\{project\}/topics/\\\{topic\}"
     #          parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #          parent_name_extractor: "projects/{project}"
+    #          parent_name_extractor: "projects/\\\{project\}"
     #
     # Sometimes, resources have multiple patterns, typically because they can
     # live under multiple parents.
     #
     # Example:
     #
-    #     message LogEntry {
-    #       option (google.api.resource) = {
+    #     message LogEntry \\\{
+    #       option (google.api.resource) = \\\{
     #         type: "logging.googleapis.com/LogEntry"
-    #         name_descriptor: {
-    #           pattern: "projects/{project}/logs/{log}"
+    #         name_descriptor: \\\{
+    #           pattern: "projects/\\\{project\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "folders/{folder}/logs/{log}"
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "folders/\\\{folder\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/{folder}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "organizations/{organization}/logs/{log}"
+    #           parent_name_extractor: "folders/\\\{folder\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/{organization}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "billingAccounts/{billing_account}/logs/{log}"
+    #           parent_name_extractor: "organizations/\\\{organization\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/{billing_account}"
-    #         }
-    #       };
-    #     }
+    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'logging.googleapis.com/LogEntry'
     #       name_descriptor:
-    #         - pattern: "projects/{project}/logs/{log}"
+    #         - pattern: "projects/\\\{project\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         - pattern: "folders/{folder}/logs/{log}"
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         - pattern: "folders/\\\{folder\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/{folder}"
-    #         - pattern: "organizations/{organization}/logs/{log}"
+    #           parent_name_extractor: "folders/\\\{folder\}"
+    #         - pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/{organization}"
-    #         - pattern: "billingAccounts/{billing_account}/logs/{log}"
+    #           parent_name_extractor: "organizations/\\\{organization\}"
+    #         - pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/{billing_account}"
+    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
     #
     # For flexible resources, the resource name doesn't contain parent names, but
     # the resource itself has parents for policy evaluation.
     #
     # Example:
     #
-    #     message Shelf {
-    #       option (google.api.resource) = {
+    #     message Shelf \\\{
+    #       option (google.api.resource) = \\\{
     #         type: "library.googleapis.com/Shelf"
-    #         name_descriptor: {
-    #           pattern: "shelves/{shelf}"
+    #         name_descriptor: \\\{
+    #           pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "shelves/{shelf}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #         }
-    #       };
-    #     }
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'library.googleapis.com/Shelf'
     #       name_descriptor:
-    #         - pattern: "shelves/{shelf}"
+    #         - pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         - pattern: "shelves/{shelf}"
+    #         - pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
     # @!attribute [rw] type
     #   @return [String]
     #     The resource type. It must be in the format of
-    #     {service_name}/{resource_type_kind}. The `resource_type_kind` must be
+    #     \\\{service_name\}/\\\{resource_type_kind\}. The `resource_type_kind` must be
     #     singular and must not include version numbers.
     #
     #     Example: `storage.googleapis.com/Bucket`
@@ -155,14 +155,14 @@ module Google
     #     The path pattern must follow the syntax, which aligns with HTTP binding
     #     syntax:
     #
-    #         Template = Segment { "/" Segment } ;
+    #         Template = Segment \\\{ "/" Segment \} ;
     #         Segment = LITERAL | Variable ;
-    #         Variable = "{" LITERAL "}" ;
+    #         Variable = "\\\{" LITERAL "\}" ;
     #
     #     Examples:
     #
-    #         - "projects/{project}/topics/{topic}"
-    #         - "projects/{project}/knowledgeBases/{knowledge_base}"
+    #         - "projects/\\\{project\}/topics/\\\{topic\}"
+    #         - "projects/\\\{project\}/knowledgeBases/\\\{knowledge_base\}"
     #
     #     The components in braces correspond to the IDs for each resource in the
     #     hierarchy. It is expected that, if multiple patterns are provided,
@@ -180,19 +180,19 @@ module Google
     #
     #         // The InspectTemplate message originally only supported resource
     #         // names with organization, and project was added later.
-    #         message InspectTemplate {
-    #           option (google.api.resource) = {
+    #         message InspectTemplate \\\{
+    #           option (google.api.resource) = \\\{
     #             type: "dlp.googleapis.com/InspectTemplate"
     #             pattern:
-    #             "organizations/{organization}/inspectTemplates/{inspect_template}"
-    #             pattern: "projects/{project}/inspectTemplates/{inspect_template}"
+    #             "organizations/\\\{organization\}/inspectTemplates/\\\{inspect_template\}"
+    #             pattern: "projects/\\\{project\}/inspectTemplates/\\\{inspect_template\}"
     #             history: ORIGINALLY_SINGLE_PATTERN
-    #           };
-    #         }
+    #           \};
+    #         \}
     # @!attribute [rw] plural
     #   @return [String]
     #     The plural name used in the resource name, such as 'projects' for
-    #     the name of 'projects/{project}'. It is the same concept of the `plural`
+    #     the name of 'projects/\\\{project\}'. It is the same concept of the `plural`
     #     field in k8s CRD spec
     #     https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
     # @!attribute [rw] singular
@@ -229,11 +229,11 @@ module Google
     #
     #     Example:
     #
-    #         message Subscription {
-    #           string topic = 2 [(google.api.resource_reference) = {
+    #         message Subscription \\\{
+    #           string topic = 2 [(google.api.resource_reference) = \\\{
     #             type: "pubsub.googleapis.com/Topic"
-    #           }];
-    #         }
+    #           \}];
+    #         \}
     # @!attribute [rw] child_type
     #   @return [String]
     #     The resource type of a child collection that the annotated field
@@ -242,11 +242,11 @@ module Google
     #
     #     Example:
     #
-    #       message ListLogEntriesRequest {
-    #         string parent = 1 [(google.api.resource_reference) = {
+    #       message ListLogEntriesRequest \\\{
+    #         string parent = 1 [(google.api.resource_reference) = \\\{
     #           child_type: "logging.googleapis.com/LogEntry"
-    #         };
-    #       }
+    #         \};
+    #       \}
     class ResourceReference
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/gapic/templates/showcase/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/longrunning/operations.rb
@@ -125,12 +125,12 @@ module Google
     # Example:
     #
     #   rpc LongRunningRecognize(LongRunningRecognizeRequest)
-    #       returns (google.longrunning.Operation) {
-    #     option (google.longrunning.operation_info) = {
+    #       returns (google.longrunning.Operation) \\\{
+    #     option (google.longrunning.operation_info) = \\\{
     #       response_type: "LongRunningRecognizeResponse"
     #       metadata_type: "LongRunningRecognizeMetadata"
-    #     };
-    #   }
+    #     \};
+    #   \}
     # @!attribute [rw] response_type
     #   @return [String]
     #     Required. The message name of the primary return type for this

--- a/shared/output/gapic/templates/showcase/proto_docs/google/protobuf/any.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/protobuf/any.rb
@@ -39,18 +39,18 @@ module Google
     #     Any any;
     #     any.PackFrom(foo);
     #     ...
-    #     if (any.UnpackTo(&foo)) {
+    #     if (any.UnpackTo(&foo)) \\\{
     #       ...
-    #     }
+    #     \}
     #
     # Example 2: Pack and unpack a message in Java.
     #
     #     Foo foo = ...;
     #     Any any = Any.pack(foo);
     #     ...
-    #     if (any.is(Foo.class)) {
+    #     if (any.is(Foo.class)) \\\{
     #       foo = any.unpack(Foo.class);
-    #     }
+    #     \}
     #
     #  Example 3: Pack and unpack a message in Python.
     #
@@ -64,13 +64,13 @@ module Google
     #
     #  Example 4: Pack and unpack a message in Go
     #
-    #      foo := &pb.Foo{...}
+    #      foo := &pb.Foo\\\{...\}
     #      any, err := ptypes.MarshalAny(foo)
     #      ...
-    #      foo := &pb.Foo{}
-    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #      foo := &pb.Foo\\\{\}
+    #      if err := ptypes.UnmarshalAny(any, foo); err != nil \\\{
     #        ...
-    #      }
+    #      \}
     #
     # The pack methods provided by protobuf library will by default use
     # 'type.googleapis.com/full.type.name' as the type URL and the unpack
@@ -86,26 +86,26 @@ module Google
     # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
-    #     message Person {
+    #     message Person \\\{
     #       string first_name = 1;
     #       string last_name = 2;
-    #     }
+    #     \}
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.profile.Person",
     #       "firstName": <string>,
     #       "lastName": <string>
-    #     }
+    #     \}
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
     # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message [google.protobuf.Duration][]):
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.protobuf.Duration",
     #       "value": "1.212s"
-    #     }
+    #     \}
     # @!attribute [rw] type_url
     #   @return [String]
     #     A URL/resource name that uniquely identifies the type of the serialized

--- a/shared/output/gapic/templates/showcase/proto_docs/google/protobuf/duration.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/protobuf/duration.rb
@@ -45,13 +45,13 @@ module Google
     #     duration.seconds = end.seconds - start.seconds;
     #     duration.nanos = end.nanos - start.nanos;
     #
-    #     if (duration.seconds < 0 && duration.nanos > 0) {
+    #     if (duration.seconds < 0 && duration.nanos > 0) \\\{
     #       duration.seconds += 1;
     #       duration.nanos -= 1000000000;
-    #     } else if (durations.seconds > 0 && duration.nanos < 0) {
+    #     \} else if (durations.seconds > 0 && duration.nanos < 0) \\\{
     #       duration.seconds -= 1;
     #       duration.nanos += 1000000000;
-    #     }
+    #     \}
     #
     # Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
     #
@@ -62,13 +62,13 @@ module Google
     #     end.seconds = start.seconds + duration.seconds;
     #     end.nanos = start.nanos + duration.nanos;
     #
-    #     if (end.nanos < 0) {
+    #     if (end.nanos < 0) \\\{
     #       end.seconds -= 1;
     #       end.nanos += 1000000000;
-    #     } else if (end.nanos >= 1000000000) {
+    #     \} else if (end.nanos >= 1000000000) \\\{
     #       end.seconds += 1;
     #       end.nanos -= 1000000000;
-    #     }
+    #     \}
     #
     # Example 3: Compute Duration from datetime.timedelta in Python.
     #

--- a/shared/output/gapic/templates/showcase/proto_docs/google/protobuf/empty.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/protobuf/empty.rb
@@ -31,11 +31,11 @@ module Google
     # empty messages in your APIs. A typical example is to use it as the request
     # or the response type of an API method. For instance:
     #
-    #     service Foo {
+    #     service Foo \\\{
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-    #     }
+    #     \}
     #
-    # The JSON representation for `Empty` is empty JSON object `{}`.
+    # The JSON representation for `Empty` is empty JSON object `\\\{\}`.
     class Empty
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/gapic/templates/showcase/proto_docs/google/protobuf/field_mask.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/protobuf/field_mask.rb
@@ -47,14 +47,14 @@ module Google
     # specified in the mask. For example, if the mask in the previous
     # example is applied to a response message as follows:
     #
-    #     f {
+    #     f \\\{
     #       a : 22
-    #       b {
+    #       b \\\{
     #         d : 1
     #         x : 2
-    #       }
+    #       \}
     #       y : 13
-    #     }
+    #     \}
     #     z: 8
     #
     # The result will not contain specific values for fields x,y and z
@@ -62,12 +62,12 @@ module Google
     # output):
     #
     #
-    #     f {
+    #     f \\\{
     #       a : 22
-    #       b {
+    #       b \\\{
     #         d : 1
-    #       }
-    #     }
+    #       \}
+    #     \}
     #
     # A repeated field is not allowed except at the last position of a
     # paths string.
@@ -105,22 +105,22 @@ module Google
     #
     # For example, given the target message:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 1
     #         x: 2
-    #       }
+    #       \}
     #       c: [1]
-    #     }
+    #     \}
     #
     # And an update message:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 10
-    #       }
+    #       \}
     #       c: [2]
-    #     }
+    #     \}
     #
     # then if the field mask is:
     #
@@ -128,13 +128,13 @@ module Google
     #
     # then the result will be:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 10
     #         x: 2
-    #       }
+    #       \}
     #       c: [1, 2]
-    #     }
+    #     \}
     #
     # An implementation may provide options to override this default behavior for
     # repeated and message fields.
@@ -172,51 +172,51 @@ module Google
     #
     # As an example, consider the following message declarations:
     #
-    #     message Profile {
+    #     message Profile \\\{
     #       User user = 1;
     #       Photo photo = 2;
-    #     }
-    #     message User {
+    #     \}
+    #     message User \\\{
     #       string display_name = 1;
     #       string address = 2;
-    #     }
+    #     \}
     #
     # In proto a field mask for `Profile` may look as such:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "user.display_name"
     #       paths: "photo"
-    #     }
+    #     \}
     #
     # In JSON, the same mask is represented as below:
     #
-    #     {
+    #     \\\{
     #       mask: "user.displayName,photo"
-    #     }
+    #     \}
     #
     # # Field Masks and Oneof Fields
     #
     # Field masks treat fields in oneofs just as regular fields. Consider the
     # following message:
     #
-    #     message SampleMessage {
-    #       oneof test_oneof {
+    #     message SampleMessage \\\{
+    #       oneof test_oneof \\\{
     #         string name = 4;
     #         SubMessage sub_message = 9;
-    #       }
-    #     }
+    #       \}
+    #     \}
     #
     # The field mask can be:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "name"
-    #     }
+    #     \}
     #
     # Or:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "sub_message"
-    #     }
+    #     \}
     #
     # Note that oneof type names ("test_oneof" in this case) cannot be used in
     # paths.

--- a/shared/output/gapic/templates/showcase/proto_docs/google/protobuf/timestamp.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/protobuf/timestamp.rb
@@ -87,9 +87,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\\{year\}-\\\{month\}-\\\{day\}T\\\{hour\}:\\\{min\}:\\\{sec\}[.\\\{frac_sec\}]Z"
+    # where \\\{year\} is always expressed using four digits while \\\{month\}, \\\{day\},
+    # \\\{hour\}, \\\{min\}, and \\\{sec\} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required. A proto3 JSON serializer should always use UTC (as indicated by

--- a/shared/output/gapic/templates/speech/proto_docs/google/cloud/speech/v1/cloud_speech.rb
+++ b/shared/output/gapic/templates/speech/proto_docs/google/cloud/speech/v1/cloud_speech.rb
@@ -570,27 +570,27 @@ module Google
         # Here's an example of a series of ten `StreamingRecognizeResponse`s that might
         # be returned while processing audio:
         #
-        # 1. results { alternatives { transcript: "tube" } stability: 0.01 }
+        # 1. results \\\{ alternatives \\\{ transcript: "tube" \} stability: 0.01 \}
         #
-        # 2. results { alternatives { transcript: "to be a" } stability: 0.01 }
+        # 2. results \\\{ alternatives \\\{ transcript: "to be a" \} stability: 0.01 \}
         #
-        # 3. results { alternatives { transcript: "to be" } stability: 0.9 }
-        #    results { alternatives { transcript: " or not to be" } stability: 0.01 }
+        # 3. results \\\{ alternatives \\\{ transcript: "to be" \} stability: 0.9 \}
+        #    results \\\{ alternatives \\\{ transcript: " or not to be" \} stability: 0.01 \}
         #
-        # 4. results { alternatives { transcript: "to be or not to be"
-        #                             confidence: 0.92 }
-        #              alternatives { transcript: "to bee or not to bee" }
-        #              is_final: true }
+        # 4. results \\\{ alternatives \\\{ transcript: "to be or not to be"
+        #                             confidence: 0.92 \}
+        #              alternatives \\\{ transcript: "to bee or not to bee" \}
+        #              is_final: true \}
         #
-        # 5. results { alternatives { transcript: " that's" } stability: 0.01 }
+        # 5. results \\\{ alternatives \\\{ transcript: " that's" \} stability: 0.01 \}
         #
-        # 6. results { alternatives { transcript: " that is" } stability: 0.9 }
-        #    results { alternatives { transcript: " the question" } stability: 0.01 }
+        # 6. results \\\{ alternatives \\\{ transcript: " that is" \} stability: 0.9 \}
+        #    results \\\{ alternatives \\\{ transcript: " the question" \} stability: 0.01 \}
         #
-        # 7. results { alternatives { transcript: " that is the question"
-        #                             confidence: 0.98 }
-        #              alternatives { transcript: " that was the question" }
-        #              is_final: true }
+        # 7. results \\\{ alternatives \\\{ transcript: " that is the question"
+        #                             confidence: 0.98 \}
+        #              alternatives \\\{ transcript: " that was the question" \}
+        #              is_final: true \}
         #
         # Notes:
         #

--- a/shared/output/gapic/templates/speech/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/gapic/templates/speech/proto_docs/google/longrunning/operations.rb
@@ -125,12 +125,12 @@ module Google
     # Example:
     #
     #   rpc LongRunningRecognize(LongRunningRecognizeRequest)
-    #       returns (google.longrunning.Operation) {
-    #     option (google.longrunning.operation_info) = {
+    #       returns (google.longrunning.Operation) \\\{
+    #     option (google.longrunning.operation_info) = \\\{
     #       response_type: "LongRunningRecognizeResponse"
     #       metadata_type: "LongRunningRecognizeMetadata"
-    #     };
-    #   }
+    #     \};
+    #   \}
     # @!attribute [rw] response_type
     #   @return [String]
     #     Required. The message name of the primary return type for this

--- a/shared/output/gapic/templates/speech/proto_docs/google/protobuf/any.rb
+++ b/shared/output/gapic/templates/speech/proto_docs/google/protobuf/any.rb
@@ -39,18 +39,18 @@ module Google
     #     Any any;
     #     any.PackFrom(foo);
     #     ...
-    #     if (any.UnpackTo(&foo)) {
+    #     if (any.UnpackTo(&foo)) \\\{
     #       ...
-    #     }
+    #     \}
     #
     # Example 2: Pack and unpack a message in Java.
     #
     #     Foo foo = ...;
     #     Any any = Any.pack(foo);
     #     ...
-    #     if (any.is(Foo.class)) {
+    #     if (any.is(Foo.class)) \\\{
     #       foo = any.unpack(Foo.class);
-    #     }
+    #     \}
     #
     #  Example 3: Pack and unpack a message in Python.
     #
@@ -64,13 +64,13 @@ module Google
     #
     #  Example 4: Pack and unpack a message in Go
     #
-    #      foo := &pb.Foo{...}
+    #      foo := &pb.Foo\\\{...\}
     #      any, err := ptypes.MarshalAny(foo)
     #      ...
-    #      foo := &pb.Foo{}
-    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #      foo := &pb.Foo\\\{\}
+    #      if err := ptypes.UnmarshalAny(any, foo); err != nil \\\{
     #        ...
-    #      }
+    #      \}
     #
     # The pack methods provided by protobuf library will by default use
     # 'type.googleapis.com/full.type.name' as the type URL and the unpack
@@ -86,26 +86,26 @@ module Google
     # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
-    #     message Person {
+    #     message Person \\\{
     #       string first_name = 1;
     #       string last_name = 2;
-    #     }
+    #     \}
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.profile.Person",
     #       "firstName": <string>,
     #       "lastName": <string>
-    #     }
+    #     \}
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
     # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message [google.protobuf.Duration][]):
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.protobuf.Duration",
     #       "value": "1.212s"
-    #     }
+    #     \}
     # @!attribute [rw] type_url
     #   @return [String]
     #     A URL/resource name that uniquely identifies the type of the serialized

--- a/shared/output/gapic/templates/speech/proto_docs/google/protobuf/duration.rb
+++ b/shared/output/gapic/templates/speech/proto_docs/google/protobuf/duration.rb
@@ -45,13 +45,13 @@ module Google
     #     duration.seconds = end.seconds - start.seconds;
     #     duration.nanos = end.nanos - start.nanos;
     #
-    #     if (duration.seconds < 0 && duration.nanos > 0) {
+    #     if (duration.seconds < 0 && duration.nanos > 0) \\\{
     #       duration.seconds += 1;
     #       duration.nanos -= 1000000000;
-    #     } else if (durations.seconds > 0 && duration.nanos < 0) {
+    #     \} else if (durations.seconds > 0 && duration.nanos < 0) \\\{
     #       duration.seconds -= 1;
     #       duration.nanos += 1000000000;
-    #     }
+    #     \}
     #
     # Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
     #
@@ -62,13 +62,13 @@ module Google
     #     end.seconds = start.seconds + duration.seconds;
     #     end.nanos = start.nanos + duration.nanos;
     #
-    #     if (end.nanos < 0) {
+    #     if (end.nanos < 0) \\\{
     #       end.seconds -= 1;
     #       end.nanos += 1000000000;
-    #     } else if (end.nanos >= 1000000000) {
+    #     \} else if (end.nanos >= 1000000000) \\\{
     #       end.seconds += 1;
     #       end.nanos -= 1000000000;
-    #     }
+    #     \}
     #
     # Example 3: Compute Duration from datetime.timedelta in Python.
     #

--- a/shared/output/gapic/templates/speech/proto_docs/google/protobuf/empty.rb
+++ b/shared/output/gapic/templates/speech/proto_docs/google/protobuf/empty.rb
@@ -31,11 +31,11 @@ module Google
     # empty messages in your APIs. A typical example is to use it as the request
     # or the response type of an API method. For instance:
     #
-    #     service Foo {
+    #     service Foo \\\{
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-    #     }
+    #     \}
     #
-    # The JSON representation for `Empty` is empty JSON object `{}`.
+    # The JSON representation for `Empty` is empty JSON object `\\\{\}`.
     class Empty
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/gapic/templates/speech/proto_docs/google/protobuf/timestamp.rb
+++ b/shared/output/gapic/templates/speech/proto_docs/google/protobuf/timestamp.rb
@@ -87,9 +87,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\\{year\}-\\\{month\}-\\\{day\}T\\\{hour\}:\\\{min\}:\\\{sec\}[.\\\{frac_sec\}]Z"
+    # where \\\{year\} is always expressed using four digits while \\\{month\}, \\\{day\},
+    # \\\{hour\}, \\\{min\}, and \\\{sec\} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required. A proto3 JSON serializer should always use UTC (as indicated by

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -131,7 +131,7 @@ module Google
             #   @param parent [String]
             #     Optional. Target project and location to make a call.
             #
-            #     Format: `projects/{project-id}/locations/{location-id}`.
+            #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
             #
             #     If no parent is specified, a region will be chosen automatically.
             #
@@ -207,7 +207,7 @@ module Google
             #   @param parent [String]
             #     Optional. Target project and location to make a call.
             #
-            #     Format: `projects/{project-id}/locations/{location-id}`.
+            #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
             #
             #     If no parent is specified, a region will be chosen automatically.
             #
@@ -288,7 +288,7 @@ module Google
             #   @param parent [String]
             #     Optional. Target project and location to make a call.
             #
-            #     Format: `projects/{project-id}/locations/{location-id}`.
+            #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
             #
             #     If no parent is specified, a region will be chosen automatically.
             #
@@ -362,7 +362,7 @@ module Google
             #   @param parent [String]
             #     Optional. Target project and location to make a call.
             #
-            #     Format: `projects/{project-id}/locations/{location-id}`.
+            #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
             #
             #     If no parent is specified, a region will be chosen automatically.
             #

--- a/shared/output/gapic/templates/vision/proto_docs/google/api/resource.rb
+++ b/shared/output/gapic/templates/vision/proto_docs/google/api/resource.rb
@@ -35,110 +35,110 @@ module Google
     #
     # Example:
     #
-    #     message Topic {
+    #     message Topic \\\{
     #       // Indicates this message defines a resource schema.
-    #       // Declares the resource type in the format of {service}/{kind}.
-    #       // For Kubernetes resources, the format is {api group}/{kind}.
-    #       option (google.api.resource) = {
+    #       // Declares the resource type in the format of \\\{service\}/\\\{kind\}.
+    #       // For Kubernetes resources, the format is \\\{api group\}/\\\{kind\}.
+    #       option (google.api.resource) = \\\{
     #         type: "pubsub.googleapis.com/Topic"
-    #         name_descriptor: {
-    #           pattern: "projects/{project}/topics/{topic}"
+    #         name_descriptor: \\\{
+    #           pattern: "projects/\\\{project\}/topics/\\\{topic\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         }
-    #       };
-    #     }
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #    resources:
     #    - type: "pubsub.googleapis.com/Topic"
     #      name_descriptor:
-    #        - pattern: "projects/{project}/topics/{topic}"
+    #        - pattern: "projects/\\\{project\}/topics/\\\{topic\}"
     #          parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #          parent_name_extractor: "projects/{project}"
+    #          parent_name_extractor: "projects/\\\{project\}"
     #
     # Sometimes, resources have multiple patterns, typically because they can
     # live under multiple parents.
     #
     # Example:
     #
-    #     message LogEntry {
-    #       option (google.api.resource) = {
+    #     message LogEntry \\\{
+    #       option (google.api.resource) = \\\{
     #         type: "logging.googleapis.com/LogEntry"
-    #         name_descriptor: {
-    #           pattern: "projects/{project}/logs/{log}"
+    #         name_descriptor: \\\{
+    #           pattern: "projects/\\\{project\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "folders/{folder}/logs/{log}"
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "folders/\\\{folder\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/{folder}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "organizations/{organization}/logs/{log}"
+    #           parent_name_extractor: "folders/\\\{folder\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/{organization}"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "billingAccounts/{billing_account}/logs/{log}"
+    #           parent_name_extractor: "organizations/\\\{organization\}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/{billing_account}"
-    #         }
-    #       };
-    #     }
+    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'logging.googleapis.com/LogEntry'
     #       name_descriptor:
-    #         - pattern: "projects/{project}/logs/{log}"
+    #         - pattern: "projects/\\\{project\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #           parent_name_extractor: "projects/{project}"
-    #         - pattern: "folders/{folder}/logs/{log}"
+    #           parent_name_extractor: "projects/\\\{project\}"
+    #         - pattern: "folders/\\\{folder\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #           parent_name_extractor: "folders/{folder}"
-    #         - pattern: "organizations/{organization}/logs/{log}"
+    #           parent_name_extractor: "folders/\\\{folder\}"
+    #         - pattern: "organizations/\\\{organization\}/logs/\\\{log\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Organization"
-    #           parent_name_extractor: "organizations/{organization}"
-    #         - pattern: "billingAccounts/{billing_account}/logs/{log}"
+    #           parent_name_extractor: "organizations/\\\{organization\}"
+    #         - pattern: "billingAccounts/\\\{billing_account\}/logs/\\\{log\}"
     #           parent_type: "billing.googleapis.com/BillingAccount"
-    #           parent_name_extractor: "billingAccounts/{billing_account}"
+    #           parent_name_extractor: "billingAccounts/\\\{billing_account\}"
     #
     # For flexible resources, the resource name doesn't contain parent names, but
     # the resource itself has parents for policy evaluation.
     #
     # Example:
     #
-    #     message Shelf {
-    #       option (google.api.resource) = {
+    #     message Shelf \\\{
+    #       option (google.api.resource) = \\\{
     #         type: "library.googleapis.com/Shelf"
-    #         name_descriptor: {
-    #           pattern: "shelves/{shelf}"
+    #         name_descriptor: \\\{
+    #           pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         }
-    #         name_descriptor: {
-    #           pattern: "shelves/{shelf}"
+    #         \}
+    #         name_descriptor: \\\{
+    #           pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
-    #         }
-    #       };
-    #     }
+    #         \}
+    #       \};
+    #     \}
     #
     # The ResourceDescriptor Yaml config will look like:
     #
     #     resources:
     #     - type: 'library.googleapis.com/Shelf'
     #       name_descriptor:
-    #         - pattern: "shelves/{shelf}"
+    #         - pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Project"
-    #         - pattern: "shelves/{shelf}"
+    #         - pattern: "shelves/\\\{shelf\}"
     #           parent_type: "cloudresourcemanager.googleapis.com/Folder"
     # @!attribute [rw] type
     #   @return [String]
     #     The resource type. It must be in the format of
-    #     {service_name}/{resource_type_kind}. The `resource_type_kind` must be
+    #     \\\{service_name\}/\\\{resource_type_kind\}. The `resource_type_kind` must be
     #     singular and must not include version numbers.
     #
     #     Example: `storage.googleapis.com/Bucket`
@@ -155,14 +155,14 @@ module Google
     #     The path pattern must follow the syntax, which aligns with HTTP binding
     #     syntax:
     #
-    #         Template = Segment { "/" Segment } ;
+    #         Template = Segment \\\{ "/" Segment \} ;
     #         Segment = LITERAL | Variable ;
-    #         Variable = "{" LITERAL "}" ;
+    #         Variable = "\\\{" LITERAL "\}" ;
     #
     #     Examples:
     #
-    #         - "projects/{project}/topics/{topic}"
-    #         - "projects/{project}/knowledgeBases/{knowledge_base}"
+    #         - "projects/\\\{project\}/topics/\\\{topic\}"
+    #         - "projects/\\\{project\}/knowledgeBases/\\\{knowledge_base\}"
     #
     #     The components in braces correspond to the IDs for each resource in the
     #     hierarchy. It is expected that, if multiple patterns are provided,
@@ -180,19 +180,19 @@ module Google
     #
     #         // The InspectTemplate message originally only supported resource
     #         // names with organization, and project was added later.
-    #         message InspectTemplate {
-    #           option (google.api.resource) = {
+    #         message InspectTemplate \\\{
+    #           option (google.api.resource) = \\\{
     #             type: "dlp.googleapis.com/InspectTemplate"
     #             pattern:
-    #             "organizations/{organization}/inspectTemplates/{inspect_template}"
-    #             pattern: "projects/{project}/inspectTemplates/{inspect_template}"
+    #             "organizations/\\\{organization\}/inspectTemplates/\\\{inspect_template\}"
+    #             pattern: "projects/\\\{project\}/inspectTemplates/\\\{inspect_template\}"
     #             history: ORIGINALLY_SINGLE_PATTERN
-    #           };
-    #         }
+    #           \};
+    #         \}
     # @!attribute [rw] plural
     #   @return [String]
     #     The plural name used in the resource name, such as 'projects' for
-    #     the name of 'projects/{project}'. It is the same concept of the `plural`
+    #     the name of 'projects/\\\{project\}'. It is the same concept of the `plural`
     #     field in k8s CRD spec
     #     https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
     # @!attribute [rw] singular
@@ -229,11 +229,11 @@ module Google
     #
     #     Example:
     #
-    #         message Subscription {
-    #           string topic = 2 [(google.api.resource_reference) = {
+    #         message Subscription \\\{
+    #           string topic = 2 [(google.api.resource_reference) = \\\{
     #             type: "pubsub.googleapis.com/Topic"
-    #           }];
-    #         }
+    #           \}];
+    #         \}
     # @!attribute [rw] child_type
     #   @return [String]
     #     The resource type of a child collection that the annotated field
@@ -242,11 +242,11 @@ module Google
     #
     #     Example:
     #
-    #       message ListLogEntriesRequest {
-    #         string parent = 1 [(google.api.resource_reference) = {
+    #       message ListLogEntriesRequest \\\{
+    #         string parent = 1 [(google.api.resource_reference) = \\\{
     #           child_type: "logging.googleapis.com/LogEntry"
-    #         };
-    #       }
+    #         \};
+    #       \}
     class ResourceReference
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/gapic/templates/vision/proto_docs/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/gapic/templates/vision/proto_docs/google/cloud/vision/v1/image_annotator.rb
@@ -703,7 +703,7 @@ module Google
         #   @return [String]
         #     Optional. Target project and location to make a call.
         #
-        #     Format: `projects/{project-id}/locations/{location-id}`.
+        #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
         #
         #     If no parent is specified, a region will be chosen automatically.
         #
@@ -788,7 +788,7 @@ module Google
         #   @return [String]
         #     Optional. Target project and location to make a call.
         #
-        #     Format: `projects/{project-id}/locations/{location-id}`.
+        #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
         #
         #     If no parent is specified, a region will be chosen automatically.
         #
@@ -851,7 +851,7 @@ module Google
         #   @return [String]
         #     Optional. Target project and location to make a call.
         #
-        #     Format: `projects/{project-id}/locations/{location-id}`.
+        #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
         #
         #     If no parent is specified, a region will be chosen automatically.
         #
@@ -884,7 +884,7 @@ module Google
         #   @return [String]
         #     Optional. Target project and location to make a call.
         #
-        #     Format: `projects/{project-id}/locations/{location-id}`.
+        #     Format: `projects/\\\{project-id\}/locations/\\\{location-id\}`.
         #
         #     If no parent is specified, a region will be chosen automatically.
         #

--- a/shared/output/gapic/templates/vision/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/gapic/templates/vision/proto_docs/google/longrunning/operations.rb
@@ -125,12 +125,12 @@ module Google
     # Example:
     #
     #   rpc LongRunningRecognize(LongRunningRecognizeRequest)
-    #       returns (google.longrunning.Operation) {
-    #     option (google.longrunning.operation_info) = {
+    #       returns (google.longrunning.Operation) \\\{
+    #     option (google.longrunning.operation_info) = \\\{
     #       response_type: "LongRunningRecognizeResponse"
     #       metadata_type: "LongRunningRecognizeMetadata"
-    #     };
-    #   }
+    #     \};
+    #   \}
     # @!attribute [rw] response_type
     #   @return [String]
     #     Required. The message name of the primary return type for this

--- a/shared/output/gapic/templates/vision/proto_docs/google/protobuf/any.rb
+++ b/shared/output/gapic/templates/vision/proto_docs/google/protobuf/any.rb
@@ -39,18 +39,18 @@ module Google
     #     Any any;
     #     any.PackFrom(foo);
     #     ...
-    #     if (any.UnpackTo(&foo)) {
+    #     if (any.UnpackTo(&foo)) \\\{
     #       ...
-    #     }
+    #     \}
     #
     # Example 2: Pack and unpack a message in Java.
     #
     #     Foo foo = ...;
     #     Any any = Any.pack(foo);
     #     ...
-    #     if (any.is(Foo.class)) {
+    #     if (any.is(Foo.class)) \\\{
     #       foo = any.unpack(Foo.class);
-    #     }
+    #     \}
     #
     #  Example 3: Pack and unpack a message in Python.
     #
@@ -64,13 +64,13 @@ module Google
     #
     #  Example 4: Pack and unpack a message in Go
     #
-    #      foo := &pb.Foo{...}
+    #      foo := &pb.Foo\\\{...\}
     #      any, err := ptypes.MarshalAny(foo)
     #      ...
-    #      foo := &pb.Foo{}
-    #      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+    #      foo := &pb.Foo\\\{\}
+    #      if err := ptypes.UnmarshalAny(any, foo); err != nil \\\{
     #        ...
-    #      }
+    #      \}
     #
     # The pack methods provided by protobuf library will by default use
     # 'type.googleapis.com/full.type.name' as the type URL and the unpack
@@ -86,26 +86,26 @@ module Google
     # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
-    #     message Person {
+    #     message Person \\\{
     #       string first_name = 1;
     #       string last_name = 2;
-    #     }
+    #     \}
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.profile.Person",
     #       "firstName": <string>,
     #       "lastName": <string>
-    #     }
+    #     \}
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
     # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message [google.protobuf.Duration][]):
     #
-    #     {
+    #     \\\{
     #       "@type": "type.googleapis.com/google.protobuf.Duration",
     #       "value": "1.212s"
-    #     }
+    #     \}
     # @!attribute [rw] type_url
     #   @return [String]
     #     A URL/resource name that uniquely identifies the type of the serialized

--- a/shared/output/gapic/templates/vision/proto_docs/google/protobuf/empty.rb
+++ b/shared/output/gapic/templates/vision/proto_docs/google/protobuf/empty.rb
@@ -31,11 +31,11 @@ module Google
     # empty messages in your APIs. A typical example is to use it as the request
     # or the response type of an API method. For instance:
     #
-    #     service Foo {
+    #     service Foo \\\{
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-    #     }
+    #     \}
     #
-    # The JSON representation for `Empty` is empty JSON object `{}`.
+    # The JSON representation for `Empty` is empty JSON object `\\\{\}`.
     class Empty
       include Google::Protobuf::MessageExts
       extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/gapic/templates/vision/proto_docs/google/protobuf/field_mask.rb
+++ b/shared/output/gapic/templates/vision/proto_docs/google/protobuf/field_mask.rb
@@ -47,14 +47,14 @@ module Google
     # specified in the mask. For example, if the mask in the previous
     # example is applied to a response message as follows:
     #
-    #     f {
+    #     f \\\{
     #       a : 22
-    #       b {
+    #       b \\\{
     #         d : 1
     #         x : 2
-    #       }
+    #       \}
     #       y : 13
-    #     }
+    #     \}
     #     z: 8
     #
     # The result will not contain specific values for fields x,y and z
@@ -62,12 +62,12 @@ module Google
     # output):
     #
     #
-    #     f {
+    #     f \\\{
     #       a : 22
-    #       b {
+    #       b \\\{
     #         d : 1
-    #       }
-    #     }
+    #       \}
+    #     \}
     #
     # A repeated field is not allowed except at the last position of a
     # paths string.
@@ -105,22 +105,22 @@ module Google
     #
     # For example, given the target message:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 1
     #         x: 2
-    #       }
+    #       \}
     #       c: [1]
-    #     }
+    #     \}
     #
     # And an update message:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 10
-    #       }
+    #       \}
     #       c: [2]
-    #     }
+    #     \}
     #
     # then if the field mask is:
     #
@@ -128,13 +128,13 @@ module Google
     #
     # then the result will be:
     #
-    #     f {
-    #       b {
+    #     f \\\{
+    #       b \\\{
     #         d: 10
     #         x: 2
-    #       }
+    #       \}
     #       c: [1, 2]
-    #     }
+    #     \}
     #
     # An implementation may provide options to override this default behavior for
     # repeated and message fields.
@@ -172,51 +172,51 @@ module Google
     #
     # As an example, consider the following message declarations:
     #
-    #     message Profile {
+    #     message Profile \\\{
     #       User user = 1;
     #       Photo photo = 2;
-    #     }
-    #     message User {
+    #     \}
+    #     message User \\\{
     #       string display_name = 1;
     #       string address = 2;
-    #     }
+    #     \}
     #
     # In proto a field mask for `Profile` may look as such:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "user.display_name"
     #       paths: "photo"
-    #     }
+    #     \}
     #
     # In JSON, the same mask is represented as below:
     #
-    #     {
+    #     \\\{
     #       mask: "user.displayName,photo"
-    #     }
+    #     \}
     #
     # # Field Masks and Oneof Fields
     #
     # Field masks treat fields in oneofs just as regular fields. Consider the
     # following message:
     #
-    #     message SampleMessage {
-    #       oneof test_oneof {
+    #     message SampleMessage \\\{
+    #       oneof test_oneof \\\{
     #         string name = 4;
     #         SubMessage sub_message = 9;
-    #       }
-    #     }
+    #       \}
+    #     \}
     #
     # The field mask can be:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "name"
-    #     }
+    #     \}
     #
     # Or:
     #
-    #     mask {
+    #     mask \\\{
     #       paths: "sub_message"
-    #     }
+    #     \}
     #
     # Note that oneof type names ("test_oneof" in this case) cannot be used in
     # paths.

--- a/shared/output/gapic/templates/vision/proto_docs/google/protobuf/timestamp.rb
+++ b/shared/output/gapic/templates/vision/proto_docs/google/protobuf/timestamp.rb
@@ -87,9 +87,9 @@ module Google
     #
     # In JSON format, the Timestamp type is encoded as a string in the
     # [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
-    # format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
-    # where {year} is always expressed using four digits while {month}, {day},
-    # {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+    # format is "\\\{year\}-\\\{month\}-\\\{day\}T\\\{hour\}:\\\{min\}:\\\{sec\}[.\\\{frac_sec\}]Z"
+    # where \\\{year\} is always expressed using four digits while \\\{month\}, \\\{day\},
+    # \\\{hour\}, \\\{min\}, and \\\{sec\} are zero-padded to two digits each. The fractional
     # seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
     # are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
     # is required. A proto3 JSON serializer should always use UTC (as indicated by

--- a/shared/output/gapic/templates/vision/proto_docs/google/type/color.rb
+++ b/shared/output/gapic/templates/vision/proto_docs/google/type/color.rb
@@ -45,7 +45,7 @@ module Google
     #      import com.google.type.Color;
     #
     #      // ...
-    #      public static java.awt.Color fromProto(Color protocolor) {
+    #      public static java.awt.Color fromProto(Color protocolor) \\\{
     #        float alpha = protocolor.hasAlpha()
     #            ? protocolor.getAlpha().getValue()
     #            : 1.0;
@@ -55,9 +55,9 @@ module Google
     #            protocolor.getGreen(),
     #            protocolor.getBlue(),
     #            alpha);
-    #      }
+    #      \}
     #
-    #      public static Color toProto(java.awt.Color color) {
+    #      public static Color toProto(java.awt.Color color) \\\{
     #        float red = (float) color.getRed();
     #        float green = (float) color.getGreen();
     #        float blue = (float) color.getBlue();
@@ -69,54 +69,54 @@ module Google
     #                .setGreen(green / denominator)
     #                .setBlue(blue / denominator);
     #        int alpha = color.getAlpha();
-    #        if (alpha != 255) {
+    #        if (alpha != 255) \\\{
     #          result.setAlpha(
     #              FloatValue
     #                  .newBuilder()
     #                  .setValue(((float) alpha) / denominator)
     #                  .build());
-    #        }
+    #        \}
     #        return resultBuilder.build();
-    #      }
+    #      \}
     #      // ...
     #
     # Example (iOS / Obj-C):
     #
     #      // ...
-    #      static UIColor* fromProto(Color* protocolor) {
+    #      static UIColor* fromProto(Color* protocolor) \\\{
     #         float red = [protocolor red];
     #         float green = [protocolor green];
     #         float blue = [protocolor blue];
     #         FloatValue* alpha_wrapper = [protocolor alpha];
     #         float alpha = 1.0;
-    #         if (alpha_wrapper != nil) {
+    #         if (alpha_wrapper != nil) \\\{
     #           alpha = [alpha_wrapper value];
-    #         }
+    #         \}
     #         return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
-    #      }
+    #      \}
     #
-    #      static Color* toProto(UIColor* color) {
+    #      static Color* toProto(UIColor* color) \\\{
     #          CGFloat red, green, blue, alpha;
-    #          if (![color getRed:&red green:&green blue:&blue alpha:&alpha]) {
+    #          if (![color getRed:&red green:&green blue:&blue alpha:&alpha]) \\\{
     #            return nil;
-    #          }
+    #          \}
     #          Color* result = [[Color alloc] init];
     #          [result setRed:red];
     #          [result setGreen:green];
     #          [result setBlue:blue];
-    #          if (alpha <= 0.9999) {
+    #          if (alpha <= 0.9999) \\\{
     #            [result setAlpha:floatWrapperWithValue(alpha)];
-    #          }
+    #          \}
     #          [result autorelease];
     #          return result;
-    #     }
+    #     \}
     #     // ...
     #
     #  Example (JavaScript):
     #
     #     // ...
     #
-    #     var protoToCssColor = function(rgb_color) {
+    #     var protoToCssColor = function(rgb_color) \\\{
     #        var redFrac = rgb_color.red || 0.0;
     #        var greenFrac = rgb_color.green || 0.0;
     #        var blueFrac = rgb_color.blue || 0.0;
@@ -124,26 +124,26 @@ module Google
     #        var green = Math.floor(greenFrac * 255);
     #        var blue = Math.floor(blueFrac * 255);
     #
-    #        if (!('alpha' in rgb_color)) {
+    #        if (!('alpha' in rgb_color)) \\\{
     #           return rgbToCssColor_(red, green, blue);
-    #        }
+    #        \}
     #
     #        var alphaFrac = rgb_color.alpha.value || 0.0;
     #        var rgbParams = [red, green, blue].join(',');
     #        return ['rgba(', rgbParams, ',', alphaFrac, ')'].join('');
-    #     };
+    #     \};
     #
-    #     var rgbToCssColor_ = function(red, green, blue) {
+    #     var rgbToCssColor_ = function(red, green, blue) \\\{
     #       var rgbNumber = new Number((red << 16) | (green << 8) | blue);
     #       var hexString = rgbNumber.toString(16);
     #       var missingZeros = 6 - hexString.length;
     #       var resultBuilder = ['#'];
-    #       for (var i = 0; i < missingZeros; i++) {
+    #       for (var i = 0; i < missingZeros; i++) \\\{
     #          resultBuilder.push('0');
-    #       }
+    #       \}
     #       resultBuilder.push(hexString);
     #       return resultBuilder.join('');
-    #     };
+    #     \};
     #
     #     // ...
     # @!attribute [rw] red


### PR DESCRIPTION
YARD uses curly braces to link to code objects, and warns if a
curly brace is not properly escaped.

We cannot use gsub to replace using multiple backslashes, so use
split and join to get the proper string result.

[fixes #280]