### PR TITLE
fix: Relax the regex around yard braces escape detection

### DIFF
--- a/gapic-generator/lib/gapic/formatting_utils.rb
+++ b/gapic-generator/lib/gapic/formatting_utils.rb
@@ -21,7 +21,7 @@ module Gapic
   # Various string formatting utils
   #
   module FormattingUtils
-    @brace_detector = /\A([^`]*(`[^`]*`[^`]*)*[^`\\])?\{([\w,]+)\}(.*)\z/m
+    @brace_detector = /\A(?<pre>[^`]*(`[^`]*`[^`]*)*[^`\\])?\{(?<inside>[^\s][^}]*)\}(?<post>.*)\z/m
     @list_element_detector = /\A\s*(\*|\+|-|[0-9a-zA-Z]+\.)\s/
 
     class << self
@@ -100,7 +100,7 @@ module Gapic
 
       def escape_line_braces line
         while (m = @brace_detector.match line)
-          line = "#{m[1]}\\\\{#{m[3]}}#{m[4]}"
+          line = "#{m[:pre]}\\\\{#{m[:inside]}}#{m[:post]}"
         end
         line
       end


### PR DESCRIPTION
Some protos contain documentation with braces that were passed into the generated code unescaped and as a result the generated library was failing its CI tests via yard

examples include: `{device-id}` from IOT and `{projects|folders|organizations}` from AccessApproval. 
it seems that most ascii nonword characters will fail yard when acting as a separator between words; 
I've found cases where `#` and `::` did not, unless the first word before the separator was capitalized, but even that is inconsistent, e.g. `{foo#bar}` passes but `{Foo#bar}` does not and even `{foo#bar ruby#world}` fails with 'cannot resolve link to `foo#bar`'.

Without any compelling reason to match yard's idiosyncrasies it seems better to err on the side of generated code not failing CI and so I've relaxed the detector's regex significantly.

Also: allowed braces that start with a space within to go unescaped since this seems to be another method to escape braces in yard.

