### PR TITLE
Update resource path helper argument checks

### DIFF
--- a/gapic-generator/templates/default/helpers/presenters/resource_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/resource_presenter.rb
@@ -64,16 +64,7 @@ class ResourcePresenter
   private
 
   def arguments_for segments
-    # We only expect that named args are present
-    arg_structs = arg_segments(segments).map do |arg|
-      OpenStruct.new(
-        name:   arg.name,
-        msg:    "#{arg.name} cannot contain /",
-        regexp: "%r{\/}"
-      )
-    end
-    arg_structs.last.regexp = nil
-    arg_structs
+    arg_segments(segments).map(&:name)
   end
 
   def arg_segments segments

--- a/gapic-generator/templates/default/service/client/_resource.erb
+++ b/gapic-generator/templates/default/service/client/_resource.erb
@@ -13,12 +13,8 @@
 # @return [String]
 <%- args = resource.patterns.first.arguments.map { |arg| "#{arg}:" }.join ", " -%>
 def <%= resource.path_helper %> <%= args %>
-<%- last_argument_index = resource.patterns.first.arguments.count - 1 -%>
-<%- resource.patterns.first.arguments.each_with_index do |arg, index| -%>
-  raise ArgumentError, "<%= arg %> must be a String" unless <%= arg %>.is_a? String
-<%- if index < last_argument_index -%>
-  raise ArgumentError, "<%= arg %> cannot contain /" if <%= arg %>.include? "/"
-<%- end -%>
+<%- resource.patterns.first.arguments[0...-1].each do |arg| -%>
+  raise ArgumentError, "<%= arg %> cannot contain /" if <%= arg %>.to_s.include? "/"
 <%- end -%>
 
   "<%= resource.patterns.first.path_string %>"

--- a/gapic-generator/templates/default/service/client/_resource.erb
+++ b/gapic-generator/templates/default/service/client/_resource.erb
@@ -17,7 +17,7 @@ def <%= resource.path_helper %> <%= args %>
 <%- resource.patterns.first.arguments.each_with_index do |arg, index| -%>
   raise ArgumentError, "<%= arg %> must be a String" unless <%= arg %>.is_a? String
 <%- if index < last_argument_index -%>
-  raise ArgumentError, "<%= arg %> cannot contain /" if <%= arg %>.include? "/".freeze
+  raise ArgumentError, "<%= arg %> cannot contain /" if <%= arg %>.include? "/"
 <%- end -%>
 <%- end -%>
 

--- a/gapic-generator/templates/default/service/client/_resource.erb
+++ b/gapic-generator/templates/default/service/client/_resource.erb
@@ -7,19 +7,17 @@
 # `<%= resource.patterns.first.template %>`
 #
 <%- resource.patterns.first.arguments.each do |arg| -%>
-# @param <%= arg.name %> [String]
-<%- if arg.desc -%>
-#   <%= arg.desc %>
-<%- end -%>
+# @param <%= arg %> [String]
 <%- end -%>
 #
 # @return [String]
-<%- args = resource.patterns.first.arguments.map { |arg| "#{arg.name}:" } -%>
-def <%= resource.path_helper %> <%= args.join ", " %>
-<%- resource.patterns.first.arguments.each do |arg| -%>
-  raise ArgumentError, "<%= arg.name %> is required" if <%= arg.name %>.nil?
-<%- if arg.regexp -%>
-  raise ArgumentError, <%= arg.msg.inspect %> if <%= arg.regexp %>.match? <%= arg.name %>
+<%- args = resource.patterns.first.arguments.map { |arg| "#{arg}:" }.join ", " -%>
+def <%= resource.path_helper %> <%= args %>
+<%- last_argument_index = resource.patterns.first.arguments.count - 1 -%>
+<%- resource.patterns.first.arguments.each_with_index do |arg, index| -%>
+  raise ArgumentError, "<%= arg %> must be a String" unless <%= arg %>.is_a? String
+<%- if index < last_argument_index -%>
+  raise ArgumentError, "<%= arg %> cannot contain /" if <%= arg %>.include? "/".freeze
 <%- end -%>
 <%- end -%>
 

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/paths.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/paths.rb
@@ -36,9 +36,9 @@ module Google
             #
             # @return [String]
             def secret_path project:, secret:
