### PR TITLE
Update runtime dependencies in generated files

### DIFF
--- a/gapic-generator-cloud/templates/cloud/gem/gemspec.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/gemspec.erb
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "gapic-common", "~> 0.1"
-  gem.add_dependency "google-cloud-errors", "~> 0.0"
+  gem.add_dependency "google-cloud-errors", "~> 1.0"
   <%- if gem.iam_dependency? -%>
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   <%- end -%>

--- a/gapic-generator-cloud/templates/cloud/gem/gemspec.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/gemspec.erb
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.0"
+  gem.add_dependency "gapic-common", "~> 0.1"
   gem.add_dependency "google-cloud-errors", "~> 0.0"
   <%- if gem.iam_dependency? -%>
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"

--- a/gapic-generator/templates/default/gem/gemfile.erb
+++ b/gapic-generator/templates/default/gem/gemfile.erb
@@ -2,5 +2,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "gapic-common", github: "googleapis/gapic-generator-ruby"

--- a/gapic-generator/templates/default/gem/gemspec.erb
+++ b/gapic-generator/templates/default/gem/gemspec.erb
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.0"
+  gem.add_dependency "gapic-common", "~> 0.1"
   <%- if gem.iam_dependency? -%>
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   <%- end -%>

--- a/shared/output/cloud/language_v1/Gemfile
+++ b/shared/output/cloud/language_v1/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "gapic-common", github: "googleapis/gapic-generator-ruby"

--- a/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
+++ b/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "gapic-common", "~> 0.1"
-  gem.add_dependency "google-cloud-errors", "~> 0.0"
+  gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
+++ b/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.0"
+  gem.add_dependency "gapic-common", "~> 0.1"
   gem.add_dependency "google-cloud-errors", "~> 0.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/cloud/language_v1beta1/Gemfile
+++ b/shared/output/cloud/language_v1beta1/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "gapic-common", github: "googleapis/gapic-generator-ruby"

--- a/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
+++ b/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "gapic-common", "~> 0.1"
-  gem.add_dependency "google-cloud-errors", "~> 0.0"
+  gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
+++ b/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.0"
+  gem.add_dependency "gapic-common", "~> 0.1"
   gem.add_dependency "google-cloud-errors", "~> 0.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/cloud/language_v1beta2/Gemfile
+++ b/shared/output/cloud/language_v1beta2/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "gapic-common", github: "googleapis/gapic-generator-ruby"

--- a/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
+++ b/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "gapic-common", "~> 0.1"
-  gem.add_dependency "google-cloud-errors", "~> 0.0"
+  gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
+++ b/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.0"
+  gem.add_dependency "gapic-common", "~> 0.1"
   gem.add_dependency "google-cloud-errors", "~> 0.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/cloud/secretmanager_v1beta1/Gemfile
+++ b/shared/output/cloud/secretmanager_v1beta1/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "gapic-common", github: "googleapis/gapic-generator-ruby"

--- a/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
+++ b/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "gapic-common", "~> 0.1"
-  gem.add_dependency "google-cloud-errors", "~> 0.0"
+  gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
+++ b/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.0"
+  gem.add_dependency "gapic-common", "~> 0.1"
   gem.add_dependency "google-cloud-errors", "~> 0.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 

--- a/shared/output/cloud/speech_v1/Gemfile
+++ b/shared/output/cloud/speech_v1/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "gapic-common", github: "googleapis/gapic-generator-ruby"

--- a/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
+++ b/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "gapic-common", "~> 0.1"
-  gem.add_dependency "google-cloud-errors", "~> 0.0"
+  gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
+++ b/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.0"
+  gem.add_dependency "gapic-common", "~> 0.1"
   gem.add_dependency "google-cloud-errors", "~> 0.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/cloud/vision_v1/Gemfile
+++ b/shared/output/cloud/vision_v1/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "gapic-common", github: "googleapis/gapic-generator-ruby"

--- a/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
+++ b/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "gapic-common", "~> 0.1"
-  gem.add_dependency "google-cloud-errors", "~> 0.0"
+  gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
+++ b/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.0"
+  gem.add_dependency "gapic-common", "~> 0.1"
   gem.add_dependency "google-cloud-errors", "~> 0.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/gapic/templates/garbage/Gemfile
+++ b/shared/output/gapic/templates/garbage/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "gapic-common", github: "googleapis/gapic-generator-ruby"

--- a/shared/output/gapic/templates/garbage/google-garbage.gemspec
+++ b/shared/output/gapic/templates/garbage/google-garbage.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.0"
+  gem.add_dependency "gapic-common", "~> 0.1"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/gapic/templates/showcase/Gemfile
+++ b/shared/output/gapic/templates/showcase/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "gapic-common", github: "googleapis/gapic-generator-ruby"

--- a/shared/output/gapic/templates/showcase/google-showcase.gemspec
+++ b/shared/output/gapic/templates/showcase/google-showcase.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.0"
+  gem.add_dependency "gapic-common", "~> 0.1"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
* Use released version of gapic-common
* Use released version of google-cloud-errors