### PR TITLE
fix: set google-cloud-ruby github as the default homepage for cloud clients

### DIFF
--- a/gapic-generator-cloud/lib/gapic/generators/cloud_generator.rb
+++ b/gapic-generator-cloud/lib/gapic/generators/cloud_generator.rb
@@ -26,6 +26,9 @@ module Gapic
       # @param api [Gapic::Schema::Api] The API model/context to
       #   generate.
       def initialize api
+        gem_config = api.configuration[:gem] ||= {}
+        gem_config[:homepage] ||= "https://github.com/googleapis/google-cloud-ruby"
+
         super
 
         # Configure to use prefer Google Cloud templates

--- a/shared/output/cloud/language_v1/README.md
+++ b/shared/output/cloud/language_v1/README.md
@@ -4,7 +4,7 @@ google-cloud-language-v1 is the official library for Google Cloud Language V1 AP
 
 API Client library for Google Cloud Language V1 API
 
-https://github.com/googleapis/googleapis
+https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 

--- a/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
+++ b/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-cloud-language-v1 is the official library for Google Cloud Language V1 API."
   gem.summary       = "API Client library for Google Cloud Language V1 API"
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/shared/output/cloud/language_v1beta1/README.md
+++ b/shared/output/cloud/language_v1beta1/README.md
@@ -4,7 +4,7 @@ google-cloud-language-v1beta1 is the official library for Google Cloud Language 
 
 API Client library for Google Cloud Language V1beta1 API
 
-https://github.com/googleapis/googleapis
+https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 

--- a/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
+++ b/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-cloud-language-v1beta1 is the official library for Google Cloud Language V1beta1 API."
   gem.summary       = "API Client library for Google Cloud Language V1beta1 API"
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/shared/output/cloud/language_v1beta2/README.md
+++ b/shared/output/cloud/language_v1beta2/README.md
@@ -4,7 +4,7 @@ google-cloud-language-v1beta2 is the official library for Google Cloud Language 
 
 API Client library for Google Cloud Language V1beta2 API
 
-https://github.com/googleapis/googleapis
+https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 

--- a/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
+++ b/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-cloud-language-v1beta2 is the official library for Google Cloud Language V1beta2 API."
   gem.summary       = "API Client library for Google Cloud Language V1beta2 API"
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/shared/output/cloud/noservice/README.md
+++ b/shared/output/cloud/noservice/README.md
@@ -4,7 +4,7 @@ google-garbage-noservice is the official library for Google Garbage Noservice AP
 
 API Client library for Google Garbage Noservice API
 
-https://github.com/googleapis/googleapis
+https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 

--- a/shared/output/cloud/noservice/google-garbage-noservice.gemspec
+++ b/shared/output/cloud/noservice/google-garbage-noservice.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-garbage-noservice is the official library for Google Garbage Noservice API."
   gem.summary       = "API Client library for Google Garbage Noservice API"
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/shared/output/cloud/secretmanager_v1beta1/README.md
+++ b/shared/output/cloud/secretmanager_v1beta1/README.md
@@ -4,7 +4,7 @@ google-cloud-secret_manager-v1beta1 is the official library for Secret Manager V
 
 Stores, manages, and secures access to application secrets.
 
-https://github.com/googleapis/googleapis
+https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 

--- a/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
+++ b/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-cloud-secret_manager-v1beta1 is the official library for Secret Manager V1beta1 API."
   gem.summary       = "Stores, manages, and secures access to application secrets."
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/shared/output/cloud/speech_v1/README.md
+++ b/shared/output/cloud/speech_v1/README.md
@@ -4,7 +4,7 @@ google-cloud-speech-v1 is the official library for Google Cloud Speech V1 API.
 
 API Client library for Google Cloud Speech V1 API
 
-https://github.com/googleapis/googleapis
+https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 

--- a/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
+++ b/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-cloud-speech-v1 is the official library for Google Cloud Speech V1 API."
   gem.summary       = "API Client library for Google Cloud Speech V1 API"
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY

--- a/shared/output/cloud/vision_v1/README.md
+++ b/shared/output/cloud/vision_v1/README.md
@@ -4,7 +4,7 @@ google-cloud-vision-v1 is the official library for Google Cloud Vision V1 API.
 
 API Client library for Google Cloud Vision V1 API
 
-https://github.com/googleapis/googleapis
+https://github.com/googleapis/google-cloud-ruby
 
 ## Installation
 

--- a/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
+++ b/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "google-cloud-vision-v1 is the official library for Google Cloud Vision V1 API."
   gem.summary       = "API Client library for Google Cloud Vision V1 API"
-  gem.homepage      = "https://github.com/googleapis/googleapis"
+  gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 
   gem.platform      = Gem::Platform::RUBY


### PR DESCRIPTION
Yet a third approach (alternative to #344 and #347).

This simply causes the cloud generator to set the configuration field to the desired default, if not already set.

Unlike #344, this isn't a horrible hack. (Maybe it's just less horrible, but if so it's a _lot_ less horrible.)

Unlike #347, this doesn't replace/duplicate templates, and retains the ability for individual libraries to override the homepage.