### PR TITLE
Reduce amount of rubocop formatting correction

### DIFF
--- a/gapic-generator-cloud/templates/cloud/gem/_slashed.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/_slashed.erb
@@ -26,9 +26,7 @@ module <%= gem.namespace.split("::")[-1] %>
 
     config_attr :credentials,  nil do |value|
       allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, ::Signet::OAuth2::Client, nil]
-      if defined? ::GRPC
-        allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials]
-      end
+      allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
       allowed.any? { |klass| klass === value }
     end
     config_attr :lib_name,     nil, String, nil

--- a/gapic-generator-cloud/templates/cloud/gem/rakefile.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/rakefile.erb
@@ -48,9 +48,10 @@ namespace :smoke_test do
   end
 end
 
+# rubocop:disable Metrics/BlockLength
 # Acceptance tests
 desc "Run the <%= gem.name %> acceptance tests."
-task :acceptance, :project, :keyfile do |t, args|
+task :acceptance, :project, :keyfile do |_t, args|
   project = args[:project]
   project ||=
     ENV["<%= gem.env_prefix %>_TEST_PROJECT"] ||
@@ -67,7 +68,9 @@ task :acceptance, :project, :keyfile do |t, args|
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or <%= gem.env_prefix %>_TEST_PROJECT=test123 <%= gem.env_prefix %>_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    raise "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or " \
+          "<%= gem.env_prefix %>_TEST_PROJECT=test123 " \
+          "<%= gem.env_prefix %>_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
 
   ENV["<%= gem.env_prefix %>_CREDENTIALS"] = nil
@@ -87,6 +90,7 @@ task :acceptance, :project, :keyfile do |t, args|
 
   Rake::Task["acceptance:run"].invoke
 end
+# rubocop:enable Metrics/BlockLength
 
 namespace :acceptance do
   Rake::TestTask.new :run do |t|

--- a/gapic-generator-cloud/templates/cloud/gem/rubocop.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/rubocop.erb
@@ -4,30 +4,60 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
-    - "<%= gem.name %>.gemspec"
     - "lib/**/*_pb.rb"
     - "proto_docs/**/*"
-    - "Rakefile"
-    - "support/**/*"
     - "test/**/*"
 
+Metrics/AbcSize:
+  Exclude:
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>
 Metrics/ClassLength:
   Exclude:
-  <%- gem.packages.each do |package| -%>
-  <%- package.services.each do |service| -%>
-    - "lib/<%= service.client_file_path %>"
-  <%- end -%>
-  <%- end -%>
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>
+Metrics/CyclomaticComplexity:
+  Exclude:
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>
 Metrics/LineLength:
   Exclude:
-  <%- gem.packages.each do |package| -%>
-  <%- package.services.each do |service| -%>
-    - "lib/<%= service.client_file_path %>"
-  <%- end -%>
-  <%- end -%>
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>
+Metrics/MethodLength:
+  Exclude:
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>
+Metrics/PerceivedComplexity:
+  Exclude:
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>
 Naming/FileName:
   Exclude:
     - "lib/<%= gem.name %>.rb"
 Style/CaseEquality:
-  Enabled: false
+  Exclude:
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>
+    - "lib/<%= gem.name.tr "-", "/" %>.rb"

--- a/gapic-generator-cloud/templates/cloud/service/client/_credentials.erb
+++ b/gapic-generator-cloud/templates/cloud/service/client/_credentials.erb
@@ -6,12 +6,9 @@ require "googleauth"
 class <%= service.credentials_name %> < Google::Auth::Credentials
   <%- if service.client_scopes.any? -%>
   self.scope = [
-    <%- client_scopes = service.client_scopes.dup -%>
-    <%- last_client_scope = client_scopes.pop -%>
-    <%- client_scopes.each do |client_scope| -%>
-    <%= client_scope.inspect %>,
-    <%- end -%>
-    <%= last_client_scope.inspect %>
+  <%- service.client_scopes.each_with_index do |client_scope, index| -%>
+    <%= client_scope.inspect %><%- if index != service.client_scopes.count - 1 -%>,<%- end -%>
+  <%- end -%>
   ]
   <%- end -%>
   self.env_vars = [

--- a/gapic-generator-cloud/templates/cloud/service/client/_credentials.erb
+++ b/gapic-generator-cloud/templates/cloud/service/client/_credentials.erb
@@ -7,7 +7,8 @@ class <%= service.credentials_name %> < Google::Auth::Credentials
   <%- if service.client_scopes.any? -%>
   self.scope = [
   <%- service.client_scopes.each_with_index do |client_scope, index| -%>
-    <%= client_scope.inspect %><%- if index != service.client_scopes.count - 1 -%>,<%- end -%>
+    <%- comma = "," if index != service.client_scopes.count - 1 -%>
+    <%= client_scope.inspect %><%= comma %>
   <%- end -%>
   ]
   <%- end -%>

--- a/gapic-generator-cloud/templates/cloud/service/client/_credentials.erb
+++ b/gapic-generator-cloud/templates/cloud/service/client/_credentials.erb
@@ -7,7 +7,7 @@ class <%= service.credentials_name %> < Google::Auth::Credentials
   <%- if service.client_scopes.any? -%>
   self.scope = [
   <%- service.client_scopes.each_with_index do |client_scope, index| -%>
-    <%- comma = "," if index != service.client_scopes.count - 1 -%>
+    <%- comma = index == service.client_scopes.count - 1 ? "" : "," -%>
     <%= client_scope.inspect %><%= comma %>
   <%- end -%>
   ]

--- a/gapic-generator/lib/gapic/file_formatter.rb
+++ b/gapic-generator/lib/gapic/file_formatter.rb
@@ -40,8 +40,7 @@ module Gapic
           write_file dir, file
         end
 
-        system "rubocop --auto-correct #{dir} -o #{dir}/rubocop.out " \
-               "-c #{configuration}"
+        system "rubocop -x #{dir} -o #{dir}/rubocop.out -c #{configuration}"
 
         files.each do |file|
           read_file dir, file

--- a/gapic-generator/templates/default/gem/rubocop.erb
+++ b/gapic-generator/templates/default/gem/rubocop.erb
@@ -4,23 +4,56 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "<%= gem.name %>.gemspec"
+    - "lib/**/*_pb.rb"
     - "proto_docs/**/*"
     - "test/**/*"
 
+Metrics/AbcSize:
+  Exclude:
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>
 Metrics/ClassLength:
   Exclude:
-  <%- gem.packages.each do |package| -%>
-  <%- package.services.each do |service| -%>
-    - "lib/<%= service.client_file_path %>"
-  <%- end -%>
-  <%- end -%>
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>
+Metrics/CyclomaticComplexity:
+  Exclude:
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>
 Metrics/LineLength:
   Exclude:
-  <%- gem.packages.each do |package| -%>
-  <%- package.services.each do |service| -%>
-    - "lib/<%= service.client_file_path %>"
-  <%- end -%>
-  <%- end -%>
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>
+Metrics/MethodLength:
+  Exclude:
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>
+Metrics/PerceivedComplexity:
+  Exclude:
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>
 Style/CaseEquality:
-  Enabled: false
+  Exclude:
+    <%- gem.packages.each do |package| -%>
+    <%- package.services.each do |service| -%>
+    - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
+    <%- end -%>
+    <%- end -%>

--- a/gapic-generator/templates/default/helpers/presenters/resource_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/resource_presenter.rb
@@ -52,7 +52,7 @@ class ResourcePresenter
       OpenStruct.new(
         name:   arg.name,
         msg:    "#{arg.name} cannot contain /",
-        regexp: '/\//'
+        regexp: "%r{\/}"
       )
     end
     arg_structs.last.regexp = nil

--- a/gapic-generator/templates/default/proto_docs/_enum.erb
+++ b/gapic-generator/templates/default/proto_docs/_enum.erb
@@ -6,7 +6,7 @@ module <%= enum.name %>
   <%- enum.values.each do |value| -%>
 
   <%- if value.doc_description -%>
-  <%= indent value.doc_description, "# " %>
+<%= indent value.doc_description, "  # " %>
   <%- end -%>
   <%= value.name %> = <%= value.number %>
   <%- end -%>

--- a/gapic-generator/templates/default/service/client/_client.erb
+++ b/gapic-generator/templates/default/service/client/_client.erb
@@ -33,7 +33,7 @@ class <%= service.client_name %>
   # @return [<%= service.client_name %>::Configuration]
   #
   def self.configure
-    <%= indent_tail render(partial: "service/client/self_configure", locals: { service: service }), 4 %>
+<%= indent render(partial: "service/client/self_configure", locals: { service: service }), 4 %>
   end
 
   ##

--- a/gapic-generator/templates/default/service/client/_config.erb
+++ b/gapic-generator/templates/default/service/client/_config.erb
@@ -8,9 +8,7 @@ class Configuration
   config_attr :endpoint,     <%= service.client_endpoint.inspect %>, String
   config_attr :credentials,  nil do |value|
     allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, ::Signet::OAuth2::Client, nil]
-    if defined? ::GRPC
-      allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials]
-    end
+    allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
     allowed.any? { |klass| klass === value }
   end
   config_attr :scope,        nil, String, Array, nil
@@ -31,7 +29,7 @@ class Configuration
   def rpcs
     @rpcs ||= begin
       parent_rpcs = nil
-      parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to?(:rpcs)
+      parent_rpcs = @parent_config.rpcs if @parent_config&.respond_to? :rpcs
       Rpcs.new parent_rpcs
     end
   end
@@ -45,10 +43,7 @@ class Configuration
 
     def initialize parent_rpcs = nil
       <%- method_service.methods.each do |method| -%>
-      <%= method.name %>_config = nil
-      if parent_rpcs&.respond_to? :<%= method.name %>
-        <%= method.name %>_config = parent_rpcs&.<%= method.name %>
-      end
+      <%= method.name %>_config = parent_rpcs&.<%= method.name %> if parent_rpcs&.respond_to? :<%= method.name %>
       @<%= method.name %> = Gapic::Config::Method.new <%= method.name %>_config
       <%- end %>
 

