### PR TITLE
Release gapic-common 0.1.0

### DIFF
--- a/gapic-common/CHANGELOG.md
+++ b/gapic-common/CHANGELOG.md
@@ -1,2 +1,5 @@
 # Release History
 
+### 0.1.0 / 2020-01-09
+
+Initial release

--- a/gapic-common/gapic-common.gemspec
+++ b/gapic-common/gapic-common.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "googleauth", "~> 0.9"
   spec.add_dependency "grpc", "~> 1.25"
 
-  spec.add_development_dependency "google-cloud-core", "~> 1.1"
+  spec.add_development_dependency "google-cloud-core", "~> 1.5"
   spec.add_development_dependency "google-style", "~> 1.24.0"
   spec.add_development_dependency "minitest", "~> 5.10"
   spec.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/gapic-common/lib/gapic/common/version.rb
+++ b/gapic-common/lib/gapic/common/version.rb
@@ -14,6 +14,6 @@
 
 module Gapic
   module Common
-    VERSION = "0.0.2".freeze
+    VERSION = "0.1.0".freeze
   end
 end


### PR DESCRIPTION
I don't think we have releasetool set up for this repo. So releasing manually.