### PR TITLE
Preserve call options in LROs

### DIFF
--- a/gapic-common/lib/gapic/call_options.rb
+++ b/gapic-common/lib/gapic/call_options.rb
@@ -64,5 +64,13 @@ module Gapic
       @metadata = metadata.merge @metadata if metadata
       @retry_policy.apply_defaults retry_policy if @retry_policy.respond_to? :apply_defaults
     end
+
+    def to_h
+      {
+        timeout:      timeout,
+        metadata:     metadata,
+        retry_policy: retry_policy
+      }
+    end
   end
 end

--- a/gapic-common/lib/gapic/operation.rb
+++ b/gapic-common/lib/gapic/operation.rb
@@ -84,12 +84,13 @@ module Gapic
     # @param metadata_type [Class] The class type to be unpacked from the metadata. If not provided the class type
     #   will be looked up. Optional.
     #
-    def initialize grpc_op, client, result_type: nil, metadata_type: nil
+    def initialize grpc_op, client, result_type: nil, metadata_type: nil, options: {}
       @grpc_op = grpc_op
       @client = client
       @result_type = result_type
       @metadata_type = metadata_type
       @on_done_callbacks = []
+      @options = options
     end
 
     ##
@@ -224,8 +225,14 @@ module Gapic
     #
     def reload! options: nil
       # Converts hash and nil to an options object
-      options = Gapic::CallOptions.new(**options.to_h) if options.respond_to? :to_h
+      options = if options.respond_to? :to_h
+                  options.to_h
+                else
+                  {}
+                end
+      options.merge! @options.to_h
 
+      options = Gapic::CallOptions.new(**options)
       gax_op = @client.get_operation({ name: @grpc_op.name }, options)
       @grpc_op = gax_op.grpc_op
 

--- a/gapic-generator-cloud/templates/cloud/gem/gemspec.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/gemspec.erb
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   <%- if gem.iam_dependency? -%>
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"

--- a/gapic-generator/templates/default/gem/gemspec.erb
+++ b/gapic-generator/templates/default/gem/gemspec.erb
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
   <%- if gem.iam_dependency? -%>
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
   <%- end -%>

--- a/gapic-generator/templates/default/service/client/method/def/_response_normal.erb
+++ b/gapic-generator/templates/default/service/client/method/def/_response_normal.erb
@@ -1,7 +1,7 @@
 <%- assert_locals method -%>
 @<%= method.service.stub_name %>.call_rpc :<%= method.name %>, request, options: options do |response, operation|
   <%- if method.lro? -%>
-  response = Gapic::Operation.new response, <%= method.service.lro_client_ivar %>
+  response = Gapic::Operation.new response, <%= method.service.lro_client_ivar %>, options: options
   <%- end -%>
   yield response, operation if block_given?
   return response

--- a/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
+++ b/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
+++ b/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
+++ b/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/cloud/noservice/google-garbage-noservice.gemspec
+++ b/shared/output/cloud/noservice/google-garbage-noservice.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
+++ b/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 

--- a/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
+++ b/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -573,7 +573,7 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @speech_stub.call_rpc :long_running_recognize, request, options: options do |response, operation|
-                response = Gapic::Operation.new response, @operations_client
+                response = Gapic::Operation.new response, @operations_client, options: options
                 yield response, operation if block_given?
                 return response
               end

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -233,7 +233,7 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
-                response = Gapic::Operation.new response, @operations_client
+                response = Gapic::Operation.new response, @operations_client, options: options
                 yield response, operation if block_given?
                 return response
               end

--- a/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
+++ b/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -374,7 +374,7 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @image_annotator_stub.call_rpc :async_batch_annotate_images, request, options: options do |response, operation|
-                response = Gapic::Operation.new response, @operations_client
+                response = Gapic::Operation.new response, @operations_client, options: options
                 yield response, operation if block_given?
                 return response
               end
