### PR TITLE
Reference gem version using top-level constant

### DIFF
--- a/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
@@ -8,7 +8,7 @@ metadata = @config.rpcs.<%= method.name %>.metadata.to_h
 # Set x-goog-api-client header
 metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
   lib_name: @config.lib_name, lib_version: @config.lib_version,
-  gapic_version: <%= method.service.gem.version_name_full %>
+  gapic_version: ::<%= method.service.gem.version_name_full %>
 <%- if method.routing_params? && !method.client_streaming? -%>
 
 header_params = {

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
@@ -142,7 +142,7 @@ module Google
                 # Set x-goog-api-client header
                 metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                   lib_name: @config.lib_name, lib_version: @config.lib_version,
-                  gapic_version: Google::Ads::GoogleAds::VERSION
+                  gapic_version: ::Google::Ads::GoogleAds::VERSION
 
                 header_params = {
                   "resource_name" => request.resource_name
@@ -210,7 +210,7 @@ module Google
                 # Set x-goog-api-client header
                 metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                   lib_name: @config.lib_name, lib_version: @config.lib_version,
-                  gapic_version: Google::Ads::GoogleAds::VERSION
+                  gapic_version: ::Google::Ads::GoogleAds::VERSION
 
                 header_params = {
                   "customer_id" => request.customer_id

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
@@ -231,7 +231,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1::VERSION
+                gapic_version: ::Google::Cloud::Language::V1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_sentiment.timeout,
                                      metadata:     metadata,
@@ -392,7 +392,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1::VERSION
+                gapic_version: ::Google::Cloud::Language::V1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_entities.timeout,
                                      metadata:     metadata,
@@ -559,7 +559,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1::VERSION
+                gapic_version: ::Google::Cloud::Language::V1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_entity_sentiment.timeout,
                                      metadata:     metadata,
@@ -730,7 +730,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1::VERSION
+                gapic_version: ::Google::Cloud::Language::V1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_syntax.timeout,
                                      metadata:     metadata,
@@ -846,7 +846,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1::VERSION
+                gapic_version: ::Google::Cloud::Language::V1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.classify_text.timeout,
                                      metadata:     metadata,
@@ -904,7 +904,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1::VERSION
+                gapic_version: ::Google::Cloud::Language::V1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.annotate_text.timeout,
                                      metadata:     metadata,

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -153,7 +153,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::Language::V1beta1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_sentiment.timeout,
                                      metadata:     metadata,
@@ -211,7 +211,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::Language::V1beta1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_entities.timeout,
                                      metadata:     metadata,
@@ -269,7 +269,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::Language::V1beta1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_syntax.timeout,
                                      metadata:     metadata,
@@ -327,7 +327,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::Language::V1beta1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.annotate_text.timeout,
                                      metadata:     metadata,

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -153,7 +153,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1beta2::VERSION
+                gapic_version: ::Google::Cloud::Language::V1beta2::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_sentiment.timeout,
                                      metadata:     metadata,
@@ -211,7 +211,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1beta2::VERSION
+                gapic_version: ::Google::Cloud::Language::V1beta2::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_entities.timeout,
                                      metadata:     metadata,
@@ -267,7 +267,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1beta2::VERSION
+                gapic_version: ::Google::Cloud::Language::V1beta2::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_entity_sentiment.timeout,
                                      metadata:     metadata,
@@ -325,7 +325,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1beta2::VERSION
+                gapic_version: ::Google::Cloud::Language::V1beta2::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_syntax.timeout,
                                      metadata:     metadata,
@@ -377,7 +377,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1beta2::VERSION
+                gapic_version: ::Google::Cloud::Language::V1beta2::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.classify_text.timeout,
                                      metadata:     metadata,
@@ -435,7 +435,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::V1beta2::VERSION
+                gapic_version: ::Google::Cloud::Language::V1beta2::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.annotate_text.timeout,
                                      metadata:     metadata,

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -161,7 +161,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "parent" => request.parent
@@ -225,7 +225,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "parent" => request.parent
@@ -288,7 +288,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "parent" => request.parent
@@ -346,7 +346,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -406,7 +406,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "secret.name" => request.secret.name
@@ -465,7 +465,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -534,7 +534,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "parent" => request.parent
@@ -602,7 +602,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -667,7 +667,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -732,7 +732,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -797,7 +797,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -864,7 +864,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -937,7 +937,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "resource" => request.resource
@@ -999,7 +999,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "resource" => request.resource
@@ -1076,7 +1076,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::SecretManager::V1beta1::VERSION
+                gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
 
               header_params = {
                 "resource" => request.resource

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -366,7 +366,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Speech::V1::VERSION
+                gapic_version: ::Google::Cloud::Speech::V1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.recognize.timeout,
                                      metadata:     metadata,
@@ -531,7 +531,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Speech::V1::VERSION
+                gapic_version: ::Google::Cloud::Speech::V1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.long_running_recognize.timeout,
                                      metadata:     metadata,
@@ -584,7 +584,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Speech::V1::VERSION
+                gapic_version: ::Google::Cloud::Speech::V1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.streaming_recognize.timeout,
                                      metadata:     metadata,

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -152,7 +152,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Speech::V1::VERSION
+                gapic_version: ::Google::Cloud::Speech::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -216,7 +216,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Speech::V1::VERSION
+                gapic_version: ::Google::Cloud::Speech::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -281,7 +281,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Speech::V1::VERSION
+                gapic_version: ::Google::Cloud::Speech::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -357,7 +357,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Speech::V1::VERSION
+                gapic_version: ::Google::Cloud::Speech::V1::VERSION
 
               header_params = {
                 "name" => request.name

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -170,7 +170,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.batch_annotate_images.timeout,
                                      metadata:     metadata,
@@ -248,7 +248,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.batch_annotate_files.timeout,
                                      metadata:     metadata,
@@ -331,7 +331,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.async_batch_annotate_images.timeout,
                                      metadata:     metadata,
@@ -407,7 +407,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.async_batch_annotate_files.timeout,
                                      metadata:     metadata,

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -152,7 +152,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -216,7 +216,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -281,7 +281,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -357,7 +357,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -176,7 +176,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "parent" => request.parent
@@ -250,7 +250,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "parent" => request.parent
@@ -320,7 +320,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -397,7 +397,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "product_set.name" => request.product_set.name
@@ -464,7 +464,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -546,7 +546,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "parent" => request.parent
@@ -619,7 +619,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "parent" => request.parent
@@ -689,7 +689,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -782,7 +782,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "product.name" => request.product.name
@@ -851,7 +851,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -956,7 +956,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "parent" => request.parent
@@ -1030,7 +1030,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -1110,7 +1110,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "parent" => request.parent
@@ -1181,7 +1181,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -1261,7 +1261,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -1327,7 +1327,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -1404,7 +1404,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -1487,7 +1487,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "parent" => request.parent
@@ -1602,7 +1602,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "parent" => request.parent

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -152,7 +152,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -216,7 +216,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -281,7 +281,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name
@@ -357,7 +357,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Vision::V1::VERSION
+                gapic_version: ::Google::Cloud::Vision::V1::VERSION
 
               header_params = {
                 "name" => request.name

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -150,7 +150,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.get_empty_garbage.timeout,
                                    metadata:     metadata,
@@ -249,7 +249,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.get_simple_garbage.timeout,
                                    metadata:     metadata,
@@ -319,7 +319,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.get_specific_garbage.timeout,
                                    metadata:     metadata,
@@ -387,7 +387,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.get_nested_garbage.timeout,
                                    metadata:     metadata,
@@ -455,7 +455,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.get_repeated_garbage.timeout,
                                    metadata:     metadata,
@@ -585,7 +585,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.get_typical_garbage.timeout,
                                    metadata:     metadata,
@@ -678,7 +678,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.get_complex_garbage.timeout,
                                    metadata:     metadata,
@@ -728,7 +728,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.get_garbage_node.timeout,
                                    metadata:     metadata,
@@ -799,7 +799,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.get_paged_garbage.timeout,
                                    metadata:     metadata,
@@ -852,7 +852,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.long_running_garbage.timeout,
                                    metadata:     metadata,
@@ -902,7 +902,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.client_garbage.timeout,
                                    metadata:     metadata,
@@ -969,7 +969,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.server_garbage.timeout,
                                    metadata:     metadata,
@@ -1018,7 +1018,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.bidi_garbage.timeout,
                                    metadata:     metadata,

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -159,7 +159,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             header_params = {
               "name" => request.name
@@ -221,7 +221,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             header_params = {
               "name" => request.name
@@ -284,7 +284,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             header_params = {
               "name" => request.name
@@ -358,7 +358,7 @@ module So
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Garbage::VERSION
+              gapic_version: ::Google::Garbage::VERSION
 
             header_params = {
               "name" => request.name

--- a/shared/output/gapic/templates/language/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/gapic/templates/language/lib/google/cloud/language/v1/language_service/client.rb
@@ -229,7 +229,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::VERSION
+                gapic_version: ::Google::Cloud::Language::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_sentiment.timeout,
                                      metadata:     metadata,
@@ -388,7 +388,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::VERSION
+                gapic_version: ::Google::Cloud::Language::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_entities.timeout,
                                      metadata:     metadata,
@@ -553,7 +553,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::VERSION
+                gapic_version: ::Google::Cloud::Language::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_entity_sentiment.timeout,
                                      metadata:     metadata,
@@ -722,7 +722,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::VERSION
+                gapic_version: ::Google::Cloud::Language::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.analyze_syntax.timeout,
                                      metadata:     metadata,
@@ -836,7 +836,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::VERSION
+                gapic_version: ::Google::Cloud::Language::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.classify_text.timeout,
                                      metadata:     metadata,
@@ -892,7 +892,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Language::VERSION
+                gapic_version: ::Google::Cloud::Language::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.annotate_text.timeout,
                                      metadata:     metadata,

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -153,7 +153,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.echo.timeout,
                                    metadata:     metadata,
@@ -207,7 +207,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.expand.timeout,
                                    metadata:     metadata,
@@ -258,7 +258,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.collect.timeout,
                                    metadata:     metadata,
@@ -309,7 +309,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.chat.timeout,
                                    metadata:     metadata,
@@ -365,7 +365,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.paged_expand.timeout,
                                    metadata:     metadata,
@@ -425,7 +425,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.wait.timeout,
                                    metadata:     metadata,
@@ -485,7 +485,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.block.timeout,
                                    metadata:     metadata,

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -159,7 +159,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -221,7 +221,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -284,7 +284,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -358,7 +358,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -150,7 +150,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.create_user.timeout,
                                    metadata:     metadata,
@@ -200,7 +200,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -259,7 +259,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "user.name" => request.user.name
@@ -315,7 +315,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -376,7 +376,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.list_users.timeout,
                                    metadata:     metadata,

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -154,7 +154,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.create_room.timeout,
                                    metadata:     metadata,
@@ -204,7 +204,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -263,7 +263,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "room.name" => request.room.name
@@ -319,7 +319,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -380,7 +380,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.list_rooms.timeout,
                                    metadata:     metadata,
@@ -438,7 +438,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "parent" => request.parent
@@ -494,7 +494,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -553,7 +553,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "blurb.name" => request.blurb.name
@@ -609,7 +609,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -675,7 +675,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "parent" => request.parent
@@ -749,7 +749,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "parent" => request.parent
@@ -810,7 +810,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -866,7 +866,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.send_blurbs.timeout,
                                    metadata:     metadata,
@@ -918,7 +918,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.connect.timeout,
                                    metadata:     metadata,

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -159,7 +159,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -221,7 +221,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -284,7 +284,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -358,7 +358,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -152,7 +152,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.create_session.timeout,
                                    metadata:     metadata,
@@ -202,7 +202,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -260,7 +260,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             options.apply_defaults timeout:      @config.rpcs.list_sessions.timeout,
                                    metadata:     metadata,
@@ -311,7 +311,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -371,7 +371,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -431,7 +431,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "parent" => request.parent
@@ -498,7 +498,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name
@@ -564,7 +564,7 @@ module Google
             # Set x-goog-api-client header
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
-              gapic_version: Google::Showcase::VERSION
+              gapic_version: ::Google::Showcase::VERSION
 
             header_params = {
               "name" => request.name

--- a/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/gapic/templates/speech/lib/google/cloud/speech/v1/speech/client.rb
@@ -364,7 +364,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Speech::VERSION
+                gapic_version: ::Google::Cloud::Speech::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.recognize.timeout,
                                      metadata:     metadata,
@@ -527,7 +527,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Speech::VERSION
+                gapic_version: ::Google::Cloud::Speech::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.long_running_recognize.timeout,
                                      metadata:     metadata,
@@ -581,7 +581,7 @@ module Google
               # Set x-goog-api-client header
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: Google::Cloud::Speech::VERSION
+                gapic_version: ::Google::Cloud::Speech::VERSION
 
               options.apply_defaults timeout:      @config.rpcs.streaming_recognize.timeout,
                                      metadata:     metadata,


### PR DESCRIPTION
This change fixes an issue where the gem's `VERSION` constant is referenced in a way that could lead to ambiguity. The example given in #325 was renaming the `google-showcase` gem to `showcase`. This caused the `VERSION` constant to be changed from `Google::Showcase::VERSION` to `Showcase::VERSION`. When the `VERSION` constant is referenced in the generated code for `Google::Showcase::V1beta1::Echo::Client`, it looked like this:

```ruby
# Set x-goog-api-client header
metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
  lib_name: @config.lib_name, lib_version: @config.lib_version,
  gapic_version: Showcase::VERSION
```

The issue is that the Ruby is walking up the current namespace to find `Showcase`. It finds it at `Google::Showcase`, but that is incorrect because it is not the top-level `Showcase`. In order to find the top-level `Showcase` the reference should be prepended with `::`:

```ruby
# Set x-goog-api-client header
metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
  lib_name: @config.lib_name, lib_version: @config.lib_version,
  gapic_version: ::Showcase::VERSION
```

This PR prepends the full `VERSION` reference with `::` to remove this ambiguity.

[fixes #325]