### PR TITLE
fix: format default config values with underscores

### DIFF
--- a/gapic-generator/templates/default/helpers/default_helper.rb
+++ b/gapic-generator/templates/default/helpers/default_helper.rb
@@ -39,6 +39,16 @@ module DefaultHelper
     input.lines[0] + indent(input.lines[1..-1].join, spacing)
   end
 
+  def format_number value
+    return value.to_s if value.abs < 10_000
+    str = value.is_a?(Integer) ? value.to_s : BigDecimal(value.to_f.to_s).to_s("F")
+    re = /^(-?\d+)(\d\d\d)([_\.][_\.\d]+)?$/
+    while (m = re.match str)
+      str = "#{m[1]}_#{m[2]}#{m[3]}"
+    end
+    str
+  end
+
   def assert_locals *locals
     locals.each { |local| raise "missing local in template" if local.nil? }
   end

--- a/gapic-generator/templates/default/helpers/default_helper.rb
+++ b/gapic-generator/templates/default/helpers/default_helper.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "bigdecimal"
 require "active_support/inflector"
 
 module DefaultHelper

--- a/gapic-generator/templates/default/service/client/_self_configure_defaults.erb
+++ b/gapic-generator/templates/default/service/client/_self_configure_defaults.erb
@@ -3,7 +3,7 @@
 <%- if service.grpc_service_config && !service.grpc_service_config.empty? -%>
 
   <%- if service.grpc_service_config.timeout_seconds -%>
-    default_config.timeout = <%= service.grpc_service_config.timeout_seconds %>
+    default_config.timeout = <%= format_number service.grpc_service_config.timeout_seconds %>
   <%- end -%>
   <%- if service.grpc_service_config.retry_policy -%>
     default_config.retry_policy = <%= indent_tail render(partial: "service/client/self_configure_retry_policy", locals: { retry_policy: service.grpc_service_config.retry_policy }), 2 %>
@@ -13,7 +13,7 @@
   <%- if method.grpc_service_config && !method.grpc_service_config.empty? -%>
 
     <%- if method.grpc_service_config.timeout_seconds -%>
-      default_config.rpcs.<%= method.name %>.timeout = <%= method.grpc_service_config.timeout_seconds %>
+      default_config.rpcs.<%= method.name %>.timeout = <%= format_number method.grpc_service_config.timeout_seconds %>
     <%- end -%>
     <%- if method.grpc_service_config.retry_policy -%>
       default_config.rpcs.<%= method.name %>.retry_policy =<%= indent_tail render(partial: "service/client/self_configure_retry_policy", locals: { retry_policy: method.grpc_service_config.retry_policy }), 2 %>

