### PR TITLE
Replace implicit kwarg hash passing with the `**` operator.

### DIFF
--- a/gapic-common/lib/gapic/call_options.rb
+++ b/gapic-common/lib/gapic/call_options.rb
@@ -42,7 +42,7 @@ module Gapic
     #
     def initialize timeout: nil, metadata: nil, retry_policy: nil
       # Converts hash and nil to a policy object
-      retry_policy = RetryPolicy.new retry_policy.to_h if retry_policy.respond_to? :to_h
+      retry_policy = RetryPolicy.new(**retry_policy.to_h) if retry_policy.respond_to? :to_h
 
       @timeout = timeout # allow to be nil so it can be overridden
       @metadata = metadata.to_h # Ensure always hash, even for nil

--- a/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
+++ b/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
@@ -112,7 +112,7 @@ module Gapic
       #
       def call request, options: nil
         # Converts hash and nil to an options object
-        options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+        options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
         deadline = calculate_deadline options
         metadata = options.metadata
 

--- a/gapic-common/lib/gapic/operation.rb
+++ b/gapic-common/lib/gapic/operation.rb
@@ -196,7 +196,7 @@ module Gapic
     #
     def cancel options: nil
       # Converts hash and nil to an options object
-      options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+      options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
       @client.cancel_operation({ name: @grpc_op.name }, options)
     end
@@ -209,7 +209,7 @@ module Gapic
     #
     def delete options: nil
       # Converts hash and nil to an options object
-      options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+      options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
       @client.delete_operation({ name: @grpc_op.name }, options)
     end
@@ -224,7 +224,7 @@ module Gapic
     #
     def reload! options: nil
       # Converts hash and nil to an options object
-      options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+      options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
       gax_op = @client.get_operation({ name: @grpc_op.name }, options)
       @grpc_op = gax_op.grpc_op

--- a/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_options_defaults.erb
@@ -1,6 +1,6 @@
 <%- assert_locals method -%>
 # Converts hash and nil to an options object
-options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
 # Customize the options with defaults
 metadata = @config.rpcs.<%= method.name %>.metadata.to_h

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
@@ -166,7 +166,7 @@ module Google
                 request = Gapic::Protobuf.coerce request, to: Google::Ads::GoogleAds::V1::Services::GetCampaignRequest
 
                 # Converts hash and nil to an options object
-                options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+                options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
                 # Customize the options with defaults
                 metadata = @config.rpcs.get_campaign.metadata.to_h
@@ -235,7 +235,7 @@ module Google
                 request = Gapic::Protobuf.coerce request, to: Google::Ads::GoogleAds::V1::Services::MutateCampaignsRequest
 
                 # Converts hash and nil to an options object