--- a/gapic-generator/templates/default/service/client/_credentials.erb
+++ b/gapic-generator/templates/default/service/client/_credentials.erb
@@ -6,12 +6,9 @@ require "googleauth"
 class <%= service.credentials_name %> < Google::Auth::Credentials
   <%- if service.client_scopes.any? -%>
   self.scope = [
-    <%- client_scopes = service.client_scopes.dup -%>
-    <%- last_client_scope = client_scopes.pop -%>
-    <%- client_scopes.each do |client_scope| -%>
-    <%= client_scope.inspect %>,
-    <%- end -%>
-    <%= last_client_scope.inspect %>
+  <%- service.client_scopes.each_with_index do |client_scope, index| -%>
+    <%= client_scope.inspect %><%- if index != service.client_scopes.count - 1 -%>,<%- end -%>
+  <%- end -%>
   ]
   <%- end -%>
   self.env_vars = [

--- a/gapic-generator/templates/default/service/client/_credentials.erb
+++ b/gapic-generator/templates/default/service/client/_credentials.erb
@@ -7,7 +7,8 @@ class <%= service.credentials_name %> < Google::Auth::Credentials
   <%- if service.client_scopes.any? -%>
   self.scope = [
   <%- service.client_scopes.each_with_index do |client_scope, index| -%>
-    <%= client_scope.inspect %><%- if index != service.client_scopes.count - 1 -%>,<%- end -%>
+    <%- comma = "," if index != service.client_scopes.count - 1 -%>
+    <%= client_scope.inspect %><%= comma %>
   <%- end -%>
   ]
   <%- end -%>

--- a/gapic-generator/templates/default/service/client/_credentials.erb
+++ b/gapic-generator/templates/default/service/client/_credentials.erb
@@ -7,7 +7,7 @@ class <%= service.credentials_name %> < Google::Auth::Credentials
   <%- if service.client_scopes.any? -%>
   self.scope = [
   <%- service.client_scopes.each_with_index do |client_scope, index| -%>
-    <%- comma = "," if index != service.client_scopes.count - 1 -%>
+    <%- comma = index == service.client_scopes.count - 1 ? "" : "," -%>
     <%= client_scope.inspect %><%= comma %>
   <%- end -%>
   ]

--- a/gapic-generator/templates/default/service/client/_paths.erb
+++ b/gapic-generator/templates/default/service/client/_paths.erb
@@ -1,4 +1,5 @@
 <%- assert_locals service -%>
+# Path helper methods for the <%= service.name %> API.
 module Paths
 <%- service.references.each do |resource| -%>
 <%= indent render(partial: "service/client/resource", locals: { resource: resource }), 2 %>

--- a/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
@@ -12,12 +12,9 @@ metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
 <%- if method.routing_params? -%>
 
 header_params = {
-<%- routing_params = method.routing_params.dup -%>
-<%- last_routing_param = routing_params.pop -%>
-<%- routing_params.each do |routing_param| -%>
-  "<%= routing_param %>" => request.<%= routing_param %>,
+<%- method.routing_params.each_with_index do |routing_param, index| -%>
+  "<%= routing_param %>" => request.<%= routing_param %><%- if index != method.routing_params.count - 1 -%>,<%- end -%>
 <%- end -%>
-  "<%= last_routing_param %>" => request.<%= last_routing_param %>
 }
 request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
 metadata[:"x-goog-request-params"] ||= request_params_header

--- a/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
@@ -13,7 +13,7 @@ metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
 
 header_params = {
 <%- method.routing_params.each_with_index do |routing_param, index| -%>
-  <%- comma = "," if index != method.routing_params.count - 1 -%>
+  <%- comma = index == method.routing_params.count - 1 ? "" : "," -%>
   "<%= routing_param %>" => request.<%= routing_param %><%= comma %>
 <%- end -%>
 }

--- a/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
@@ -13,7 +13,8 @@ metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
 
 header_params = {
 <%- method.routing_params.each_with_index do |routing_param, index| -%>
-  "<%= routing_param %>" => request.<%= routing_param %><%- if index != method.routing_params.count - 1 -%>,<%- end -%>
+  <%- comma = "," if index != method.routing_params.count - 1 -%>
+  "<%= routing_param %>" => request.<%= routing_param %><%= comma %>
 <%- end -%>
 }
 request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")

--- a/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
@@ -12,16 +12,19 @@ metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
 <%- if method.routing_params? -%>
 
 header_params = {
-<%- method.routing_params.each do |rp| -%>
-  "<%= rp %>" => request.<%= rp %>,
+<%- routing_params = method.routing_params.dup -%>
+<%- last_routing_param = routing_params.pop -%>
+<%- routing_params.each do |routing_param| -%>
+  "<%= routing_param %>" => request.<%= routing_param %>,
 <%- end -%>
+  "<%= last_routing_param %>" => request.<%= last_routing_param %>
 }
 request_params_header = header_params.map { |k, v| "#{k}=#{v}" }.join("&")
 metadata[:"x-goog-request-params"] ||= request_params_header
 <%- end -%>
 
-options.apply_defaults timeout: @config.rpcs.<%= method.name %>.timeout,
-                       metadata: metadata,
+options.apply_defaults timeout:      @config.rpcs.<%= method.name %>.timeout,
+                       metadata:     metadata,
                        retry_policy: @config.rpcs.<%= method.name %>.retry_policy
-options.apply_defaults metadata: @config.metadata,
+options.apply_defaults metadata:     @config.metadata,
                        retry_policy: @config.retry_policy

--- a/gapic-generator/templates/default/service/client/method/def/_request_streaming.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_request_streaming.erb
@@ -1,10 +1,7 @@
 <%- assert_locals method -%>
 unless request.is_a? Enumerable
-  if request.respond_to? :to_enum
-    request = request.to_enum
-  else
-    raise ArgumentError, "request must be an Enumerable"
-  end
+  raise ArgumentError, "request must be an Enumerable" unless request.respond_to? :to_enum
+  request = request.to_enum
 end
 
 request = request.lazy.map do |req|

--- a/gapic-generator/templates/default/service/client/method/def/_response_paged.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_response_paged.erb
@@ -1,9 +1,9 @@
 <%- assert_locals method -%>
 @<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options do |response, operation|
   <%- if method.lro? -%>
-  wrap_gax_operation = ->(response) { Gapic::Operation.new(response, <%= method.service.lro_client_ivar %>) }
+  wrap_lro_operation = ->(op_response) { Gapic::Operation.new op_response, <%= method.service.lro_client_ivar %> }
   <%- end -%>
-  response = Gapic::PagedEnumerable.new @<%= method.service.stub_name %>, :<%= method.name %>, request, response, operation, options<%- if method.lro? -%>, format_resource: wrap_gax_operation<%- end -%>
+  response = Gapic::PagedEnumerable.new @<%= method.service.stub_name %>, :<%= method.name %>, request, response, operation, options<%- if method.lro? -%>, format_resource: wrap_lro_operation<%- end -%>
   yield response, operation if block_given?
   return response
 end

--- a/gapic-generator/templates/default/service/client/method/docs/request_field/_hash.erb
+++ b/gapic-generator/templates/default/service/client/method/docs/request_field/_hash.erb
@@ -4,7 +4,6 @@
 <%= key %> = {
 <%- value.each_with_index do |nested_field, index| -%>
 <%- nested_comma = index != value.count - 1 -%>
-<%- nested_comma = false if value.count < 2 -%>
 <%= indent render(partial: "service/client/method/docs/request_field/hash", locals: { field: nested_field, comma: nested_comma }), "  " %>
 <%- end -%>
 }<%= "," if comma %>

--- a/gapic-generator/templates/default/service/test/method/_normal.erb
+++ b/gapic-generator/templates/default/service/test/method/_normal.erb
@@ -32,7 +32,6 @@ def test_<%= method.name %>
     end
 
     # Use hash object
-    # TODO: parens and curly braces are getting removed by rubocop, plz fix
     client.<%= method.name %>({ <%= fields.map(&:as_kwarg).join ", " %> }) do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
@@ -53,7 +52,7 @@ def test_<%= method.name %>
     end
 
     # Use protobuf object with options
-    client.<%= method.name %> <%= method.request_type %>.new({ <%= fields.map(&:as_kwarg).join ", " %> }), grpc_options do |response, operation|
+    client.<%= method.name %> <%= method.request_type %>.new(<%= fields.map(&:as_kwarg).join ", " %>), grpc_options do |response, operation|
       <%= indent_tail render(partial: "service/test/method/assert_response", locals: { method: method }), 6 %>
     end
 

--- a/shared/.rubocop.yml
+++ b/shared/.rubocop.yml
@@ -1,8 +1,0 @@
-inherit_gem:
-  google-style: google-style.yml
-
-AllCops:
-  Exclude:
-    - "protobuf/**/*"
-    - "output/**/*"
-    - "test/**/*"

--- a/shared/Rakefile
+++ b/shared/Rakefile
@@ -70,6 +70,30 @@ namespace :test do
     t.test_files = FileList["test/showcase/**/*_test.rb"]
     t.warning = false
   end
+
+  desc "Runs tests for all expected output gems."
+  task :output do
+    {
+      gapic: [:showcase, :garbage],
+      cloud: [:language, :speech, :vision]
+    }.each do |generator, gems|
+      directory = (generator == :gapic) ? "gapic/templates" : generator
+      gems.each do |gem|
+        Dir.chdir "./output/#{directory}/#{gem}" do
+          puts ""
+          puts "#"*42
+          puts "# Testing output for #{generator}'s #{gem}"
+          puts "#"*42
+
+          Bundler.with_unbundled_env do
+            sh "bundle install"
+            puts "Running rubocop for #{gem}"
+            sh "bundle exec rubocop -c .rubocop.yml"
+          end
+        end
+      end
+    end
+  end
 end
 
 desc "Start an interactive shell."
@@ -95,6 +119,7 @@ desc "Run the CI build"
 task :ci do
   puts "\nshared test\n"
   Rake::Task[:test].invoke
+  Rake::Task[:"test:output"].invoke
 end
 
 task default: :ci

--- a/shared/Rakefile
+++ b/shared/Rakefile
@@ -88,7 +88,7 @@ namespace :test do
           Bundler.with_unbundled_env do
             sh "bundle install"
             puts "Running rubocop for #{gem}"
-            sh "bundle exec rubocop -c .rubocop.yml"
+            sh "bundle exec rake rubocop"
           end
         end
       end

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
@@ -273,13 +273,9 @@ module Google
                   attr_reader :mutate_campaigns
 
                   def initialize parent_rpcs = nil
-                    get_campaign_config = nil
                     get_campaign_config = parent_rpcs&.get_campaign if parent_rpcs&.respond_to? :get_campaign
                     @get_campaign = Gapic::Config::Method.new get_campaign_config
-                    mutate_campaigns_config = nil
-                    if parent_rpcs&.respond_to? :mutate_campaigns
-                      mutate_campaigns_config = parent_rpcs&.mutate_campaigns
-                    end
+                    mutate_campaigns_config = parent_rpcs&.mutate_campaigns if parent_rpcs&.respond_to? :mutate_campaigns
                     @mutate_campaigns = Gapic::Config::Method.new mutate_campaigns_config
 
                     yield self if block_given?

--- a/shared/output/cloud/language/.rubocop.yml
+++ b/shared/output/cloud/language/.rubocop.yml
@@ -3,26 +3,46 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
-    - "google-cloud-language.gemspec"
     - "lib/**/*_pb.rb"
     - "proto_docs/**/*"
-    - "Rakefile"
-    - "support/**/*"
     - "test/**/*"
 
+Metrics/AbcSize:
+  Exclude:
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"
 Metrics/ClassLength:
   Exclude:
-    - "lib/google/cloud/language/v1/language_service/client.rb"
-    - "lib/google/cloud/language/v1beta1/language_service/client.rb"
-    - "lib/google/cloud/language/v1beta2/language_service/client.rb"
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"
 Metrics/LineLength:
   Exclude:
-    - "lib/google/cloud/language/v1/language_service/client.rb"
-    - "lib/google/cloud/language/v1beta1/language_service/client.rb"
-    - "lib/google/cloud/language/v1beta2/language_service/client.rb"
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"
+Metrics/MethodLength:
+  Exclude:
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"
+Metrics/PerceivedComplexity:
+  Exclude:
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-language.rb"
 Style/CaseEquality:
-  Enabled: false
+  Exclude:
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"
+    - "lib/google/cloud/language.rb"

--- a/shared/output/cloud/language/Rakefile
+++ b/shared/output/cloud/language/Rakefile
@@ -63,6 +63,7 @@ namespace :smoke_test do
   end
 end
 
+# rubocop:disable Metrics/BlockLength
 # Acceptance tests
 desc "Run the google-cloud-language acceptance tests."
 task :acceptance, :project, :keyfile do |_t, args|
@@ -82,7 +83,9 @@ task :acceptance, :project, :keyfile do |_t, args|
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    raise "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or LANGUAGE_TEST_PROJECT=test123 LANGUAGE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    raise "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or " \
+          "LANGUAGE_TEST_PROJECT=test123 " \
+          "LANGUAGE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
 
   ENV["LANGUAGE_CREDENTIALS"] = nil
@@ -102,6 +105,7 @@ task :acceptance, :project, :keyfile do |_t, args|
 
   Rake::Task["acceptance:run"].invoke
 end
+# rubocop:enable Metrics/BlockLength
 
 namespace :acceptance do
   Rake::TestTask.new :run do |t|

--- a/shared/output/cloud/language/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language/lib/google/cloud/language/v1/language_service/client.rb
@@ -960,26 +960,16 @@ module Google
                 attr_reader :annotate_text
 
                 def initialize parent_rpcs = nil
-                  analyze_sentiment_config = nil
-                  if parent_rpcs&.respond_to? :analyze_sentiment
-                    analyze_sentiment_config = parent_rpcs&.analyze_sentiment
-                  end
+                  analyze_sentiment_config = parent_rpcs&.analyze_sentiment if parent_rpcs&.respond_to? :analyze_sentiment
                   @analyze_sentiment = Gapic::Config::Method.new analyze_sentiment_config
-                  analyze_entities_config = nil
                   analyze_entities_config = parent_rpcs&.analyze_entities if parent_rpcs&.respond_to? :analyze_entities
                   @analyze_entities = Gapic::Config::Method.new analyze_entities_config
-                  analyze_entity_sentiment_config = nil
-                  if parent_rpcs&.respond_to? :analyze_entity_sentiment
-                    analyze_entity_sentiment_config = parent_rpcs&.analyze_entity_sentiment
-                  end
+                  analyze_entity_sentiment_config = parent_rpcs&.analyze_entity_sentiment if parent_rpcs&.respond_to? :analyze_entity_sentiment
                   @analyze_entity_sentiment = Gapic::Config::Method.new analyze_entity_sentiment_config
-                  analyze_syntax_config = nil
                   analyze_syntax_config = parent_rpcs&.analyze_syntax if parent_rpcs&.respond_to? :analyze_syntax
                   @analyze_syntax = Gapic::Config::Method.new analyze_syntax_config
-                  classify_text_config = nil
                   classify_text_config = parent_rpcs&.classify_text if parent_rpcs&.respond_to? :classify_text
                   @classify_text = Gapic::Config::Method.new classify_text_config
-                  annotate_text_config = nil
                   annotate_text_config = parent_rpcs&.annotate_text if parent_rpcs&.respond_to? :annotate_text
                   @annotate_text = Gapic::Config::Method.new annotate_text_config
 

--- a/shared/output/cloud/language/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/cloud/language/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -381,18 +381,12 @@ module Google
                 attr_reader :annotate_text
 
                 def initialize parent_rpcs = nil
-                  analyze_sentiment_config = nil
-                  if parent_rpcs&.respond_to? :analyze_sentiment
-                    analyze_sentiment_config = parent_rpcs&.analyze_sentiment
-                  end
+                  analyze_sentiment_config = parent_rpcs&.analyze_sentiment if parent_rpcs&.respond_to? :analyze_sentiment
                   @analyze_sentiment = Gapic::Config::Method.new analyze_sentiment_config
-                  analyze_entities_config = nil
                   analyze_entities_config = parent_rpcs&.analyze_entities if parent_rpcs&.respond_to? :analyze_entities
                   @analyze_entities = Gapic::Config::Method.new analyze_entities_config
-                  analyze_syntax_config = nil
                   analyze_syntax_config = parent_rpcs&.analyze_syntax if parent_rpcs&.respond_to? :analyze_syntax
                   @analyze_syntax = Gapic::Config::Method.new analyze_syntax_config
-                  annotate_text_config = nil
                   annotate_text_config = parent_rpcs&.annotate_text if parent_rpcs&.respond_to? :annotate_text
                   @annotate_text = Gapic::Config::Method.new annotate_text_config
 

--- a/shared/output/cloud/language/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -491,26 +491,16 @@ module Google
                 attr_reader :annotate_text
 
                 def initialize parent_rpcs = nil
-                  analyze_sentiment_config = nil
-                  if parent_rpcs&.respond_to? :analyze_sentiment
-                    analyze_sentiment_config = parent_rpcs&.analyze_sentiment
-                  end
+                  analyze_sentiment_config = parent_rpcs&.analyze_sentiment if parent_rpcs&.respond_to? :analyze_sentiment
                   @analyze_sentiment = Gapic::Config::Method.new analyze_sentiment_config
-                  analyze_entities_config = nil
                   analyze_entities_config = parent_rpcs&.analyze_entities if parent_rpcs&.respond_to? :analyze_entities
                   @analyze_entities = Gapic::Config::Method.new analyze_entities_config
-                  analyze_entity_sentiment_config = nil
-                  if parent_rpcs&.respond_to? :analyze_entity_sentiment
-                    analyze_entity_sentiment_config = parent_rpcs&.analyze_entity_sentiment
-                  end
+                  analyze_entity_sentiment_config = parent_rpcs&.analyze_entity_sentiment if parent_rpcs&.respond_to? :analyze_entity_sentiment
                   @analyze_entity_sentiment = Gapic::Config::Method.new analyze_entity_sentiment_config
-                  analyze_syntax_config = nil
                   analyze_syntax_config = parent_rpcs&.analyze_syntax if parent_rpcs&.respond_to? :analyze_syntax
                   @analyze_syntax = Gapic::Config::Method.new analyze_syntax_config
-                  classify_text_config = nil
                   classify_text_config = parent_rpcs&.classify_text if parent_rpcs&.respond_to? :classify_text
                   @classify_text = Gapic::Config::Method.new classify_text_config
-                  annotate_text_config = nil
                   annotate_text_config = parent_rpcs&.annotate_text if parent_rpcs&.respond_to? :annotate_text
                   @annotate_text = Gapic::Config::Method.new annotate_text_config
 

--- a/shared/output/cloud/language/test/google/cloud/language/v1/language_service_test.rb
+++ b/shared/output/cloud/language/test/google/cloud/language/v1/language_service_test.rb
@@ -69,8 +69,7 @@ class Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -129,8 +128,7 @@ class Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -189,8 +187,7 @@ class Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_entity_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -249,8 +246,7 @@ class Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -307,8 +303,7 @@ class Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.classify_text document: document do |response, operation|
+      client.classify_text({ document: document }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -369,8 +364,7 @@ class Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
+      client.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/language/test/google/cloud/language/v1beta1/language_service_test.rb
+++ b/shared/output/cloud/language/test/google/cloud/language/v1beta1/language_service_test.rb
@@ -69,8 +69,7 @@ class Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -129,8 +128,7 @@ class Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -189,8 +187,7 @@ class Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -251,8 +248,7 @@ class Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
+      client.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/language/test/google/cloud/language/v1beta2/language_service_test.rb
+++ b/shared/output/cloud/language/test/google/cloud/language/v1beta2/language_service_test.rb
@@ -69,8 +69,7 @@ class Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -129,8 +128,7 @@ class Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -189,8 +187,7 @@ class Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_entity_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -249,8 +246,7 @@ class Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -307,8 +303,7 @@ class Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.classify_text document: document do |response, operation|
+      client.classify_text({ document: document }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -369,8 +364,7 @@ class Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
+      client.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/showcase/.rubocop.yml
+++ b/shared/output/cloud/showcase/.rubocop.yml
@@ -3,28 +3,53 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
-    - "google-showcase.gemspec"
     - "lib/**/*_pb.rb"
     - "proto_docs/**/*"
-    - "Rakefile"
-    - "support/**/*"
     - "test/**/*"
 
+Metrics/AbcSize:
+  Exclude:
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"
 Metrics/ClassLength:
   Exclude:
-    - "lib/google/showcase/v1beta1/echo/client.rb"
-    - "lib/google/showcase/v1beta1/identity/client.rb"
-    - "lib/google/showcase/v1beta1/messaging/client.rb"
-    - "lib/google/showcase/v1beta1/testing/client.rb"
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"
 Metrics/LineLength:
   Exclude:
-    - "lib/google/showcase/v1beta1/echo/client.rb"
-    - "lib/google/showcase/v1beta1/identity/client.rb"
-    - "lib/google/showcase/v1beta1/messaging/client.rb"
-    - "lib/google/showcase/v1beta1/testing/client.rb"
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"
+Metrics/MethodLength:
+  Exclude:
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"
+Metrics/PerceivedComplexity:
+  Exclude:
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/google-showcase.rb"
 Style/CaseEquality:
-  Enabled: false
+  Exclude:
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"
+    - "lib/google/showcase.rb"

--- a/shared/output/cloud/showcase/Rakefile
+++ b/shared/output/cloud/showcase/Rakefile
@@ -63,6 +63,7 @@ namespace :smoke_test do
   end
 end
 
+# rubocop:disable Metrics/BlockLength
 # Acceptance tests
 desc "Run the google-showcase acceptance tests."
 task :acceptance, :project, :keyfile do |_t, args|
@@ -82,7 +83,9 @@ task :acceptance, :project, :keyfile do |_t, args|
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    raise "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or SHOWCASE_TEST_PROJECT=test123 SHOWCASE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    raise "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or " \
+          "SHOWCASE_TEST_PROJECT=test123 " \
+          "SHOWCASE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
 
   ENV["SHOWCASE_CREDENTIALS"] = nil
@@ -102,6 +105,7 @@ task :acceptance, :project, :keyfile do |_t, args|
 
   Rake::Task["acceptance:run"].invoke
 end
+# rubocop:enable Metrics/BlockLength
 
 namespace :acceptance do
   Rake::TestTask.new :run do |t|

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -242,11 +242,8 @@ module Google
           #
           def collect request, options = nil
             unless request.is_a? Enumerable
-              if request.respond_to? :to_enum
-                request = request.to_enum
-              else
-                raise ArgumentError, "request must be an Enumerable"
-              end
+              raise ArgumentError, "request must be an Enumerable" unless request.respond_to? :to_enum
+              request = request.to_enum
             end
 
             request = request.lazy.map do |req|
@@ -298,11 +295,8 @@ module Google
           #
           def chat request, options = nil
             unless request.is_a? Enumerable
-              if request.respond_to? :to_enum
-                request = request.to_enum
-              else
-                raise ArgumentError, "request must be an Enumerable"
-              end
+              raise ArgumentError, "request must be an Enumerable" unless request.respond_to? :to_enum
+              request = request.to_enum
             end
 
             request = request.lazy.map do |req|
@@ -562,25 +556,18 @@ module Google
               attr_reader :block
 
               def initialize parent_rpcs = nil
-                echo_config = nil
                 echo_config = parent_rpcs&.echo if parent_rpcs&.respond_to? :echo
                 @echo = Gapic::Config::Method.new echo_config
-                expand_config = nil
                 expand_config = parent_rpcs&.expand if parent_rpcs&.respond_to? :expand
                 @expand = Gapic::Config::Method.new expand_config
-                collect_config = nil
                 collect_config = parent_rpcs&.collect if parent_rpcs&.respond_to? :collect
                 @collect = Gapic::Config::Method.new collect_config
-                chat_config = nil
                 chat_config = parent_rpcs&.chat if parent_rpcs&.respond_to? :chat
                 @chat = Gapic::Config::Method.new chat_config
-                paged_expand_config = nil
                 paged_expand_config = parent_rpcs&.paged_expand if parent_rpcs&.respond_to? :paged_expand
                 @paged_expand = Gapic::Config::Method.new paged_expand_config
-                wait_config = nil
                 wait_config = parent_rpcs&.wait if parent_rpcs&.respond_to? :wait
                 @wait = Gapic::Config::Method.new wait_config
-                block_config = nil
                 block_config = parent_rpcs&.block if parent_rpcs&.respond_to? :block
                 @block = Gapic::Config::Method.new block_config
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -166,8 +166,8 @@ module Google
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+              wrap_lro_operation = ->(op_response) { Gapic::Operation.new op_response, @operations_client }
+              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_lro_operation
               yield response, operation if block_given?
               return response
             end
@@ -421,16 +421,12 @@ module Google
               attr_reader :cancel_operation
 
               def initialize parent_rpcs = nil
-                list_operations_config = nil
                 list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
                 @list_operations = Gapic::Config::Method.new list_operations_config
-                get_operation_config = nil
                 get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
                 @get_operation = Gapic::Config::Method.new get_operation_config
-                delete_operation_config = nil
                 delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
                 @delete_operation = Gapic::Config::Method.new delete_operation_config
-                cancel_operation_config = nil
                 cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
                 @cancel_operation = Gapic::Config::Method.new cancel_operation_config
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -442,19 +442,14 @@ module Google
               attr_reader :list_users
 
               def initialize parent_rpcs = nil
-                create_user_config = nil
                 create_user_config = parent_rpcs&.create_user if parent_rpcs&.respond_to? :create_user
                 @create_user = Gapic::Config::Method.new create_user_config
-                get_user_config = nil
                 get_user_config = parent_rpcs&.get_user if parent_rpcs&.respond_to? :get_user
                 @get_user = Gapic::Config::Method.new get_user_config
-                update_user_config = nil
                 update_user_config = parent_rpcs&.update_user if parent_rpcs&.respond_to? :update_user
                 @update_user = Gapic::Config::Method.new update_user_config
-                delete_user_config = nil
                 delete_user_config = parent_rpcs&.delete_user if parent_rpcs&.respond_to? :delete_user
                 @delete_user = Gapic::Config::Method.new delete_user_config
-                list_users_config = nil
                 list_users_config = parent_rpcs&.list_users if parent_rpcs&.respond_to? :list_users
                 @list_users = Gapic::Config::Method.new list_users_config
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/identity/paths.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/identity/paths.rb
@@ -21,6 +21,7 @@ module Google
   module Showcase
     module V1beta1
       module Identity
+        # Path helper methods for the Identity API.
         module Paths
           ##
           # Create a fully-qualified User resource string.

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -870,11 +870,8 @@ module Google
           #
           def send_blurbs request, options = nil
             unless request.is_a? Enumerable
-              if request.respond_to? :to_enum
-                request = request.to_enum
-              else
-                raise ArgumentError, "request must be an Enumerable"
-              end
+              raise ArgumentError, "request must be an Enumerable" unless request.respond_to? :to_enum
+              request = request.to_enum
             end
 
             request = request.lazy.map do |req|
@@ -933,11 +930,8 @@ module Google
           #
           def connect request, options = nil
             unless request.is_a? Enumerable
-              if request.respond_to? :to_enum
-                request = request.to_enum
-              else
-                raise ArgumentError, "request must be an Enumerable"
-              end
+              raise ArgumentError, "request must be an Enumerable" unless request.respond_to? :to_enum
+              request = request.to_enum
             end
 
             request = request.lazy.map do |req|
@@ -1022,46 +1016,32 @@ module Google
               attr_reader :connect
 
               def initialize parent_rpcs = nil
-                create_room_config = nil
                 create_room_config = parent_rpcs&.create_room if parent_rpcs&.respond_to? :create_room
                 @create_room = Gapic::Config::Method.new create_room_config
-                get_room_config = nil
                 get_room_config = parent_rpcs&.get_room if parent_rpcs&.respond_to? :get_room
                 @get_room = Gapic::Config::Method.new get_room_config
-                update_room_config = nil
                 update_room_config = parent_rpcs&.update_room if parent_rpcs&.respond_to? :update_room
                 @update_room = Gapic::Config::Method.new update_room_config
-                delete_room_config = nil
                 delete_room_config = parent_rpcs&.delete_room if parent_rpcs&.respond_to? :delete_room
                 @delete_room = Gapic::Config::Method.new delete_room_config
-                list_rooms_config = nil
                 list_rooms_config = parent_rpcs&.list_rooms if parent_rpcs&.respond_to? :list_rooms
                 @list_rooms = Gapic::Config::Method.new list_rooms_config
-                create_blurb_config = nil
                 create_blurb_config = parent_rpcs&.create_blurb if parent_rpcs&.respond_to? :create_blurb
                 @create_blurb = Gapic::Config::Method.new create_blurb_config
-                get_blurb_config = nil
                 get_blurb_config = parent_rpcs&.get_blurb if parent_rpcs&.respond_to? :get_blurb
                 @get_blurb = Gapic::Config::Method.new get_blurb_config
-                update_blurb_config = nil
                 update_blurb_config = parent_rpcs&.update_blurb if parent_rpcs&.respond_to? :update_blurb
                 @update_blurb = Gapic::Config::Method.new update_blurb_config
-                delete_blurb_config = nil
                 delete_blurb_config = parent_rpcs&.delete_blurb if parent_rpcs&.respond_to? :delete_blurb
                 @delete_blurb = Gapic::Config::Method.new delete_blurb_config
-                list_blurbs_config = nil
                 list_blurbs_config = parent_rpcs&.list_blurbs if parent_rpcs&.respond_to? :list_blurbs
                 @list_blurbs = Gapic::Config::Method.new list_blurbs_config
-                search_blurbs_config = nil
                 search_blurbs_config = parent_rpcs&.search_blurbs if parent_rpcs&.respond_to? :search_blurbs
                 @search_blurbs = Gapic::Config::Method.new search_blurbs_config
-                stream_blurbs_config = nil
                 stream_blurbs_config = parent_rpcs&.stream_blurbs if parent_rpcs&.respond_to? :stream_blurbs
                 @stream_blurbs = Gapic::Config::Method.new stream_blurbs_config
-                send_blurbs_config = nil
                 send_blurbs_config = parent_rpcs&.send_blurbs if parent_rpcs&.respond_to? :send_blurbs
                 @send_blurbs = Gapic::Config::Method.new send_blurbs_config
-                connect_config = nil
                 connect_config = parent_rpcs&.connect if parent_rpcs&.respond_to? :connect
                 @connect = Gapic::Config::Method.new connect_config
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -166,8 +166,8 @@ module Google
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+              wrap_lro_operation = ->(op_response) { Gapic::Operation.new op_response, @operations_client }
+              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_lro_operation
               yield response, operation if block_given?
               return response
             end
@@ -421,16 +421,12 @@ module Google
               attr_reader :cancel_operation
 
               def initialize parent_rpcs = nil
-                list_operations_config = nil
                 list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
                 @list_operations = Gapic::Config::Method.new list_operations_config
-                get_operation_config = nil
                 get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
                 @get_operation = Gapic::Config::Method.new get_operation_config
-                delete_operation_config = nil
                 delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
                 @delete_operation = Gapic::Config::Method.new delete_operation_config
-                cancel_operation_config = nil
                 cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
                 @cancel_operation = Gapic::Config::Method.new cancel_operation_config
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/paths.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/messaging/paths.rb
@@ -21,6 +21,7 @@ module Google
   module Showcase
     module V1beta1
       module Messaging
+        # Path helper methods for the Messaging API.
         module Paths
           ##
           # Create a fully-qualified Blurb resource string.

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -644,28 +644,20 @@ module Google
               attr_reader :verify_test
 
               def initialize parent_rpcs = nil
-                create_session_config = nil
                 create_session_config = parent_rpcs&.create_session if parent_rpcs&.respond_to? :create_session
                 @create_session = Gapic::Config::Method.new create_session_config
-                get_session_config = nil
                 get_session_config = parent_rpcs&.get_session if parent_rpcs&.respond_to? :get_session
                 @get_session = Gapic::Config::Method.new get_session_config
-                list_sessions_config = nil
                 list_sessions_config = parent_rpcs&.list_sessions if parent_rpcs&.respond_to? :list_sessions
                 @list_sessions = Gapic::Config::Method.new list_sessions_config
-                delete_session_config = nil
                 delete_session_config = parent_rpcs&.delete_session if parent_rpcs&.respond_to? :delete_session
                 @delete_session = Gapic::Config::Method.new delete_session_config
-                report_session_config = nil
                 report_session_config = parent_rpcs&.report_session if parent_rpcs&.respond_to? :report_session
                 @report_session = Gapic::Config::Method.new report_session_config
-                list_tests_config = nil
                 list_tests_config = parent_rpcs&.list_tests if parent_rpcs&.respond_to? :list_tests
                 @list_tests = Gapic::Config::Method.new list_tests_config
-                delete_test_config = nil
                 delete_test_config = parent_rpcs&.delete_test if parent_rpcs&.respond_to? :delete_test
                 @delete_test = Gapic::Config::Method.new delete_test_config
-                verify_test_config = nil
                 verify_test_config = parent_rpcs&.verify_test if parent_rpcs&.respond_to? :verify_test
                 @verify_test = Gapic::Config::Method.new verify_test_config
 

--- a/shared/output/cloud/showcase/lib/google/showcase/v1beta1/testing/paths.rb
+++ b/shared/output/cloud/showcase/lib/google/showcase/v1beta1/testing/paths.rb
@@ -21,6 +21,7 @@ module Google
   module Showcase
     module V1beta1
       module Testing
+        # Path helper methods for the Testing API.
         module Paths
           ##
           # Create a fully-qualified Session resource string.

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -73,8 +73,7 @@ class Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -131,8 +130,7 @@ class Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_operation name: name do |response, operation|
+      client.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -194,8 +192,7 @@ class Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_operation name: name do |response, operation|
+      client.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -252,8 +249,7 @@ class Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.cancel_operation name: name do |response, operation|
+      client.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -67,8 +67,7 @@ class Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.echo content: content do |response, operation|
+      client.echo({ content: content }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -135,8 +134,7 @@ class Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.paged_expand content: content, page_size: page_size, page_token: page_token do |response, operation|
+      client.paged_expand({ content: content, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -195,8 +193,7 @@ class Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.wait end_time: end_time, error: error do |response, operation|
+      client.wait({ end_time: end_time, error: error }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -258,8 +255,7 @@ class Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.block response_delay: response_delay do |response, operation|
+      client.block({ response_delay: response_delay }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -67,8 +67,7 @@ class Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_user user: user do |response, operation|
+      client.create_user({ user: user }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -125,8 +124,7 @@ class Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_user name: name do |response, operation|
+      client.get_user({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -185,8 +183,7 @@ class Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.update_user user: user, update_mask: update_mask do |response, operation|
+      client.update_user({ user: user, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -243,8 +240,7 @@ class Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_user name: name do |response, operation|
+      client.delete_user({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -303,8 +299,7 @@ class Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_users page_size: page_size, page_token: page_token do |response, operation|
+      client.list_users({ page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -73,8 +73,7 @@ class Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -131,8 +130,7 @@ class Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_operation name: name do |response, operation|
+      client.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -194,8 +192,7 @@ class Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_operation name: name do |response, operation|
+      client.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -252,8 +249,7 @@ class Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.cancel_operation name: name do |response, operation|
+      client.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -67,8 +67,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_room room: room do |response, operation|
+      client.create_room({ room: room }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -125,8 +124,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_room name: name do |response, operation|
+      client.get_room({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -185,8 +183,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.update_room room: room, update_mask: update_mask do |response, operation|
+      client.update_room({ room: room, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -243,8 +240,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_room name: name do |response, operation|
+      client.delete_room({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -303,8 +299,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_rooms page_size: page_size, page_token: page_token do |response, operation|
+      client.list_rooms({ page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -363,8 +358,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_blurb parent: parent, blurb: blurb do |response, operation|
+      client.create_blurb({ parent: parent, blurb: blurb }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -421,8 +415,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_blurb name: name do |response, operation|
+      client.get_blurb({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -481,8 +474,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.update_blurb blurb: blurb, update_mask: update_mask do |response, operation|
+      client.update_blurb({ blurb: blurb, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -539,8 +531,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_blurb name: name do |response, operation|
+      client.delete_blurb({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -601,8 +592,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_blurbs parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -665,8 +655,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/cloud/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -67,8 +67,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_session session: session do |response, operation|
+      client.create_session({ session: session }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -125,8 +124,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_session name: name do |response, operation|
+      client.get_session({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -185,8 +183,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_sessions page_size: page_size, page_token: page_token do |response, operation|
+      client.list_sessions({ page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -243,8 +240,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_session name: name do |response, operation|
+      client.delete_session({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -301,8 +297,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.report_session name: name do |response, operation|
+      client.report_session({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -363,8 +358,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_tests parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_tests({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -421,8 +415,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_test name: name do |response, operation|
+      client.delete_test({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -483,8 +476,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.verify_test name: name, answer: answer, answers: answers do |response, operation|
+      client.verify_test({ name: name, answer: answer, answers: answers }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/speech/.rubocop.yml
+++ b/shared/output/cloud/speech/.rubocop.yml
@@ -3,22 +3,32 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
-    - "google-cloud-speech.gemspec"
     - "lib/**/*_pb.rb"
     - "proto_docs/**/*"
-    - "Rakefile"
-    - "support/**/*"
     - "test/**/*"
 
+Metrics/AbcSize:
+  Exclude:
+    - "lib/google/cloud/speech/v1/speech/*.rb"
 Metrics/ClassLength:
   Exclude:
-    - "lib/google/cloud/speech/v1/speech/client.rb"
+    - "lib/google/cloud/speech/v1/speech/*.rb"
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - "lib/google/cloud/speech/v1/speech/*.rb"
 Metrics/LineLength:
   Exclude:
-    - "lib/google/cloud/speech/v1/speech/client.rb"
+    - "lib/google/cloud/speech/v1/speech/*.rb"
+Metrics/MethodLength:
+  Exclude:
+    - "lib/google/cloud/speech/v1/speech/*.rb"
+Metrics/PerceivedComplexity:
+  Exclude:
+    - "lib/google/cloud/speech/v1/speech/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-speech.rb"
 Style/CaseEquality:
-  Enabled: false
+  Exclude:
+    - "lib/google/cloud/speech/v1/speech/*.rb"
+    - "lib/google/cloud/speech.rb"

--- a/shared/output/cloud/speech/Rakefile
+++ b/shared/output/cloud/speech/Rakefile
@@ -63,6 +63,7 @@ namespace :smoke_test do
   end
 end
 
+# rubocop:disable Metrics/BlockLength
 # Acceptance tests
 desc "Run the google-cloud-speech acceptance tests."
 task :acceptance, :project, :keyfile do |_t, args|
@@ -82,7 +83,9 @@ task :acceptance, :project, :keyfile do |_t, args|
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    raise "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or SPEECH_TEST_PROJECT=test123 SPEECH_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    raise "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or " \
+          "SPEECH_TEST_PROJECT=test123 " \
+          "SPEECH_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
 
   ENV["SPEECH_CREDENTIALS"] = nil
@@ -102,6 +105,7 @@ task :acceptance, :project, :keyfile do |_t, args|
 
   Rake::Task["acceptance:run"].invoke
 end
+# rubocop:enable Metrics/BlockLength
 
 namespace :acceptance do
   Rake::TestTask.new :run do |t|

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -562,11 +562,8 @@ module Google
             #
             def streaming_recognize request, options = nil
               unless request.is_a? Enumerable
-                if request.respond_to? :to_enum
-                  request = request.to_enum
-                else
-                  raise ArgumentError, "request must be an Enumerable"
-                end
+                raise ArgumentError, "request must be an Enumerable" unless request.respond_to? :to_enum
+                request = request.to_enum
               end
 
               request = request.lazy.map do |req|
@@ -640,18 +637,11 @@ module Google
                 attr_reader :streaming_recognize
 
                 def initialize parent_rpcs = nil
-                  recognize_config = nil
                   recognize_config = parent_rpcs&.recognize if parent_rpcs&.respond_to? :recognize
                   @recognize = Gapic::Config::Method.new recognize_config
-                  long_running_recognize_config = nil
-                  if parent_rpcs&.respond_to? :long_running_recognize
-                    long_running_recognize_config = parent_rpcs&.long_running_recognize
-                  end
+                  long_running_recognize_config = parent_rpcs&.long_running_recognize if parent_rpcs&.respond_to? :long_running_recognize
                   @long_running_recognize = Gapic::Config::Method.new long_running_recognize_config
-                  streaming_recognize_config = nil
-                  if parent_rpcs&.respond_to? :streaming_recognize
-                    streaming_recognize_config = parent_rpcs&.streaming_recognize
-                  end
+                  streaming_recognize_config = parent_rpcs&.streaming_recognize if parent_rpcs&.respond_to? :streaming_recognize
                   @streaming_recognize = Gapic::Config::Method.new streaming_recognize_config
 
                   yield self if block_given?

--- a/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -167,8 +167,8 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
-                wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                wrap_lro_operation = ->(op_response) { Gapic::Operation.new op_response, @operations_client }
+                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_lro_operation
                 yield response, operation if block_given?
                 return response
               end
@@ -422,16 +422,12 @@ module Google
                 attr_reader :cancel_operation
 
                 def initialize parent_rpcs = nil
-                  list_operations_config = nil
                   list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
                   @list_operations = Gapic::Config::Method.new list_operations_config
-                  get_operation_config = nil
                   get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
                   @get_operation = Gapic::Config::Method.new get_operation_config
-                  delete_operation_config = nil
                   delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
                   @delete_operation = Gapic::Config::Method.new delete_operation_config
-                  cancel_operation_config = nil
                   cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
                   @cancel_operation = Gapic::Config::Method.new cancel_operation_config
 

--- a/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -73,8 +73,7 @@ class Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -131,8 +130,7 @@ class Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_operation name: name do |response, operation|
+      client.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -194,8 +192,7 @@ class Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_operation name: name do |response, operation|
+      client.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -252,8 +249,7 @@ class Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.cancel_operation name: name do |response, operation|
+      client.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech/test/google/cloud/speech/v1/speech_test.rb
@@ -69,8 +69,7 @@ class Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.recognize config: config, audio: audio do |response, operation|
+      client.recognize({ config: config, audio: audio }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -129,8 +128,7 @@ class Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.long_running_recognize config: config, audio: audio do |response, operation|
+      client.long_running_recognize({ config: config, audio: audio }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/vision/.rubocop.yml
+++ b/shared/output/cloud/vision/.rubocop.yml
@@ -3,24 +3,39 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
-    - "google-cloud-vision.gemspec"
     - "lib/**/*_pb.rb"
     - "proto_docs/**/*"
-    - "Rakefile"
-    - "support/**/*"
     - "test/**/*"
 
+Metrics/AbcSize:
+  Exclude:
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"
 Metrics/ClassLength:
   Exclude:
-    - "lib/google/cloud/vision/v1/product_search/client.rb"
-    - "lib/google/cloud/vision/v1/image_annotator/client.rb"
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"
 Metrics/LineLength:
   Exclude:
-    - "lib/google/cloud/vision/v1/product_search/client.rb"
-    - "lib/google/cloud/vision/v1/image_annotator/client.rb"
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"
+Metrics/MethodLength:
+  Exclude:
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"
+Metrics/PerceivedComplexity:
+  Exclude:
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-vision.rb"
 Style/CaseEquality:
-  Enabled: false
+  Exclude:
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"
+    - "lib/google/cloud/vision.rb"

--- a/shared/output/cloud/vision/Rakefile
+++ b/shared/output/cloud/vision/Rakefile
@@ -63,6 +63,7 @@ namespace :smoke_test do
   end
 end
 
+# rubocop:disable Metrics/BlockLength
 # Acceptance tests
 desc "Run the google-cloud-vision acceptance tests."
 task :acceptance, :project, :keyfile do |_t, args|
@@ -82,7 +83,9 @@ task :acceptance, :project, :keyfile do |_t, args|
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    raise "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or VISION_TEST_PROJECT=test123 VISION_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    raise "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or " \
+          "VISION_TEST_PROJECT=test123 " \
+          "VISION_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
 
   ENV["VISION_CREDENTIALS"] = nil
@@ -102,6 +105,7 @@ task :acceptance, :project, :keyfile do |_t, args|
 
   Rake::Task["acceptance:run"].invoke
 end
+# rubocop:enable Metrics/BlockLength
 
 namespace :acceptance do
   Rake::TestTask.new :run do |t|

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -459,25 +459,13 @@ module Google
                 attr_reader :async_batch_annotate_files
 
                 def initialize parent_rpcs = nil
-                  batch_annotate_images_config = nil
-                  if parent_rpcs&.respond_to? :batch_annotate_images
-                    batch_annotate_images_config = parent_rpcs&.batch_annotate_images
-                  end
+                  batch_annotate_images_config = parent_rpcs&.batch_annotate_images if parent_rpcs&.respond_to? :batch_annotate_images
                   @batch_annotate_images = Gapic::Config::Method.new batch_annotate_images_config
-                  batch_annotate_files_config = nil
-                  if parent_rpcs&.respond_to? :batch_annotate_files
-                    batch_annotate_files_config = parent_rpcs&.batch_annotate_files
-                  end
+                  batch_annotate_files_config = parent_rpcs&.batch_annotate_files if parent_rpcs&.respond_to? :batch_annotate_files
                   @batch_annotate_files = Gapic::Config::Method.new batch_annotate_files_config
-                  async_batch_annotate_images_config = nil
-                  if parent_rpcs&.respond_to? :async_batch_annotate_images
-                    async_batch_annotate_images_config = parent_rpcs&.async_batch_annotate_images
-                  end
+                  async_batch_annotate_images_config = parent_rpcs&.async_batch_annotate_images if parent_rpcs&.respond_to? :async_batch_annotate_images
                   @async_batch_annotate_images = Gapic::Config::Method.new async_batch_annotate_images_config
-                  async_batch_annotate_files_config = nil
-                  if parent_rpcs&.respond_to? :async_batch_annotate_files
-                    async_batch_annotate_files_config = parent_rpcs&.async_batch_annotate_files
-                  end
+                  async_batch_annotate_files_config = parent_rpcs&.async_batch_annotate_files if parent_rpcs&.respond_to? :async_batch_annotate_files
                   @async_batch_annotate_files = Gapic::Config::Method.new async_batch_annotate_files_config
 
                   yield self if block_given?

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -167,8 +167,8 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
-                wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                wrap_lro_operation = ->(op_response) { Gapic::Operation.new op_response, @operations_client }
+                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_lro_operation
                 yield response, operation if block_given?
                 return response
               end
@@ -422,16 +422,12 @@ module Google
                 attr_reader :cancel_operation
 
                 def initialize parent_rpcs = nil
-                  list_operations_config = nil
                   list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
                   @list_operations = Gapic::Config::Method.new list_operations_config
-                  get_operation_config = nil
                   get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
                   @get_operation = Gapic::Config::Method.new get_operation_config
-                  delete_operation_config = nil
                   delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
                   @delete_operation = Gapic::Config::Method.new delete_operation_config
-                  cancel_operation_config = nil
                   cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
                   @cancel_operation = Gapic::Config::Method.new cancel_operation_config
 

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -1678,85 +1678,42 @@ module Google
                 attr_reader :purge_products
 
                 def initialize parent_rpcs = nil
-                  create_product_set_config = nil
-                  if parent_rpcs&.respond_to? :create_product_set
-                    create_product_set_config = parent_rpcs&.create_product_set
-                  end
+                  create_product_set_config = parent_rpcs&.create_product_set if parent_rpcs&.respond_to? :create_product_set
                   @create_product_set = Gapic::Config::Method.new create_product_set_config
-                  list_product_sets_config = nil
-                  if parent_rpcs&.respond_to? :list_product_sets
-                    list_product_sets_config = parent_rpcs&.list_product_sets
-                  end
+                  list_product_sets_config = parent_rpcs&.list_product_sets if parent_rpcs&.respond_to? :list_product_sets
                   @list_product_sets = Gapic::Config::Method.new list_product_sets_config
-                  get_product_set_config = nil
                   get_product_set_config = parent_rpcs&.get_product_set if parent_rpcs&.respond_to? :get_product_set
                   @get_product_set = Gapic::Config::Method.new get_product_set_config
-                  update_product_set_config = nil
-                  if parent_rpcs&.respond_to? :update_product_set
-                    update_product_set_config = parent_rpcs&.update_product_set
-                  end
+                  update_product_set_config = parent_rpcs&.update_product_set if parent_rpcs&.respond_to? :update_product_set
                   @update_product_set = Gapic::Config::Method.new update_product_set_config
-                  delete_product_set_config = nil
-                  if parent_rpcs&.respond_to? :delete_product_set
-                    delete_product_set_config = parent_rpcs&.delete_product_set
-                  end
+                  delete_product_set_config = parent_rpcs&.delete_product_set if parent_rpcs&.respond_to? :delete_product_set
                   @delete_product_set = Gapic::Config::Method.new delete_product_set_config
-                  create_product_config = nil
                   create_product_config = parent_rpcs&.create_product if parent_rpcs&.respond_to? :create_product
                   @create_product = Gapic::Config::Method.new create_product_config
-                  list_products_config = nil
                   list_products_config = parent_rpcs&.list_products if parent_rpcs&.respond_to? :list_products
                   @list_products = Gapic::Config::Method.new list_products_config
-                  get_product_config = nil
                   get_product_config = parent_rpcs&.get_product if parent_rpcs&.respond_to? :get_product
                   @get_product = Gapic::Config::Method.new get_product_config
-                  update_product_config = nil
                   update_product_config = parent_rpcs&.update_product if parent_rpcs&.respond_to? :update_product
                   @update_product = Gapic::Config::Method.new update_product_config
-                  delete_product_config = nil
                   delete_product_config = parent_rpcs&.delete_product if parent_rpcs&.respond_to? :delete_product
                   @delete_product = Gapic::Config::Method.new delete_product_config
-                  create_reference_image_config = nil
-                  if parent_rpcs&.respond_to? :create_reference_image
-                    create_reference_image_config = parent_rpcs&.create_reference_image
-                  end
+                  create_reference_image_config = parent_rpcs&.create_reference_image if parent_rpcs&.respond_to? :create_reference_image
                   @create_reference_image = Gapic::Config::Method.new create_reference_image_config
-                  delete_reference_image_config = nil
-                  if parent_rpcs&.respond_to? :delete_reference_image
-                    delete_reference_image_config = parent_rpcs&.delete_reference_image
-                  end
+                  delete_reference_image_config = parent_rpcs&.delete_reference_image if parent_rpcs&.respond_to? :delete_reference_image
                   @delete_reference_image = Gapic::Config::Method.new delete_reference_image_config
-                  list_reference_images_config = nil
-                  if parent_rpcs&.respond_to? :list_reference_images
-                    list_reference_images_config = parent_rpcs&.list_reference_images
-                  end
+                  list_reference_images_config = parent_rpcs&.list_reference_images if parent_rpcs&.respond_to? :list_reference_images
                   @list_reference_images = Gapic::Config::Method.new list_reference_images_config
-                  get_reference_image_config = nil
-                  if parent_rpcs&.respond_to? :get_reference_image
-                    get_reference_image_config = parent_rpcs&.get_reference_image
-                  end
+                  get_reference_image_config = parent_rpcs&.get_reference_image if parent_rpcs&.respond_to? :get_reference_image
                   @get_reference_image = Gapic::Config::Method.new get_reference_image_config
-                  add_product_to_product_set_config = nil
-                  if parent_rpcs&.respond_to? :add_product_to_product_set
-                    add_product_to_product_set_config = parent_rpcs&.add_product_to_product_set
-                  end
+                  add_product_to_product_set_config = parent_rpcs&.add_product_to_product_set if parent_rpcs&.respond_to? :add_product_to_product_set
                   @add_product_to_product_set = Gapic::Config::Method.new add_product_to_product_set_config
-                  remove_product_from_product_set_config = nil
-                  if parent_rpcs&.respond_to? :remove_product_from_product_set
-                    remove_product_from_product_set_config = parent_rpcs&.remove_product_from_product_set
-                  end
+                  remove_product_from_product_set_config = parent_rpcs&.remove_product_from_product_set if parent_rpcs&.respond_to? :remove_product_from_product_set
                   @remove_product_from_product_set = Gapic::Config::Method.new remove_product_from_product_set_config
-                  list_products_in_product_set_config = nil
-                  if parent_rpcs&.respond_to? :list_products_in_product_set
-                    list_products_in_product_set_config = parent_rpcs&.list_products_in_product_set
-                  end
+                  list_products_in_product_set_config = parent_rpcs&.list_products_in_product_set if parent_rpcs&.respond_to? :list_products_in_product_set
                   @list_products_in_product_set = Gapic::Config::Method.new list_products_in_product_set_config
-                  import_product_sets_config = nil
-                  if parent_rpcs&.respond_to? :import_product_sets
-                    import_product_sets_config = parent_rpcs&.import_product_sets
-                  end
+                  import_product_sets_config = parent_rpcs&.import_product_sets if parent_rpcs&.respond_to? :import_product_sets
                   @import_product_sets = Gapic::Config::Method.new import_product_sets_config
-                  purge_products_config = nil
                   purge_products_config = parent_rpcs&.purge_products if parent_rpcs&.respond_to? :purge_products
                   @purge_products = Gapic::Config::Method.new purge_products_config
 

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -167,8 +167,8 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
-                wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                wrap_lro_operation = ->(op_response) { Gapic::Operation.new op_response, @operations_client }
+                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_lro_operation
                 yield response, operation if block_given?
                 return response
               end
@@ -422,16 +422,12 @@ module Google
                 attr_reader :cancel_operation
 
                 def initialize parent_rpcs = nil
-                  list_operations_config = nil
                   list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
                   @list_operations = Gapic::Config::Method.new list_operations_config
-                  get_operation_config = nil
                   get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
                   @get_operation = Gapic::Config::Method.new get_operation_config
-                  delete_operation_config = nil
                   delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
                   @delete_operation = Gapic::Config::Method.new delete_operation_config
-                  cancel_operation_config = nil
                   cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
                   @cancel_operation = Gapic::Config::Method.new cancel_operation_config
 

--- a/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/paths.rb
+++ b/shared/output/cloud/vision/lib/google/cloud/vision/v1/product_search/paths.rb
@@ -22,6 +22,7 @@ module Google
     module Vision
       module V1
         module ProductSearch
+          # Path helper methods for the ProductSearch API.
           module Paths
             ##
             # Create a fully-qualified Product resource string.

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -73,8 +73,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -131,8 +130,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_operation name: name do |response, operation|
+      client.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -194,8 +192,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_operation name: name do |response, operation|
+      client.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -252,8 +249,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.cancel_operation name: name do |response, operation|
+      client.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -69,8 +69,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.batch_annotate_images requests: requests, parent: parent do |response, operation|
+      client.batch_annotate_images({ requests: requests, parent: parent }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -129,8 +128,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.batch_annotate_files requests: requests, parent: parent do |response, operation|
+      client.batch_annotate_files({ requests: requests, parent: parent }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -191,8 +189,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent do |response, operation|
+      client.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -256,8 +253,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.async_batch_annotate_files requests: requests, parent: parent do |response, operation|
+      client.async_batch_annotate_files({ requests: requests, parent: parent }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -73,8 +73,7 @@ class Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -131,8 +130,7 @@ class Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_operation name: name do |response, operation|
+      client.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -194,8 +192,7 @@ class Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_operation name: name do |response, operation|
+      client.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -252,8 +249,7 @@ class Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.cancel_operation name: name do |response, operation|
+      client.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision/test/google/cloud/vision/v1/product_search_test.rb
@@ -71,8 +71,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |response, operation|
+      client.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -133,8 +132,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -191,8 +189,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_product_set name: name do |response, operation|
+      client.get_product_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -251,8 +248,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.update_product_set product_set: product_set, update_mask: update_mask do |response, operation|
+      client.update_product_set({ product_set: product_set, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -309,8 +305,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_product_set name: name do |response, operation|
+      client.delete_product_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -371,8 +366,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_product parent: parent, product: product, product_id: product_id do |response, operation|
+      client.create_product({ parent: parent, product: product, product_id: product_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -433,8 +427,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_products parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -491,8 +484,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_product name: name do |response, operation|
+      client.get_product({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -551,8 +543,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.update_product product: product, update_mask: update_mask do |response, operation|
+      client.update_product({ product: product, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -609,8 +600,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_product name: name do |response, operation|
+      client.delete_product({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -671,8 +661,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |response, operation|
+      client.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -729,8 +718,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_reference_image name: name do |response, operation|
+      client.delete_reference_image({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -791,8 +779,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -849,8 +836,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_reference_image name: name do |response, operation|
+      client.get_reference_image({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -909,8 +895,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.add_product_to_product_set name: name, product: product do |response, operation|
+      client.add_product_to_product_set({ name: name, product: product }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -969,8 +954,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.remove_product_from_product_set name: name, product: product do |response, operation|
+      client.remove_product_from_product_set({ name: name, product: product }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -1031,8 +1015,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -1091,8 +1074,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.import_product_sets parent: parent, input_config: input_config do |response, operation|
+      client.import_product_sets({ parent: parent, input_config: input_config }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -1154,8 +1136,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.purge_products product_set_purge_config: product_set_purge_config do |response, operation|
+      client.purge_products({ product_set_purge_config: product_set_purge_config }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/garbage/.rubocop.yml
+++ b/shared/output/gapic/templates/garbage/.rubocop.yml
@@ -3,15 +3,28 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "google-garbage.gemspec"
+    - "lib/**/*_pb.rb"
     - "proto_docs/**/*"
     - "test/**/*"
 
+Metrics/AbcSize:
+  Exclude:
+    - "lib/so/much/trash/garbage_service/*.rb"
 Metrics/ClassLength:
   Exclude:
-    - "lib/so/much/trash/garbage_service/client.rb"
+    - "lib/so/much/trash/garbage_service/*.rb"
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - "lib/so/much/trash/garbage_service/*.rb"
 Metrics/LineLength:
   Exclude:
-    - "lib/so/much/trash/garbage_service/client.rb"
+    - "lib/so/much/trash/garbage_service/*.rb"
+Metrics/MethodLength:
+  Exclude:
+    - "lib/so/much/trash/garbage_service/*.rb"
+Metrics/PerceivedComplexity:
+  Exclude:
+    - "lib/so/much/trash/garbage_service/*.rb"
 Style/CaseEquality:
-  Enabled: false
+  Exclude:
+    - "lib/so/much/trash/garbage_service/*.rb"

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -787,11 +787,8 @@ module So
           #
           def client_garbage request, options = nil
             unless request.is_a? Enumerable
-              if request.respond_to? :to_enum
-                request = request.to_enum
-              else
-                raise ArgumentError, "request must be an Enumerable"
-              end
+              raise ArgumentError, "request must be an Enumerable" unless request.respond_to? :to_enum
+              request = request.to_enum
             end
 
             request = request.lazy.map do |req|
@@ -906,11 +903,8 @@ module So
           #
           def bidi_garbage request, options = nil
             unless request.is_a? Enumerable
-              if request.respond_to? :to_enum
-                request = request.to_enum
-              else
-                raise ArgumentError, "request must be an Enumerable"
-              end
+              raise ArgumentError, "request must be an Enumerable" unless request.respond_to? :to_enum
+              request = request.to_enum
             end
 
             request = request.lazy.map do |req|
@@ -990,51 +984,26 @@ module So
               attr_reader :bidi_garbage
 
               def initialize parent_rpcs = nil
-                get_simple_garbage_config = nil
-                if parent_rpcs&.respond_to? :get_simple_garbage
-                  get_simple_garbage_config = parent_rpcs&.get_simple_garbage
-                end
+                get_simple_garbage_config = parent_rpcs&.get_simple_garbage if parent_rpcs&.respond_to? :get_simple_garbage
                 @get_simple_garbage = Gapic::Config::Method.new get_simple_garbage_config
-                get_specific_garbage_config = nil
-                if parent_rpcs&.respond_to? :get_specific_garbage
-                  get_specific_garbage_config = parent_rpcs&.get_specific_garbage
-                end
+                get_specific_garbage_config = parent_rpcs&.get_specific_garbage if parent_rpcs&.respond_to? :get_specific_garbage
                 @get_specific_garbage = Gapic::Config::Method.new get_specific_garbage_config
-                get_nested_garbage_config = nil
-                if parent_rpcs&.respond_to? :get_nested_garbage
-                  get_nested_garbage_config = parent_rpcs&.get_nested_garbage
-                end
+                get_nested_garbage_config = parent_rpcs&.get_nested_garbage if parent_rpcs&.respond_to? :get_nested_garbage
                 @get_nested_garbage = Gapic::Config::Method.new get_nested_garbage_config
-                get_repeated_garbage_config = nil
-                if parent_rpcs&.respond_to? :get_repeated_garbage
-                  get_repeated_garbage_config = parent_rpcs&.get_repeated_garbage
-                end
+                get_repeated_garbage_config = parent_rpcs&.get_repeated_garbage if parent_rpcs&.respond_to? :get_repeated_garbage
                 @get_repeated_garbage = Gapic::Config::Method.new get_repeated_garbage_config
-                get_typical_garbage_config = nil
-                if parent_rpcs&.respond_to? :get_typical_garbage
-                  get_typical_garbage_config = parent_rpcs&.get_typical_garbage
-                end
+                get_typical_garbage_config = parent_rpcs&.get_typical_garbage if parent_rpcs&.respond_to? :get_typical_garbage
                 @get_typical_garbage = Gapic::Config::Method.new get_typical_garbage_config
-                get_complex_garbage_config = nil
-                if parent_rpcs&.respond_to? :get_complex_garbage
-                  get_complex_garbage_config = parent_rpcs&.get_complex_garbage
-                end
+                get_complex_garbage_config = parent_rpcs&.get_complex_garbage if parent_rpcs&.respond_to? :get_complex_garbage
                 @get_complex_garbage = Gapic::Config::Method.new get_complex_garbage_config
-                get_paged_garbage_config = nil
                 get_paged_garbage_config = parent_rpcs&.get_paged_garbage if parent_rpcs&.respond_to? :get_paged_garbage
                 @get_paged_garbage = Gapic::Config::Method.new get_paged_garbage_config
-                long_running_garbage_config = nil
-                if parent_rpcs&.respond_to? :long_running_garbage
-                  long_running_garbage_config = parent_rpcs&.long_running_garbage
-                end
+                long_running_garbage_config = parent_rpcs&.long_running_garbage if parent_rpcs&.respond_to? :long_running_garbage
                 @long_running_garbage = Gapic::Config::Method.new long_running_garbage_config
-                client_garbage_config = nil
                 client_garbage_config = parent_rpcs&.client_garbage if parent_rpcs&.respond_to? :client_garbage
                 @client_garbage = Gapic::Config::Method.new client_garbage_config
-                server_garbage_config = nil
                 server_garbage_config = parent_rpcs&.server_garbage if parent_rpcs&.respond_to? :server_garbage
                 @server_garbage = Gapic::Config::Method.new server_garbage_config
-                bidi_garbage_config = nil
                 bidi_garbage_config = parent_rpcs&.bidi_garbage if parent_rpcs&.respond_to? :bidi_garbage
                 @bidi_garbage = Gapic::Config::Method.new bidi_garbage_config
 

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -174,8 +174,8 @@ module So
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+              wrap_lro_operation = ->(op_response) { Gapic::Operation.new op_response, @operations_client }
+              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_lro_operation
               yield response, operation if block_given?
               return response
             end
@@ -421,16 +421,12 @@ module So
               attr_reader :cancel_operation
 
               def initialize parent_rpcs = nil
-                list_operations_config = nil
                 list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
                 @list_operations = Gapic::Config::Method.new list_operations_config
-                get_operation_config = nil
                 get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
                 @get_operation = Gapic::Config::Method.new get_operation_config
-                delete_operation_config = nil
                 delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
                 @delete_operation = Gapic::Config::Method.new delete_operation_config
-                cancel_operation_config = nil
                 cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
                 @cancel_operation = Gapic::Config::Method.new cancel_operation_config
 

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/paths.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/paths.rb
@@ -29,6 +29,7 @@ module So
   module Much
     module Trash
       module GarbageService
+        # Path helper methods for the GarbageService API.
         module Paths
           ##
           # Create a fully-qualified SimpleGarbage resource string.

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
@@ -81,8 +81,7 @@ class So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -139,8 +138,7 @@ class So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_operation name: name do |response, operation|
+      client.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -202,8 +200,7 @@ class So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_operation name: name do |response, operation|
+      client.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -260,8 +257,7 @@ class So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.cancel_operation name: name do |response, operation|
+      client.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
@@ -75,8 +75,7 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_simple_garbage name: name do |response, operation|
+      client.get_simple_garbage({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -155,8 +154,7 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_specific_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested do |response, operation|
+      client.get_specific_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum, nested: nested }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -233,8 +231,7 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_nested_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum do |response, operation|
+      client.get_nested_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, msg: msg, enum: enum }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -311,8 +308,7 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_repeated_garbage repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum do |response, operation|
+      client.get_repeated_garbage({ repeated_name: repeated_name, repeated_int32: repeated_int32, repeated_int64: repeated_int64, repeated_uint32: repeated_uint32, repeated_uint64: repeated_uint64, repeated_bool: repeated_bool, repeated_float: repeated_float, repeated_double: repeated_double, repeated_bytes: repeated_bytes, repeated_msg: repeated_msg, repeated_enum: repeated_enum }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -393,8 +389,7 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_typical_garbage name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum do |response, operation|
+      client.get_typical_garbage({ name: name, int32: int32, int64: int64, uint32: uint32, uint64: uint64, bool: bool, float: float, double: double, bytes: bytes, timeout: timeout, duration: duration, msg: msg, enum: enum }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -451,8 +446,7 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_complex_garbage layer1: layer1 do |response, operation|
+      client.get_complex_garbage({ layer1: layer1 }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -513,8 +507,7 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_paged_garbage garbage: garbage, page_size: page_size, page_token: page_token do |response, operation|
+      client.get_paged_garbage({ garbage: garbage, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -571,8 +564,7 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.long_running_garbage garbage: garbage do |response, operation|
+      client.long_running_garbage({ garbage: garbage }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/language/.rubocop.yml
+++ b/shared/output/gapic/templates/language/.rubocop.yml
@@ -3,19 +3,42 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "google-cloud-language.gemspec"
+    - "lib/**/*_pb.rb"
     - "proto_docs/**/*"
     - "test/**/*"
 
+Metrics/AbcSize:
+  Exclude:
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"
 Metrics/ClassLength:
   Exclude:
-    - "lib/google/cloud/language/v1/language_service/client.rb"
-    - "lib/google/cloud/language/v1beta1/language_service/client.rb"
-    - "lib/google/cloud/language/v1beta2/language_service/client.rb"
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"
 Metrics/LineLength:
   Exclude:
-    - "lib/google/cloud/language/v1/language_service/client.rb"
-    - "lib/google/cloud/language/v1beta1/language_service/client.rb"
-    - "lib/google/cloud/language/v1beta2/language_service/client.rb"
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"
+Metrics/MethodLength:
+  Exclude:
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"
+Metrics/PerceivedComplexity:
+  Exclude:
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"
 Style/CaseEquality:
-  Enabled: false
+  Exclude:
+    - "lib/google/cloud/language/v1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta1/language_service/*.rb"
+    - "lib/google/cloud/language/v1beta2/language_service/*.rb"

--- a/shared/output/gapic/templates/language/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/gapic/templates/language/lib/google/cloud/language/v1/language_service/client.rb
@@ -951,26 +951,16 @@ module Google
                 attr_reader :annotate_text
 
                 def initialize parent_rpcs = nil
-                  analyze_sentiment_config = nil
-                  if parent_rpcs&.respond_to? :analyze_sentiment
-                    analyze_sentiment_config = parent_rpcs&.analyze_sentiment
-                  end
+                  analyze_sentiment_config = parent_rpcs&.analyze_sentiment if parent_rpcs&.respond_to? :analyze_sentiment
                   @analyze_sentiment = Gapic::Config::Method.new analyze_sentiment_config
-                  analyze_entities_config = nil
                   analyze_entities_config = parent_rpcs&.analyze_entities if parent_rpcs&.respond_to? :analyze_entities
                   @analyze_entities = Gapic::Config::Method.new analyze_entities_config
-                  analyze_entity_sentiment_config = nil
-                  if parent_rpcs&.respond_to? :analyze_entity_sentiment
-                    analyze_entity_sentiment_config = parent_rpcs&.analyze_entity_sentiment
-                  end
+                  analyze_entity_sentiment_config = parent_rpcs&.analyze_entity_sentiment if parent_rpcs&.respond_to? :analyze_entity_sentiment
                   @analyze_entity_sentiment = Gapic::Config::Method.new analyze_entity_sentiment_config
-                  analyze_syntax_config = nil
                   analyze_syntax_config = parent_rpcs&.analyze_syntax if parent_rpcs&.respond_to? :analyze_syntax
                   @analyze_syntax = Gapic::Config::Method.new analyze_syntax_config
-                  classify_text_config = nil
                   classify_text_config = parent_rpcs&.classify_text if parent_rpcs&.respond_to? :classify_text
                   @classify_text = Gapic::Config::Method.new classify_text_config
-                  annotate_text_config = nil
                   annotate_text_config = parent_rpcs&.annotate_text if parent_rpcs&.respond_to? :annotate_text
                   @annotate_text = Gapic::Config::Method.new annotate_text_config
 

--- a/shared/output/gapic/templates/language/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/gapic/templates/language/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -376,18 +376,12 @@ module Google
                 attr_reader :annotate_text
 
                 def initialize parent_rpcs = nil
-                  analyze_sentiment_config = nil
-                  if parent_rpcs&.respond_to? :analyze_sentiment
-                    analyze_sentiment_config = parent_rpcs&.analyze_sentiment
-                  end
+                  analyze_sentiment_config = parent_rpcs&.analyze_sentiment if parent_rpcs&.respond_to? :analyze_sentiment
                   @analyze_sentiment = Gapic::Config::Method.new analyze_sentiment_config
-                  analyze_entities_config = nil
                   analyze_entities_config = parent_rpcs&.analyze_entities if parent_rpcs&.respond_to? :analyze_entities
                   @analyze_entities = Gapic::Config::Method.new analyze_entities_config
-                  analyze_syntax_config = nil
                   analyze_syntax_config = parent_rpcs&.analyze_syntax if parent_rpcs&.respond_to? :analyze_syntax
                   @analyze_syntax = Gapic::Config::Method.new analyze_syntax_config
-                  annotate_text_config = nil
                   annotate_text_config = parent_rpcs&.annotate_text if parent_rpcs&.respond_to? :annotate_text
                   @annotate_text = Gapic::Config::Method.new annotate_text_config
 

--- a/shared/output/gapic/templates/language/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/gapic/templates/language/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -482,26 +482,16 @@ module Google
                 attr_reader :annotate_text
 
                 def initialize parent_rpcs = nil
-                  analyze_sentiment_config = nil
-                  if parent_rpcs&.respond_to? :analyze_sentiment
-                    analyze_sentiment_config = parent_rpcs&.analyze_sentiment
-                  end
+                  analyze_sentiment_config = parent_rpcs&.analyze_sentiment if parent_rpcs&.respond_to? :analyze_sentiment
                   @analyze_sentiment = Gapic::Config::Method.new analyze_sentiment_config
-                  analyze_entities_config = nil
                   analyze_entities_config = parent_rpcs&.analyze_entities if parent_rpcs&.respond_to? :analyze_entities
                   @analyze_entities = Gapic::Config::Method.new analyze_entities_config
-                  analyze_entity_sentiment_config = nil
-                  if parent_rpcs&.respond_to? :analyze_entity_sentiment
-                    analyze_entity_sentiment_config = parent_rpcs&.analyze_entity_sentiment
-                  end
+                  analyze_entity_sentiment_config = parent_rpcs&.analyze_entity_sentiment if parent_rpcs&.respond_to? :analyze_entity_sentiment
                   @analyze_entity_sentiment = Gapic::Config::Method.new analyze_entity_sentiment_config
-                  analyze_syntax_config = nil
                   analyze_syntax_config = parent_rpcs&.analyze_syntax if parent_rpcs&.respond_to? :analyze_syntax
                   @analyze_syntax = Gapic::Config::Method.new analyze_syntax_config
-                  classify_text_config = nil
                   classify_text_config = parent_rpcs&.classify_text if parent_rpcs&.respond_to? :classify_text
                   @classify_text = Gapic::Config::Method.new classify_text_config
-                  annotate_text_config = nil
                   annotate_text_config = parent_rpcs&.annotate_text if parent_rpcs&.respond_to? :annotate_text
                   @annotate_text = Gapic::Config::Method.new annotate_text_config
 

--- a/shared/output/gapic/templates/language/test/google/cloud/language/v1/language_service_test.rb
+++ b/shared/output/gapic/templates/language/test/google/cloud/language/v1/language_service_test.rb
@@ -77,8 +77,7 @@ class Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -137,8 +136,7 @@ class Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -197,8 +195,7 @@ class Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_entity_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -257,8 +254,7 @@ class Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -315,8 +311,7 @@ class Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.classify_text document: document do |response, operation|
+      client.classify_text({ document: document }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -377,8 +372,7 @@ class Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
+      client.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/language/test/google/cloud/language/v1beta1/language_service_test.rb
+++ b/shared/output/gapic/templates/language/test/google/cloud/language/v1beta1/language_service_test.rb
@@ -77,8 +77,7 @@ class Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -137,8 +136,7 @@ class Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -197,8 +195,7 @@ class Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -259,8 +256,7 @@ class Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
+      client.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/language/test/google/cloud/language/v1beta2/language_service_test.rb
+++ b/shared/output/gapic/templates/language/test/google/cloud/language/v1beta2/language_service_test.rb
@@ -77,8 +77,7 @@ class Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -137,8 +136,7 @@ class Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_entities document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_entities({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -197,8 +195,7 @@ class Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_entity_sentiment document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_entity_sentiment({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -257,8 +254,7 @@ class Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.analyze_syntax document: document, encoding_type: encoding_type do |response, operation|
+      client.analyze_syntax({ document: document, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -315,8 +311,7 @@ class Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.classify_text document: document do |response, operation|
+      client.classify_text({ document: document }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -377,8 +372,7 @@ class Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.annotate_text document: document, features: features, encoding_type: encoding_type do |response, operation|
+      client.annotate_text({ document: document, features: features, encoding_type: encoding_type }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/showcase/.rubocop.yml
+++ b/shared/output/gapic/templates/showcase/.rubocop.yml
@@ -3,21 +3,49 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "google-showcase.gemspec"
+    - "lib/**/*_pb.rb"
     - "proto_docs/**/*"
     - "test/**/*"
 
+Metrics/AbcSize:
+  Exclude:
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"
 Metrics/ClassLength:
   Exclude:
-    - "lib/google/showcase/v1beta1/echo/client.rb"
-    - "lib/google/showcase/v1beta1/identity/client.rb"
-    - "lib/google/showcase/v1beta1/messaging/client.rb"
-    - "lib/google/showcase/v1beta1/testing/client.rb"
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"
 Metrics/LineLength:
   Exclude:
-    - "lib/google/showcase/v1beta1/echo/client.rb"
-    - "lib/google/showcase/v1beta1/identity/client.rb"
-    - "lib/google/showcase/v1beta1/messaging/client.rb"
-    - "lib/google/showcase/v1beta1/testing/client.rb"
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"
+Metrics/MethodLength:
+  Exclude:
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"
+Metrics/PerceivedComplexity:
+  Exclude:
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"
 Style/CaseEquality:
-  Enabled: false
+  Exclude:
+    - "lib/google/showcase/v1beta1/echo/*.rb"
+    - "lib/google/showcase/v1beta1/identity/*.rb"
+    - "lib/google/showcase/v1beta1/messaging/*.rb"
+    - "lib/google/showcase/v1beta1/testing/*.rb"

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -241,11 +241,8 @@ module Google
           #
           def collect request, options = nil
             unless request.is_a? Enumerable
-              if request.respond_to? :to_enum
-                request = request.to_enum
-              else
-                raise ArgumentError, "request must be an Enumerable"
-              end
+              raise ArgumentError, "request must be an Enumerable" unless request.respond_to? :to_enum
+              request = request.to_enum
             end
 
             request = request.lazy.map do |req|
@@ -295,11 +292,8 @@ module Google
           #
           def chat request, options = nil
             unless request.is_a? Enumerable
-              if request.respond_to? :to_enum
-                request = request.to_enum
-              else
-                raise ArgumentError, "request must be an Enumerable"
-              end
+              raise ArgumentError, "request must be an Enumerable" unless request.respond_to? :to_enum
+              request = request.to_enum
             end
 
             request = request.lazy.map do |req|
@@ -551,25 +545,18 @@ module Google
               attr_reader :block
 
               def initialize parent_rpcs = nil
-                echo_config = nil
                 echo_config = parent_rpcs&.echo if parent_rpcs&.respond_to? :echo
                 @echo = Gapic::Config::Method.new echo_config
-                expand_config = nil
                 expand_config = parent_rpcs&.expand if parent_rpcs&.respond_to? :expand
                 @expand = Gapic::Config::Method.new expand_config
-                collect_config = nil
                 collect_config = parent_rpcs&.collect if parent_rpcs&.respond_to? :collect
                 @collect = Gapic::Config::Method.new collect_config
-                chat_config = nil
                 chat_config = parent_rpcs&.chat if parent_rpcs&.respond_to? :chat
                 @chat = Gapic::Config::Method.new chat_config
-                paged_expand_config = nil
                 paged_expand_config = parent_rpcs&.paged_expand if parent_rpcs&.respond_to? :paged_expand
                 @paged_expand = Gapic::Config::Method.new paged_expand_config
-                wait_config = nil
                 wait_config = parent_rpcs&.wait if parent_rpcs&.respond_to? :wait
                 @wait = Gapic::Config::Method.new wait_config
-                block_config = nil
                 block_config = parent_rpcs&.block if parent_rpcs&.respond_to? :block
                 @block = Gapic::Config::Method.new block_config
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -174,8 +174,8 @@ module Google
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+              wrap_lro_operation = ->(op_response) { Gapic::Operation.new op_response, @operations_client }
+              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_lro_operation
               yield response, operation if block_given?
               return response
             end
@@ -421,16 +421,12 @@ module Google
               attr_reader :cancel_operation
 
               def initialize parent_rpcs = nil
-                list_operations_config = nil
                 list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
                 @list_operations = Gapic::Config::Method.new list_operations_config
-                get_operation_config = nil
                 get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
                 @get_operation = Gapic::Config::Method.new get_operation_config
-                delete_operation_config = nil
                 delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
                 @delete_operation = Gapic::Config::Method.new delete_operation_config
-                cancel_operation_config = nil
                 cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
                 @cancel_operation = Gapic::Config::Method.new cancel_operation_config
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -435,19 +435,14 @@ module Google
               attr_reader :list_users
 
               def initialize parent_rpcs = nil
-                create_user_config = nil
                 create_user_config = parent_rpcs&.create_user if parent_rpcs&.respond_to? :create_user
                 @create_user = Gapic::Config::Method.new create_user_config
-                get_user_config = nil
                 get_user_config = parent_rpcs&.get_user if parent_rpcs&.respond_to? :get_user
                 @get_user = Gapic::Config::Method.new get_user_config
-                update_user_config = nil
                 update_user_config = parent_rpcs&.update_user if parent_rpcs&.respond_to? :update_user
                 @update_user = Gapic::Config::Method.new update_user_config
-                delete_user_config = nil
                 delete_user_config = parent_rpcs&.delete_user if parent_rpcs&.respond_to? :delete_user
                 @delete_user = Gapic::Config::Method.new delete_user_config
-                list_users_config = nil
                 list_users_config = parent_rpcs&.list_users if parent_rpcs&.respond_to? :list_users
                 @list_users = Gapic::Config::Method.new list_users_config
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/paths.rb
@@ -29,6 +29,7 @@ module Google
   module Showcase
     module V1beta1
       module Identity
+        # Path helper methods for the Identity API.
         module Paths
           ##
           # Create a fully-qualified User resource string.

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -849,11 +849,8 @@ module Google
           #
           def send_blurbs request, options = nil
             unless request.is_a? Enumerable
-              if request.respond_to? :to_enum
-                request = request.to_enum
-              else
-                raise ArgumentError, "request must be an Enumerable"
-              end
+              raise ArgumentError, "request must be an Enumerable" unless request.respond_to? :to_enum
+              request = request.to_enum
             end
 
             request = request.lazy.map do |req|
@@ -910,11 +907,8 @@ module Google
           #
           def connect request, options = nil
             unless request.is_a? Enumerable
-              if request.respond_to? :to_enum
-                request = request.to_enum
-              else
-                raise ArgumentError, "request must be an Enumerable"
-              end
+              raise ArgumentError, "request must be an Enumerable" unless request.respond_to? :to_enum
+              request = request.to_enum
             end
 
             request = request.lazy.map do |req|
@@ -997,46 +991,32 @@ module Google
               attr_reader :connect
 
               def initialize parent_rpcs = nil
-                create_room_config = nil
                 create_room_config = parent_rpcs&.create_room if parent_rpcs&.respond_to? :create_room
                 @create_room = Gapic::Config::Method.new create_room_config
-                get_room_config = nil
                 get_room_config = parent_rpcs&.get_room if parent_rpcs&.respond_to? :get_room
                 @get_room = Gapic::Config::Method.new get_room_config
-                update_room_config = nil
                 update_room_config = parent_rpcs&.update_room if parent_rpcs&.respond_to? :update_room
                 @update_room = Gapic::Config::Method.new update_room_config
-                delete_room_config = nil
                 delete_room_config = parent_rpcs&.delete_room if parent_rpcs&.respond_to? :delete_room
                 @delete_room = Gapic::Config::Method.new delete_room_config
-                list_rooms_config = nil
                 list_rooms_config = parent_rpcs&.list_rooms if parent_rpcs&.respond_to? :list_rooms
                 @list_rooms = Gapic::Config::Method.new list_rooms_config
-                create_blurb_config = nil
                 create_blurb_config = parent_rpcs&.create_blurb if parent_rpcs&.respond_to? :create_blurb
                 @create_blurb = Gapic::Config::Method.new create_blurb_config
-                get_blurb_config = nil
                 get_blurb_config = parent_rpcs&.get_blurb if parent_rpcs&.respond_to? :get_blurb
                 @get_blurb = Gapic::Config::Method.new get_blurb_config
-                update_blurb_config = nil
                 update_blurb_config = parent_rpcs&.update_blurb if parent_rpcs&.respond_to? :update_blurb
                 @update_blurb = Gapic::Config::Method.new update_blurb_config
-                delete_blurb_config = nil
                 delete_blurb_config = parent_rpcs&.delete_blurb if parent_rpcs&.respond_to? :delete_blurb
                 @delete_blurb = Gapic::Config::Method.new delete_blurb_config
-                list_blurbs_config = nil
                 list_blurbs_config = parent_rpcs&.list_blurbs if parent_rpcs&.respond_to? :list_blurbs
                 @list_blurbs = Gapic::Config::Method.new list_blurbs_config
-                search_blurbs_config = nil
                 search_blurbs_config = parent_rpcs&.search_blurbs if parent_rpcs&.respond_to? :search_blurbs
                 @search_blurbs = Gapic::Config::Method.new search_blurbs_config
-                stream_blurbs_config = nil
                 stream_blurbs_config = parent_rpcs&.stream_blurbs if parent_rpcs&.respond_to? :stream_blurbs
                 @stream_blurbs = Gapic::Config::Method.new stream_blurbs_config
-                send_blurbs_config = nil
                 send_blurbs_config = parent_rpcs&.send_blurbs if parent_rpcs&.respond_to? :send_blurbs
                 @send_blurbs = Gapic::Config::Method.new send_blurbs_config
-                connect_config = nil
                 connect_config = parent_rpcs&.connect if parent_rpcs&.respond_to? :connect
                 @connect = Gapic::Config::Method.new connect_config
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -174,8 +174,8 @@ module Google
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
-              wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+              wrap_lro_operation = ->(op_response) { Gapic::Operation.new op_response, @operations_client }
+              response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_lro_operation
               yield response, operation if block_given?
               return response
             end
@@ -421,16 +421,12 @@ module Google
               attr_reader :cancel_operation
 
               def initialize parent_rpcs = nil
-                list_operations_config = nil
                 list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
                 @list_operations = Gapic::Config::Method.new list_operations_config
-                get_operation_config = nil
                 get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
                 @get_operation = Gapic::Config::Method.new get_operation_config
-                delete_operation_config = nil
                 delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
                 @delete_operation = Gapic::Config::Method.new delete_operation_config
-                cancel_operation_config = nil
                 cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
                 @cancel_operation = Gapic::Config::Method.new cancel_operation_config
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/paths.rb
@@ -29,6 +29,7 @@ module Google
   module Showcase
     module V1beta1
       module Messaging
+        # Path helper methods for the Messaging API.
         module Paths
           ##
           # Create a fully-qualified Blurb resource string.

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -631,28 +631,20 @@ module Google
               attr_reader :verify_test
 
               def initialize parent_rpcs = nil
-                create_session_config = nil
                 create_session_config = parent_rpcs&.create_session if parent_rpcs&.respond_to? :create_session
                 @create_session = Gapic::Config::Method.new create_session_config
-                get_session_config = nil
                 get_session_config = parent_rpcs&.get_session if parent_rpcs&.respond_to? :get_session
                 @get_session = Gapic::Config::Method.new get_session_config
-                list_sessions_config = nil
                 list_sessions_config = parent_rpcs&.list_sessions if parent_rpcs&.respond_to? :list_sessions
                 @list_sessions = Gapic::Config::Method.new list_sessions_config
-                delete_session_config = nil
                 delete_session_config = parent_rpcs&.delete_session if parent_rpcs&.respond_to? :delete_session
                 @delete_session = Gapic::Config::Method.new delete_session_config
-                report_session_config = nil
                 report_session_config = parent_rpcs&.report_session if parent_rpcs&.respond_to? :report_session
                 @report_session = Gapic::Config::Method.new report_session_config
-                list_tests_config = nil
                 list_tests_config = parent_rpcs&.list_tests if parent_rpcs&.respond_to? :list_tests
                 @list_tests = Gapic::Config::Method.new list_tests_config
-                delete_test_config = nil
                 delete_test_config = parent_rpcs&.delete_test if parent_rpcs&.respond_to? :delete_test
                 @delete_test = Gapic::Config::Method.new delete_test_config
-                verify_test_config = nil
                 verify_test_config = parent_rpcs&.verify_test if parent_rpcs&.respond_to? :verify_test
                 @verify_test = Gapic::Config::Method.new verify_test_config
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/paths.rb
@@ -29,6 +29,7 @@ module Google
   module Showcase
     module V1beta1
       module Testing
+        # Path helper methods for the Testing API.
         module Paths
           ##
           # Create a fully-qualified Session resource string.

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -81,8 +81,7 @@ class Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -139,8 +138,7 @@ class Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_operation name: name do |response, operation|
+      client.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -202,8 +200,7 @@ class Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_operation name: name do |response, operation|
+      client.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -260,8 +257,7 @@ class Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.cancel_operation name: name do |response, operation|
+      client.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -75,8 +75,7 @@ class Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.echo content: content do |response, operation|
+      client.echo({ content: content }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -143,8 +142,7 @@ class Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.paged_expand content: content, page_size: page_size, page_token: page_token do |response, operation|
+      client.paged_expand({ content: content, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -203,8 +201,7 @@ class Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.wait end_time: end_time, error: error do |response, operation|
+      client.wait({ end_time: end_time, error: error }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -266,8 +263,7 @@ class Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.block response_delay: response_delay do |response, operation|
+      client.block({ response_delay: response_delay }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -75,8 +75,7 @@ class Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_user user: user do |response, operation|
+      client.create_user({ user: user }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -133,8 +132,7 @@ class Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_user name: name do |response, operation|
+      client.get_user({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -193,8 +191,7 @@ class Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.update_user user: user, update_mask: update_mask do |response, operation|
+      client.update_user({ user: user, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -251,8 +248,7 @@ class Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_user name: name do |response, operation|
+      client.delete_user({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -311,8 +307,7 @@ class Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_users page_size: page_size, page_token: page_token do |response, operation|
+      client.list_users({ page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -81,8 +81,7 @@ class Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -139,8 +138,7 @@ class Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_operation name: name do |response, operation|
+      client.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -202,8 +200,7 @@ class Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_operation name: name do |response, operation|
+      client.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -260,8 +257,7 @@ class Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.cancel_operation name: name do |response, operation|
+      client.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -75,8 +75,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_room room: room do |response, operation|
+      client.create_room({ room: room }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -133,8 +132,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_room name: name do |response, operation|
+      client.get_room({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -193,8 +191,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.update_room room: room, update_mask: update_mask do |response, operation|
+      client.update_room({ room: room, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -251,8 +248,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_room name: name do |response, operation|
+      client.delete_room({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -311,8 +307,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_rooms page_size: page_size, page_token: page_token do |response, operation|
+      client.list_rooms({ page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -371,8 +366,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_blurb parent: parent, blurb: blurb do |response, operation|
+      client.create_blurb({ parent: parent, blurb: blurb }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -429,8 +423,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_blurb name: name do |response, operation|
+      client.get_blurb({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -489,8 +482,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.update_blurb blurb: blurb, update_mask: update_mask do |response, operation|
+      client.update_blurb({ blurb: blurb, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -547,8 +539,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_blurb name: name do |response, operation|
+      client.delete_blurb({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -609,8 +600,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_blurbs parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_blurbs({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -673,8 +663,7 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.search_blurbs query: query, parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client.search_blurbs({ query: query, parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -75,8 +75,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_session session: session do |response, operation|
+      client.create_session({ session: session }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -133,8 +132,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_session name: name do |response, operation|
+      client.get_session({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -193,8 +191,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_sessions page_size: page_size, page_token: page_token do |response, operation|
+      client.list_sessions({ page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -251,8 +248,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_session name: name do |response, operation|
+      client.delete_session({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -309,8 +305,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.report_session name: name do |response, operation|
+      client.report_session({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -371,8 +366,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_tests parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_tests({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -429,8 +423,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_test name: name do |response, operation|
+      client.delete_test({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -491,8 +484,7 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.verify_test name: name, answer: answer, answers: answers do |response, operation|
+      client.verify_test({ name: name, answer: answer, answers: answers }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/speech/.rubocop.yml
+++ b/shared/output/gapic/templates/speech/.rubocop.yml
@@ -3,15 +3,28 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "google-cloud-speech.gemspec"
+    - "lib/**/*_pb.rb"
     - "proto_docs/**/*"
     - "test/**/*"
 
+Metrics/AbcSize:
+  Exclude:
+    - "lib/google/cloud/speech/v1/speech/*.rb"
 Metrics/ClassLength:
   Exclude:
-    - "lib/google/cloud/speech/v1/speech/client.rb"
+    - "lib/google/cloud/speech/v1/speech/*.rb"
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - "lib/google/cloud/speech/v1/speech/*.rb"
 Metrics/LineLength:
   Exclude:
-    - "lib/google/cloud/speech/v1/speech/client.rb"
+    - "lib/google/cloud/speech/v1/speech/*.rb"
+Metrics/MethodLength:
+  Exclude:
+    - "lib/google/cloud/speech/v1/speech/*.rb"
+Metrics/PerceivedComplexity:
+  Exclude:
+    - "lib/google/cloud/speech/v1/speech/*.rb"
 Style/CaseEquality:
-  Enabled: false
+  Exclude:
+    - "lib/google/cloud/speech/v1/speech/*.rb"

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -561,11 +561,8 @@ module Google
             #
             def streaming_recognize request, options = nil
               unless request.is_a? Enumerable
-                if request.respond_to? :to_enum
-                  request = request.to_enum
-                else
-                  raise ArgumentError, "request must be an Enumerable"
-                end
+                raise ArgumentError, "request must be an Enumerable" unless request.respond_to? :to_enum
+                request = request.to_enum
               end
 
               request = request.lazy.map do |req|
@@ -637,18 +634,11 @@ module Google
                 attr_reader :streaming_recognize
 
                 def initialize parent_rpcs = nil
-                  recognize_config = nil
                   recognize_config = parent_rpcs&.recognize if parent_rpcs&.respond_to? :recognize
                   @recognize = Gapic::Config::Method.new recognize_config
-                  long_running_recognize_config = nil
-                  if parent_rpcs&.respond_to? :long_running_recognize
-                    long_running_recognize_config = parent_rpcs&.long_running_recognize
-                  end
+                  long_running_recognize_config = parent_rpcs&.long_running_recognize if parent_rpcs&.respond_to? :long_running_recognize
                   @long_running_recognize = Gapic::Config::Method.new long_running_recognize_config
-                  streaming_recognize_config = nil
-                  if parent_rpcs&.respond_to? :streaming_recognize
-                    streaming_recognize_config = parent_rpcs&.streaming_recognize
-                  end
+                  streaming_recognize_config = parent_rpcs&.streaming_recognize if parent_rpcs&.respond_to? :streaming_recognize
                   @streaming_recognize = Gapic::Config::Method.new streaming_recognize_config
 
                   yield self if block_given?

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/operations.rb
@@ -175,8 +175,8 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
-                wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                wrap_lro_operation = ->(op_response) { Gapic::Operation.new op_response, @operations_client }
+                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_lro_operation
                 yield response, operation if block_given?
                 return response
               end
@@ -422,16 +422,12 @@ module Google
                 attr_reader :cancel_operation
 
                 def initialize parent_rpcs = nil
-                  list_operations_config = nil
                   list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
                   @list_operations = Gapic::Config::Method.new list_operations_config
-                  get_operation_config = nil
                   get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
                   @get_operation = Gapic::Config::Method.new get_operation_config
-                  delete_operation_config = nil
                   delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
                   @delete_operation = Gapic::Config::Method.new delete_operation_config
-                  cancel_operation_config = nil
                   cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
                   @cancel_operation = Gapic::Config::Method.new cancel_operation_config
 

--- a/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -81,8 +81,7 @@ class Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -139,8 +138,7 @@ class Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_operation name: name do |response, operation|
+      client.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -202,8 +200,7 @@ class Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_operation name: name do |response, operation|
+      client.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -260,8 +257,7 @@ class Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.cancel_operation name: name do |response, operation|
+      client.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/gapic/templates/speech/test/google/cloud/speech/v1/speech_test.rb
@@ -77,8 +77,7 @@ class Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.recognize config: config, audio: audio do |response, operation|
+      client.recognize({ config: config, audio: audio }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -137,8 +136,7 @@ class Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.long_running_recognize config: config, audio: audio do |response, operation|
+      client.long_running_recognize({ config: config, audio: audio }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/vision/.rubocop.yml
+++ b/shared/output/gapic/templates/vision/.rubocop.yml
@@ -3,17 +3,35 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "google-cloud-vision.gemspec"
+    - "lib/**/*_pb.rb"
     - "proto_docs/**/*"
     - "test/**/*"
 
+Metrics/AbcSize:
+  Exclude:
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"
 Metrics/ClassLength:
   Exclude:
-    - "lib/google/cloud/vision/v1/product_search/client.rb"
-    - "lib/google/cloud/vision/v1/image_annotator/client.rb"
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"
 Metrics/LineLength:
   Exclude:
-    - "lib/google/cloud/vision/v1/product_search/client.rb"
-    - "lib/google/cloud/vision/v1/image_annotator/client.rb"
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"
+Metrics/MethodLength:
+  Exclude:
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"
+Metrics/PerceivedComplexity:
+  Exclude:
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"
 Style/CaseEquality:
-  Enabled: false
+  Exclude:
+    - "lib/google/cloud/vision/v1/product_search/*.rb"
+    - "lib/google/cloud/vision/v1/image_annotator/*.rb"

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -454,25 +454,13 @@ module Google
                 attr_reader :async_batch_annotate_files
 
                 def initialize parent_rpcs = nil
-                  batch_annotate_images_config = nil
-                  if parent_rpcs&.respond_to? :batch_annotate_images
-                    batch_annotate_images_config = parent_rpcs&.batch_annotate_images
-                  end
+                  batch_annotate_images_config = parent_rpcs&.batch_annotate_images if parent_rpcs&.respond_to? :batch_annotate_images
                   @batch_annotate_images = Gapic::Config::Method.new batch_annotate_images_config
-                  batch_annotate_files_config = nil
-                  if parent_rpcs&.respond_to? :batch_annotate_files
-                    batch_annotate_files_config = parent_rpcs&.batch_annotate_files
-                  end
+                  batch_annotate_files_config = parent_rpcs&.batch_annotate_files if parent_rpcs&.respond_to? :batch_annotate_files
                   @batch_annotate_files = Gapic::Config::Method.new batch_annotate_files_config
-                  async_batch_annotate_images_config = nil
-                  if parent_rpcs&.respond_to? :async_batch_annotate_images
-                    async_batch_annotate_images_config = parent_rpcs&.async_batch_annotate_images
-                  end
+                  async_batch_annotate_images_config = parent_rpcs&.async_batch_annotate_images if parent_rpcs&.respond_to? :async_batch_annotate_images
                   @async_batch_annotate_images = Gapic::Config::Method.new async_batch_annotate_images_config
-                  async_batch_annotate_files_config = nil
-                  if parent_rpcs&.respond_to? :async_batch_annotate_files
-                    async_batch_annotate_files_config = parent_rpcs&.async_batch_annotate_files
-                  end
+                  async_batch_annotate_files_config = parent_rpcs&.async_batch_annotate_files if parent_rpcs&.respond_to? :async_batch_annotate_files
                   @async_batch_annotate_files = Gapic::Config::Method.new async_batch_annotate_files_config
 
                   yield self if block_given?

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -175,8 +175,8 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
-                wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                wrap_lro_operation = ->(op_response) { Gapic::Operation.new op_response, @operations_client }
+                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_lro_operation
                 yield response, operation if block_given?
                 return response
               end
@@ -422,16 +422,12 @@ module Google
                 attr_reader :cancel_operation
 
                 def initialize parent_rpcs = nil
-                  list_operations_config = nil
                   list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
                   @list_operations = Gapic::Config::Method.new list_operations_config
-                  get_operation_config = nil
                   get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
                   @get_operation = Gapic::Config::Method.new get_operation_config
-                  delete_operation_config = nil
                   delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
                   @delete_operation = Gapic::Config::Method.new delete_operation_config
-                  cancel_operation_config = nil
                   cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
                   @cancel_operation = Gapic::Config::Method.new cancel_operation_config
 

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/client.rb
@@ -1643,85 +1643,42 @@ module Google
                 attr_reader :purge_products
 
                 def initialize parent_rpcs = nil
-                  create_product_set_config = nil
-                  if parent_rpcs&.respond_to? :create_product_set
-                    create_product_set_config = parent_rpcs&.create_product_set
-                  end
+                  create_product_set_config = parent_rpcs&.create_product_set if parent_rpcs&.respond_to? :create_product_set
                   @create_product_set = Gapic::Config::Method.new create_product_set_config
-                  list_product_sets_config = nil
-                  if parent_rpcs&.respond_to? :list_product_sets
-                    list_product_sets_config = parent_rpcs&.list_product_sets
-                  end
+                  list_product_sets_config = parent_rpcs&.list_product_sets if parent_rpcs&.respond_to? :list_product_sets
                   @list_product_sets = Gapic::Config::Method.new list_product_sets_config
-                  get_product_set_config = nil
                   get_product_set_config = parent_rpcs&.get_product_set if parent_rpcs&.respond_to? :get_product_set
                   @get_product_set = Gapic::Config::Method.new get_product_set_config
-                  update_product_set_config = nil
-                  if parent_rpcs&.respond_to? :update_product_set
-                    update_product_set_config = parent_rpcs&.update_product_set
-                  end
+                  update_product_set_config = parent_rpcs&.update_product_set if parent_rpcs&.respond_to? :update_product_set
                   @update_product_set = Gapic::Config::Method.new update_product_set_config
-                  delete_product_set_config = nil
-                  if parent_rpcs&.respond_to? :delete_product_set
-                    delete_product_set_config = parent_rpcs&.delete_product_set
-                  end
+                  delete_product_set_config = parent_rpcs&.delete_product_set if parent_rpcs&.respond_to? :delete_product_set
                   @delete_product_set = Gapic::Config::Method.new delete_product_set_config
-                  create_product_config = nil
                   create_product_config = parent_rpcs&.create_product if parent_rpcs&.respond_to? :create_product
                   @create_product = Gapic::Config::Method.new create_product_config
-                  list_products_config = nil
                   list_products_config = parent_rpcs&.list_products if parent_rpcs&.respond_to? :list_products
                   @list_products = Gapic::Config::Method.new list_products_config
-                  get_product_config = nil
                   get_product_config = parent_rpcs&.get_product if parent_rpcs&.respond_to? :get_product
                   @get_product = Gapic::Config::Method.new get_product_config
-                  update_product_config = nil
                   update_product_config = parent_rpcs&.update_product if parent_rpcs&.respond_to? :update_product
                   @update_product = Gapic::Config::Method.new update_product_config
-                  delete_product_config = nil
                   delete_product_config = parent_rpcs&.delete_product if parent_rpcs&.respond_to? :delete_product
                   @delete_product = Gapic::Config::Method.new delete_product_config
-                  create_reference_image_config = nil
-                  if parent_rpcs&.respond_to? :create_reference_image
-                    create_reference_image_config = parent_rpcs&.create_reference_image
-                  end
+                  create_reference_image_config = parent_rpcs&.create_reference_image if parent_rpcs&.respond_to? :create_reference_image
                   @create_reference_image = Gapic::Config::Method.new create_reference_image_config
-                  delete_reference_image_config = nil
-                  if parent_rpcs&.respond_to? :delete_reference_image
-                    delete_reference_image_config = parent_rpcs&.delete_reference_image
-                  end
+                  delete_reference_image_config = parent_rpcs&.delete_reference_image if parent_rpcs&.respond_to? :delete_reference_image
                   @delete_reference_image = Gapic::Config::Method.new delete_reference_image_config
-                  list_reference_images_config = nil
-                  if parent_rpcs&.respond_to? :list_reference_images
-                    list_reference_images_config = parent_rpcs&.list_reference_images
-                  end
+                  list_reference_images_config = parent_rpcs&.list_reference_images if parent_rpcs&.respond_to? :list_reference_images
                   @list_reference_images = Gapic::Config::Method.new list_reference_images_config
-                  get_reference_image_config = nil
-                  if parent_rpcs&.respond_to? :get_reference_image
-                    get_reference_image_config = parent_rpcs&.get_reference_image
-                  end
+                  get_reference_image_config = parent_rpcs&.get_reference_image if parent_rpcs&.respond_to? :get_reference_image
                   @get_reference_image = Gapic::Config::Method.new get_reference_image_config
-                  add_product_to_product_set_config = nil
-                  if parent_rpcs&.respond_to? :add_product_to_product_set
-                    add_product_to_product_set_config = parent_rpcs&.add_product_to_product_set
-                  end
+                  add_product_to_product_set_config = parent_rpcs&.add_product_to_product_set if parent_rpcs&.respond_to? :add_product_to_product_set
                   @add_product_to_product_set = Gapic::Config::Method.new add_product_to_product_set_config
-                  remove_product_from_product_set_config = nil
-                  if parent_rpcs&.respond_to? :remove_product_from_product_set
-                    remove_product_from_product_set_config = parent_rpcs&.remove_product_from_product_set
-                  end
+                  remove_product_from_product_set_config = parent_rpcs&.remove_product_from_product_set if parent_rpcs&.respond_to? :remove_product_from_product_set
                   @remove_product_from_product_set = Gapic::Config::Method.new remove_product_from_product_set_config
-                  list_products_in_product_set_config = nil
-                  if parent_rpcs&.respond_to? :list_products_in_product_set
-                    list_products_in_product_set_config = parent_rpcs&.list_products_in_product_set
-                  end
+                  list_products_in_product_set_config = parent_rpcs&.list_products_in_product_set if parent_rpcs&.respond_to? :list_products_in_product_set
                   @list_products_in_product_set = Gapic::Config::Method.new list_products_in_product_set_config
-                  import_product_sets_config = nil
-                  if parent_rpcs&.respond_to? :import_product_sets
-                    import_product_sets_config = parent_rpcs&.import_product_sets
-                  end
+                  import_product_sets_config = parent_rpcs&.import_product_sets if parent_rpcs&.respond_to? :import_product_sets
                   @import_product_sets = Gapic::Config::Method.new import_product_sets_config
-                  purge_products_config = nil
                   purge_products_config = parent_rpcs&.purge_products if parent_rpcs&.respond_to? :purge_products
                   @purge_products = Gapic::Config::Method.new purge_products_config
 

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -175,8 +175,8 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :list_operations, request, options: options do |response, operation|
-                wrap_gax_operation = ->(response) { Gapic::Operation.new response, @operations_client }
-                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_gax_operation
+                wrap_lro_operation = ->(op_response) { Gapic::Operation.new op_response, @operations_client }
+                response = Gapic::PagedEnumerable.new @operations_stub, :list_operations, request, response, operation, options, format_resource: wrap_lro_operation
                 yield response, operation if block_given?
                 return response
               end
@@ -422,16 +422,12 @@ module Google
                 attr_reader :cancel_operation
 
                 def initialize parent_rpcs = nil
-                  list_operations_config = nil
                   list_operations_config = parent_rpcs&.list_operations if parent_rpcs&.respond_to? :list_operations
                   @list_operations = Gapic::Config::Method.new list_operations_config
-                  get_operation_config = nil
                   get_operation_config = parent_rpcs&.get_operation if parent_rpcs&.respond_to? :get_operation
                   @get_operation = Gapic::Config::Method.new get_operation_config
-                  delete_operation_config = nil
                   delete_operation_config = parent_rpcs&.delete_operation if parent_rpcs&.respond_to? :delete_operation
                   @delete_operation = Gapic::Config::Method.new delete_operation_config
-                  cancel_operation_config = nil
                   cancel_operation_config = parent_rpcs&.cancel_operation if parent_rpcs&.respond_to? :cancel_operation
                   @cancel_operation = Gapic::Config::Method.new cancel_operation_config
 

--- a/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/paths.rb
+++ b/shared/output/gapic/templates/vision/lib/google/cloud/vision/v1/product_search/paths.rb
@@ -30,6 +30,7 @@ module Google
     module Vision
       module V1
         module ProductSearch
+          # Path helper methods for the ProductSearch API.
           module Paths
             ##
             # Create a fully-qualified Product resource string.

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -81,8 +81,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -139,8 +138,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_operation name: name do |response, operation|
+      client.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -202,8 +200,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_operation name: name do |response, operation|
+      client.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -260,8 +257,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.cancel_operation name: name do |response, operation|
+      client.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -77,8 +77,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.batch_annotate_images requests: requests, parent: parent do |response, operation|
+      client.batch_annotate_images({ requests: requests, parent: parent }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -137,8 +136,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.batch_annotate_files requests: requests, parent: parent do |response, operation|
+      client.batch_annotate_files({ requests: requests, parent: parent }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -199,8 +197,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent do |response, operation|
+      client.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -264,8 +261,7 @@ class Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.async_batch_annotate_files requests: requests, parent: parent do |response, operation|
+      client.async_batch_annotate_files({ requests: requests, parent: parent }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -81,8 +81,7 @@ class Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -139,8 +138,7 @@ class Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_operation name: name do |response, operation|
+      client.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -202,8 +200,7 @@ class Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_operation name: name do |response, operation|
+      client.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -260,8 +257,7 @@ class Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.cancel_operation name: name do |response, operation|
+      client.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end

--- a/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/gapic/templates/vision/test/google/cloud/vision/v1/product_search_test.rb
@@ -79,8 +79,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |response, operation|
+      client.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -141,8 +140,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -199,8 +197,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_product_set name: name do |response, operation|
+      client.get_product_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -259,8 +256,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.update_product_set product_set: product_set, update_mask: update_mask do |response, operation|
+      client.update_product_set({ product_set: product_set, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -317,8 +313,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_product_set name: name do |response, operation|
+      client.delete_product_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -379,8 +374,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_product parent: parent, product: product, product_id: product_id do |response, operation|
+      client.create_product({ parent: parent, product: product, product_id: product_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -441,8 +435,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_products parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -499,8 +492,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_product name: name do |response, operation|
+      client.get_product({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -559,8 +551,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.update_product product: product, update_mask: update_mask do |response, operation|
+      client.update_product({ product: product, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -617,8 +608,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_product name: name do |response, operation|
+      client.delete_product({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -679,8 +669,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |response, operation|
+      client.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -737,8 +726,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.delete_reference_image name: name do |response, operation|
+      client.delete_reference_image({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -799,8 +787,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -857,8 +844,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.get_reference_image name: name do |response, operation|
+      client.get_reference_image({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -917,8 +903,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.add_product_to_product_set name: name, product: product do |response, operation|
+      client.add_product_to_product_set({ name: name, product: product }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -977,8 +962,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.remove_product_from_product_set name: name, product: product do |response, operation|
+      client.remove_product_from_product_set({ name: name, product: product }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -1039,8 +1023,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |response, operation|
+      client.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_equal @mock_page_enum, response
         assert_equal grpc_operation, operation
       end
@@ -1099,8 +1082,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.import_product_sets parent: parent, input_config: input_config do |response, operation|
+      client.import_product_sets({ parent: parent, input_config: input_config }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -1162,8 +1144,7 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       end
 
       # Use hash object
-      # TODO: parens and curly braces are getting removed by rubocop, plz fix
-      client.purge_products product_set_purge_config: product_set_purge_config do |response, operation|
+      client.purge_products({ product_set_purge_config: product_set_purge_config }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation


### PR DESCRIPTION
Adjust templates to generate more correct code by default.
Only apply formatting rubocop rules, which increases performance.