### PR TITLE
fix: set the default value for the floating point fields to 3.5

### DIFF
--- a/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/field_presenter.rb
@@ -126,7 +126,7 @@ class FieldPresenter
       ":#{@field.enum.values.first.name}"
     else
       case @field.type
-      when 1, 2                              then "3.14"
+      when 1, 2                              then "3.5"
       when 3, 4, 5, 6, 7, 13, 15, 16, 17, 18 then "42"
       when 9, 12                             then "\"hello world\""
       when 8                                 then "true"

--- a/gapic-generator/test/gapic/presenters/field_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/field_presenter_test.rb
@@ -67,7 +67,7 @@ class FieldPresenterTest < PresenterTest
       assert_equal "@!attribute [rw] #{field_name}", fp.doc_attribute_type
       assert_equal "Float", fp.output_doc_types
       assert_equal fp.doc_description, "The #{field_name} of this garbage.\n"
-      assert_equal "3.14", fp.default_value
+      assert_equal "3.5", fp.default_value
       assert_equal "", fp.type_name
       assert_nil fp.type_name_full
     end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
@@ -125,8 +125,8 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
     uint32 = 42
     uint64 = 42
     bool = true
-    float = 3.14
-    double = 3.14
+    float = 3.5
+    double = 3.5
     bytes = "hello world"
     msg = {}
     enum = :Default
@@ -141,8 +141,8 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       assert_equal 42, request.uint32
       assert_equal 42, request.uint64
       assert_equal true, request.bool
-      assert_equal 3.14, request.float
-      assert_equal 3.14, request.double
+      assert_equal 3.5, request.float
+      assert_equal 3.5, request.double
       assert_equal "hello world", request.bytes
       assert_equal Gapic::Protobuf.coerce({}, to: So::Much::Trash::GarbageMap), request.msg
       assert_equal :Default, request.enum
@@ -205,8 +205,8 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
     uint32 = 42
     uint64 = 42
     bool = true
-    float = 3.14
-    double = 3.14
+    float = 3.5
+    double = 3.5
     bytes = "hello world"
     msg = {}
     enum = :Default
@@ -220,8 +220,8 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       assert_equal 42, request.uint32
       assert_equal 42, request.uint64
       assert_equal true, request.bool
-      assert_equal 3.14, request.float
-      assert_equal 3.14, request.double
+      assert_equal 3.5, request.float
+      assert_equal 3.5, request.double
       assert_equal "hello world", request.bytes
       assert_equal Gapic::Protobuf.coerce({}, to: So::Much::Trash::GarbageMap), request.msg
       assert_equal :Default, request.enum
@@ -283,8 +283,8 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
     repeated_uint32 = [42]
     repeated_uint64 = [42]
     repeated_bool = [true]
-    repeated_float = [3.14]
-    repeated_double = [3.14]
+    repeated_float = [3.5]
+    repeated_double = [3.5]
     repeated_bytes = ["hello world"]
     repeated_msg = [{}]
     repeated_enum = [:Default]
@@ -298,8 +298,8 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       assert_equal [42], request.repeated_uint32
       assert_equal [42], request.repeated_uint64
       assert_equal [true], request.repeated_bool
-      assert_equal [3.14], request.repeated_float
-      assert_equal [3.14], request.repeated_double
+      assert_equal [3.5], request.repeated_float
+      assert_equal [3.5], request.repeated_double
       assert_equal ["hello world"], request.repeated_bytes
       assert_kind_of So::Much::Trash::GarbageMap, request.repeated_msg.first
       assert_equal [:Default], request.repeated_enum
@@ -361,8 +361,8 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
     uint32 = 42
     uint64 = 42
     bool = true
-    float = 3.14
-    double = 3.14
+    float = 3.5
+    double = 3.5
     bytes = "hello world"
     timeout = {}
     duration = {}
@@ -379,8 +379,8 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       assert_equal 42, request.uint32
       assert_equal 42, request.uint64
       assert_equal true, request.bool
-      assert_equal 3.14, request.float
-      assert_equal 3.14, request.double
+      assert_equal 3.5, request.float
+      assert_equal 3.5, request.double
       assert_equal "hello world", request.bytes
       assert_equal Gapic::Protobuf.coerce({}, to: Google::Protobuf::Timestamp), request.timeout
       assert_equal Gapic::Protobuf.coerce({}, to: Google::Protobuf::Duration), request.duration


### PR DESCRIPTION
fix: set the default value for the floating point fields testing to 3.5 to avoid issues with converting between protobuf's float and Ruby's float. Previous default 3.14 after a round of back-n-forth conversion became 3.140000104904175, a difference greater than Ruby's Float:EPSILON.