-                options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+                options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
                 # Customize the options with defaults
                 metadata = @config.rpcs.mutate_campaigns.metadata.to_h

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
@@ -301,7 +301,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1::AnalyzeSentimentRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_sentiment.metadata.to_h
@@ -463,7 +463,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1::AnalyzeEntitiesRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_entities.metadata.to_h
@@ -631,7 +631,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_entity_sentiment.metadata.to_h
@@ -803,7 +803,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1::AnalyzeSyntaxRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_syntax.metadata.to_h
@@ -920,7 +920,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1::ClassifyTextRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.classify_text.metadata.to_h
@@ -979,7 +979,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1::AnnotateTextRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.annotate_text.metadata.to_h

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -175,7 +175,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_sentiment.metadata.to_h
@@ -234,7 +234,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_entities.metadata.to_h
@@ -293,7 +293,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_syntax.metadata.to_h
@@ -352,7 +352,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1beta1::AnnotateTextRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.annotate_text.metadata.to_h

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -175,7 +175,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_sentiment.metadata.to_h
@@ -234,7 +234,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_entities.metadata.to_h
@@ -291,7 +291,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_entity_sentiment.metadata.to_h
@@ -350,7 +350,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.analyze_syntax.metadata.to_h
@@ -403,7 +403,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1beta2::ClassifyTextRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.classify_text.metadata.to_h
@@ -462,7 +462,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Language::V1beta2::AnnotateTextRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.annotate_text.metadata.to_h

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -183,7 +183,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::ListSecretsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_secrets.metadata.to_h
@@ -248,7 +248,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::CreateSecretRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.create_secret.metadata.to_h
@@ -312,7 +312,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.add_secret_version.metadata.to_h
@@ -371,7 +371,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::GetSecretRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_secret.metadata.to_h
@@ -432,7 +432,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.update_secret.metadata.to_h
@@ -492,7 +492,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.delete_secret.metadata.to_h
@@ -562,7 +562,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_secret_versions.metadata.to_h
@@ -631,7 +631,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_secret_version.metadata.to_h
@@ -697,7 +697,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.access_secret_version.metadata.to_h
@@ -763,7 +763,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.disable_secret_version.metadata.to_h
@@ -829,7 +829,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.enable_secret_version.metadata.to_h
@@ -897,7 +897,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.destroy_secret_version.metadata.to_h
@@ -971,7 +971,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Iam::V1::SetIamPolicyRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.set_iam_policy.metadata.to_h
@@ -1034,7 +1034,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Iam::V1::GetIamPolicyRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_iam_policy.metadata.to_h
@@ -1112,7 +1112,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Iam::V1::TestIamPermissionsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.test_iam_permissions.metadata.to_h

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -389,7 +389,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Speech::V1::RecognizeRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.recognize.metadata.to_h
@@ -555,7 +555,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Speech::V1::LongRunningRecognizeRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.long_running_recognize.metadata.to_h
@@ -609,7 +609,7 @@ module Google
               end
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.streaming_recognize.metadata.to_h

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -144,7 +144,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_operations.metadata.to_h
@@ -209,7 +209,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_operation.metadata.to_h
@@ -275,7 +275,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.delete_operation.metadata.to_h
@@ -352,7 +352,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.cancel_operation.metadata.to_h

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -193,7 +193,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.batch_annotate_images.metadata.to_h
@@ -272,7 +272,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::BatchAnnotateFilesRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.batch_annotate_files.metadata.to_h
@@ -356,7 +356,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.async_batch_annotate_images.metadata.to_h
@@ -433,7 +433,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.async_batch_annotate_files.metadata.to_h

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -144,7 +144,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_operations.metadata.to_h
@@ -209,7 +209,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_operation.metadata.to_h
@@ -275,7 +275,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.delete_operation.metadata.to_h
@@ -352,7 +352,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.cancel_operation.metadata.to_h

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -199,7 +199,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductSetRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.create_product_set.metadata.to_h
@@ -274,7 +274,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductSetsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_product_sets.metadata.to_h
@@ -345,7 +345,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductSetRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_product_set.metadata.to_h
@@ -423,7 +423,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductSetRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.update_product_set.metadata.to_h
@@ -491,7 +491,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductSetRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.delete_product_set.metadata.to_h
@@ -574,7 +574,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateProductRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.create_product.metadata.to_h
@@ -648,7 +648,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_products.metadata.to_h
@@ -719,7 +719,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetProductRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_product.metadata.to_h
@@ -813,7 +813,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::UpdateProductRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.update_product.metadata.to_h
@@ -883,7 +883,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteProductRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.delete_product.metadata.to_h
@@ -989,7 +989,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::CreateReferenceImageRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.create_reference_image.metadata.to_h
@@ -1064,7 +1064,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::DeleteReferenceImageRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.delete_reference_image.metadata.to_h
@@ -1145,7 +1145,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListReferenceImagesRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_reference_images.metadata.to_h
@@ -1217,7 +1217,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::GetReferenceImageRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_reference_image.metadata.to_h
@@ -1298,7 +1298,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::AddProductToProductSetRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.add_product_to_product_set.metadata.to_h
@@ -1365,7 +1365,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.remove_product_from_product_set.metadata.to_h
@@ -1443,7 +1443,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ListProductsInProductSetRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_products_in_product_set.metadata.to_h
@@ -1527,7 +1527,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::ImportProductSetsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.import_product_sets.metadata.to_h
@@ -1643,7 +1643,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Cloud::Vision::V1::PurgeProductsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.purge_products.metadata.to_h

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -144,7 +144,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.list_operations.metadata.to_h
@@ -209,7 +209,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.get_operation.metadata.to_h
@@ -275,7 +275,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.delete_operation.metadata.to_h
@@ -352,7 +352,7 @@ module Google
               request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
               # Converts hash and nil to an options object