-              raise ArgumentError, "project is required" if project.nil?
-              raise ArgumentError, "project cannot contain /" if %r{/}.match? project
-              raise ArgumentError, "secret is required" if secret.nil?
+              raise ArgumentError, "project must be a String" unless project.is_a? String
+              raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+              raise ArgumentError, "secret must be a String" unless secret.is_a? String
 
               "projects/#{project}/secrets/#{secret}"
             end
@@ -56,11 +56,11 @@ module Google
             #
             # @return [String]
             def secret_version_path project:, secret:, secret_version:
-              raise ArgumentError, "project is required" if project.nil?
-              raise ArgumentError, "project cannot contain /" if %r{/}.match? project
-              raise ArgumentError, "secret is required" if secret.nil?
-              raise ArgumentError, "secret cannot contain /" if %r{/}.match? secret
-              raise ArgumentError, "secret_version is required" if secret_version.nil?
+              raise ArgumentError, "project must be a String" unless project.is_a? String
+              raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+              raise ArgumentError, "secret must be a String" unless secret.is_a? String
+              raise ArgumentError, "secret cannot contain /" if secret.include? "/".freeze
+              raise ArgumentError, "secret_version must be a String" unless secret_version.is_a? String
 
               "projects/#{project}/secrets/#{secret}/versions/#{secret_version}"
             end

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/paths.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/paths.rb
@@ -36,9 +36,7 @@ module Google
             #
             # @return [String]
             def secret_path project:, secret:
-              raise ArgumentError, "project must be a String" unless project.is_a? String
-              raise ArgumentError, "project cannot contain /" if project.include? "/"
-              raise ArgumentError, "secret must be a String" unless secret.is_a? String
+              raise ArgumentError, "project cannot contain /" if project.to_s.include? "/"
 
               "projects/#{project}/secrets/#{secret}"
             end
@@ -56,11 +54,8 @@ module Google
             #
             # @return [String]
             def secret_version_path project:, secret:, secret_version:
-              raise ArgumentError, "project must be a String" unless project.is_a? String
-              raise ArgumentError, "project cannot contain /" if project.include? "/"
-              raise ArgumentError, "secret must be a String" unless secret.is_a? String
-              raise ArgumentError, "secret cannot contain /" if secret.include? "/"
-              raise ArgumentError, "secret_version must be a String" unless secret_version.is_a? String
+              raise ArgumentError, "project cannot contain /" if project.to_s.include? "/"
+              raise ArgumentError, "secret cannot contain /" if secret.to_s.include? "/"
 
               "projects/#{project}/secrets/#{secret}/versions/#{secret_version}"
             end

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/paths.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/paths.rb
@@ -37,7 +37,7 @@ module Google
             # @return [String]
             def secret_path project:, secret:
               raise ArgumentError, "project must be a String" unless project.is_a? String
-              raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+              raise ArgumentError, "project cannot contain /" if project.include? "/"
               raise ArgumentError, "secret must be a String" unless secret.is_a? String
 
               "projects/#{project}/secrets/#{secret}"
@@ -57,9 +57,9 @@ module Google
             # @return [String]
             def secret_version_path project:, secret:, secret_version:
               raise ArgumentError, "project must be a String" unless project.is_a? String
-              raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+              raise ArgumentError, "project cannot contain /" if project.include? "/"
               raise ArgumentError, "secret must be a String" unless secret.is_a? String
