### PR TITLE
fix: require the simplecov library explicitly in generated tests

### DIFF
--- a/gapic-generator-cloud/templates/cloud/gem/gemspec.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/gemspec.erb
@@ -33,6 +33,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rake", "~> 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "simplecov", "~> 0.18"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/gapic-generator/templates/default/gem/gemspec.erb
+++ b/gapic-generator/templates/default/gem/gemspec.erb
@@ -32,6 +32,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rake", "~> 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "simplecov", "~> 0.18"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/gapic-generator/templates/default/service/test/client.erb
+++ b/gapic-generator/templates/default/service/test/client.erb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 <%= render partial: "shared/license" %>
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/gapic-generator/templates/default/service/test/client_operations.erb
+++ b/gapic-generator/templates/default/service/test/client_operations.erb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 <%= render partial: "shared/license" %>
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/gapic-generator/templates/default/service/test/smoke.erb
+++ b/gapic-generator/templates/default/service/test/smoke.erb
@@ -1,6 +1,7 @@
 <%- assert_locals gem -%>
 <%= render partial: "shared/header" -%>
 
+require "simplecov"
 require "minitest/autorun"
 require "minitest/spec"
 

--- a/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
+++ b/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rake", "~> 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "simplecov", "~> 0.18"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
+++ b/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
+++ b/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rake", "~> 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "simplecov", "~> 0.18"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
+++ b/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rake", "~> 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "simplecov", "~> 0.18"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/cloud/noservice/google-garbage-noservice.gemspec
+++ b/shared/output/cloud/noservice/google-garbage-noservice.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rake", "~> 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "simplecov", "~> 0.18"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
+++ b/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rake", "~> 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "simplecov", "~> 0.18"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
+++ b/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rake", "~> 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "simplecov", "~> 0.18"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
+++ b/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rake", "~> 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "simplecov", "~> 0.18"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/gapic/templates/garbage/google-garbage.gemspec
+++ b/shared/output/gapic/templates/garbage/google-garbage.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rake", "~> 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "simplecov", "~> 0.18"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/gapic/templates/showcase/google-showcase.gemspec
+++ b/shared/output/gapic/templates/showcase/google-showcase.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest", "~> 5.10"
   gem.add_development_dependency "rake", "~> 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
-  gem.add_development_dependency "simplecov", "~> 0.9"
+  gem.add_development_dependency "simplecov", "~> 0.18"
   gem.add_development_dependency "yard", "~> 0.9"
 end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require "simplecov"
 require "minitest/autorun"
 
 require "gapic/grpc/service_stub"


### PR DESCRIPTION
Recent versions of simplecov assume the library is required explicitly, before even minitest loads. Update the templates to `require "simplecov"` at the top of test files. Also update the simplecov dependency to a more recent version.