-              options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+              options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
               # Customize the options with defaults
               metadata = @config.rpcs.cancel_operation.metadata.to_h

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -175,7 +175,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: So::Much::Trash::EmptyGarbage
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_empty_garbage.metadata.to_h
@@ -275,7 +275,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: So::Much::Trash::SimpleGarbage
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_simple_garbage.metadata.to_h
@@ -346,7 +346,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: So::Much::Trash::SpecificGarbage
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_specific_garbage.metadata.to_h
@@ -415,7 +415,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: So::Much::Trash::SpecificGarbage::NestedGarbage
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_nested_garbage.metadata.to_h
@@ -484,7 +484,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: So::Much::Trash::RepeatedGarbage
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_repeated_garbage.metadata.to_h
@@ -615,7 +615,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: So::Much::Trash::TypicalGarbage
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_typical_garbage.metadata.to_h
@@ -709,7 +709,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: So::Much::Trash::ComplexGarbage
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_complex_garbage.metadata.to_h
@@ -760,7 +760,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: So::Much::Trash::GarbageNode
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_garbage_node.metadata.to_h
@@ -832,7 +832,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: So::Much::Trash::PagedGarbageRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_paged_garbage.metadata.to_h
@@ -886,7 +886,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: So::Much::Trash::LongRunningGarbageRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.long_running_garbage.metadata.to_h
@@ -937,7 +937,7 @@ module So
             end
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.client_garbage.metadata.to_h
@@ -1005,7 +1005,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: So::Much::Trash::ListGarbageRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.server_garbage.metadata.to_h
@@ -1055,7 +1055,7 @@ module So
             end
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.bidi_garbage.metadata.to_h

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -151,7 +151,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.list_operations.metadata.to_h
@@ -214,7 +214,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_operation.metadata.to_h
@@ -278,7 +278,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.delete_operation.metadata.to_h
@@ -353,7 +353,7 @@ module So
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.cancel_operation.metadata.to_h

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/client.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/client.rb
@@ -163,7 +163,7 @@ module Testing
           request = Gapic::Protobuf.coerce request, to: Testing::GrpcServiceConfig::Request
 
           # Converts hash and nil to an options object
-          options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+          options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
           # Customize the options with defaults
           metadata = @config.rpcs.no_retry_method.metadata.to_h

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
@@ -179,7 +179,7 @@ module Testing
           request = Gapic::Protobuf.coerce request, to: Testing::GrpcServiceConfig::Request
 
           # Converts hash and nil to an options object
-          options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+          options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
           # Customize the options with defaults
           metadata = @config.rpcs.service_level_retry_method.metadata.to_h
@@ -223,7 +223,7 @@ module Testing
           request = Gapic::Protobuf.coerce request, to: Testing::GrpcServiceConfig::Request
 
           # Converts hash and nil to an options object