-              raise ArgumentError, "secret cannot contain /" if secret.include? "/".freeze
+              raise ArgumentError, "secret cannot contain /" if secret.include? "/"
               raise ArgumentError, "secret_version must be a String" unless secret_version.is_a? String
 
               "projects/#{project}/secrets/#{secret}/versions/#{secret_version}"

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/paths.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/paths.rb
@@ -37,11 +37,8 @@ module Google
             #
             # @return [String]
             def product_set_path project:, location:, product_set:
-              raise ArgumentError, "project must be a String" unless project.is_a? String
-              raise ArgumentError, "project cannot contain /" if project.include? "/"
-              raise ArgumentError, "location must be a String" unless location.is_a? String
-              raise ArgumentError, "location cannot contain /" if location.include? "/"
-              raise ArgumentError, "product_set must be a String" unless product_set.is_a? String
+              raise ArgumentError, "project cannot contain /" if project.to_s.include? "/"
+              raise ArgumentError, "location cannot contain /" if location.to_s.include? "/"
 
               "projects/#{project}/locations/#{location}/productSets/#{product_set}"
             end

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/paths.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/paths.rb
@@ -38,9 +38,9 @@ module Google
             # @return [String]
             def product_set_path project:, location:, product_set:
               raise ArgumentError, "project must be a String" unless project.is_a? String
-              raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+              raise ArgumentError, "project cannot contain /" if project.include? "/"
               raise ArgumentError, "location must be a String" unless location.is_a? String
-              raise ArgumentError, "location cannot contain /" if location.include? "/".freeze
+              raise ArgumentError, "location cannot contain /" if location.include? "/"
               raise ArgumentError, "product_set must be a String" unless product_set.is_a? String
 
               "projects/#{project}/locations/#{location}/productSets/#{product_set}"

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/paths.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/paths.rb
@@ -37,11 +37,11 @@ module Google
             #
             # @return [String]
             def product_set_path project:, location:, product_set:
-              raise ArgumentError, "project is required" if project.nil?
-              raise ArgumentError, "project cannot contain /" if %r{/}.match? project
-              raise ArgumentError, "location is required" if location.nil?
-              raise ArgumentError, "location cannot contain /" if %r{/}.match? location
-              raise ArgumentError, "product_set is required" if product_set.nil?
+              raise ArgumentError, "project must be a String" unless project.is_a? String
+              raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+              raise ArgumentError, "location must be a String" unless location.is_a? String
+              raise ArgumentError, "location cannot contain /" if location.include? "/".freeze
+              raise ArgumentError, "product_set must be a String" unless product_set.is_a? String
 
               "projects/#{project}/locations/#{location}/productSets/#{product_set}"
             end

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/paths.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/paths.rb
@@ -38,9 +38,9 @@ module Google
             # @return [String]
             def product_path project:, location:, product:
               raise ArgumentError, "project must be a String" unless project.is_a? String
-              raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+              raise ArgumentError, "project cannot contain /" if project.include? "/"
               raise ArgumentError, "location must be a String" unless location.is_a? String
-              raise ArgumentError, "location cannot contain /" if location.include? "/".freeze
+              raise ArgumentError, "location cannot contain /" if location.include? "/"
               raise ArgumentError, "product must be a String" unless product.is_a? String
 
               "projects/#{project}/locations/#{location}/products/#{product}"
@@ -60,9 +60,9 @@ module Google
             # @return [String]
             def product_set_path project:, location:, product_set:
               raise ArgumentError, "project must be a String" unless project.is_a? String
-              raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+              raise ArgumentError, "project cannot contain /" if project.include? "/"
               raise ArgumentError, "location must be a String" unless location.is_a? String
-              raise ArgumentError, "location cannot contain /" if location.include? "/".freeze
+              raise ArgumentError, "location cannot contain /" if location.include? "/"
               raise ArgumentError, "product_set must be a String" unless product_set.is_a? String
 
               "projects/#{project}/locations/#{location}/productSets/#{product_set}"