--- a/gapic-generator/templates/default/service/client/_self_configure_retry_policy.erb
+++ b/gapic-generator/templates/default/service/client/_self_configure_retry_policy.erb
@@ -1,13 +1,13 @@
 <%- assert_locals retry_policy -%>
 {
   <%- if retry_policy.initial_delay_seconds -%>
-  initial_delay: <%= retry_policy.initial_delay_seconds %>,
+  initial_delay: <%= format_number retry_policy.initial_delay_seconds %>,
   <%- end -%>
   <%- if retry_policy.max_delay_seconds -%>
-  max_delay: <%= retry_policy.max_delay_seconds %>,
+  max_delay: <%= format_number retry_policy.max_delay_seconds %>,
   <%- end -%>
   <%- if retry_policy.multiplier -%>
-  multiplier: <%= retry_policy.multiplier %>,
+  multiplier: <%= format_number retry_policy.multiplier %>,
   <%- end-%>
   <%- if retry_policy.status_codes -%>
   retry_codes: <%= retry_policy.status_codes %>

--- a/gapic-generator/test/gapic/grpc_service_config/service_config_parsing_test.rb
+++ b/gapic-generator/test/gapic/grpc_service_config/service_config_parsing_test.rb
@@ -62,7 +62,7 @@ class ServiceConfigParsingTest < Minitest::Test
     service_method_configs = service_config.service_method_level_configs["testing.grpcserviceconfig.ServiceWithRetries"]
     method_level_retry_config = service_method_configs["MethodLevelRetryMethod"]
 
-    assert_equal 60, method_level_retry_config.timeout_seconds
+    assert_equal 86_400, method_level_retry_config.timeout_seconds
     assert_equal 1, method_level_retry_config.retry_policy.initial_delay_seconds
     assert_equal 10, method_level_retry_config.retry_policy.max_delay_seconds
     assert_equal 3.0, method_level_retry_config.retry_policy.multiplier

--- a/gapic-generator/test/gapic/helpers/default_helper_test.rb
+++ b/gapic-generator/test/gapic/helpers/default_helper_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+
+class DefaultHelperTest < Minitest::Test
+  class HelperInstance
+    include DefaultHelper
+  end
+
+  def helper
+    @helper ||= HelperInstance.new
+  end
+
+  def test_format_number_small_integer
+    str = helper.format_number 1
+    assert_equal "1", str
+  end
+
+  def test_format_number_4digit_integer
+    str = helper.format_number 1234
+    assert_equal "1234", str
+  end
+
+  def test_format_number_5digit_integer
+    str = helper.format_number 12_345
+    assert_equal "12_345", str
+  end
+
+  def test_format_number_7digit_integer
+    str = helper.format_number 1_234_567
+    assert_equal "1_234_567", str
+  end
+
+  def test_format_number_negative_4digit_integer
+    str = helper.format_number(-1234)
+    assert_equal "-1234", str
+  end
+
+  def test_format_number_negative_5digit_integer
+    str = helper.format_number(-12_345)
+    assert_equal "-12_345", str
+  end
+
+  def test_format_number_negative_7digit_integer
+    str = helper.format_number(-1_234_567)
+    assert_equal "-1_234_567", str
+  end
+
+  def test_format_number_small_float
+    str = helper.format_number 1.2345
+    assert_equal "1.2345", str
+  end
+
+  def test_format_number_negative_small_float
+    str = helper.format_number(-1.2345)
+    assert_equal "-1.2345", str
+  end
+
+  def test_format_number_tiny_float
+    str = helper.format_number 0.000123
+    assert_equal "0.000123", str
+  end
+
+  def test_format_number_large_float
+    str = helper.format_number 1_234_567.89
+    assert_equal "1_234_567.89", str
+  end
+
+  def test_format_number_negative_large_float
+    str = helper.format_number(-1_234_567.89)
+    assert_equal "-1_234_567.89", str
+  end
+end

--- a/gapic-generator/test/test_helper.rb
+++ b/gapic-generator/test/test_helper.rb
@@ -63,6 +63,7 @@ class AnnotationTest < Minitest::Test
   end
 end
 
+require_relative "../templates/default/helpers/default_helper"
 require_relative "../templates/default/helpers/filepath_helper"
 require_relative "../templates/default/helpers/namespace_helper"
 require_relative "../templates/default/helpers/presenter_helper"

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
@@ -72,7 +72,7 @@ module Testing
               retry_codes:   ["DEADLINE_EXCEEDED", "RESOURCE_EXHAUSTED"]
             }
 
-            default_config.rpcs.method_level_retry_method.timeout = 60.0
+            default_config.rpcs.method_level_retry_method.timeout = 86_400.0
             default_config.rpcs.method_level_retry_method.retry_policy = {
               initial_delay: 1.0,
               max_delay:     10.0,

--- a/shared/protos/testing/grpc_service_config/grpc_service_config2.json
+++ b/shared/protos/testing/grpc_service_config/grpc_service_config2.json
@@ -7,7 +7,7 @@
           "method": "MethodLevelRetryMethod"
         }
       ],
-      "timeout": "60s",
+      "timeout": "86400s",
       "retry_policy": {
         "initial_backoff": "1s",
         "max_backoff": "10s",


### PR DESCRIPTION
Create a `format_number` helper that inserts underscores for values >= 10_000, and use it for timeout and retry config settings, so the resulting code will pass rubocop.