-          options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+          options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
           # Customize the options with defaults
           metadata = @config.rpcs.method_level_retry_method.metadata.to_h

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -178,7 +178,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::EchoRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.echo.metadata.to_h
@@ -233,7 +233,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ExpandRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.expand.metadata.to_h
@@ -285,7 +285,7 @@ module Google
             end
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.collect.metadata.to_h
@@ -337,7 +337,7 @@ module Google
             end
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.chat.metadata.to_h
@@ -394,7 +394,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::PagedExpandRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.paged_expand.metadata.to_h
@@ -455,7 +455,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::WaitRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.wait.metadata.to_h
@@ -516,7 +516,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::BlockRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.block.metadata.to_h

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -151,7 +151,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.list_operations.metadata.to_h
@@ -214,7 +214,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_operation.metadata.to_h
@@ -278,7 +278,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.delete_operation.metadata.to_h
@@ -353,7 +353,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.cancel_operation.metadata.to_h

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -174,7 +174,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::CreateUserRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.create_user.metadata.to_h
@@ -225,7 +225,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::GetUserRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_user.metadata.to_h
@@ -285,7 +285,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::UpdateUserRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.update_user.metadata.to_h
@@ -342,7 +342,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteUserRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.delete_user.metadata.to_h
@@ -404,7 +404,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListUsersRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.list_users.metadata.to_h

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -179,7 +179,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::CreateRoomRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.create_room.metadata.to_h
@@ -230,7 +230,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::GetRoomRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_room.metadata.to_h
@@ -290,7 +290,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::UpdateRoomRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.update_room.metadata.to_h
@@ -347,7 +347,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteRoomRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.delete_room.metadata.to_h
@@ -409,7 +409,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListRoomsRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.list_rooms.metadata.to_h
@@ -468,7 +468,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::CreateBlurbRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.create_blurb.metadata.to_h
@@ -525,7 +525,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::GetBlurbRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_blurb.metadata.to_h
@@ -585,7 +585,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::UpdateBlurbRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.update_blurb.metadata.to_h
@@ -642,7 +642,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteBlurbRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.delete_blurb.metadata.to_h
@@ -709,7 +709,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListBlurbsRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.list_blurbs.metadata.to_h
@@ -784,7 +784,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::SearchBlurbsRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.search_blurbs.metadata.to_h
@@ -846,7 +846,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::StreamBlurbsRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.stream_blurbs.metadata.to_h
@@ -903,7 +903,7 @@ module Google
             end
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.send_blurbs.metadata.to_h
@@ -956,7 +956,7 @@ module Google
             end
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.connect.metadata.to_h

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -151,7 +151,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::ListOperationsRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.list_operations.metadata.to_h
@@ -214,7 +214,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::GetOperationRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_operation.metadata.to_h
@@ -278,7 +278,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::DeleteOperationRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.delete_operation.metadata.to_h
@@ -353,7 +353,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Longrunning::CancelOperationRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.cancel_operation.metadata.to_h

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -176,7 +176,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::CreateSessionRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.create_session.metadata.to_h
@@ -227,7 +227,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::GetSessionRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.get_session.metadata.to_h
@@ -286,7 +286,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListSessionsRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.list_sessions.metadata.to_h
@@ -338,7 +338,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteSessionRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.delete_session.metadata.to_h
@@ -399,7 +399,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ReportSessionRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.report_session.metadata.to_h
@@ -460,7 +460,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::ListTestsRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.list_tests.metadata.to_h
@@ -528,7 +528,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::DeleteTestRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.delete_test.metadata.to_h
@@ -595,7 +595,7 @@ module Google
             request = Gapic::Protobuf.coerce request, to: Google::Showcase::V1beta1::VerifyTestRequest
 
             # Converts hash and nil to an options object
-            options = Gapic::CallOptions.new options.to_h if options.respond_to? :to_h
+            options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
 
             # Customize the options with defaults
             metadata = @config.rpcs.verify_test.metadata.to_h


### PR DESCRIPTION
In Rubies below 2.7, passing kwargs as the only hash argument is a
supported but unintentional valid way to call a function. However, in
[Ruby 2.7](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)
this is a warning, and will break in Ruby 3.0.

This commit replaces all instances of passing hashes in kwarg positions with the
`**` operator, which is valid in old rubies, as well as 2.7.