### PR TITLE
[Docs] Add the instructions on using the Docker image to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,39 @@ Create Ruby clients from a protocol buffer description of an API.
 **Note** This project is a preview. Please try it out and let us know what you think,
 but there are currently no guarantees of stability or support.
 
-## Usage
+## Getting started using the Docker image
+The easiest way to use the generator is to run it with the Docker image.
+
+### Download the sample protos for the Showcase API
+The [Showcase API](https://github.com/googleapis/gapic-showcase) is a good API to
+play with if you want to start generating your own client libraries. It has several
+services, we'll use `Echo` ([echo.proto](https://github.com/googleapis/gapic-showcase/blob/master/schema/google/showcase/v1beta1/echo.proto)) service as an example.
+
+Download the proto files locally (the following examples work in Linux or macOS):
+
+```sh
+$ curl -L https://github.com/googleapis/gapic-showcase/releases/download/v0.6.1/gapic-showcase-0.6.1-protos.tar.gz | tar xz
+```
+
+### Run the generator using the Docker image
+
+```sh
+$ mkdir showcase-ruby
+$ docker run --rm --user $UID \
+  --mount type=bind,source=`pwd`/google/showcase/v1beta1,destination=/in/google/showcase/v1beta1,readonly \
+  --mount type=bind,source=`pwd`/showcase-ruby,destination=/out \
+  gcr.io/gapic-images/gapic-generator-ruby:latest --ruby-cloud-gem-name=showcase
+```
+
+The resulting files are in `showcase-ruby` folder:
+
+```sh
+$ cd showcase-ruby
+$ bundle install   # install dependencies
+$ bundle exec rake ci  # run unit tests
+```
+
+## Building, installation and API generation without the Docker image
 ### Install the Proto Compiler
 This generator relies on the Protocol Buffer Compiler to [orchestrate] the
 client generation. Install protoc version 3.7 or later.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Create Ruby clients from a protocol buffer description of an API.
 but there are currently no guarantees of stability or support.
 
 ## Getting started using the Docker image
-The easiest way to use the generator is to run it with the Docker image.
+The easiest way to use the generator is to run it with the Docker image. There are several docker images containing various flavors of gapic generators, we are going to use the `gapic-generator-ruby` image which is generating code using the [gapic-generator-cloud](https://github.com/googleapis/gapic-generator-ruby/tree/master/gapic-generator-cloud).
 
 ### Download the sample protos for the Showcase API
 The [Showcase API](https://github.com/googleapis/gapic-showcase) is a good API to
@@ -26,8 +26,10 @@ $ mkdir showcase-ruby
 $ docker run --rm --user $UID \
   --mount type=bind,source=`pwd`/google/showcase/v1beta1,destination=/in/google/showcase/v1beta1,readonly \
   --mount type=bind,source=`pwd`/showcase-ruby,destination=/out \
-  gcr.io/gapic-images/gapic-generator-ruby:latest --ruby-cloud-gem-name=showcase
+  gcr.io/gapic-images/gapic-generator-ruby:latest --ruby-cloud-gem-name=google-showcase
 ```
+
+NB: `ruby-cloud-gem-name` currently has to partialy (excluding version) match the package option from the proto files. For showcase the package is `google.showcase.v1beta1` and so the `ruby-cloud-gem-name` has to be `google-showcase`
 
 The resulting files are in `showcase-ruby` folder:
 
@@ -57,7 +59,7 @@ $ export PROTOBUF_VERSION=3.7.1
 # export PROTOBUF_SYSTEM=osx-x86_64
 $ export PROTOBUF_SYSTEM=linux-x86_64
 
-# Get the precompiled protobuf compiler
+# Get the precompiled protobuf compiler.
 $ mkdir /usr/src/protoc
 $ curl --location https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-${PROTOBUF_SYSTEM}.zip --output /usr/src/protoc/protoc-${PROTOBUF_VERSION}.zip
 $ cd /usr/src/protoc/


### PR DESCRIPTION
added some basic instructions on generating Showcase with Docker. As-is right now generated Showcase will have the VERSION bug ( https://github.com/googleapis/gapic-generator-ruby/issues/325 ) so I'll make sure it is fixed before merging this.

['--ruby-cloud-gem-name' issue 323](https://github.com/googleapis/gapic-generator-ruby/issues/323) is not a blocker but it is possible to update instructions after it is fixed.