@@ -83,11 +83,11 @@ module Google
             # @return [String]
             def reference_image_path project:, location:, product:, reference_image:
               raise ArgumentError, "project must be a String" unless project.is_a? String
-              raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+              raise ArgumentError, "project cannot contain /" if project.include? "/"
               raise ArgumentError, "location must be a String" unless location.is_a? String
-              raise ArgumentError, "location cannot contain /" if location.include? "/".freeze
+              raise ArgumentError, "location cannot contain /" if location.include? "/"
               raise ArgumentError, "product must be a String" unless product.is_a? String
-              raise ArgumentError, "product cannot contain /" if product.include? "/".freeze
+              raise ArgumentError, "product cannot contain /" if product.include? "/"
               raise ArgumentError, "reference_image must be a String" unless reference_image.is_a? String
 
               "projects/#{project}/locations/#{location}/products/#{product}/referenceImages/#{reference_image}"

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/paths.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/paths.rb
@@ -37,11 +37,8 @@ module Google
             #
             # @return [String]
             def product_path project:, location:, product:
-              raise ArgumentError, "project must be a String" unless project.is_a? String
-              raise ArgumentError, "project cannot contain /" if project.include? "/"
-              raise ArgumentError, "location must be a String" unless location.is_a? String
-              raise ArgumentError, "location cannot contain /" if location.include? "/"
-              raise ArgumentError, "product must be a String" unless product.is_a? String
+              raise ArgumentError, "project cannot contain /" if project.to_s.include? "/"
+              raise ArgumentError, "location cannot contain /" if location.to_s.include? "/"
 
               "projects/#{project}/locations/#{location}/products/#{product}"
             end
@@ -59,11 +56,8 @@ module Google
             #
             # @return [String]
             def product_set_path project:, location:, product_set:
-              raise ArgumentError, "project must be a String" unless project.is_a? String
-              raise ArgumentError, "project cannot contain /" if project.include? "/"
-              raise ArgumentError, "location must be a String" unless location.is_a? String
-              raise ArgumentError, "location cannot contain /" if location.include? "/"
-              raise ArgumentError, "product_set must be a String" unless product_set.is_a? String
+              raise ArgumentError, "project cannot contain /" if project.to_s.include? "/"
+              raise ArgumentError, "location cannot contain /" if location.to_s.include? "/"
 
               "projects/#{project}/locations/#{location}/productSets/#{product_set}"
             end
@@ -82,13 +76,9 @@ module Google
             #
             # @return [String]
             def reference_image_path project:, location:, product:, reference_image:
-              raise ArgumentError, "project must be a String" unless project.is_a? String
-              raise ArgumentError, "project cannot contain /" if project.include? "/"
-              raise ArgumentError, "location must be a String" unless location.is_a? String
-              raise ArgumentError, "location cannot contain /" if location.include? "/"
-              raise ArgumentError, "product must be a String" unless product.is_a? String
-              raise ArgumentError, "product cannot contain /" if product.include? "/"
-              raise ArgumentError, "reference_image must be a String" unless reference_image.is_a? String
+              raise ArgumentError, "project cannot contain /" if project.to_s.include? "/"
+              raise ArgumentError, "location cannot contain /" if location.to_s.include? "/"
+              raise ArgumentError, "product cannot contain /" if product.to_s.include? "/"
 
               "projects/#{project}/locations/#{location}/products/#{product}/referenceImages/#{reference_image}"
             end

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/paths.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/paths.rb
@@ -37,11 +37,11 @@ module Google
             #
             # @return [String]
             def product_path project:, location:, product:
-              raise ArgumentError, "project is required" if project.nil?
-              raise ArgumentError, "project cannot contain /" if %r{/}.match? project
-              raise ArgumentError, "location is required" if location.nil?
-              raise ArgumentError, "location cannot contain /" if %r{/}.match? location
-              raise ArgumentError, "product is required" if product.nil?
+              raise ArgumentError, "project must be a String" unless project.is_a? String
+              raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+              raise ArgumentError, "location must be a String" unless location.is_a? String
+              raise ArgumentError, "location cannot contain /" if location.include? "/".freeze
+              raise ArgumentError, "product must be a String" unless product.is_a? String
 
               "projects/#{project}/locations/#{location}/products/#{product}"
             end
