### PR TITLE
Support setting all configuration from the plugin parameter

### DIFF
--- a/gapic-generator/lib/gapic/schema/api.rb
+++ b/gapic-generator/lib/gapic/schema/api.rb
@@ -229,15 +229,6 @@ module Gapic
         left.merge right do |_k, lt, rt|
           if lt.is_a?(Hash) && rt.is_a?(Hash)
             deep_merge lt, rt
-          elsif !lt.is_a?(Hash) && !rt.is_a?(Hash)
-            val = Array(lt) + Array(rt)
-            if val.empty?
-              nil
-            elsif val.size == 1
-              val.first
-            else
-              val
-            end
           else
             rt
           end

--- a/gapic-generator/test/gapic/schema/api_test.rb
+++ b/gapic-generator/test/gapic/schema/api_test.rb
@@ -28,7 +28,7 @@ class ApiTest < Minitest::Test
     parameter = ":a.:b=1,:a.:c=2,:a.:c=3"
     request = OpenStruct.new parameter: parameter, proto_file: []
     api = Gapic::Schema::Api.new request
-    assert_equal({ a: { b: 1, c: [2, 3] } }, api.configuration)
+    assert_equal({ a: { b: "1", c: ["2", "3"] } }, api.configuration)
   end
 
   def test_parameter_reconstruction

--- a/gapic-generator/test/gapic/schema/api_test.rb
+++ b/gapic-generator/test/gapic/schema/api_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+
+class ApiTest < Minitest::Test
+  def test_parse_protoc_options
+    parameter = "a=b\\\\\\,\\=,c=d=e,:f="
+    request = OpenStruct.new parameter: parameter, proto_file: []
+    api = Gapic::Schema::Api.new request
+    assert_equal({ "a" => "b\\,=", "c" => ["d", "e"], f: nil }, api.protoc_options)
+  end
+
+  def test_configuration_construction
+    parameter = ":a.:b=1,:a.:c=2,:a.:c=3"
+    request = OpenStruct.new parameter: parameter, proto_file: []
+    api = Gapic::Schema::Api.new request
+    assert_equal({ a: { b: 1, c: [2, 3] } }, api.configuration)
+  end
+
+  def test_parameter_reconstruction
+    parameter = "a=b\\\\\\,\\=,c=d=e,:f="
+    request = OpenStruct.new parameter: parameter, proto_file: []
+    api = Gapic::Schema::Api.new request
+    assert_equal parameter, api.protoc_parameter
+  end
+end

--- a/gapic-generator/test/gapic/schema/api_test.rb
+++ b/gapic-generator/test/gapic/schema/api_test.rb
@@ -25,10 +25,10 @@ class ApiTest < Minitest::Test
   end
 
   def test_configuration_construction
-    parameter = ":a.:b=1,:a.:c=2,:a.:c=3"
+    parameter = ":a.:b=1,:a.:c=2,:a.:c.:d=3"
     request = OpenStruct.new parameter: parameter, proto_file: []
     api = Gapic::Schema::Api.new request
-    assert_equal({ a: { b: "1", c: ["2", "3"] } }, api.configuration)
+    assert_equal({ a: { b: "1", c: { d: "3" } } }, api.configuration)
   end
 
   def test_parameter_reconstruction


### PR DESCRIPTION
The high level goal here is to allow configuration without a config file, since it is not currently possible to pass a custom config file from synthtool. Instead, we expand the parsing of the request parameter string to support all the data we currently have in our structured configuration—including string and symbol keys, and nested hashes. Existing usage is still supported.

The following additions/improvements were made when parsing request parameter into `protoc_options`:
* Keys are now parsed. A key that begins with a colon is turned into a symbol, otherwise a string key is used.
* Values can now contain commas and equals signs if they are backslash-escaped. (Backslashes must also be escaped.)
* Fixed a crash when a value length was a single character.

Configuration now comes directly from the `protoc_options`.
* Nested structures are supported by interpreting multi-segment keys. If a key in the `protoc_options` has multiple segments, period-delimited, they are considered nested hashes. All the entries are deep-merged into the final structured configuration. This should allow any of our configurations to be expressed as a request parameter string.
* The `"configuration"` key is special when constructing configuration. It is treated as the file name of a configuration YAML file, which is loaded and merged into the configuration. In this way, existing usage remains unaffected.

Also:
* Removed some duplicate configuration parsing from the Runner class and consolidated all configuration code in the API class. (This includes the re-marshaling of modified `protoc_options` into the request parameter after removing the `binary_output` key.)
* Note that, because of the key parsing, existing keys to `protoc_options` are now strings rather than symbols. (for example, `protoc_options["generator"]`). Existing uses have been changed.