@@ -451,7 +451,7 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @image_annotator_stub.call_rpc :async_batch_annotate_files, request, options: options do |response, operation|
-                response = Gapic::Operation.new response, @operations_client
+                response = Gapic::Operation.new response, @operations_client, options: options
                 yield response, operation if block_given?
                 return response
               end

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -233,7 +233,7 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
-                response = Gapic::Operation.new response, @operations_client
+                response = Gapic::Operation.new response, @operations_client, options: options
                 yield response, operation if block_given?
                 return response
               end

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -1551,7 +1551,7 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :import_product_sets, request, options: options do |response, operation|
-                response = Gapic::Operation.new response, @operations_client
+                response = Gapic::Operation.new response, @operations_client, options: options
                 yield response, operation if block_given?
                 return response
               end
@@ -1667,7 +1667,7 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @product_search_stub.call_rpc :purge_products, request, options: options do |response, operation|
-                response = Gapic::Operation.new response, @operations_client
+                response = Gapic::Operation.new response, @operations_client, options: options
                 yield response, operation if block_given?
                 return response
               end

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -233,7 +233,7 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
-                response = Gapic::Operation.new response, @operations_client
+                response = Gapic::Operation.new response, @operations_client, options: options
                 yield response, operation if block_given?
                 return response
               end

--- a/shared/output/gapic/templates/garbage/google-garbage.gemspec
+++ b/shared/output/gapic/templates/garbage/google-garbage.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -904,7 +904,7 @@ module So
                                    retry_policy: @config.retry_policy
 
             @garbage_service_stub.call_rpc :long_running_garbage, request, options: options do |response, operation|
-              response = Gapic::Operation.new response, @operations_client
+              response = Gapic::Operation.new response, @operations_client, options: options
               yield response, operation if block_given?
               return response
             end

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -238,7 +238,7 @@ module So
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
-              response = Gapic::Operation.new response, @operations_client
+              response = Gapic::Operation.new response, @operations_client, options: options
               yield response, operation if block_given?
               return response
             end

--- a/shared/output/gapic/templates/grpc_service_config/testing-grpc_service_config.gemspec
+++ b/shared/output/gapic/templates/grpc_service_config/testing-grpc_service_config.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/shared/output/gapic/templates/showcase/google-showcase.gemspec
+++ b/shared/output/gapic/templates/showcase/google-showcase.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "gapic-common", "~> 0.1.0"
+  gem.add_dependency "gapic-common", "~> 0.2"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -473,7 +473,7 @@ module Google
                                    retry_policy: @config.retry_policy
 
             @echo_stub.call_rpc :wait, request, options: options do |response, operation|
-              response = Gapic::Operation.new response, @operations_client
+              response = Gapic::Operation.new response, @operations_client, options: options
               yield response, operation if block_given?
               return response
             end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -238,7 +238,7 @@ module Google
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
-              response = Gapic::Operation.new response, @operations_client
+              response = Gapic::Operation.new response, @operations_client, options: options
               yield response, operation if block_given?
               return response
             end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -808,7 +808,7 @@ module Google
                                    retry_policy: @config.retry_policy
 
             @messaging_stub.call_rpc :search_blurbs, request, options: options do |response, operation|
-              response = Gapic::Operation.new response, @operations_client
+              response = Gapic::Operation.new response, @operations_client, options: options
               yield response, operation if block_given?
               return response
             end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -238,7 +238,7 @@ module Google
                                    retry_policy: @config.retry_policy
 
             @operations_stub.call_rpc :get_operation, request, options: options do |response, operation|
-              response = Gapic::Operation.new response, @operations_client
+              response = Gapic::Operation.new response, @operations_client, options: options
               yield response, operation if block_given?
               return response
             end


### PR DESCRIPTION
With ads, customer ID and Developer Token are passed as call metadata,
as such, we need them to be preserved to follow on calls made through
call metadata.

This patch ensures that `Gapic::Operation` instances created in clients
that use an `OperationsClient` preserve metadata from the calls that
created them.