@@ -59,11 +59,11 @@ module Google
             #
             # @return [String]
             def product_set_path project:, location:, product_set:
-              raise ArgumentError, "project is required" if project.nil?
-              raise ArgumentError, "project cannot contain /" if %r{/}.match? project
-              raise ArgumentError, "location is required" if location.nil?
-              raise ArgumentError, "location cannot contain /" if %r{/}.match? location
-              raise ArgumentError, "product_set is required" if product_set.nil?
+              raise ArgumentError, "project must be a String" unless project.is_a? String
+              raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+              raise ArgumentError, "location must be a String" unless location.is_a? String
+              raise ArgumentError, "location cannot contain /" if location.include? "/".freeze
+              raise ArgumentError, "product_set must be a String" unless product_set.is_a? String
 
               "projects/#{project}/locations/#{location}/productSets/#{product_set}"
             end
@@ -82,13 +82,13 @@ module Google
             #
             # @return [String]
             def reference_image_path project:, location:, product:, reference_image:
-              raise ArgumentError, "project is required" if project.nil?
-              raise ArgumentError, "project cannot contain /" if %r{/}.match? project
-              raise ArgumentError, "location is required" if location.nil?
-              raise ArgumentError, "location cannot contain /" if %r{/}.match? location
-              raise ArgumentError, "product is required" if product.nil?
-              raise ArgumentError, "product cannot contain /" if %r{/}.match? product
-              raise ArgumentError, "reference_image is required" if reference_image.nil?
+              raise ArgumentError, "project must be a String" unless project.is_a? String
+              raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+              raise ArgumentError, "location must be a String" unless location.is_a? String
+              raise ArgumentError, "location cannot contain /" if location.include? "/".freeze
+              raise ArgumentError, "product must be a String" unless product.is_a? String
+              raise ArgumentError, "product cannot contain /" if product.include? "/".freeze
+              raise ArgumentError, "reference_image must be a String" unless reference_image.is_a? String
 
               "projects/#{project}/locations/#{location}/products/#{product}/referenceImages/#{reference_image}"
             end

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/paths.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/paths.rb
@@ -43,9 +43,9 @@ module So
           #
           # @return [String]
           def garbage_path project:, simple_garbage:
-            raise ArgumentError, "project is required" if project.nil?
-            raise ArgumentError, "project cannot contain /" if %r{/}.match? project
-            raise ArgumentError, "simple_garbage is required" if simple_garbage.nil?
+            raise ArgumentError, "project must be a String" unless project.is_a? String
+            raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+            raise ArgumentError, "simple_garbage must be a String" unless simple_garbage.is_a? String
 
             "projects/#{project}/simple_garbage/#{simple_garbage}"
           end
@@ -62,9 +62,9 @@ module So
           #
           # @return [String]
           def simple_garbage_path project:, garbage:
-            raise ArgumentError, "project is required" if project.nil?
-            raise ArgumentError, "project cannot contain /" if %r{/}.match? project
-            raise ArgumentError, "garbage is required" if garbage.nil?
+            raise ArgumentError, "project must be a String" unless project.is_a? String
+            raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+            raise ArgumentError, "garbage must be a String" unless garbage.is_a? String
 
             "projects/#{project}/simple_garbage/#{garbage}"
           end

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/paths.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/paths.rb
@@ -44,7 +44,7 @@ module So
           # @return [String]
           def garbage_path project:, simple_garbage:
             raise ArgumentError, "project must be a String" unless project.is_a? String
-            raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+            raise ArgumentError, "project cannot contain /" if project.include? "/"
             raise ArgumentError, "simple_garbage must be a String" unless simple_garbage.is_a? String
 
             "projects/#{project}/simple_garbage/#{simple_garbage}"
