### PR TITLE
fix: interpret proto cross-reference syntax

### DIFF
--- a/gapic-generator/.rubocop.yml
+++ b/gapic-generator/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - test/gapic/annotations/**/*
     - test/gapic/presenters/**/*
     - test/gapic/*.rb
+    - test/test_helper.rb
     - Rakefile
 
 Metrics/ClassLength:

--- a/gapic-generator/lib/gapic/schema/api.rb
+++ b/gapic-generator/lib/gapic/schema/api.rb
@@ -53,6 +53,14 @@ module Gapic
         @files.each { |f| f.parent = self }
       end
 
+      def containing_api
+        self
+      end
+
+      def containing_file
+        nil
+      end
+
       def lookup address
         address = address.join "." if address.is_a? Array
         @files.each do |f|

--- a/gapic-generator/lib/gapic/schema/wrappers.rb
+++ b/gapic-generator/lib/gapic/schema/wrappers.rb
@@ -95,6 +95,18 @@ module Gapic
         @docs = docs
       end
 
+      # Returns the "root" of this schema.
+      # @return [Gapic::Schema::Api]
+      def containing_api
+        parent&.containing_api
+      end
+
+      # Returns the file containing this proto entity
+      # @return [Gapic::Schema::File]
+      def containing_file
+        parent&.containing_file
+      end
+
       # Gets the cleaned up leading comments documentation
       def docs_leading_comments
         return nil if @docs.nil?
@@ -102,7 +114,7 @@ module Gapic
 
         lines = @docs.leading_comments.each_line.to_a
         lines.map! { |line| line.start_with?(" ") ? line[1..-1] : line }
-        lines = FormattingUtils.escape_braces lines
+        lines = FormattingUtils.format_doc_lines containing_api, lines
         lines.join
       end
 
@@ -374,6 +386,10 @@ module Gapic
         @messages.each { |m| m.parent = self }
         @enums.each    { |m| m.parent = self }
         @services.each { |m| m.parent = self }
+      end
+
+      def containing_file
+        self
       end
 
       def lookup address

--- a/gapic-generator/test/gapic/formatting_utils_test.rb
+++ b/gapic-generator/test/gapic/formatting_utils_test.rb
@@ -330,7 +330,7 @@ class FormattingUtilsTest < Minitest::Test
       end
     end
     result = Gapic::FormattingUtils.format_doc_lines api, ["Hello, [World][google.longrunning.Operations]!\n"]
-    assert_equal ["Hello, `World`!\n"], result
+    assert_equal ["Hello, World!\n"], result
   end
 
   def test_xref_operations_method
@@ -342,7 +342,7 @@ class FormattingUtilsTest < Minitest::Test
       end
     end
     result = Gapic::FormattingUtils.format_doc_lines api, ["Hello, [World][google.longrunning.Operations.get_operation]!\n"]
-    assert_equal ["Hello, `World`!\n"], result
+    assert_equal ["Hello, World!\n"], result
   end
 
   def test_format_number_small_integer

--- a/gapic-generator/test/gapic/formatting_utils_test.rb
+++ b/gapic-generator/test/gapic/formatting_utils_test.rb
@@ -19,57 +19,57 @@ require "gapic/formatting_utils"
 
 class FormattingUtilsTest < Minitest::Test
   def test_escape_braces_empty
-    result = Gapic::FormattingUtils.escape_braces []
+    result = Gapic::FormattingUtils.format_doc_lines nil, []
     assert_equal [], result
   end
 
   def test_escape_braces_no_brace_line
-    result = Gapic::FormattingUtils.escape_braces ["hello world\n"]
+    result = Gapic::FormattingUtils.format_doc_lines nil, ["hello world\n"]
     assert_equal ["hello world\n"], result
   end
 
   def test_escape_braces_simple_brace_line
-    result = Gapic::FormattingUtils.escape_braces ["hello {ruby} world\n"]
+    result = Gapic::FormattingUtils.format_doc_lines nil, ["hello {ruby} world\n"]
     assert_equal ["hello \\\\{ruby} world\n"], result
   end
 
   def test_escape_braces_simple_brace_onechar_line
-    result = Gapic::FormattingUtils.escape_braces ["hello {r} world\n"]
+    result = Gapic::FormattingUtils.format_doc_lines nil, ["hello {r} world\n"]
     assert_equal ["hello \\\\{r} world\n"], result
   end
 
   def test_escape_braces_backtick_brace_line
-    result = Gapic::FormattingUtils.escape_braces ["hello `{ruby}` world\n"]
+    result = Gapic::FormattingUtils.format_doc_lines nil, ["hello `{ruby}` world\n"]
     assert_equal ["hello `{ruby}` world\n"], result
   end
 
   def test_escape_braces_unmatched_brace_line
-    result = Gapic::FormattingUtils.escape_braces ["hello {ruby world\n"]
+    result = Gapic::FormattingUtils.format_doc_lines nil, ["hello {ruby world\n"]
     assert_equal ["hello {ruby world\n"], result
   end
 
   def test_escape_braces_escaped_brace_line
-    result = Gapic::FormattingUtils.escape_braces ["hello \\{ruby world}\n"]
+    result = Gapic::FormattingUtils.format_doc_lines nil, ["hello \\{ruby world}\n"]
     assert_equal ["hello \\{ruby world}\n"], result
   end
 
   def test_escape_braces_multiple_backtick_brace_line
-    result = Gapic::FormattingUtils.escape_braces ["hello `stuff` `{ruby}` world\n"]
+    result = Gapic::FormattingUtils.format_doc_lines nil, ["hello `stuff` `{ruby}` world\n"]
     assert_equal ["hello `stuff` `{ruby}` world\n"], result
   end
 
   def test_escape_braces_multiple_brace_line
-    result = Gapic::FormattingUtils.escape_braces ["hello {ruby} {world} with {cheese}\n"]
+    result = Gapic::FormattingUtils.format_doc_lines nil, ["hello {ruby} {world} with {cheese}\n"]
     assert_equal ["hello \\\\{ruby} \\\\{world} with \\\\{cheese}\n"], result
   end
 
   def test_escape_braces_line_starting_with_brace
-    result = Gapic::FormattingUtils.escape_braces ["{hello} world\n"]
+    result = Gapic::FormattingUtils.format_doc_lines nil, ["{hello} world\n"]
     assert_equal ["\\\\{hello} world\n"], result
   end
 
   def test_escape_braces_with_normal_blocks
-    result = Gapic::FormattingUtils.escape_braces [
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
       "hello {ruby}\n",
       "     hello {world}\n",
       "this {works}\n"
@@ -82,7 +82,7 @@ class FormattingUtilsTest < Minitest::Test
   end
 
   def test_escape_braces_with_pre_and_normal_blocks
-    result = Gapic::FormattingUtils.escape_braces [
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
       "hello {ruby}\n",
       "\n",
       "    hello {world}\n",
@@ -97,7 +97,7 @@ class FormattingUtilsTest < Minitest::Test
   end
 
   def test_escape_braces_with_list_block
-    result = Gapic::FormattingUtils.escape_braces [
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
       "* hello {ruby}\n",
       "\n",
       "    hello {ruby3}\n"
@@ -110,7 +110,7 @@ class FormattingUtilsTest < Minitest::Test
   end
 
   def test_escape_braces_with_list_and_pre_block
-    result = Gapic::FormattingUtils.escape_braces [
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
       "* hello {ruby}\n",
       "\n",
       "        hello {ruby3}\n"
@@ -123,7 +123,7 @@ class FormattingUtilsTest < Minitest::Test
   end
 
   def test_escape_braces_with_indented_list_block
-    result = Gapic::FormattingUtils.escape_braces [
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
       " * hello {ruby}\n",
       "\n",
       "       hello {ruby3}\n"
@@ -136,7 +136,7 @@ class FormattingUtilsTest < Minitest::Test
   end
 
   def test_escape_braces_with_indented_list_and_pre_block
-    result = Gapic::FormattingUtils.escape_braces [
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
       " * hello {ruby}\n",
       "\n",
       "        hello {ruby3}\n"
@@ -149,7 +149,7 @@ class FormattingUtilsTest < Minitest::Test
   end
 
   def test_escape_braces_with_nested_list_blocks
-    result = Gapic::FormattingUtils.escape_braces [
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
       "* hello {ruby}\n",
       " * hello {ruby2}\n",
       "\n",
@@ -164,7 +164,7 @@ class FormattingUtilsTest < Minitest::Test
   end
 
   def test_escape_braces_with_nested_list_and_pre_blocks
-    result = Gapic::FormattingUtils.escape_braces [
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
       "* hello {ruby}\n",
       " * hello {ruby2}\n",
       "\n",
@@ -179,7 +179,7 @@ class FormattingUtilsTest < Minitest::Test
   end
 
   def test_escape_braces_with_plus_list_block
-    result = Gapic::FormattingUtils.escape_braces [
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
       "+ hello {ruby}\n",
       "\n",
       "    hello {ruby3}\n"
@@ -192,7 +192,7 @@ class FormattingUtilsTest < Minitest::Test
   end
 
   def test_escape_braces_with_minus_list_block
-    result = Gapic::FormattingUtils.escape_braces [
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
       "- hello {ruby}\n",
       "\n",
       "    hello {ruby3}\n"
@@ -205,7 +205,7 @@ class FormattingUtilsTest < Minitest::Test
   end
 
   def test_escape_braces_with_ordered_list_block
-    result = Gapic::FormattingUtils.escape_braces [
+    result = Gapic::FormattingUtils.format_doc_lines nil, [
       "12. hello {ruby}\n",
       "\n",
       "    hello {ruby3}\n"
@@ -219,7 +219,7 @@ class FormattingUtilsTest < Minitest::Test
 
   # the other escape method is space after the bracket: { something}
   def test_dont_escape_open_space_bracket
-    result = Gapic::FormattingUtils.escape_braces ["hello { ruby world}\n"]
+    result = Gapic::FormattingUtils.format_doc_lines nil, ["hello { ruby world}\n"]
     assert_equal ["hello { ruby world}\n"], result
   end
 
@@ -228,7 +228,7 @@ class FormattingUtilsTest < Minitest::Test
     separators = ["-", "|", "%", "$", "^", "~", "*", ":"]
 
     separators.each do |separator|
-      result = Gapic::FormattingUtils.escape_braces ["hello {ruby#{separator}world}\n"]
+      result = Gapic::FormattingUtils.format_doc_lines nil, ["hello {ruby#{separator}world}\n"]
       assert_equal ["hello \\\\{ruby#{separator}world}\n"], result
     end
   end
@@ -239,24 +239,110 @@ class FormattingUtilsTest < Minitest::Test
     separators = ["#", "::"]
 
     separators.each do |separator|
-      result = Gapic::FormattingUtils.escape_braces ["hello {Ruby#{separator}world}\n"]
+      result = Gapic::FormattingUtils.format_doc_lines nil, ["hello {Ruby#{separator}world}\n"]
       assert_equal ["hello \\\\{Ruby#{separator}world}\n"], result
     end
   end
 
   def test_escape_braces_yardexample_object
-    result = Gapic::FormattingUtils.escape_braces ["hello {ObjectName#method OPTIONAL_TITLE}\n"]
+    result = Gapic::FormattingUtils.format_doc_lines nil, ["hello {ObjectName#method OPTIONAL_TITLE}\n"]
     assert_equal ["hello \\\\{ObjectName#method OPTIONAL_TITLE}\n"], result
   end
 
   def test_escape_braces_yardexample_class
-    result = Gapic::FormattingUtils.escape_braces ["hello {Class::CONSTANT My constant's title}\n"]
+    result = Gapic::FormattingUtils.format_doc_lines nil, ["hello {Class::CONSTANT My constant's title}\n"]
     assert_equal ["hello \\\\{Class::CONSTANT My constant's title}\n"], result
   end
   
   def test_escape_braces_yardexample_method
-    result = Gapic::FormattingUtils.escape_braces ["hello {#method_inside_current_namespace}\n"]
+    result = Gapic::FormattingUtils.format_doc_lines nil, ["hello {#method_inside_current_namespace}\n"]
     assert_equal ["hello \\\\{#method_inside_current_namespace}\n"], result
+  end
+
+  def test_xref_message
+    api = FakeApi.new do |api|
+      api.add_file! "google.cloud.example" do
+        api.add_message! "Earth"
+      end
+    end
+    result = Gapic::FormattingUtils.format_doc_lines api, ["Hello, [World][google.cloud.example.Earth]!\n"]
+    assert_equal ["Hello, {Google::Cloud::Example::Earth World}!\n"], result
+  end
+
+  def test_xref_message_with_ruby_package
+    api = FakeApi.new do |api|
+      api.add_file! "google.cloud.example", "Google::Cloud::MyExample" do
+        api.add_message! "Earth"
+      end
+    end
+    result = Gapic::FormattingUtils.format_doc_lines api, ["Hello, [World][google.cloud.example.Earth]!\n"]
+    assert_equal ["Hello, {Google::Cloud::MyExample::Earth World}!\n"], result
+  end
+
+  def test_xref_multiple_messages
+    api = FakeApi.new do |api|
+      api.add_file! "google.cloud.example" do
+        api.add_message! "Earth"
+        api.add_message! "Ruby"
+      end
+    end
+    result = Gapic::FormattingUtils.format_doc_lines api,
+      ["Hello, [Ruby][google.cloud.example.Ruby] [World][google.cloud.example.Earth]!\n"]
+    assert_equal ["Hello, {Google::Cloud::Example::Ruby Ruby} {Google::Cloud::Example::Earth World}!\n"], result
+  end
+
+  def test_xref_proto_not_found
+    api = FakeApi.new do |api|
+      api.add_file! "google.cloud.example" do
+        api.add_message! "Earth"
+      end
+    end
+    result = Gapic::FormattingUtils.format_doc_lines api, ["Hello, [Ruby][google.cloud.example.Ruby]!\n"]
+    assert_equal ["Hello, [Ruby][google.cloud.example.Ruby]!\n"], result
+  end
+
+  def test_xref_service
+    api = FakeApi.new do |api|
+      api.add_file! "google.cloud.example" do
+        api.add_service! "Earth"
+      end
+    end
+    result = Gapic::FormattingUtils.format_doc_lines api, ["Hello, [World][google.cloud.example.Earth]!\n"]
+    assert_equal ["Hello, {Google::Cloud::Example::Earth::Client World}!\n"], result
+  end
+
+  def test_xref_with_method
+    api = FakeApi.new do |api|
+      api.add_file! "google.cloud.example" do
+        api.add_service! "Earth" do
+          api.add_method! "get_name"
+        end
+      end
+    end
+    result = Gapic::FormattingUtils.format_doc_lines api, ["Hello, [World][google.cloud.example.Earth.get_name]!\n"]
+    assert_equal ["Hello, {Google::Cloud::Example::Earth::Client#get_name World}!\n"], result
+  end
+
+  def test_xref_operations_service
+    api = FakeApi.new do |api|
+      api.add_file! "google.longrunning" do
+        api.add_service! "Operations"
+      end
+    end
+    result = Gapic::FormattingUtils.format_doc_lines api, ["Hello, [World][google.longrunning.Operations]!\n"]
+    assert_equal ["Hello, `World`!\n"], result
+  end
+
+  def test_xref_operations_method
+    api = FakeApi.new do |api|
+      api.add_file! "google.longrunning" do
+        api.add_service! "Operations" do
+          api.add_method! "get_operation"
+        end
+      end
+    end
+    result = Gapic::FormattingUtils.format_doc_lines api, ["Hello, [World][google.longrunning.Operations.get_operation]!\n"]
+    assert_equal ["Hello, `World`!\n"], result
   end
 
   def test_format_number_small_integer

--- a/gapic-generator/test/gapic/formatting_utils_test.rb
+++ b/gapic-generator/test/gapic/formatting_utils_test.rb
@@ -291,6 +291,30 @@ class FormattingUtilsTest < Minitest::Test
     assert_equal ["Hello, {Google::Cloud::Example::Ruby Ruby} {Google::Cloud::Example::Earth World}!\n"], result
   end
 
+  def test_xref_nested_message
+    api = FakeApi.new do |api|
+      api.add_file! "google.cloud.example" do
+        api.add_message! "Earth" do
+          api.add_message! "Continent"
+        end
+      end
+    end
+    result = Gapic::FormattingUtils.format_doc_lines api, ["Hello, [World][google.cloud.example.Earth.Continent]!\n"]
+    assert_equal ["Hello, {Google::Cloud::Example::Earth::Continent World}!\n"], result
+  end
+
+  def test_xref_field
+    api = FakeApi.new do |api|
+      api.add_file! "google.cloud.example" do
+        api.add_message! "Earth" do
+          api.add_field! "population"
+        end
+      end
+    end
+    result = Gapic::FormattingUtils.format_doc_lines api, ["Hello, [World][google.cloud.example.Earth.population]!\n"]
+    assert_equal ["Hello, {Google::Cloud::Example::Earth#population World}!\n"], result
+  end
+
   def test_xref_proto_not_found
     api = FakeApi.new do |api|
       api.add_file! "google.cloud.example" do

--- a/gapic-generator/test/test_helper.rb
+++ b/gapic-generator/test/test_helper.rb
@@ -169,6 +169,7 @@ class FakeApi
     descriptor = OpenStruct.new options: { ruby_package: ruby_package }, package: package
     file = Gapic::Schema::File.new descriptor, @cur_address, nil, @cur_messages, @cur_enums,
                                    @cur_services, nil, @cur_registry
+    file.parent = self
     @files << file
     @cur_messages = @cur_enums = @cur_services = @cur_registry = @cur_address = nil
     self
@@ -255,6 +256,10 @@ class FakeApi
       return object unless object.nil?
     end
     nil
+  end
+
+  def containing_api
+    self
   end
 
   def fix_namespace name

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v1/services/campaign_service.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v1/services/campaign_service.rb
@@ -23,7 +23,7 @@ module Google
       module V1
         module Services
           # Request message for
-          # [CampaignService.GetCampaign][google.ads.googleads.v1.services.CampaignService.GetCampaign].
+          # {Google::Ads::GoogleAds::V1::Services::CampaignService::Client#get_campaign CampaignService.GetCampaign}.
           # @!attribute [rw] resource_name
           #   @return [String]
           #     The resource name of the campaign to fetch.
@@ -33,7 +33,7 @@ module Google
           end
 
           # Request message for
-          # [CampaignService.MutateCampaigns][google.ads.googleads.v1.services.CampaignService.MutateCampaigns].
+          # {Google::Ads::GoogleAds::V1::Services::CampaignService::Client#mutate_campaigns CampaignService.MutateCampaigns}.
           # @!attribute [rw] customer_id
           #   @return [String]
           #     The ID of the customer whose campaigns are being modified.

--- a/shared/output/ads/googleads/proto_docs/google/rpc/status.rb
+++ b/shared/output/ads/googleads/proto_docs/google/rpc/status.rb
@@ -78,7 +78,7 @@ module Google
     #   @return [String]
     #     A developer-facing error message, which should be in English. Any
     #     user-facing error message should be localized and sent in the
-    #     [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+    #     {Google::Rpc::Status#details google.rpc.Status.details} field, or localized by the client.
     # @!attribute [rw] details
     #   @return [Array<Google::Protobuf::Any>]
     #     A list of messages that carry the error details.  There is a common set of

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
@@ -489,12 +489,12 @@ module Google
             end
 
             ##
-            # Finds entities, similar to [AnalyzeEntities][google.cloud.language.v1.LanguageService.AnalyzeEntities] in the text and analyzes
+            # Finds entities, similar to {Google::Cloud::Language::V1::LanguageService::Client#analyze_entities AnalyzeEntities} in the text and analyzes
             # sentiment associated with each entity and its mentions.
             #
             # @overload analyze_entity_sentiment(request, options = nil)
             #   @param request [Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest | Hash]
-            #     Finds entities, similar to [AnalyzeEntities][google.cloud.language.v1.LanguageService.AnalyzeEntities] in the text and analyzes
+            #     Finds entities, similar to {Google::Cloud::Language::V1::LanguageService::Client#analyze_entities AnalyzeEntities} in the text and analyzes
             #     sentiment associated with each entity and its mentions.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/shared/output/cloud/language_v1/proto_docs/google/cloud/language/v1/language_service.rb
+++ b/shared/output/cloud/language_v1/proto_docs/google/cloud/language/v1/language_service.rb
@@ -72,7 +72,7 @@ module Google
         # @!attribute [rw] sentiment
         #   @return [Google::Cloud::Language::V1::Sentiment]
         #     For calls to [AnalyzeSentiment][] or if
-        #     [AnnotateTextRequest.Features.extract_document_sentiment][google.cloud.language.v1.AnnotateTextRequest.Features.extract_document_sentiment] is set to
+        #     {Google::Cloud::Language::V1::AnnotateTextRequest::Features#extract_document_sentiment AnnotateTextRequest.Features.extract_document_sentiment} is set to
         #     true, this field will contain the sentiment for the sentence.
         class Sentence
           include Google::Protobuf::MessageExts
@@ -110,7 +110,7 @@ module Google
         # @!attribute [rw] sentiment
         #   @return [Google::Cloud::Language::V1::Sentiment]
         #     For calls to [AnalyzeEntitySentiment][] or if
-        #     [AnnotateTextRequest.Features.extract_entity_sentiment][google.cloud.language.v1.AnnotateTextRequest.Features.extract_entity_sentiment] is set to
+        #     {Google::Cloud::Language::V1::AnnotateTextRequest::Features#extract_entity_sentiment AnnotateTextRequest.Features.extract_entity_sentiment} is set to
         #     true, this field will contain the aggregate sentiment expressed for this
         #     entity in the provided document.
         class Entity
@@ -845,7 +845,7 @@ module Google
         # @!attribute [rw] sentiment
         #   @return [Google::Cloud::Language::V1::Sentiment]
         #     For calls to [AnalyzeEntitySentiment][] or if
-        #     [AnnotateTextRequest.Features.extract_entity_sentiment][google.cloud.language.v1.AnnotateTextRequest.Features.extract_entity_sentiment] is set to
+        #     {Google::Cloud::Language::V1::AnnotateTextRequest::Features#extract_entity_sentiment AnnotateTextRequest.Features.extract_entity_sentiment} is set to
         #     true, this field will contain the sentiment expressed for this mention of
         #     the entity in the provided document.
         class EntityMention
@@ -872,7 +872,7 @@ module Google
         # @!attribute [rw] begin_offset
         #   @return [Integer]
         #     The API calculates the beginning offset of the content in the original
-        #     document according to the [EncodingType][google.cloud.language.v1.EncodingType] specified in the API request.
+        #     document according to the {Google::Cloud::Language::V1::EncodingType EncodingType} specified in the API request.
         class TextSpan
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -912,7 +912,7 @@ module Google
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1.Document.language] field for more details.
+        #     See {Google::Cloud::Language::V1::Document#language Document.language} field for more details.
         # @!attribute [rw] sentences
         #   @return [Array<Google::Cloud::Language::V1::Sentence>]
         #     The sentiment for all the sentences in the document.
@@ -941,7 +941,7 @@ module Google
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1.Document.language] field for more details.
+        #     See {Google::Cloud::Language::V1::Document#language Document.language} field for more details.
         class AnalyzeEntitySentimentResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -967,7 +967,7 @@ module Google
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1.Document.language] field for more details.
+        #     See {Google::Cloud::Language::V1::Document#language Document.language} field for more details.
         class AnalyzeEntitiesResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -996,7 +996,7 @@ module Google
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1.Document.language] field for more details.
+        #     See {Google::Cloud::Language::V1::Document#language Document.language} field for more details.
         class AnalyzeSyntaxResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -1062,26 +1062,26 @@ module Google
         # @!attribute [rw] sentences
         #   @return [Array<Google::Cloud::Language::V1::Sentence>]
         #     Sentences in the input document. Populated if the user enables
-        #     [AnnotateTextRequest.Features.extract_syntax][google.cloud.language.v1.AnnotateTextRequest.Features.extract_syntax].
+        #     {Google::Cloud::Language::V1::AnnotateTextRequest::Features#extract_syntax AnnotateTextRequest.Features.extract_syntax}.
         # @!attribute [rw] tokens
         #   @return [Array<Google::Cloud::Language::V1::Token>]
         #     Tokens, along with their syntactic information, in the input document.
         #     Populated if the user enables
-        #     [AnnotateTextRequest.Features.extract_syntax][google.cloud.language.v1.AnnotateTextRequest.Features.extract_syntax].
+        #     {Google::Cloud::Language::V1::AnnotateTextRequest::Features#extract_syntax AnnotateTextRequest.Features.extract_syntax}.
         # @!attribute [rw] entities
         #   @return [Array<Google::Cloud::Language::V1::Entity>]
         #     Entities, along with their semantic information, in the input document.
         #     Populated if the user enables
-        #     [AnnotateTextRequest.Features.extract_entities][google.cloud.language.v1.AnnotateTextRequest.Features.extract_entities].
+        #     {Google::Cloud::Language::V1::AnnotateTextRequest::Features#extract_entities AnnotateTextRequest.Features.extract_entities}.
         # @!attribute [rw] document_sentiment
         #   @return [Google::Cloud::Language::V1::Sentiment]
         #     The overall sentiment for the document. Populated if the user enables
-        #     [AnnotateTextRequest.Features.extract_document_sentiment][google.cloud.language.v1.AnnotateTextRequest.Features.extract_document_sentiment].
+        #     {Google::Cloud::Language::V1::AnnotateTextRequest::Features#extract_document_sentiment AnnotateTextRequest.Features.extract_document_sentiment}.
         # @!attribute [rw] language
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1.Document.language] field for more details.
+        #     See {Google::Cloud::Language::V1::Document#language Document.language} field for more details.
         # @!attribute [rw] categories
         #   @return [Array<Google::Cloud::Language::V1::ClassificationCategory>]
         #     Categories identified in the input document.

--- a/shared/output/cloud/language_v1beta1/proto_docs/google/cloud/language/v1beta1/language_service.rb
+++ b/shared/output/cloud/language_v1beta1/proto_docs/google/cloud/language/v1beta1/language_service.rb
@@ -71,7 +71,7 @@ module Google
         # @!attribute [rw] sentiment
         #   @return [Google::Cloud::Language::V1beta1::Sentiment]
         #     For calls to [AnalyzeSentiment][] or if
-        #     [AnnotateTextRequest.Features.extract_document_sentiment][google.cloud.language.v1beta1.AnnotateTextRequest.Features.extract_document_sentiment]
+        #     {Google::Cloud::Language::V1beta1::AnnotateTextRequest::Features#extract_document_sentiment AnnotateTextRequest.Features.extract_document_sentiment}
         #     is set to true, this field will contain the sentiment for the sentence.
         class Sentence
           include Google::Protobuf::MessageExts
@@ -799,7 +799,7 @@ module Google
         #   @return [Integer]
         #     The API calculates the beginning offset of the content in the original
         #     document according to the
-        #     [EncodingType][google.cloud.language.v1beta1.EncodingType] specified in the
+        #     {Google::Cloud::Language::V1beta1::EncodingType EncodingType} specified in the
         #     API request.
         class TextSpan
           include Google::Protobuf::MessageExts
@@ -827,7 +827,7 @@ module Google
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1beta1.Document.language]
+        #     See {Google::Cloud::Language::V1beta1::Document#language Document.language}
         #     field for more details.
         # @!attribute [rw] sentences
         #   @return [Array<Google::Cloud::Language::V1beta1::Sentence>]
@@ -857,7 +857,7 @@ module Google
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1beta1.Document.language]
+        #     See {Google::Cloud::Language::V1beta1::Document#language Document.language}
         #     field for more details.
         class AnalyzeEntitiesResponse
           include Google::Protobuf::MessageExts
@@ -887,7 +887,7 @@ module Google
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1beta1.Document.language]
+        #     See {Google::Cloud::Language::V1beta1::Document#language Document.language}
         #     field for more details.
         class AnalyzeSyntaxResponse
           include Google::Protobuf::MessageExts
@@ -930,26 +930,26 @@ module Google
         # @!attribute [rw] sentences
         #   @return [Array<Google::Cloud::Language::V1beta1::Sentence>]
         #     Sentences in the input document. Populated if the user enables
-        #     [AnnotateTextRequest.Features.extract_syntax][google.cloud.language.v1beta1.AnnotateTextRequest.Features.extract_syntax].
+        #     {Google::Cloud::Language::V1beta1::AnnotateTextRequest::Features#extract_syntax AnnotateTextRequest.Features.extract_syntax}.
         # @!attribute [rw] tokens
         #   @return [Array<Google::Cloud::Language::V1beta1::Token>]
         #     Tokens, along with their syntactic information, in the input document.
         #     Populated if the user enables
-        #     [AnnotateTextRequest.Features.extract_syntax][google.cloud.language.v1beta1.AnnotateTextRequest.Features.extract_syntax].
+        #     {Google::Cloud::Language::V1beta1::AnnotateTextRequest::Features#extract_syntax AnnotateTextRequest.Features.extract_syntax}.
         # @!attribute [rw] entities
         #   @return [Array<Google::Cloud::Language::V1beta1::Entity>]
         #     Entities, along with their semantic information, in the input document.
         #     Populated if the user enables
-        #     [AnnotateTextRequest.Features.extract_entities][google.cloud.language.v1beta1.AnnotateTextRequest.Features.extract_entities].
+        #     {Google::Cloud::Language::V1beta1::AnnotateTextRequest::Features#extract_entities AnnotateTextRequest.Features.extract_entities}.
         # @!attribute [rw] document_sentiment
         #   @return [Google::Cloud::Language::V1beta1::Sentiment]
         #     The overall sentiment for the document. Populated if the user enables
-        #     [AnnotateTextRequest.Features.extract_document_sentiment][google.cloud.language.v1beta1.AnnotateTextRequest.Features.extract_document_sentiment].
+        #     {Google::Cloud::Language::V1beta1::AnnotateTextRequest::Features#extract_document_sentiment AnnotateTextRequest.Features.extract_document_sentiment}.
         # @!attribute [rw] language
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1beta1.Document.language]
+        #     See {Google::Cloud::Language::V1beta1::Document#language Document.language}
         #     field for more details.
         class AnnotateTextResponse
           include Google::Protobuf::MessageExts

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -260,12 +260,12 @@ module Google
             end
 
             ##
-            # Finds entities, similar to [AnalyzeEntities][google.cloud.language.v1beta2.LanguageService.AnalyzeEntities] in the text and analyzes
+            # Finds entities, similar to {Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_entities AnalyzeEntities} in the text and analyzes
             # sentiment associated with each entity and its mentions.
             #
             # @overload analyze_entity_sentiment(request, options = nil)
             #   @param request [Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest | Hash]
-            #     Finds entities, similar to [AnalyzeEntities][google.cloud.language.v1beta2.LanguageService.AnalyzeEntities] in the text and analyzes
+            #     Finds entities, similar to {Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_entities AnalyzeEntities} in the text and analyzes
             #     sentiment associated with each entity and its mentions.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/shared/output/cloud/language_v1beta2/proto_docs/google/cloud/language/v1beta2/language_service.rb
+++ b/shared/output/cloud/language_v1beta2/proto_docs/google/cloud/language/v1beta2/language_service.rb
@@ -72,7 +72,7 @@ module Google
         # @!attribute [rw] sentiment
         #   @return [Google::Cloud::Language::V1beta2::Sentiment]
         #     For calls to [AnalyzeSentiment][] or if
-        #     [AnnotateTextRequest.Features.extract_document_sentiment][google.cloud.language.v1beta2.AnnotateTextRequest.Features.extract_document_sentiment] is set to
+        #     {Google::Cloud::Language::V1beta2::AnnotateTextRequest::Features#extract_document_sentiment AnnotateTextRequest.Features.extract_document_sentiment} is set to
         #     true, this field will contain the sentiment for the sentence.
         class Sentence
           include Google::Protobuf::MessageExts
@@ -110,7 +110,7 @@ module Google
         # @!attribute [rw] sentiment
         #   @return [Google::Cloud::Language::V1beta2::Sentiment]
         #     For calls to [AnalyzeEntitySentiment][] or if
-        #     [AnnotateTextRequest.Features.extract_entity_sentiment][google.cloud.language.v1beta2.AnnotateTextRequest.Features.extract_entity_sentiment] is set to
+        #     {Google::Cloud::Language::V1beta2::AnnotateTextRequest::Features#extract_entity_sentiment AnnotateTextRequest.Features.extract_entity_sentiment} is set to
         #     true, this field will contain the aggregate sentiment expressed for this
         #     entity in the provided document.
         class Entity
@@ -851,7 +851,7 @@ module Google
         # @!attribute [rw] sentiment
         #   @return [Google::Cloud::Language::V1beta2::Sentiment]
         #     For calls to [AnalyzeEntitySentiment][] or if
-        #     [AnnotateTextRequest.Features.extract_entity_sentiment][google.cloud.language.v1beta2.AnnotateTextRequest.Features.extract_entity_sentiment] is set to
+        #     {Google::Cloud::Language::V1beta2::AnnotateTextRequest::Features#extract_entity_sentiment AnnotateTextRequest.Features.extract_entity_sentiment} is set to
         #     true, this field will contain the sentiment expressed for this mention of
         #     the entity in the provided document.
         class EntityMention
@@ -878,7 +878,7 @@ module Google
         # @!attribute [rw] begin_offset
         #   @return [Integer]
         #     The API calculates the beginning offset of the content in the original
-        #     document according to the [EncodingType][google.cloud.language.v1beta2.EncodingType] specified in the API request.
+        #     document according to the {Google::Cloud::Language::V1beta2::EncodingType EncodingType} specified in the API request.
         class TextSpan
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -919,7 +919,7 @@ module Google
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1beta2.Document.language] field for more details.
+        #     See {Google::Cloud::Language::V1beta2::Document#language Document.language} field for more details.
         # @!attribute [rw] sentences
         #   @return [Array<Google::Cloud::Language::V1beta2::Sentence>]
         #     The sentiment for all the sentences in the document.
@@ -948,7 +948,7 @@ module Google
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1beta2.Document.language] field for more details.
+        #     See {Google::Cloud::Language::V1beta2::Document#language Document.language} field for more details.
         class AnalyzeEntitySentimentResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -974,7 +974,7 @@ module Google
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1beta2.Document.language] field for more details.
+        #     See {Google::Cloud::Language::V1beta2::Document#language Document.language} field for more details.
         class AnalyzeEntitiesResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -1003,7 +1003,7 @@ module Google
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1beta2.Document.language] field for more details.
+        #     See {Google::Cloud::Language::V1beta2::Document#language Document.language} field for more details.
         class AnalyzeSyntaxResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
@@ -1072,26 +1072,26 @@ module Google
         # @!attribute [rw] sentences
         #   @return [Array<Google::Cloud::Language::V1beta2::Sentence>]
         #     Sentences in the input document. Populated if the user enables
-        #     [AnnotateTextRequest.Features.extract_syntax][google.cloud.language.v1beta2.AnnotateTextRequest.Features.extract_syntax].
+        #     {Google::Cloud::Language::V1beta2::AnnotateTextRequest::Features#extract_syntax AnnotateTextRequest.Features.extract_syntax}.
         # @!attribute [rw] tokens
         #   @return [Array<Google::Cloud::Language::V1beta2::Token>]
         #     Tokens, along with their syntactic information, in the input document.
         #     Populated if the user enables
-        #     [AnnotateTextRequest.Features.extract_syntax][google.cloud.language.v1beta2.AnnotateTextRequest.Features.extract_syntax].
+        #     {Google::Cloud::Language::V1beta2::AnnotateTextRequest::Features#extract_syntax AnnotateTextRequest.Features.extract_syntax}.
         # @!attribute [rw] entities
         #   @return [Array<Google::Cloud::Language::V1beta2::Entity>]
         #     Entities, along with their semantic information, in the input document.
         #     Populated if the user enables
-        #     [AnnotateTextRequest.Features.extract_entities][google.cloud.language.v1beta2.AnnotateTextRequest.Features.extract_entities].
+        #     {Google::Cloud::Language::V1beta2::AnnotateTextRequest::Features#extract_entities AnnotateTextRequest.Features.extract_entities}.
         # @!attribute [rw] document_sentiment
         #   @return [Google::Cloud::Language::V1beta2::Sentiment]
         #     The overall sentiment for the document. Populated if the user enables
-        #     [AnnotateTextRequest.Features.extract_document_sentiment][google.cloud.language.v1beta2.AnnotateTextRequest.Features.extract_document_sentiment].
+        #     {Google::Cloud::Language::V1beta2::AnnotateTextRequest::Features#extract_document_sentiment AnnotateTextRequest.Features.extract_document_sentiment}.
         # @!attribute [rw] language
         #   @return [String]
         #     The language of the text, which will be the same as the language specified
         #     in the request or, if not specified, the automatically-detected language.
-        #     See [Document.language][google.cloud.language.v1beta2.Document.language] field for more details.
+        #     See {Google::Cloud::Language::V1beta2::Document#language Document.language} field for more details.
         # @!attribute [rw] categories
         #   @return [Array<Google::Cloud::Language::V1beta2::ClassificationCategory>]
         #     Categories identified in the input document.

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -148,25 +148,25 @@ module Google
             # Service calls
 
             ##
-            # Lists [Secrets][google.cloud.secrets.v1beta1.Secret].
+            # Lists {Google::Cloud::SecretManager::V1beta1::Secret Secrets}.
             #
             # @overload list_secrets(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::ListSecretsRequest | Hash]
-            #     Lists [Secrets][google.cloud.secrets.v1beta1.Secret].
+            #     Lists {Google::Cloud::SecretManager::V1beta1::Secret Secrets}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload list_secrets(parent: nil, page_size: nil, page_token: nil)
             #   @param parent [String]
             #     Required. The resource name of the project associated with the
-            #     [Secrets][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`.
+            #     {Google::Cloud::SecretManager::V1beta1::Secret Secrets}, in the format `projects/*`.
             #   @param page_size [Integer]
             #     Optional. The maximum number of results to be returned in a single page. If
             #     set to 0, the server decides the number of results to return. If the
             #     number is greater than 25000, it is capped at 25000.
             #   @param page_token [String]
             #     Optional. Pagination token, returned earlier via
-            #     [ListSecretsResponse.next_page_token][google.cloud.secrets.v1beta1.ListSecretsResponse.next_page_token].
+            #     {Google::Cloud::SecretManager::V1beta1::ListSecretsResponse#next_page_token ListSecretsResponse.next_page_token}.
             #
             #
             # @yield [response, operation] Access the result along with the RPC operation
@@ -216,22 +216,22 @@ module Google
             end
 
             ##
-            # Creates a new [Secret][google.cloud.secrets.v1beta1.Secret] containing no [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion].
+            # Creates a new {Google::Cloud::SecretManager::V1beta1::Secret Secret} containing no {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions}.
             #
             # @overload create_secret(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::CreateSecretRequest | Hash]
-            #     Creates a new [Secret][google.cloud.secrets.v1beta1.Secret] containing no [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion].
+            #     Creates a new {Google::Cloud::SecretManager::V1beta1::Secret Secret} containing no {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload create_secret(parent: nil, secret_id: nil, secret: nil)
             #   @param parent [String]
             #     Required. The resource name of the project to associate with the
-            #     [Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`.
+            #     {Google::Cloud::SecretManager::V1beta1::Secret Secret}, in the format `projects/*`.
             #   @param secret_id [String]
             #     Required. This must be unique within the project.
             #   @param secret [Google::Cloud::SecretManager::V1beta1::Secret | Hash]
-            #     A [Secret][google.cloud.secrets.v1beta1.Secret] with initial field values.
+            #     A {Google::Cloud::SecretManager::V1beta1::Secret Secret} with initial field values.
             #
             #
             # @yield [response, operation] Access the result along with the RPC operation
@@ -280,22 +280,22 @@ module Google
             end
 
             ##
-            # Creates a new [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] containing secret data and attaches
-            # it to an existing [Secret][google.cloud.secrets.v1beta1.Secret].
+            # Creates a new {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} containing secret data and attaches
+            # it to an existing {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload add_secret_version(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest | Hash]
-            #     Creates a new [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] containing secret data and attaches
-            #     it to an existing [Secret][google.cloud.secrets.v1beta1.Secret].
+            #     Creates a new {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} containing secret data and attaches
+            #     it to an existing {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload add_secret_version(parent: nil, payload: nil)
             #   @param parent [String]
-            #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to associate with the
-            #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format `projects/*/secrets/*`.
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} to associate with the
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format `projects/*/secrets/*`.
             #   @param payload [Google::Cloud::SecretManager::V1beta1::SecretPayload | Hash]
-            #     Required. The secret payload of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     Required. The secret payload of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             #
             # @yield [response, operation] Access the result along with the RPC operation
@@ -344,17 +344,17 @@ module Google
             end
 
             ##
-            # Gets metadata for a given [Secret][google.cloud.secrets.v1beta1.Secret].
+            # Gets metadata for a given {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload get_secret(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::GetSecretRequest | Hash]
-            #     Gets metadata for a given [Secret][google.cloud.secrets.v1beta1.Secret].
+            #     Gets metadata for a given {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload get_secret(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/*/secrets/*`.
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret}, in the format `projects/*/secrets/*`.
             #
             #
             # @yield [response, operation] Access the result along with the RPC operation
@@ -403,17 +403,17 @@ module Google
             end
 
             ##
-            # Updates metadata of an existing [Secret][google.cloud.secrets.v1beta1.Secret].
+            # Updates metadata of an existing {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload update_secret(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest | Hash]
-            #     Updates metadata of an existing [Secret][google.cloud.secrets.v1beta1.Secret].
+            #     Updates metadata of an existing {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload update_secret(secret: nil, update_mask: nil)
             #   @param secret [Google::Cloud::SecretManager::V1beta1::Secret | Hash]
-            #     Required. [Secret][google.cloud.secrets.v1beta1.Secret] with updated field values.
+            #     Required. {Google::Cloud::SecretManager::V1beta1::Secret Secret} with updated field values.
             #   @param update_mask [Google::Protobuf::FieldMask | Hash]
             #     Required. Specifies the fields to be updated.
             #
@@ -464,17 +464,17 @@ module Google
             end
 
             ##
-            # Deletes a [Secret][google.cloud.secrets.v1beta1.Secret].
+            # Deletes a {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload delete_secret(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest | Hash]
-            #     Deletes a [Secret][google.cloud.secrets.v1beta1.Secret].
+            #     Deletes a {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload delete_secret(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to delete in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} to delete in the format
             #     `projects/*/secrets/*`.
             #
             #
@@ -524,20 +524,20 @@ module Google
             end
 
             ##
-            # Lists [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion]. This call does not return secret
+            # Lists {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions}. This call does not return secret
             # data.
             #
             # @overload list_secret_versions(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest | Hash]
-            #     Lists [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion]. This call does not return secret
+            #     Lists {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions}. This call does not return secret
             #     data.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload list_secret_versions(parent: nil, page_size: nil, page_token: nil)
             #   @param parent [String]
-            #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] associated with the
-            #     [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] to list, in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} associated with the
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} to list, in the format
             #     `projects/*/secrets/*`.
             #   @param page_size [Integer]
             #     Optional. The maximum number of results to be returned in a single page. If
@@ -595,26 +595,26 @@ module Google
             end
 
             ##
-            # Gets metadata for a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            # Gets metadata for a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             # `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-            # [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            # {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             # @overload get_secret_version(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest | Hash]
-            #     Gets metadata for a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     Gets metadata for a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             #     `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-            #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload get_secret_version(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format
             #     `projects/*/secrets/*/versions/*`.
             #     `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-            #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             #
             # @yield [response, operation] Access the result along with the RPC operation
@@ -663,23 +663,23 @@ module Google
             end
 
             ##
-            # Accesses a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]. This call returns the secret data.
+            # Accesses a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}. This call returns the secret data.
             #
             # `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-            # [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            # {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             # @overload access_secret_version(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest | Hash]
-            #     Accesses a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion]. This call returns the secret data.
+            #     Accesses a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}. This call returns the secret data.
             #
             #     `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-            #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload access_secret_version(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format
             #     `projects/*/secrets/*/versions/*`.
             #
             #
@@ -729,23 +729,23 @@ module Google
             end
 
             ##
-            # Disables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            # Disables a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
-            # Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-            # [DISABLED][google.cloud.secrets.v1beta1.SecretVersion.State.DISABLED].
+            # Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
+            # {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::DISABLED DISABLED}.
             #
             # @overload disable_secret_version(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest | Hash]
-            #     Disables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     Disables a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
-            #     Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-            #     [DISABLED][google.cloud.secrets.v1beta1.SecretVersion.State.DISABLED].
+            #     Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::DISABLED DISABLED}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload disable_secret_version(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to disable in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to disable in the format
             #     `projects/*/secrets/*/versions/*`.
             #
             #
@@ -795,23 +795,23 @@ module Google
             end
 
             ##
-            # Enables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            # Enables a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
-            # Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-            # [ENABLED][google.cloud.secrets.v1beta1.SecretVersion.State.ENABLED].
+            # Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
+            # {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::ENABLED ENABLED}.
             #
             # @overload enable_secret_version(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest | Hash]
-            #     Enables a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     Enables a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
-            #     Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-            #     [ENABLED][google.cloud.secrets.v1beta1.SecretVersion.State.ENABLED].
+            #     Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::ENABLED ENABLED}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload enable_secret_version(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to enable in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to enable in the format
             #     `projects/*/secrets/*/versions/*`.
             #
             #
@@ -861,25 +861,25 @@ module Google
             end
 
             ##
-            # Destroys a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            # Destroys a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
-            # Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-            # [DESTROYED][google.cloud.secrets.v1beta1.SecretVersion.State.DESTROYED] and irrevocably destroys the
+            # Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
+            # {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::DESTROYED DESTROYED} and irrevocably destroys the
             # secret data.
             #
             # @overload destroy_secret_version(request, options = nil)
             #   @param request [Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest | Hash]
-            #     Destroys a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+            #     Destroys a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
-            #     Sets the [state][google.cloud.secrets.v1beta1.SecretVersion.state] of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to
-            #     [DESTROYED][google.cloud.secrets.v1beta1.SecretVersion.State.DESTROYED] and irrevocably destroys the
+            #     Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
+            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::DESTROYED DESTROYED} and irrevocably destroys the
             #     secret data.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload destroy_secret_version(name: nil)
             #   @param name [String]
-            #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to destroy in the format
+            #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to destroy in the format
             #     `projects/*/secrets/*/versions/*`.
             #
             #
@@ -932,16 +932,16 @@ module Google
             # Sets the access control policy on the specified secret. Replaces any
             # existing policy.
             #
-            # Permissions on [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] are enforced according
-            # to the policy set on the associated [Secret][google.cloud.secrets.v1beta1.Secret].
+            # Permissions on {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} are enforced according
+            # to the policy set on the associated {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload set_iam_policy(request, options = nil)
             #   @param request [Google::Iam::V1::SetIamPolicyRequest | Hash]
             #     Sets the access control policy on the specified secret. Replaces any
             #     existing policy.
             #
-            #     Permissions on [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] are enforced according
-            #     to the policy set on the associated [Secret][google.cloud.secrets.v1beta1.Secret].
+            #     Permissions on {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} are enforced according
+            #     to the policy set on the associated {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/cloud/secrets/v1beta1/resources.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/cloud/secrets/v1beta1/resources.rb
@@ -21,22 +21,22 @@ module Google
   module Cloud
     module SecretManager
       module V1beta1
-        # A [Secret][google.cloud.secrets.v1beta1.Secret] is a logical secret whose value and versions can
+        # A {Google::Cloud::SecretManager::V1beta1::Secret Secret} is a logical secret whose value and versions can
         # be accessed.
         #
-        # A [Secret][google.cloud.secrets.v1beta1.Secret] is made up of zero or more [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] that
+        # A {Google::Cloud::SecretManager::V1beta1::Secret Secret} is made up of zero or more {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} that
         # represent the secret data.
         # @!attribute [r] name
         #   @return [String]
-        #     Output only. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] in the format `projects/*/secrets/*`.
+        #     Output only. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} in the format `projects/*/secrets/*`.
         # @!attribute [rw] replication
         #   @return [Google::Cloud::SecretManager::V1beta1::Replication]
-        #     Required. Immutable. The replication policy of the secret data attached to the [Secret][google.cloud.secrets.v1beta1.Secret].
+        #     Required. Immutable. The replication policy of the secret data attached to the {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
         #
         #     The replication policy cannot be changed after the Secret has been created.
         # @!attribute [r] create_time
         #   @return [Google::Protobuf::Timestamp]
-        #     Output only. The time at which the [Secret][google.cloud.secrets.v1beta1.Secret] was created.
+        #     Output only. The time at which the {Google::Cloud::SecretManager::V1beta1::Secret Secret} was created.
         # @!attribute [rw] labels
         #   @return [Google::Protobuf::Map{String => String}]
         #     The labels assigned to this Secret.
@@ -67,40 +67,40 @@ module Google
         # A secret version resource in the Secret Manager API.
         # @!attribute [r] name
         #   @return [String]
-        #     Output only. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the
+        #     Output only. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the
         #     format `projects/*/secrets/*/versions/*`.
         #
-        #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] IDs in a [Secret][google.cloud.secrets.v1beta1.Secret] start at 1 and
+        #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} IDs in a {Google::Cloud::SecretManager::V1beta1::Secret Secret} start at 1 and
         #     are incremented for each subsequent version of the secret.
         # @!attribute [r] create_time
         #   @return [Google::Protobuf::Timestamp]
-        #     Output only. The time at which the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] was created.
+        #     Output only. The time at which the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} was created.
         # @!attribute [r] destroy_time
         #   @return [Google::Protobuf::Timestamp]
-        #     Output only. The time this [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] was destroyed.
-        #     Only present if [state][google.cloud.secrets.v1beta1.SecretVersion.state] is
-        #     [DESTROYED][google.cloud.secrets.v1beta1.SecretVersion.State.DESTROYED].
+        #     Output only. The time this {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} was destroyed.
+        #     Only present if {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} is
+        #     {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::DESTROYED DESTROYED}.
         # @!attribute [r] state
         #   @return [Google::Cloud::SecretManager::V1beta1::SecretVersion::State]
-        #     Output only. The current state of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+        #     Output only. The current state of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
         class SecretVersion
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
 
-          # The state of a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion], indicating if it can be accessed.
+          # The state of a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}, indicating if it can be accessed.
           module State
             # Not specified. This value is unused and invalid.
             STATE_UNSPECIFIED = 0
 
-            # The [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] may be accessed.
+            # The {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} may be accessed.
             ENABLED = 1
 
-            # The [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] may not be accessed, but the secret data
-            # is still available and can be placed back into the [ENABLED][google.cloud.secrets.v1beta1.SecretVersion.State.ENABLED]
+            # The {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} may not be accessed, but the secret data
+            # is still available and can be placed back into the {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::ENABLED ENABLED}
             # state.
             DISABLED = 2
 
-            # The [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] is destroyed and the secret data is no longer
+            # The {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} is destroyed and the secret data is no longer
             # stored. A version may not leave this state once entered.
             DESTROYED = 3
           end
@@ -109,33 +109,33 @@ module Google
         # A policy that defines the replication configuration of data.
         # @!attribute [rw] automatic
         #   @return [Google::Cloud::SecretManager::V1beta1::Replication::Automatic]
-        #     The [Secret][google.cloud.secrets.v1beta1.Secret] will automatically be replicated without any restrictions.
+        #     The {Google::Cloud::SecretManager::V1beta1::Secret Secret} will automatically be replicated without any restrictions.
         # @!attribute [rw] user_managed
         #   @return [Google::Cloud::SecretManager::V1beta1::Replication::UserManaged]
-        #     The [Secret][google.cloud.secrets.v1beta1.Secret] will only be replicated into the locations specified.
+        #     The {Google::Cloud::SecretManager::V1beta1::Secret Secret} will only be replicated into the locations specified.
         class Replication
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
 
-          # A replication policy that replicates the [Secret][google.cloud.secrets.v1beta1.Secret] payload without any
+          # A replication policy that replicates the {Google::Cloud::SecretManager::V1beta1::Secret Secret} payload without any
           # restrictions.
           class Automatic
             include Google::Protobuf::MessageExts
             extend Google::Protobuf::MessageExts::ClassMethods
           end
 
-          # A replication policy that replicates the [Secret][google.cloud.secrets.v1beta1.Secret] payload into the
+          # A replication policy that replicates the {Google::Cloud::SecretManager::V1beta1::Secret Secret} payload into the
           # locations specified in [Secret.replication.user_managed.replicas][]
           # @!attribute [rw] replicas
           #   @return [Array<Google::Cloud::SecretManager::V1beta1::Replication::UserManaged::Replica>]
-          #     Required. The list of Replicas for this [Secret][google.cloud.secrets.v1beta1.Secret].
+          #     Required. The list of Replicas for this {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
           #
           #     Cannot be empty.
           class UserManaged
             include Google::Protobuf::MessageExts
             extend Google::Protobuf::MessageExts::ClassMethods
 
-            # Represents a Replica for this [Secret][google.cloud.secrets.v1beta1.Secret].
+            # Represents a Replica for this {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             # @!attribute [rw] location
             #   @return [String]
             #     The canonical IDs of the location to replicate data.
@@ -148,7 +148,7 @@ module Google
         end
 
         # A secret payload resource in the Secret Manager API. This contains the
-        # sensitive secret data that is associated with a [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+        # sensitive secret data that is associated with a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
         # @!attribute [rw] data
         #   @return [String]
         #     The secret data. Must be no larger than 64KiB.

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/cloud/secrets/v1beta1/service.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/cloud/secrets/v1beta1/service.rb
@@ -21,11 +21,11 @@ module Google
   module Cloud
     module SecretManager
       module V1beta1
-        # Request message for [SecretManagerService.ListSecrets][google.cloud.secrets.v1beta1.SecretManagerService.ListSecrets].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secrets SecretManagerService.ListSecrets}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the project associated with the
-        #     [Secrets][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`.
+        #     {Google::Cloud::SecretManager::V1beta1::Secret Secrets}, in the format `projects/*`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Optional. The maximum number of results to be returned in a single page. If
@@ -34,72 +34,72 @@ module Google
         # @!attribute [rw] page_token
         #   @return [String]
         #     Optional. Pagination token, returned earlier via
-        #     [ListSecretsResponse.next_page_token][google.cloud.secrets.v1beta1.ListSecretsResponse.next_page_token].
+        #     {Google::Cloud::SecretManager::V1beta1::ListSecretsResponse#next_page_token ListSecretsResponse.next_page_token}.
         class ListSecretsRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Response message for [SecretManagerService.ListSecrets][google.cloud.secrets.v1beta1.SecretManagerService.ListSecrets].
+        # Response message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secrets SecretManagerService.ListSecrets}.
         # @!attribute [rw] secrets
         #   @return [Array<Google::Cloud::SecretManager::V1beta1::Secret>]
-        #     The list of [Secrets][google.cloud.secrets.v1beta1.Secret] sorted in reverse by create_time (newest
+        #     The list of {Google::Cloud::SecretManager::V1beta1::Secret Secrets} sorted in reverse by create_time (newest
         #     first).
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     A token to retrieve the next page of results. Pass this value in
-        #     [ListSecretsRequest.page_token][google.cloud.secrets.v1beta1.ListSecretsRequest.page_token] to retrieve the next page.
+        #     {Google::Cloud::SecretManager::V1beta1::ListSecretsRequest#page_token ListSecretsRequest.page_token} to retrieve the next page.
         # @!attribute [rw] total_size
         #   @return [Integer]
-        #     The total number of [Secrets][google.cloud.secrets.v1beta1.Secret].
+        #     The total number of {Google::Cloud::SecretManager::V1beta1::Secret Secrets}.
         class ListSecretsResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.CreateSecret][google.cloud.secrets.v1beta1.SecretManagerService.CreateSecret].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#create_secret SecretManagerService.CreateSecret}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the project to associate with the
-        #     [Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/*`.
+        #     {Google::Cloud::SecretManager::V1beta1::Secret Secret}, in the format `projects/*`.
         # @!attribute [rw] secret_id
         #   @return [String]
         #     Required. This must be unique within the project.
         # @!attribute [rw] secret
         #   @return [Google::Cloud::SecretManager::V1beta1::Secret]
-        #     A [Secret][google.cloud.secrets.v1beta1.Secret] with initial field values.
+        #     A {Google::Cloud::SecretManager::V1beta1::Secret Secret} with initial field values.
         class CreateSecretRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.AddSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.AddSecretVersion].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#add_secret_version SecretManagerService.AddSecretVersion}.
         # @!attribute [rw] parent
         #   @return [String]
-        #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to associate with the
-        #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format `projects/*/secrets/*`.
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} to associate with the
+        #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format `projects/*/secrets/*`.
         # @!attribute [rw] payload
         #   @return [Google::Cloud::SecretManager::V1beta1::SecretPayload]
-        #     Required. The secret payload of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+        #     Required. The secret payload of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
         class AddSecretVersionRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.GetSecret][google.cloud.secrets.v1beta1.SecretManagerService.GetSecret].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_secret SecretManagerService.GetSecret}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret], in the format `projects/*/secrets/*`.
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret}, in the format `projects/*/secrets/*`.
         class GetSecretRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.ListSecretVersions][google.cloud.secrets.v1beta1.SecretManagerService.ListSecretVersions].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secret_versions SecretManagerService.ListSecretVersions}.
         # @!attribute [rw] parent
         #   @return [String]
-        #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] associated with the
-        #     [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] to list, in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} associated with the
+        #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} to list, in the format
         #     `projects/*/secrets/*`.
         # @!attribute [rw] page_size
         #   @return [Integer]
@@ -115,39 +115,39 @@ module Google
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Response message for [SecretManagerService.ListSecretVersions][google.cloud.secrets.v1beta1.SecretManagerService.ListSecretVersions].
+        # Response message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secret_versions SecretManagerService.ListSecretVersions}.
         # @!attribute [rw] versions
         #   @return [Array<Google::Cloud::SecretManager::V1beta1::SecretVersion>]
-        #     The list of [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion] sorted in reverse by
+        #     The list of {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} sorted in reverse by
         #     create_time (newest first).
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     A token to retrieve the next page of results. Pass this value in
-        #     [ListSecretVersionsRequest.page_token][google.cloud.secrets.v1beta1.ListSecretVersionsRequest.page_token] to retrieve the next page.
+        #     {Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest#page_token ListSecretVersionsRequest.page_token} to retrieve the next page.
         # @!attribute [rw] total_size
         #   @return [Integer]
-        #     The total number of [SecretVersions][google.cloud.secrets.v1beta1.SecretVersion].
+        #     The total number of {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions}.
         class ListSecretVersionsResponse
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.GetSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.GetSecretVersion].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_secret_version SecretManagerService.GetSecretVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format
         #     `projects/*/secrets/*/versions/*`.
         #     `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-        #     [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion].
+        #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
         class GetSecretVersionRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.UpdateSecret][google.cloud.secrets.v1beta1.SecretManagerService.UpdateSecret].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#update_secret SecretManagerService.UpdateSecret}.
         # @!attribute [rw] secret
         #   @return [Google::Cloud::SecretManager::V1beta1::Secret]
-        #     Required. [Secret][google.cloud.secrets.v1beta1.Secret] with updated field values.
+        #     Required. {Google::Cloud::SecretManager::V1beta1::Secret Secret} with updated field values.
         # @!attribute [rw] update_mask
         #   @return [Google::Protobuf::FieldMask]
         #     Required. Specifies the fields to be updated.
@@ -156,20 +156,20 @@ module Google
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.AccessSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.AccessSecretVersion].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#access_secret_version SecretManagerService.AccessSecretVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format
         #     `projects/*/secrets/*/versions/*`.
         class AccessSecretVersionRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Response message for [SecretManagerService.AccessSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.AccessSecretVersion].
+        # Response message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#access_secret_version SecretManagerService.AccessSecretVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] in the format
+        #     The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format
         #     `projects/*/secrets/*/versions/*`.
         # @!attribute [rw] payload
         #   @return [Google::Cloud::SecretManager::V1beta1::SecretPayload]
@@ -179,40 +179,40 @@ module Google
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.DeleteSecret][google.cloud.secrets.v1beta1.SecretManagerService.DeleteSecret].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#delete_secret SecretManagerService.DeleteSecret}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [Secret][google.cloud.secrets.v1beta1.Secret] to delete in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} to delete in the format
         #     `projects/*/secrets/*`.
         class DeleteSecretRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.DisableSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.DisableSecretVersion].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#disable_secret_version SecretManagerService.DisableSecretVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to disable in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to disable in the format
         #     `projects/*/secrets/*/versions/*`.
         class DisableSecretVersionRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.EnableSecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.EnableSecretVersion].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#enable_secret_version SecretManagerService.EnableSecretVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to enable in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to enable in the format
         #     `projects/*/secrets/*/versions/*`.
         class EnableSecretVersionRequest
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods
         end
 
-        # Request message for [SecretManagerService.DestroySecretVersion][google.cloud.secrets.v1beta1.SecretManagerService.DestroySecretVersion].
+        # Request message for {Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#destroy_secret_version SecretManagerService.DestroySecretVersion}.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required. The resource name of the [SecretVersion][google.cloud.secrets.v1beta1.SecretVersion] to destroy in the format
+        #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to destroy in the format
         #     `projects/*/secrets/*/versions/*`.
         class DestroySecretVersionRequest
           include Google::Protobuf::MessageExts

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -311,7 +311,7 @@ module Google
             # makes a best effort to cancel the operation, but success is not
             # guaranteed.  If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            # `Operations.GetOperation` or
+            # Operations.GetOperation or
             # other methods to check whether the cancellation succeeded or whether the
             # operation completed despite cancellation. On successful cancellation,
             # the operation is not deleted; instead, it becomes an operation with
@@ -324,7 +324,7 @@ module Google
             #     makes a best effort to cancel the operation, but success is not
             #     guaranteed.  If the server doesn't support this method, it returns
             #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     `Operations.GetOperation` or
+            #     Operations.GetOperation or
             #     other methods to check whether the cancellation succeeded or whether the
             #     operation completed despite cancellation. On successful cancellation,
             #     the operation is not deleted; instead, it becomes an operation with

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -311,11 +311,11 @@ module Google
             # makes a best effort to cancel the operation, but success is not
             # guaranteed.  If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            # [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            # `Operations.GetOperation` or
             # other methods to check whether the cancellation succeeded or whether the
             # operation completed despite cancellation. On successful cancellation,
             # the operation is not deleted; instead, it becomes an operation with
-            # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            # an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
             # corresponding to `Code.CANCELLED`.
             #
             # @overload cancel_operation(request, options = nil)
@@ -324,11 +324,11 @@ module Google
             #     makes a best effort to cancel the operation, but success is not
             #     guaranteed.  If the server doesn't support this method, it returns
             #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #     `Operations.GetOperation` or
             #     other methods to check whether the cancellation succeeded or whether the
             #     operation completed despite cancellation. On successful cancellation,
             #     the operation is not deleted; instead, it becomes an operation with
-            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #     an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
             #     corresponding to `Code.CANCELLED`.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/shared/output/cloud/speech_v1/proto_docs/google/cloud/speech/v1/cloud_speech.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/cloud/speech/v1/cloud_speech.rb
@@ -109,7 +109,7 @@ module Google
         #   @return [Google::Cloud::Speech::V1::RecognitionConfig::AudioEncoding]
         #     Encoding of audio data sent in all `RecognitionAudio` messages.
         #     This field is optional for `FLAC` and `WAV` audio files and required
-        #     for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
+        #     for all other audio formats. For details, see {Google::Cloud::Speech::V1::RecognitionConfig::AudioEncoding AudioEncoding}.
         # @!attribute [rw] sample_rate_hertz
         #   @return [Integer]
         #     Sample rate in Hertz of the audio data sent in all
@@ -118,7 +118,7 @@ module Google
         #     source to 16000 Hz. If that's not possible, use the native sample rate of
         #     the audio source (instead of re-sampling).
         #     This field is optional for FLAC and WAV audio files, but is
-        #     required for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
+        #     required for all other audio formats. For details, see {Google::Cloud::Speech::V1::RecognitionConfig::AudioEncoding AudioEncoding}.
         # @!attribute [rw] audio_channel_count
         #   @return [Integer]
         #     The number of channels in the input audio data.
@@ -162,7 +162,7 @@ module Google
         #     won't be filtered out.
         # @!attribute [rw] speech_contexts
         #   @return [Array<Google::Cloud::Speech::V1::SpeechContext>]
-        #     Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
+        #     Array of {Google::Cloud::Speech::V1::SpeechContext SpeechContext}.
         #     A means to provide context to assist the speech recognition. For more
         #     information, see
         #     [speech
@@ -604,7 +604,7 @@ module Google
         #     one or more (repeated) `results`.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]
-        #     If set, returns a [google.rpc.Status][google.rpc.Status] message that
+        #     If set, returns a {Google::Rpc::Status google.rpc.Status} message that
         #     specifies the error for the operation.
         # @!attribute [rw] results
         #   @return [Array<Google::Cloud::Speech::V1::StreamingRecognitionResult>]

--- a/shared/output/cloud/speech_v1/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/longrunning/operations.rb
@@ -55,7 +55,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.GetOperation`.
+    # The request message for Operations.GetOperation.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource.
@@ -64,7 +64,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.ListOperations`.
+    # The request message for Operations.ListOperations.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation collection.
@@ -82,7 +82,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The response message for `Operations.ListOperations`.
+    # The response message for Operations.ListOperations.
     # @!attribute [rw] operations
     #   @return [Array<Google::Longrunning::Operation>]
     #     A list of operations that matches the specified filter in the request.
@@ -94,7 +94,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.CancelOperation`.
+    # The request message for Operations.CancelOperation.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be cancelled.
@@ -103,7 +103,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.DeleteOperation`.
+    # The request message for Operations.DeleteOperation.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be deleted.

--- a/shared/output/cloud/speech_v1/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/longrunning/operations.rb
@@ -55,7 +55,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.GetOperation][google.longrunning.Operations.GetOperation].
+    # The request message for `Operations.GetOperation`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource.
@@ -64,7 +64,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+    # The request message for `Operations.ListOperations`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation collection.
@@ -82,7 +82,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The response message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+    # The response message for `Operations.ListOperations`.
     # @!attribute [rw] operations
     #   @return [Array<Google::Longrunning::Operation>]
     #     A list of operations that matches the specified filter in the request.
@@ -94,7 +94,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.CancelOperation][google.longrunning.Operations.CancelOperation].
+    # The request message for `Operations.CancelOperation`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be cancelled.
@@ -103,7 +103,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.DeleteOperation][google.longrunning.Operations.DeleteOperation].
+    # The request message for `Operations.DeleteOperation`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be deleted.

--- a/shared/output/cloud/speech_v1/proto_docs/google/rpc/status.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/rpc/status.rb
@@ -78,7 +78,7 @@ module Google
     #   @return [String]
     #     A developer-facing error message, which should be in English. Any
     #     user-facing error message should be localized and sent in the
-    #     [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+    #     {Google::Rpc::Status#details google.rpc.Status.details} field, or localized by the client.
     # @!attribute [rw] details
     #   @return [Array<Google::Protobuf::Any>]
     #     A list of messages that carry the error details.  There is a common set of

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -311,7 +311,7 @@ module Google
             # makes a best effort to cancel the operation, but success is not
             # guaranteed.  If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            # `Operations.GetOperation` or
+            # Operations.GetOperation or
             # other methods to check whether the cancellation succeeded or whether the
             # operation completed despite cancellation. On successful cancellation,
             # the operation is not deleted; instead, it becomes an operation with
@@ -324,7 +324,7 @@ module Google
             #     makes a best effort to cancel the operation, but success is not
             #     guaranteed.  If the server doesn't support this method, it returns
             #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     `Operations.GetOperation` or
+            #     Operations.GetOperation or
             #     other methods to check whether the cancellation succeeded or whether the
             #     operation completed despite cancellation. On successful cancellation,
             #     the operation is not deleted; instead, it becomes an operation with

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -311,11 +311,11 @@ module Google
             # makes a best effort to cancel the operation, but success is not
             # guaranteed.  If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            # [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            # `Operations.GetOperation` or
             # other methods to check whether the cancellation succeeded or whether the
             # operation completed despite cancellation. On successful cancellation,
             # the operation is not deleted; instead, it becomes an operation with
-            # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            # an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
             # corresponding to `Code.CANCELLED`.
             #
             # @overload cancel_operation(request, options = nil)
@@ -324,11 +324,11 @@ module Google
             #     makes a best effort to cancel the operation, but success is not
             #     guaranteed.  If the server doesn't support this method, it returns
             #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #     `Operations.GetOperation` or
             #     other methods to check whether the cancellation succeeded or whether the
             #     operation completed despite cancellation. On successful cancellation,
             #     the operation is not deleted; instead, it becomes an operation with
-            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #     an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
             #     corresponding to `Code.CANCELLED`.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -403,7 +403,7 @@ module Google
             #   @param product_set [Google::Cloud::Vision::V1::ProductSet | Hash]
             #     Required. The ProductSet resource which replaces the one on the server.
             #   @param update_mask [Google::Protobuf::FieldMask | Hash]
-            #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields to
+            #     The {Google::Protobuf::FieldMask FieldMask} that specifies which fields to
             #     update.
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask path is `display_name`.
@@ -792,7 +792,7 @@ module Google
             #     Required. The Product resource which replaces the one on the server.
             #     product.name is immutable.
             #   @param update_mask [Google::Protobuf::FieldMask | Hash]
-            #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields
+            #     The {Google::Protobuf::FieldMask FieldMask} that specifies which fields
             #     to update.
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask paths include `product_labels`, `display_name`, and
@@ -1479,28 +1479,28 @@ module Google
             # Asynchronous API that imports a list of reference images to specified
             # product sets based on a list of image information.
             #
-            # The [google.longrunning.Operation][google.longrunning.Operation] API can be used to keep track of the
+            # The {Google::Longrunning::Operation google.longrunning.Operation} API can be used to keep track of the
             # progress and results of the request.
             # `Operation.metadata` contains `BatchOperationMetadata`. (progress)
             # `Operation.response` contains `ImportProductSetsResponse`. (results)
             #
             # The input source of this method is a csv file on Google Cloud Storage.
             # For the format of the csv file please see
-            # [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+            # {Google::Cloud::Vision::V1::ImportProductSetsGcsSource#csv_file_uri ImportProductSetsGcsSource.csv_file_uri}.
             #
             # @overload import_product_sets(request, options = nil)
             #   @param request [Google::Cloud::Vision::V1::ImportProductSetsRequest | Hash]
             #     Asynchronous API that imports a list of reference images to specified
             #     product sets based on a list of image information.
             #
-            #     The [google.longrunning.Operation][google.longrunning.Operation] API can be used to keep track of the
+            #     The {Google::Longrunning::Operation google.longrunning.Operation} API can be used to keep track of the
             #     progress and results of the request.
             #     `Operation.metadata` contains `BatchOperationMetadata`. (progress)
             #     `Operation.response` contains `ImportProductSetsResponse`. (results)
             #
             #     The input source of this method is a csv file on Google Cloud Storage.
             #     For the format of the csv file please see
-            #     [ImportProductSetsGcsSource.csv_file_uri][google.cloud.vision.v1.ImportProductSetsGcsSource.csv_file_uri].
+            #     {Google::Cloud::Vision::V1::ImportProductSetsGcsSource#csv_file_uri ImportProductSetsGcsSource.csv_file_uri}.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
@@ -1581,7 +1581,7 @@ module Google
             # ProductSet, you must wait until the PurgeProducts operation has finished
             # for that ProductSet.
             #
-            # The [google.longrunning.Operation][google.longrunning.Operation] API can be used to keep track of the
+            # The {Google::Longrunning::Operation google.longrunning.Operation} API can be used to keep track of the
             # progress and results of the request.
             # `Operation.metadata` contains `BatchOperationMetadata`. (progress)
             #
@@ -1608,7 +1608,7 @@ module Google
             #     ProductSet, you must wait until the PurgeProducts operation has finished
             #     for that ProductSet.
             #
-            #     The [google.longrunning.Operation][google.longrunning.Operation] API can be used to keep track of the
+            #     The {Google::Longrunning::Operation google.longrunning.Operation} API can be used to keep track of the
             #     progress and results of the request.
             #     `Operation.metadata` contains `BatchOperationMetadata`. (progress)
             #   @param options [Gapic::CallOptions, Hash]

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -311,7 +311,7 @@ module Google
             # makes a best effort to cancel the operation, but success is not
             # guaranteed.  If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            # `Operations.GetOperation` or
+            # Operations.GetOperation or
             # other methods to check whether the cancellation succeeded or whether the
             # operation completed despite cancellation. On successful cancellation,
             # the operation is not deleted; instead, it becomes an operation with
@@ -324,7 +324,7 @@ module Google
             #     makes a best effort to cancel the operation, but success is not
             #     guaranteed.  If the server doesn't support this method, it returns
             #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     `Operations.GetOperation` or
+            #     Operations.GetOperation or
             #     other methods to check whether the cancellation succeeded or whether the
             #     operation completed despite cancellation. On successful cancellation,
             #     the operation is not deleted; instead, it becomes an operation with

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -311,11 +311,11 @@ module Google
             # makes a best effort to cancel the operation, but success is not
             # guaranteed.  If the server doesn't support this method, it returns
             # `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            # [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            # `Operations.GetOperation` or
             # other methods to check whether the cancellation succeeded or whether the
             # operation completed despite cancellation. On successful cancellation,
             # the operation is not deleted; instead, it becomes an operation with
-            # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            # an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
             # corresponding to `Code.CANCELLED`.
             #
             # @overload cancel_operation(request, options = nil)
@@ -324,11 +324,11 @@ module Google
             #     makes a best effort to cancel the operation, but success is not
             #     guaranteed.  If the server doesn't support this method, it returns
             #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+            #     `Operations.GetOperation` or
             #     other methods to check whether the cancellation succeeded or whether the
             #     operation completed despite cancellation. On successful cancellation,
             #     the operation is not deleted; instead, it becomes an operation with
-            #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+            #     an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
             #     corresponding to `Code.CANCELLED`.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/product_search.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/product_search.rb
@@ -28,7 +28,7 @@ module Google
         #     Optional. If it is not specified, system discretion will be applied.
         # @!attribute [rw] product_set
         #   @return [String]
-        #     The resource name of a [ProductSet][google.cloud.vision.v1.ProductSet] to be searched for similar images.
+        #     The resource name of a {Google::Cloud::Vision::V1::ProductSet ProductSet} to be searched for similar images.
         #
         #     Format is:
         #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`.

--- a/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/product_search_service.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/product_search_service.rb
@@ -214,7 +214,7 @@ module Google
         #     product.name is immutable.
         # @!attribute [rw] update_mask
         #   @return [Google::Protobuf::FieldMask]
-        #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields
+        #     The {Google::Protobuf::FieldMask FieldMask} that specifies which fields
         #     to update.
         #     If update_mask isn't specified, all mutable fields are to be updated.
         #     Valid mask paths include `product_labels`, `display_name`, and
@@ -304,7 +304,7 @@ module Google
         #     Required. The ProductSet resource which replaces the one on the server.
         # @!attribute [rw] update_mask
         #   @return [Google::Protobuf::FieldMask]
-        #     The [FieldMask][google.protobuf.FieldMask] that specifies which fields to
+        #     The {Google::Protobuf::FieldMask FieldMask} that specifies which fields to
         #     update.
         #     If update_mask isn't specified, all mutable fields are to be updated.
         #     Valid mask path is `display_name`.
@@ -503,16 +503,16 @@ module Google
         #     `product-id` values does not exist, then the system will create a new
         #     `ProductSet` or `Product` for the image. In this case, the
         #     `product-display-name` column refers to
-        #     [display_name][google.cloud.vision.v1.Product.display_name], the
+        #     {Google::Cloud::Vision::V1::Product#display_name display_name}, the
         #     `product-category` column refers to
-        #     [product_category][google.cloud.vision.v1.Product.product_category], and the
-        #     `labels` column refers to [product_labels][google.cloud.vision.v1.Product.product_labels].
+        #     {Google::Cloud::Vision::V1::Product#product_category product_category}, and the
+        #     `labels` column refers to {Google::Cloud::Vision::V1::Product#product_labels product_labels}.
         #
         #     The `image-id` column is optional but must be unique if provided. If it is
         #     empty, the system will automatically assign a unique id to the image.
         #
         #     The `product-display-name` column is optional. If it is empty, the system
-        #     sets the [display_name][google.cloud.vision.v1.Product.display_name] field for the product to a
+        #     sets the {Google::Cloud::Vision::V1::Product#display_name display_name} field for the product to a
         #     space (" "). You can update the `display_name` later by using the API.
         #
         #     If a `Product` with the specified `product-id` already exists, then the
@@ -573,8 +573,8 @@ module Google
         # Response message for the `ImportProductSets` method.
         #
         # This message is returned by the
-        # [google.longrunning.Operations.GetOperation][google.longrunning.Operations.GetOperation] method in the returned
-        # [google.longrunning.Operation.response][google.longrunning.Operation.response] field.
+        # `google.longrunning.Operations.GetOperation` method in the returned
+        # {Google::Longrunning::Operation#response google.longrunning.Operation.response} field.
         # @!attribute [rw] reference_images
         #   @return [Array<Google::Cloud::Vision::V1::ReferenceImage>]
         #     The list of reference_images that are imported successfully.
@@ -604,7 +604,7 @@ module Google
         # @!attribute [rw] end_time
         #   @return [Google::Protobuf::Timestamp]
         #     The time when the batch request is finished and
-        #     [google.longrunning.Operation.done][google.longrunning.Operation.done] is set to true.
+        #     {Google::Longrunning::Operation#done google.longrunning.Operation.done} is set to true.
         class BatchOperationMetadata
           include Google::Protobuf::MessageExts
           extend Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/product_search_service.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/product_search_service.rb
@@ -573,7 +573,7 @@ module Google
         # Response message for the `ImportProductSets` method.
         #
         # This message is returned by the
-        # `google.longrunning.Operations.GetOperation` method in the returned
+        # google.longrunning.Operations.GetOperation method in the returned
         # {Google::Longrunning::Operation#response google.longrunning.Operation.response} field.
         # @!attribute [rw] reference_images
         #   @return [Array<Google::Cloud::Vision::V1::ReferenceImage>]

--- a/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/text_annotation.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/text_annotation.rb
@@ -26,7 +26,7 @@ module Google
         #     TextAnnotation -> Page -> Block -> Paragraph -> Word -> Symbol
         # Each structural component, starting from Page, may further have their own
         # properties. Properties describe detected languages, breaks etc.. Please refer
-        # to the [TextAnnotation.TextProperty][google.cloud.vision.v1.TextAnnotation.TextProperty] message definition below for more
+        # to the {Google::Cloud::Vision::V1::TextAnnotation::TextProperty TextAnnotation.TextProperty} message definition below for more
         # detail.
         # @!attribute [rw] pages
         #   @return [Array<Google::Cloud::Vision::V1::Page>]

--- a/shared/output/cloud/vision_v1/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/longrunning/operations.rb
@@ -55,7 +55,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.GetOperation`.
+    # The request message for Operations.GetOperation.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource.
@@ -64,7 +64,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.ListOperations`.
+    # The request message for Operations.ListOperations.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation collection.
@@ -82,7 +82,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The response message for `Operations.ListOperations`.
+    # The response message for Operations.ListOperations.
     # @!attribute [rw] operations
     #   @return [Array<Google::Longrunning::Operation>]
     #     A list of operations that matches the specified filter in the request.
@@ -94,7 +94,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.CancelOperation`.
+    # The request message for Operations.CancelOperation.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be cancelled.
@@ -103,7 +103,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.DeleteOperation`.
+    # The request message for Operations.DeleteOperation.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be deleted.

--- a/shared/output/cloud/vision_v1/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/longrunning/operations.rb
@@ -55,7 +55,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.GetOperation][google.longrunning.Operations.GetOperation].
+    # The request message for `Operations.GetOperation`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource.
@@ -64,7 +64,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+    # The request message for `Operations.ListOperations`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation collection.
@@ -82,7 +82,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The response message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+    # The response message for `Operations.ListOperations`.
     # @!attribute [rw] operations
     #   @return [Array<Google::Longrunning::Operation>]
     #     A list of operations that matches the specified filter in the request.
@@ -94,7 +94,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.CancelOperation][google.longrunning.Operations.CancelOperation].
+    # The request message for `Operations.CancelOperation`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be cancelled.
@@ -103,7 +103,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.DeleteOperation][google.longrunning.Operations.DeleteOperation].
+    # The request message for `Operations.DeleteOperation`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be deleted.

--- a/shared/output/cloud/vision_v1/proto_docs/google/rpc/status.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/rpc/status.rb
@@ -78,7 +78,7 @@ module Google
     #   @return [String]
     #     A developer-facing error message, which should be in English. Any
     #     user-facing error message should be localized and sent in the
-    #     [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+    #     {Google::Rpc::Status#details google.rpc.Status.details} field, or localized by the client.
     # @!attribute [rw] details
     #   @return [Array<Google::Protobuf::Any>]
     #     A list of messages that carry the error details.  There is a common set of

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -312,7 +312,7 @@ module So
           # makes a best effort to cancel the operation, but success is not
           # guaranteed.  If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          # `Operations.GetOperation` or
+          # Operations.GetOperation or
           # other methods to check whether the cancellation succeeded or whether the
           # operation completed despite cancellation. On successful cancellation,
           # the operation is not deleted; instead, it becomes an operation with
@@ -325,7 +325,7 @@ module So
           #     makes a best effort to cancel the operation, but success is not
           #     guaranteed.  If the server doesn't support this method, it returns
           #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #     `Operations.GetOperation` or
+          #     Operations.GetOperation or
           #     other methods to check whether the cancellation succeeded or whether the
           #     operation completed despite cancellation. On successful cancellation,
           #     the operation is not deleted; instead, it becomes an operation with

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -312,11 +312,11 @@ module So
           # makes a best effort to cancel the operation, but success is not
           # guaranteed.  If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          # [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          # `Operations.GetOperation` or
           # other methods to check whether the cancellation succeeded or whether the
           # operation completed despite cancellation. On successful cancellation,
           # the operation is not deleted; instead, it becomes an operation with
-          # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          # an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
           # corresponding to `Code.CANCELLED`.
           #
           # @overload cancel_operation(request, options = nil)
@@ -325,11 +325,11 @@ module So
           #     makes a best effort to cancel the operation, but success is not
           #     guaranteed.  If the server doesn't support this method, it returns
           #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          #     `Operations.GetOperation` or
           #     other methods to check whether the cancellation succeeded or whether the
           #     operation completed despite cancellation. On successful cancellation,
           #     the operation is not deleted; instead, it becomes an operation with
-          #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          #     an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
           #     corresponding to `Code.CANCELLED`.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/shared/output/gapic/templates/garbage/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/gapic/templates/garbage/proto_docs/google/longrunning/operations.rb
@@ -63,7 +63,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.GetOperation][google.longrunning.Operations.GetOperation].
+    # The request message for `Operations.GetOperation`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource.
@@ -72,7 +72,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+    # The request message for `Operations.ListOperations`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation collection.
@@ -90,7 +90,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The response message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+    # The response message for `Operations.ListOperations`.
     # @!attribute [rw] operations
     #   @return [Array<Google::Longrunning::Operation>]
     #     A list of operations that matches the specified filter in the request.
@@ -102,7 +102,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.CancelOperation][google.longrunning.Operations.CancelOperation].
+    # The request message for `Operations.CancelOperation`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be cancelled.
@@ -111,7 +111,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.DeleteOperation][google.longrunning.Operations.DeleteOperation].
+    # The request message for `Operations.DeleteOperation`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be deleted.

--- a/shared/output/gapic/templates/garbage/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/gapic/templates/garbage/proto_docs/google/longrunning/operations.rb
@@ -63,7 +63,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.GetOperation`.
+    # The request message for Operations.GetOperation.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource.
@@ -72,7 +72,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.ListOperations`.
+    # The request message for Operations.ListOperations.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation collection.
@@ -90,7 +90,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The response message for `Operations.ListOperations`.
+    # The response message for Operations.ListOperations.
     # @!attribute [rw] operations
     #   @return [Array<Google::Longrunning::Operation>]
     #     A list of operations that matches the specified filter in the request.
@@ -102,7 +102,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.CancelOperation`.
+    # The request message for Operations.CancelOperation.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be cancelled.
@@ -111,7 +111,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.DeleteOperation`.
+    # The request message for Operations.DeleteOperation.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be deleted.

--- a/shared/output/gapic/templates/garbage/proto_docs/google/rpc/status.rb
+++ b/shared/output/gapic/templates/garbage/proto_docs/google/rpc/status.rb
@@ -86,7 +86,7 @@ module Google
     #   @return [String]
     #     A developer-facing error message, which should be in English. Any
     #     user-facing error message should be localized and sent in the
-    #     [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+    #     {Google::Rpc::Status#details google.rpc.Status.details} field, or localized by the client.
     # @!attribute [rw] details
     #   @return [Array<Google::Protobuf::Any>]
     #     A list of messages that carry the error details.  There is a common set of

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -312,7 +312,7 @@ module Google
           # makes a best effort to cancel the operation, but success is not
           # guaranteed.  If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          # `Operations.GetOperation` or
+          # Operations.GetOperation or
           # other methods to check whether the cancellation succeeded or whether the
           # operation completed despite cancellation. On successful cancellation,
           # the operation is not deleted; instead, it becomes an operation with
@@ -325,7 +325,7 @@ module Google
           #     makes a best effort to cancel the operation, but success is not
           #     guaranteed.  If the server doesn't support this method, it returns
           #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #     `Operations.GetOperation` or
+          #     Operations.GetOperation or
           #     other methods to check whether the cancellation succeeded or whether the
           #     operation completed despite cancellation. On successful cancellation,
           #     the operation is not deleted; instead, it becomes an operation with

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -312,11 +312,11 @@ module Google
           # makes a best effort to cancel the operation, but success is not
           # guaranteed.  If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          # [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          # `Operations.GetOperation` or
           # other methods to check whether the cancellation succeeded or whether the
           # operation completed despite cancellation. On successful cancellation,
           # the operation is not deleted; instead, it becomes an operation with
-          # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          # an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
           # corresponding to `Code.CANCELLED`.
           #
           # @overload cancel_operation(request, options = nil)
@@ -325,11 +325,11 @@ module Google
           #     makes a best effort to cancel the operation, but success is not
           #     guaranteed.  If the server doesn't support this method, it returns
           #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          #     `Operations.GetOperation` or
           #     other methods to check whether the cancellation succeeded or whether the
           #     operation completed despite cancellation. On successful cancellation,
           #     the operation is not deleted; instead, it becomes an operation with
-          #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          #     an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
           #     corresponding to `Code.CANCELLED`.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -312,7 +312,7 @@ module Google
           # makes a best effort to cancel the operation, but success is not
           # guaranteed.  If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          # `Operations.GetOperation` or
+          # Operations.GetOperation or
           # other methods to check whether the cancellation succeeded or whether the
           # operation completed despite cancellation. On successful cancellation,
           # the operation is not deleted; instead, it becomes an operation with
@@ -325,7 +325,7 @@ module Google
           #     makes a best effort to cancel the operation, but success is not
           #     guaranteed.  If the server doesn't support this method, it returns
           #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #     `Operations.GetOperation` or
+          #     Operations.GetOperation or
           #     other methods to check whether the cancellation succeeded or whether the
           #     operation completed despite cancellation. On successful cancellation,
           #     the operation is not deleted; instead, it becomes an operation with

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -312,11 +312,11 @@ module Google
           # makes a best effort to cancel the operation, but success is not
           # guaranteed.  If the server doesn't support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          # [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          # `Operations.GetOperation` or
           # other methods to check whether the cancellation succeeded or whether the
           # operation completed despite cancellation. On successful cancellation,
           # the operation is not deleted; instead, it becomes an operation with
-          # an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          # an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
           # corresponding to `Code.CANCELLED`.
           #
           # @overload cancel_operation(request, options = nil)
@@ -325,11 +325,11 @@ module Google
           #     makes a best effort to cancel the operation, but success is not
           #     guaranteed.  If the server doesn't support this method, it returns
           #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #     [Operations.GetOperation][google.longrunning.Operations.GetOperation] or
+          #     `Operations.GetOperation` or
           #     other methods to check whether the cancellation succeeded or whether the
           #     operation completed despite cancellation. On successful cancellation,
           #     the operation is not deleted; instead, it becomes an operation with
-          #     an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
+          #     an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
           #     corresponding to `Code.CANCELLED`.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/shared/output/gapic/templates/showcase/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/longrunning/operations.rb
@@ -63,7 +63,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.GetOperation][google.longrunning.Operations.GetOperation].
+    # The request message for `Operations.GetOperation`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource.
@@ -72,7 +72,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+    # The request message for `Operations.ListOperations`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation collection.
@@ -90,7 +90,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The response message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+    # The response message for `Operations.ListOperations`.
     # @!attribute [rw] operations
     #   @return [Array<Google::Longrunning::Operation>]
     #     A list of operations that matches the specified filter in the request.
@@ -102,7 +102,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.CancelOperation][google.longrunning.Operations.CancelOperation].
+    # The request message for `Operations.CancelOperation`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be cancelled.
@@ -111,7 +111,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for [Operations.DeleteOperation][google.longrunning.Operations.DeleteOperation].
+    # The request message for `Operations.DeleteOperation`.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be deleted.

--- a/shared/output/gapic/templates/showcase/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/longrunning/operations.rb
@@ -63,7 +63,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.GetOperation`.
+    # The request message for Operations.GetOperation.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource.
@@ -72,7 +72,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.ListOperations`.
+    # The request message for Operations.ListOperations.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation collection.
@@ -90,7 +90,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The response message for `Operations.ListOperations`.
+    # The response message for Operations.ListOperations.
     # @!attribute [rw] operations
     #   @return [Array<Google::Longrunning::Operation>]
     #     A list of operations that matches the specified filter in the request.
@@ -102,7 +102,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.CancelOperation`.
+    # The request message for Operations.CancelOperation.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be cancelled.
@@ -111,7 +111,7 @@ module Google
       extend Google::Protobuf::MessageExts::ClassMethods
     end
 
-    # The request message for `Operations.DeleteOperation`.
+    # The request message for Operations.DeleteOperation.
     # @!attribute [rw] name
     #   @return [String]
     #     The name of the operation resource to be deleted.

--- a/shared/output/gapic/templates/showcase/proto_docs/google/rpc/status.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/rpc/status.rb
@@ -86,7 +86,7 @@ module Google
     #   @return [String]
     #     A developer-facing error message, which should be in English. Any
     #     user-facing error message should be localized and sent in the
-    #     [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+    #     {Google::Rpc::Status#details google.rpc.Status.details} field, or localized by the client.
     # @!attribute [rw] details
     #   @return [Array<Google::Protobuf::Any>]
     #     A list of messages that carry the error details.  There is a common set of


### PR DESCRIPTION
AIP 192 describes [a format for cross-references in comments](https://aip.dev/192#cross-references). This PR detects cross-references and replaces them with the corresponding YARD syntax for generating links to the appropriate documentation.

Note: we treat `google.longrunning.Operations` as a special case, because the generator creates special operations clients that live in the generated service namespace rather than under `Google::Longrunning::Operations`. Because there might be multiple such operations clients, and it might be ambiguous which one to use, we punt and just provide the text without a yard reference.