### PR TITLE
fix: add rubocop to runtime dependencies and set real gem versions

### DIFF
--- a/gapic-generator-ads/gapic-generator-ads.gemspec
+++ b/gapic-generator-ads/gapic-generator-ads.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "actionpack", "~> 5.2"
-  spec.add_dependency "gapic-generator", "~> 0.0.0.dev"
+  spec.add_dependency "gapic-generator", "~> 0.0.1"
   spec.add_dependency "protobuf", "~> 3.8"
 
   spec.add_development_dependency "bundler", "~> 2.1"

--- a/gapic-generator-ads/lib/gapic/generator/ads/version.rb
+++ b/gapic-generator-ads/lib/gapic/generator/ads/version.rb
@@ -18,7 +18,7 @@
 module Gapic
   module Generator
     module Ads
-      VERSION = "0.0.1.dev.1"
+      VERSION = "0.0.1"
     end
   end
 end

--- a/gapic-generator-cloud/gapic-generator-cloud.gemspec
+++ b/gapic-generator-cloud/gapic-generator-cloud.gemspec
@@ -40,10 +40,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "actionpack", "~> 5.2"
   spec.add_dependency "gapic-generator", "~> 0.0.1"
+  spec.add_dependency "google-style", "~> 1.24.0"
   spec.add_dependency "protobuf", "~> 3.8"
 
   spec.add_development_dependency "bundler", "~> 2.1"
-  spec.add_development_dependency "google-style", "~> 1.24.0"
   spec.add_development_dependency "grpc-tools", "~> 1.19"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/gapic-generator-cloud/gapic-generator-cloud.gemspec
+++ b/gapic-generator-cloud/gapic-generator-cloud.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "actionpack", "~> 5.2"
-  spec.add_dependency "gapic-generator", "~> 0.0.0.dev"
+  spec.add_dependency "gapic-generator", "~> 0.0.1"
   spec.add_dependency "protobuf", "~> 3.8"
 
   spec.add_development_dependency "bundler", "~> 2.1"

--- a/gapic-generator-cloud/lib/gapic/generator/cloud/version.rb
+++ b/gapic-generator-cloud/lib/gapic/generator/cloud/version.rb
@@ -17,7 +17,7 @@
 module Gapic
   module Generator
     module Cloud
-      VERSION = "0.0.1.dev.1"
+      VERSION = "0.0.1"
     end
   end
 end

--- a/gapic-generator/gapic-generator.gemspec
+++ b/gapic-generator/gapic-generator.gemspec
@@ -40,7 +40,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "actionpack", "~> 5.2"
   spec.add_dependency "protobuf", "~> 3.8"
-  spec.add_dependency "rubocop", ">= 0.74.0"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "google-style", "~> 1.24.0"

--- a/gapic-generator/gapic-generator.gemspec
+++ b/gapic-generator/gapic-generator.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "actionpack", "~> 5.2"
   spec.add_dependency "protobuf", "~> 3.8"
+  spec.add_dependency "rubocop", ">= 0.74.0"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "google-style", "~> 1.24.0"

--- a/gapic-generator/lib/gapic/generator/version.rb
+++ b/gapic-generator/lib/gapic/generator/version.rb
@@ -16,6 +16,6 @@
 
 module Gapic
   module Generator
-    VERSION = "0.0.1.dev.1"
+    VERSION = "0.0.1"
   end
 end


### PR DESCRIPTION
Two  updates to versions/dependencies:
* Rubocop needs to be a runtime dependency of the generators, because its code formatter is run as a postprocessing step when generating Ruby code. On recommendation from @blowmage, rubocop itself is a dependency of gapic-generator, while google-style is a dependency of gapic-generator-cloud.
* Clean up the gem versions so they're set to something real when we push docker images. This isn't strictly necessary, but I wanted our docker image tags to match the actual gem versions, just because.