### PR TITLE
feat(gapic-common): make quota_project_id available on the stub

### DIFF
--- a/gapic-common/CHANGELOG.md
+++ b/gapic-common/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.2.0 / 2020-03-06
+
+* Provide quota_project_id field on the service stub.
+
 ### 0.1.0 / 2020-01-09
 
 Initial release

--- a/gapic-common/lib/gapic/common/version.rb
+++ b/gapic-common/lib/gapic/common/version.rb
@@ -14,6 +14,6 @@
 
 module Gapic
   module Common
-    VERSION = "0.1.0".freeze
+    VERSION = "0.2.0".freeze
   end
 end

--- a/gapic-common/test/gapic/grpc/stub_test.rb
+++ b/gapic-common/test/gapic/grpc/stub_test.rb
@@ -44,6 +44,10 @@ class GrpcStubTest < Minitest::Spec
     def updater_proc
       ->{}
     end
+
+    def quota_project_id
+      "the_quota_project_id"
+    end
   end
 
   def test_with_channel
@@ -65,9 +69,11 @@ class GrpcStubTest < Minitest::Spec
     mock.expect :nil?, false
     mock.expect :new, nil, ["service:port", fake_channel_creds, channel_args: {}, interceptors: []]
 
-    Gapic::ServiceStub.new mock, endpoint: "service:port", credentials: fake_channel_creds
+    stub = Gapic::ServiceStub.new mock, endpoint: "service:port", credentials: fake_channel_creds
 
     mock.verify
+
+    assert_nil stub.quota_project_id
   end
 
   def test_with_credentials
@@ -77,9 +83,11 @@ class GrpcStubTest < Minitest::Spec
         mock.expect :nil?, false
         mock.expect :new, nil, ["service:port", FakeCallCredentials, channel_args: {}, interceptors: []]
 
-        Gapic::ServiceStub.new mock, endpoint: "service:port", credentials: FakeCredentials.new
+        stub = Gapic::ServiceStub.new mock, endpoint: "service:port", credentials: FakeCredentials.new
 
         mock.verify
+
+        assert_equal "the_quota_project_id", stub.quota_project_id
       end
     end
   end


### PR DESCRIPTION
We've been asked to read `quota_project_id` from credentials, and set the `X-Goog-User-Project` header accordingly if it is present. (This is for a 3LO case where billing/quota project may be different from the target/data project.)

This PR sets a field on the stub if the given credentials object has an appropriately set `:quota_project_id` field. (See googleapis/google-auth-library-ruby#254). It will be followed up by a generator change that uses the field and sets the appropriate header.