@@ -63,7 +63,7 @@ module So
           # @return [String]
           def simple_garbage_path project:, garbage:
             raise ArgumentError, "project must be a String" unless project.is_a? String
-            raise ArgumentError, "project cannot contain /" if project.include? "/".freeze
+            raise ArgumentError, "project cannot contain /" if project.include? "/"
             raise ArgumentError, "garbage must be a String" unless garbage.is_a? String
 
             "projects/#{project}/simple_garbage/#{garbage}"

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/paths.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/paths.rb
@@ -43,9 +43,7 @@ module So
           #
           # @return [String]
           def garbage_path project:, simple_garbage:
-            raise ArgumentError, "project must be a String" unless project.is_a? String
-            raise ArgumentError, "project cannot contain /" if project.include? "/"
-            raise ArgumentError, "simple_garbage must be a String" unless simple_garbage.is_a? String
+            raise ArgumentError, "project cannot contain /" if project.to_s.include? "/"
 
             "projects/#{project}/simple_garbage/#{simple_garbage}"
           end
@@ -62,9 +60,7 @@ module So
           #
           # @return [String]
           def simple_garbage_path project:, garbage:
-            raise ArgumentError, "project must be a String" unless project.is_a? String
-            raise ArgumentError, "project cannot contain /" if project.include? "/"
-            raise ArgumentError, "garbage must be a String" unless garbage.is_a? String
+            raise ArgumentError, "project cannot contain /" if project.to_s.include? "/"
 
             "projects/#{project}/simple_garbage/#{garbage}"
           end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/paths.rb
@@ -42,7 +42,7 @@ module Google
           #
           # @return [String]
           def user_path user_id:
-            raise ArgumentError, "user_id is required" if user_id.nil?
+            raise ArgumentError, "user_id must be a String" unless user_id.is_a? String
 
             "users/#{user_id}"
           end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/paths.rb
@@ -42,8 +42,6 @@ module Google
           #
           # @return [String]
           def user_path user_id:
-            raise ArgumentError, "user_id must be a String" unless user_id.is_a? String
-
             "users/#{user_id}"
           end
         end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/paths.rb
@@ -43,9 +43,9 @@ module Google
           #
           # @return [String]
           def blurb_path room_id:, blurb_id:
-            raise ArgumentError, "room_id is required" if room_id.nil?
-            raise ArgumentError, "room_id cannot contain /" if %r{/}.match? room_id
-            raise ArgumentError, "blurb_id is required" if blurb_id.nil?
+            raise ArgumentError, "room_id must be a String" unless room_id.is_a? String
+            raise ArgumentError, "room_id cannot contain /" if room_id.include? "/".freeze
+            raise ArgumentError, "blurb_id must be a String" unless blurb_id.is_a? String
 
             "rooms/#{room_id}/blurbs/#{blurb_id}"
           end
@@ -61,7 +61,7 @@ module Google
           #
           # @return [String]
           def room_path room_id:
-            raise ArgumentError, "room_id is required" if room_id.nil?
+            raise ArgumentError, "room_id must be a String" unless room_id.is_a? String
 
             "rooms/#{room_id}"
           end
@@ -77,7 +77,7 @@ module Google
           #
           # @return [String]
           def user_path user_id:
-            raise ArgumentError, "user_id is required" if user_id.nil?
+            raise ArgumentError, "user_id must be a String" unless user_id.is_a? String
 
             "users/#{user_id}"
           end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/paths.rb
@@ -44,7 +44,7 @@ module Google
           # @return [String]
           def blurb_path room_id:, blurb_id:
             raise ArgumentError, "room_id must be a String" unless room_id.is_a? String
