### PR TITLE
feat: send x-goog-user-project header based on quota_project_id

### DIFF
--- a/gapic-generator/templates/default/service/client/_client.erb
+++ b/gapic-generator/templates/default/service/client/_client.erb
@@ -106,13 +106,14 @@ class <%= service.client_name %>
     if credentials.is_a?(String) || credentials.is_a?(Hash)
       credentials = Credentials.new credentials, scope: @config.scope
     end
+    @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
     <%- if service.lro? -%>
     <%= service.lro_client_ivar %> = <%= service.operations_name %>.new do |config|
       config.credentials = credentials
     end
-    <%- end -%>
 
+    <%- end -%>
     @<%= service.stub_name %> = Gapic::ServiceStub.new(
       <%= service.proto_service_stub_name_full %>,
       credentials:  credentials,

--- a/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
@@ -5,10 +5,11 @@ options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
 # Customize the options with defaults
 metadata = @config.rpcs.<%= method.name %>.metadata.to_h
 
-# Set x-goog-api-client header
+# Set x-goog-api-client and x-goog-user-project headers
 metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
   lib_name: @config.lib_name, lib_version: @config.lib_version,
   gapic_version: ::<%= method.service.gem.version_name_full %>
+metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 <%- if method.routing_params? && !method.client_streaming? -%>
 
 header_params = {

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
@@ -125,7 +125,7 @@ module Google
                 if credentials.is_a?(String) || credentials.is_a?(Hash)
                   credentials = Credentials.new credentials, scope: @config.scope
                 end
-
+                @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
                 @campaign_service_stub = Gapic::ServiceStub.new(
                   Google::Ads::GoogleAds::V1::Services::CampaignService::Stub,
@@ -171,10 +171,11 @@ module Google
                 # Customize the options with defaults
                 metadata = @config.rpcs.get_campaign.metadata.to_h
 
-                # Set x-goog-api-client header
+                # Set x-goog-api-client and x-goog-user-project headers
                 metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                   lib_name: @config.lib_name, lib_version: @config.lib_version,
                   gapic_version: ::Google::Ads::GoogleAds::VERSION
+                metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
                 header_params = {
                   "resource_name" => request.resource_name
@@ -239,10 +240,11 @@ module Google
                 # Customize the options with defaults
                 metadata = @config.rpcs.mutate_campaigns.metadata.to_h
 
-                # Set x-goog-api-client header
+                # Set x-goog-api-client and x-goog-user-project headers
                 metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                   lib_name: @config.lib_name, lib_version: @config.lib_version,
                   gapic_version: ::Google::Ads::GoogleAds::VERSION
+                metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
                 header_params = {
                   "customer_id" => request.customer_id

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
@@ -129,7 +129,7 @@ module Google
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
-
+              @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
               @language_service_stub = Gapic::ServiceStub.new(
                 Google::Cloud::Language::V1::LanguageService::Stub,
@@ -256,10 +256,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_sentiment.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.analyze_sentiment.timeout,
                                      metadata:     metadata,
@@ -417,10 +418,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_entities.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.analyze_entities.timeout,
                                      metadata:     metadata,
@@ -584,10 +586,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_entity_sentiment.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.analyze_entity_sentiment.timeout,
                                      metadata:     metadata,
@@ -755,10 +758,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_syntax.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.analyze_syntax.timeout,
                                      metadata:     metadata,
@@ -871,10 +875,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.classify_text.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.classify_text.timeout,
                                      metadata:     metadata,
@@ -929,10 +934,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.annotate_text.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.annotate_text.timeout,
                                      metadata:     metadata,

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -129,7 +129,7 @@ module Google
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
-
+              @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
               @language_service_stub = Gapic::ServiceStub.new(
                 Google::Cloud::Language::V1beta1::LanguageService::Stub,
@@ -178,10 +178,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_sentiment.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.analyze_sentiment.timeout,
                                      metadata:     metadata,
@@ -236,10 +237,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_entities.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.analyze_entities.timeout,
                                      metadata:     metadata,
@@ -294,10 +296,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_syntax.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.analyze_syntax.timeout,
                                      metadata:     metadata,
@@ -352,10 +355,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.annotate_text.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.annotate_text.timeout,
                                      metadata:     metadata,

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -129,7 +129,7 @@ module Google
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
-
+              @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
               @language_service_stub = Gapic::ServiceStub.new(
                 Google::Cloud::Language::V1beta2::LanguageService::Stub,
@@ -178,10 +178,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_sentiment.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1beta2::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.analyze_sentiment.timeout,
                                      metadata:     metadata,
@@ -236,10 +237,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_entities.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1beta2::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.analyze_entities.timeout,
                                      metadata:     metadata,
@@ -292,10 +294,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_entity_sentiment.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1beta2::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.analyze_entity_sentiment.timeout,
                                      metadata:     metadata,
@@ -350,10 +353,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_syntax.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1beta2::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.analyze_syntax.timeout,
                                      metadata:     metadata,
@@ -402,10 +406,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.classify_text.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1beta2::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.classify_text.timeout,
                                      metadata:     metadata,
@@ -460,10 +465,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.annotate_text.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Language::V1beta2::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.annotate_text.timeout,
                                      metadata:     metadata,

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -132,7 +132,7 @@ module Google
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
-
+              @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
               @secret_manager_service_stub = Gapic::ServiceStub.new(
                 Google::Cloud::SecretManager::V1beta1::SecretManagerService::Stub,
@@ -186,10 +186,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_secrets.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -250,10 +251,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.create_secret.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -313,10 +315,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.add_secret_version.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -371,10 +374,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_secret.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -431,10 +435,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.update_secret.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "secret.name" => request.secret.name
@@ -490,10 +495,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_secret.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -559,10 +565,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_secret_versions.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -627,10 +634,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_secret_version.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -692,10 +700,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.access_secret_version.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -757,10 +766,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.disable_secret_version.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -822,10 +832,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.enable_secret_version.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -889,10 +900,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.destroy_secret_version.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -962,10 +974,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.set_iam_policy.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "resource" => request.resource
@@ -1024,10 +1037,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_iam_policy.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "resource" => request.resource
@@ -1101,10 +1115,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.test_iam_permissions.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::SecretManager::V1beta1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "resource" => request.resource

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -130,6 +130,7 @@ module Google
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
+              @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
@@ -391,10 +392,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.recognize.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Speech::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.recognize.timeout,
                                      metadata:     metadata,
@@ -556,10 +558,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.long_running_recognize.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Speech::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.long_running_recognize.timeout,
                                      metadata:     metadata,
@@ -609,10 +612,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.streaming_recognize.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Speech::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.streaming_recognize.timeout,
                                      metadata:     metadata,

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -149,10 +149,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_operations.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Speech::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -213,10 +214,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_operation.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Speech::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -278,10 +280,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_operation.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Speech::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -354,10 +357,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Speech::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -133,6 +133,7 @@ module Google
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
+              @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
@@ -195,10 +196,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.batch_annotate_images.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.batch_annotate_images.timeout,
                                      metadata:     metadata,
@@ -273,10 +275,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.batch_annotate_files.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.batch_annotate_files.timeout,
                                      metadata:     metadata,
@@ -356,10 +359,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.async_batch_annotate_images.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.async_batch_annotate_images.timeout,
                                      metadata:     metadata,
@@ -432,10 +436,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.async_batch_annotate_files.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               options.apply_defaults timeout:      @config.rpcs.async_batch_annotate_files.timeout,
                                      metadata:     metadata,

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -149,10 +149,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_operations.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -213,10 +214,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_operation.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -278,10 +280,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_operation.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -354,10 +357,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -133,6 +133,7 @@ module Google
               if credentials.is_a?(String) || credentials.is_a?(Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
+              @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
@@ -201,10 +202,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.create_product_set.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -275,10 +277,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_product_sets.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -345,10 +348,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_product_set.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -422,10 +426,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.update_product_set.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "product_set.name" => request.product_set.name
@@ -489,10 +494,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_product_set.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -571,10 +577,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.create_product.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -644,10 +651,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_products.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -714,10 +722,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_product.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -807,10 +816,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.update_product.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "product.name" => request.product.name
@@ -876,10 +886,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_product.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -981,10 +992,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.create_reference_image.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -1055,10 +1067,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_reference_image.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -1135,10 +1148,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_reference_images.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -1206,10 +1220,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_reference_image.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -1286,10 +1301,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.add_product_to_product_set.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -1352,10 +1368,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.remove_product_from_product_set.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -1429,10 +1446,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_products_in_product_set.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -1512,10 +1530,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.import_product_sets.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent
@@ -1627,10 +1646,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.purge_products.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "parent" => request.parent

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -149,10 +149,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.list_operations.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -213,10 +214,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.get_operation.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -278,10 +280,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.delete_operation.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name
@@ -354,10 +357,11 @@ module Google
               # Customize the options with defaults
               metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-              # Set x-goog-api-client header
+              # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
                 gapic_version: ::Google::Cloud::Vision::V1::VERSION
+              metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
                 "name" => request.name

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -134,6 +134,7 @@ module So
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
+            @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
             @operations_client = Operations.new do |config|
               config.credentials = credentials
@@ -179,10 +180,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.get_empty_garbage.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.get_empty_garbage.timeout,
                                    metadata:     metadata,
@@ -278,10 +280,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.get_simple_garbage.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.get_simple_garbage.timeout,
                                    metadata:     metadata,
@@ -348,10 +351,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.get_specific_garbage.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.get_specific_garbage.timeout,
                                    metadata:     metadata,
@@ -416,10 +420,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.get_nested_garbage.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.get_nested_garbage.timeout,
                                    metadata:     metadata,
@@ -484,10 +489,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.get_repeated_garbage.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.get_repeated_garbage.timeout,
                                    metadata:     metadata,
@@ -614,10 +620,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.get_typical_garbage.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.get_typical_garbage.timeout,
                                    metadata:     metadata,
@@ -707,10 +714,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.get_complex_garbage.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.get_complex_garbage.timeout,
                                    metadata:     metadata,
@@ -757,10 +765,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.get_garbage_node.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.get_garbage_node.timeout,
                                    metadata:     metadata,
@@ -828,10 +837,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.get_paged_garbage.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.get_paged_garbage.timeout,
                                    metadata:     metadata,
@@ -881,10 +891,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.long_running_garbage.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.long_running_garbage.timeout,
                                    metadata:     metadata,
@@ -931,10 +942,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.client_garbage.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.client_garbage.timeout,
                                    metadata:     metadata,
@@ -998,10 +1010,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.server_garbage.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.server_garbage.timeout,
                                    metadata:     metadata,
@@ -1047,10 +1060,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.bidi_garbage.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.bidi_garbage.timeout,
                                    metadata:     metadata,

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -156,10 +156,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.list_operations.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -218,10 +219,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.get_operation.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -281,10 +283,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.delete_operation.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -355,10 +358,11 @@ module So
             # Customize the options with defaults
             metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Garbage::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/client.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/client.rb
@@ -129,7 +129,7 @@ module Testing
           if credentials.is_a?(String) || credentials.is_a?(Hash)
             credentials = Credentials.new credentials, scope: @config.scope
           end
-
+          @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
           @service_no_retry_stub = Gapic::ServiceStub.new(
             Testing::GrpcServiceConfig::ServiceNoRetry::Stub,
@@ -168,10 +168,11 @@ module Testing
           # Customize the options with defaults
           metadata = @config.rpcs.no_retry_method.metadata.to_h
 
-          # Set x-goog-api-client header
+          # Set x-goog-api-client and x-goog-user-project headers
           metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
             lib_name: @config.lib_name, lib_version: @config.lib_version,
             gapic_version: ::Testing::GrpcServiceConfig::VERSION
+          metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
           options.apply_defaults timeout:      @config.rpcs.no_retry_method.timeout,
                                  metadata:     metadata,

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
@@ -145,7 +145,7 @@ module Testing
           if credentials.is_a?(String) || credentials.is_a?(Hash)
             credentials = Credentials.new credentials, scope: @config.scope
           end
-
+          @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
           @service_with_retries_stub = Gapic::ServiceStub.new(
             Testing::GrpcServiceConfig::ServiceWithRetries::Stub,
@@ -184,10 +184,11 @@ module Testing
           # Customize the options with defaults
           metadata = @config.rpcs.service_level_retry_method.metadata.to_h
 
-          # Set x-goog-api-client header
+          # Set x-goog-api-client and x-goog-user-project headers
           metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
             lib_name: @config.lib_name, lib_version: @config.lib_version,
             gapic_version: ::Testing::GrpcServiceConfig::VERSION
+          metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
           options.apply_defaults timeout:      @config.rpcs.service_level_retry_method.timeout,
                                  metadata:     metadata,
@@ -227,10 +228,11 @@ module Testing
           # Customize the options with defaults
           metadata = @config.rpcs.method_level_retry_method.metadata.to_h
 
-          # Set x-goog-api-client header
+          # Set x-goog-api-client and x-goog-user-project headers
           metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
             lib_name: @config.lib_name, lib_version: @config.lib_version,
             gapic_version: ::Testing::GrpcServiceConfig::VERSION
+          metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
           options.apply_defaults timeout:      @config.rpcs.method_level_retry_method.timeout,
                                  metadata:     metadata,

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -131,6 +131,7 @@ module Google
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
+            @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
             @operations_client = Operations.new do |config|
               config.credentials = credentials
@@ -182,10 +183,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.echo.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.echo.timeout,
                                    metadata:     metadata,
@@ -236,10 +238,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.expand.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.expand.timeout,
                                    metadata:     metadata,
@@ -287,10 +290,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.collect.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.collect.timeout,
                                    metadata:     metadata,
@@ -338,10 +342,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.chat.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.chat.timeout,
                                    metadata:     metadata,
@@ -394,10 +399,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.paged_expand.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.paged_expand.timeout,
                                    metadata:     metadata,
@@ -454,10 +460,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.wait.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.wait.timeout,
                                    metadata:     metadata,
@@ -514,10 +521,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.block.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.block.timeout,
                                    metadata:     metadata,

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -156,10 +156,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_operations.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -218,10 +219,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_operation.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -281,10 +283,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_operation.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -355,10 +358,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -133,7 +133,7 @@ module Google
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
-
+            @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
             @identity_stub = Gapic::ServiceStub.new(
               Google::Showcase::V1beta1::Identity::Stub,
@@ -179,10 +179,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.create_user.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.create_user.timeout,
                                    metadata:     metadata,
@@ -229,10 +230,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_user.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -288,10 +290,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.update_user.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "user.name" => request.user.name
@@ -344,10 +347,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_user.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -405,10 +409,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_users.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.list_users.timeout,
                                    metadata:     metadata,

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -134,6 +134,7 @@ module Google
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
+            @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
             @operations_client = Operations.new do |config|
               config.credentials = credentials
@@ -183,10 +184,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.create_room.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.create_room.timeout,
                                    metadata:     metadata,
@@ -233,10 +235,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_room.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -292,10 +295,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.update_room.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "room.name" => request.room.name
@@ -348,10 +352,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_room.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -409,10 +414,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_rooms.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.list_rooms.timeout,
                                    metadata:     metadata,
@@ -467,10 +473,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.create_blurb.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "parent" => request.parent
@@ -523,10 +530,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_blurb.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -582,10 +590,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.update_blurb.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "blurb.name" => request.blurb.name
@@ -638,10 +647,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_blurb.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -704,10 +714,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_blurbs.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "parent" => request.parent
@@ -778,10 +789,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.search_blurbs.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "parent" => request.parent
@@ -839,10 +851,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.stream_blurbs.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -895,10 +908,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.send_blurbs.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.send_blurbs.timeout,
                                    metadata:     metadata,
@@ -947,10 +961,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.connect.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.connect.timeout,
                                    metadata:     metadata,

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -156,10 +156,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_operations.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -218,10 +219,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_operation.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -281,10 +283,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_operation.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -355,10 +358,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.cancel_operation.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -133,7 +133,7 @@ module Google
             if credentials.is_a?(String) || credentials.is_a?(Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
-
+            @quota_project_id = credentials.respond_to?(:quota_project_id) ? credentials.quota_project_id : nil
 
             @testing_stub = Gapic::ServiceStub.new(
               Google::Showcase::V1beta1::Testing::Stub,
@@ -181,10 +181,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.create_session.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.create_session.timeout,
                                    metadata:     metadata,
@@ -231,10 +232,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.get_session.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -289,10 +291,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_sessions.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             options.apply_defaults timeout:      @config.rpcs.list_sessions.timeout,
                                    metadata:     metadata,
@@ -340,10 +343,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_session.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -400,10 +404,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.report_session.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -460,10 +465,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.list_tests.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "parent" => request.parent
@@ -527,10 +533,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.delete_test.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name
@@ -593,10 +600,11 @@ module Google
             # Customize the options with defaults
             metadata = @config.rpcs.verify_test.metadata.to_h
 
-            # Set x-goog-api-client header
+            # Set x-goog-api-client and x-goog-user-project headers
             metadata[:"x-goog-api-client"] ||= Gapic::Headers.x_goog_api_client \
               lib_name: @config.lib_name, lib_version: @config.lib_version,
               gapic_version: ::Google::Showcase::VERSION
+            metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
             header_params = {
               "name" => request.name


### PR DESCRIPTION
We've been asked to read `quota_project_id` from credentials, and set the `X-Goog-User-Project` header accordingly if it is present. (This is for a 3LO case where billing/quota project may be different from the target/data project.)

This PR updates the microgenerator to set the appropriate header if the credentials object has an appropriately set `quota_project_id` field. This works in tandem with https://github.com/googleapis/google-auth-library-ruby/pull/254 (note that there is no hard dependency; if the credentials object field does not exist, the header will not be set.)