### PR TITLE
fix: sort input files in docker entrypoint

### DIFF
--- a/gapic-generator-ads/lib/gapic/generator/ads/version.rb
+++ b/gapic-generator-ads/lib/gapic/generator/ads/version.rb
@@ -18,7 +18,7 @@
 module Gapic
   module Generator
     module Ads
-      VERSION = "0.0.1"
+      VERSION = "0.0.2"
     end
   end
 end

--- a/gapic-generator-cloud/bin/ruby-cloud-docker-entrypoint
+++ b/gapic-generator-cloud/bin/ruby-cloud-docker-entrypoint
@@ -54,7 +54,7 @@ protoc_cmd = [
   "--grpc_out=/out/lib",
   "--ruby_cloud_out=/out/",
   "--ruby_cloud_opt", parameter_strs.join(",")
-] + ARGV + `find /in/ -name *.proto`.split
+] + ARGV + Dir.glob("/in/**/*.proto").sort
 
 FileUtils.mkdir_p "/out/lib"
 exec(*protoc_cmd)

--- a/gapic-generator-cloud/lib/gapic/generator/cloud/version.rb
+++ b/gapic-generator-cloud/lib/gapic/generator/cloud/version.rb
@@ -17,7 +17,7 @@
 module Gapic
   module Generator
     module Cloud
-      VERSION = "0.0.1"
+      VERSION = "0.0.2"
     end
   end
 end

--- a/gapic-generator/lib/gapic/generator/version.rb
+++ b/gapic-generator/lib/gapic/generator/version.rb
@@ -16,6 +16,6 @@
 
 module Gapic
   module Generator
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end


### PR DESCRIPTION
GNU find (and `Dir.glob` as well) do not guarantee sorted results, so the ordering may not be stable across separate git pulls or unarchivings of the directory structure. This can result in changes to the ordering within generated artifacts (e.g. https://github.com/googleapis/google-cloud-ruby/pull/4749). This change tries to fix this issue by sorting input files.

Also, instead of shelling out, we use the Ruby call to glob for results, which should be more resilient against potential corner cases such as spaces in file paths.