-            raise ArgumentError, "room_id cannot contain /" if room_id.include? "/".freeze
+            raise ArgumentError, "room_id cannot contain /" if room_id.include? "/"
             raise ArgumentError, "blurb_id must be a String" unless blurb_id.is_a? String
 
             "rooms/#{room_id}/blurbs/#{blurb_id}"

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/paths.rb
@@ -43,9 +43,7 @@ module Google
           #
           # @return [String]
           def blurb_path room_id:, blurb_id:
-            raise ArgumentError, "room_id must be a String" unless room_id.is_a? String
-            raise ArgumentError, "room_id cannot contain /" if room_id.include? "/"
-            raise ArgumentError, "blurb_id must be a String" unless blurb_id.is_a? String
+            raise ArgumentError, "room_id cannot contain /" if room_id.to_s.include? "/"
 
             "rooms/#{room_id}/blurbs/#{blurb_id}"
           end
@@ -61,8 +59,6 @@ module Google
           #
           # @return [String]
           def room_path room_id:
-            raise ArgumentError, "room_id must be a String" unless room_id.is_a? String
-
             "rooms/#{room_id}"
           end
 
@@ -77,8 +73,6 @@ module Google
           #
           # @return [String]
           def user_path user_id:
-            raise ArgumentError, "user_id must be a String" unless user_id.is_a? String
-
             "users/#{user_id}"
           end
         end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/paths.rb
@@ -42,8 +42,6 @@ module Google
           #
           # @return [String]
           def session_path session:
-            raise ArgumentError, "session must be a String" unless session.is_a? String
-
             "sessions/#{session}"
           end
 
@@ -59,9 +57,7 @@ module Google
           #
           # @return [String]
           def test_path session:, test:
-            raise ArgumentError, "session must be a String" unless session.is_a? String
-            raise ArgumentError, "session cannot contain /" if session.include? "/"
-            raise ArgumentError, "test must be a String" unless test.is_a? String
+            raise ArgumentError, "session cannot contain /" if session.to_s.include? "/"
 
             "sessions/#{session}/tests/#{test}"
           end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/paths.rb
@@ -42,7 +42,7 @@ module Google
           #
           # @return [String]
           def session_path session:
-            raise ArgumentError, "session is required" if session.nil?
+            raise ArgumentError, "session must be a String" unless session.is_a? String
 
             "sessions/#{session}"
           end
@@ -59,9 +59,9 @@ module Google
           #
           # @return [String]
           def test_path session:, test:
-            raise ArgumentError, "session is required" if session.nil?
-            raise ArgumentError, "session cannot contain /" if %r{/}.match? session
-            raise ArgumentError, "test is required" if test.nil?
+            raise ArgumentError, "session must be a String" unless session.is_a? String
+            raise ArgumentError, "session cannot contain /" if session.include? "/".freeze
+            raise ArgumentError, "test must be a String" unless test.is_a? String
 
             "sessions/#{session}/tests/#{test}"
           end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/paths.rb
@@ -60,7 +60,7 @@ module Google
           # @return [String]
           def test_path session:, test:
             raise ArgumentError, "session must be a String" unless session.is_a? String
-            raise ArgumentError, "session cannot contain /" if session.include? "/".freeze
+            raise ArgumentError, "session cannot contain /" if session.include? "/"
             raise ArgumentError, "test must be a String" unless test.is_a? String
 
             "sessions/#{session}/tests/#{test}"


### PR DESCRIPTION
As discussed in https://github.com/googleapis/gapic-generator-ruby/pull/313#discussion_r365598211, and reinforced in https://github.com/googleapis/gapic-generator-ruby/pull/314#discussion_r366668620, the argument checks should use `String#include?` instead of using a regexp for performance reasons. This change does the following:

* Replace `nil` check with a check for a `String` object.
* Replace regexp match with a call to the `String#include?` method.

This change also removes some unused argument template code checking for a `#desc` value that was never implemented. The logic to check for `/` characters in all but the last argument was moved from the presenter to the template because the logic is not much simpler.

This PR is a draft PR until #314 is accepted and merged, as it dependent on it.