### PR TITLE
fix: set google-cloud-ruby github as the default homepage for cloud clients

### DIFF
--- a/gapic-generator-cloud/templates/cloud/gem/gemspec.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/gemspec.erb
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = <%= gem.email.inspect %>
   gem.description   = <%= gem.description.inspect %>
   gem.summary       = <%= gem.summary.inspect %>
-  gem.homepage      = <%= gem.homepage.inspect %>
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/gapic-generator-cloud/templates/cloud/gem/readme.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/readme.erb
@@ -1,15 +1,15 @@
-# Google Cloud Speech V1
+# <%= gem.title %>
 
-google-cloud-speech-v1 is the official library for Google Cloud Speech V1 API.
+<%= gem.description %>
 
-API Client library for Google Cloud Speech V1 API
+<%= gem.summary %>
 
 https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 
 ```
-$ gem install google-cloud-speech-v1
+$ gem install <%= gem.name %>
 ```
 
 ## Supported Ruby Versions

--- a/shared/output/cloud/language_v1/README.md
+++ b/shared/output/cloud/language_v1/README.md
@@ -4,7 +4,7 @@ google-cloud-language-v1 is the official library for Google Cloud Language V1 AP
 
 API Client library for Google Cloud Language V1 API
 
-https://github.com/googleapis/googleapis
+https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 

--- a/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
+++ b/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-cloud-language-v1 is the official library for Google Cloud Language V1 API."
   gem.summary       = "API Client library for Google Cloud Language V1 API"
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/shared/output/cloud/language_v1beta1/README.md
+++ b/shared/output/cloud/language_v1beta1/README.md
@@ -4,7 +4,7 @@ google-cloud-language-v1beta1 is the official library for Google Cloud Language 
 
 API Client library for Google Cloud Language V1beta1 API
 
-https://github.com/googleapis/googleapis
+https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 

--- a/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
+++ b/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-cloud-language-v1beta1 is the official library for Google Cloud Language V1beta1 API."
   gem.summary       = "API Client library for Google Cloud Language V1beta1 API"
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/shared/output/cloud/language_v1beta2/README.md
+++ b/shared/output/cloud/language_v1beta2/README.md
@@ -4,7 +4,7 @@ google-cloud-language-v1beta2 is the official library for Google Cloud Language 
 
 API Client library for Google Cloud Language V1beta2 API
 
-https://github.com/googleapis/googleapis
+https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 

--- a/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
+++ b/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-cloud-language-v1beta2 is the official library for Google Cloud Language V1beta2 API."
   gem.summary       = "API Client library for Google Cloud Language V1beta2 API"
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/shared/output/cloud/noservice/README.md
+++ b/shared/output/cloud/noservice/README.md
@@ -4,7 +4,7 @@ google-garbage-noservice is the official library for Google Garbage Noservice AP
 
 API Client library for Google Garbage Noservice API
 
-https://github.com/googleapis/googleapis
+https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 

--- a/shared/output/cloud/noservice/google-garbage-noservice.gemspec
+++ b/shared/output/cloud/noservice/google-garbage-noservice.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-garbage-noservice is the official library for Google Garbage Noservice API."
   gem.summary       = "API Client library for Google Garbage Noservice API"
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/shared/output/cloud/secretmanager_v1beta1/README.md
+++ b/shared/output/cloud/secretmanager_v1beta1/README.md
@@ -4,7 +4,7 @@ google-cloud-secret_manager-v1beta1 is the official library for Secret Manager V
 
 Stores, manages, and secures access to application secrets.
 
-https://github.com/googleapis/googleapis
+https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 

--- a/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
+++ b/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-cloud-secret_manager-v1beta1 is the official library for Secret Manager V1beta1 API."
   gem.summary       = "Stores, manages, and secures access to application secrets."
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
+++ b/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-cloud-speech-v1 is the official library for Google Cloud Speech V1 API."
   gem.summary       = "API Client library for Google Cloud Speech V1 API"
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/shared/output/cloud/vision_v1/README.md
+++ b/shared/output/cloud/vision_v1/README.md
@@ -4,7 +4,7 @@ google-cloud-vision-v1 is the official library for Google Cloud Vision V1 API.
 
 API Client library for Google Cloud Vision V1 API
 
-https://github.com/googleapis/googleapis
+https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 

--- a/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
+++ b/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-cloud-vision-v1 is the official library for Google Cloud Vision V1 API."
   gem.summary       = "API Client library for Google Cloud Vision V1 API"
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY


### PR DESCRIPTION
Alternate implementation to #344.

Simply override the templates and hardcode the homepage. All good unless you need configurable values!