### PR TITLE
fix: Update the default assert for map fields

### DIFF
--- a/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
@@ -78,6 +78,10 @@ class FieldPresenter
     @field.repeated?
   end
 
+  def map?
+    @field.map?
+  end
+
   protected
 
   def field_doc_types field, output

--- a/gapic-generator/templates/default/service/test/method/_normal.erb
+++ b/gapic-generator/templates/default/service/test/method/_normal.erb
@@ -17,7 +17,7 @@ def test_<%= method.name %>
     assert_equal :<%= method.name %>, name
     assert_kind_of <%= method.request_type %>, request
     <%- fields.each do |field| -%>
-    <%- if field.message? && field.repeated? -%>
+    <%- if field.message? && field.repeated? && !field.map? -%>
     assert_kind_of <%= field.type_name_full %>, request.<%= field.name %>.first
     <%- elsif field.message? -%>
     assert_equal Gapic::Protobuf.coerce(<%= field.default_value %>, to: <%= field.type_name_full %>), request.<%= field.name %>

--- a/gapic-generator/templates/default/service/test/method/_normal.erb
+++ b/gapic-generator/templates/default/service/test/method/_normal.erb
@@ -19,6 +19,8 @@ def test_<%= method.name %>
     <%- fields.each do |field| -%>
     <%- if field.message? && field.repeated? && !field.map? -%>
     assert_kind_of <%= field.type_name_full %>, request.<%= field.name %>.first
+    <%- elsif field.map? -%>
+    assert_equal(<%= field.default_value %>, request.<%= field.name %>.to_h)
     <%- elsif field.message? -%>
     assert_equal Gapic::Protobuf.coerce(<%= field.default_value %>, to: <%= field.type_name_full %>), request.<%= field.name %>
     <%- else -%>

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
@@ -386,7 +386,7 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       assert_equal Gapic::Protobuf.coerce({}, to: Google::Protobuf::Duration), request.duration
       assert_equal Gapic::Protobuf.coerce({}, to: So::Much::Trash::GarbageMap), request.msg
       assert_equal :Default, request.enum
-      assert_equal Gapic::Protobuf.coerce({}, to: So::Much::Trash::TypicalGarbage::AmapEntry), request.amap
+      assert_equal({}, request.amap.to_h)
       refute_nil options
     end
 

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
@@ -386,7 +386,7 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       assert_equal Gapic::Protobuf.coerce({}, to: Google::Protobuf::Duration), request.duration
       assert_equal Gapic::Protobuf.coerce({}, to: So::Much::Trash::GarbageMap), request.msg
       assert_equal :Default, request.enum
-      assert_kind_of So::Much::Trash::TypicalGarbage::AmapEntry, request.amap.first
+      assert_equal Gapic::Protobuf.coerce({}, to: So::Much::Trash::TypicalGarbage::AmapEntry), request.amap
       refute_nil options
     end
 


### PR DESCRIPTION
Update the default assert for map fields in unary methods to be the same as other non-repeated fields