### PR TITLE
feat: path modules extend self so helpers can be invoked on them directly

### DIFF
--- a/gapic-generator-cloud/templates/cloud/gem/rubocop.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/rubocop.erb
@@ -62,3 +62,5 @@ Style/CaseEquality:
     <%- end -%>
     <%- end -%>
     - "lib/<%= gem.name.tr "-", "/" %>.rb"
+Style/ModuleFunction:
+  Enabled: false

--- a/gapic-generator/templates/default/gem/rubocop.erb
+++ b/gapic-generator/templates/default/gem/rubocop.erb
@@ -57,3 +57,5 @@ Style/CaseEquality:
     - "lib/<%= service.client_file_path.sub "client.rb", "*.rb" %>"
     <%- end -%>
     <%- end -%>
+Style/ModuleFunction:
+  Enabled: false

--- a/gapic-generator/templates/default/service/client/_paths.erb
+++ b/gapic-generator/templates/default/service/client/_paths.erb
@@ -5,4 +5,5 @@ module Paths
 <%= indent render(partial: "service/client/resource", locals: { resource: resource }), 2 %>
 
 <%- end %>
+  extend self
 end

--- a/shared/output/cloud/language_v1/.rubocop.yml
+++ b/shared/output/cloud/language_v1/.rubocop.yml
@@ -33,3 +33,5 @@ Style/CaseEquality:
   Exclude:
     - "lib/google/cloud/language/v1/language_service/*.rb"
     - "lib/google/cloud/language/v1.rb"
+Style/ModuleFunction:
+  Enabled: false

--- a/shared/output/cloud/language_v1beta1/.rubocop.yml
+++ b/shared/output/cloud/language_v1beta1/.rubocop.yml
@@ -33,3 +33,5 @@ Style/CaseEquality:
   Exclude:
     - "lib/google/cloud/language/v1beta1/language_service/*.rb"
     - "lib/google/cloud/language/v1beta1.rb"
+Style/ModuleFunction:
+  Enabled: false

--- a/shared/output/cloud/language_v1beta2/.rubocop.yml
+++ b/shared/output/cloud/language_v1beta2/.rubocop.yml
@@ -33,3 +33,5 @@ Style/CaseEquality:
   Exclude:
     - "lib/google/cloud/language/v1beta2/language_service/*.rb"
     - "lib/google/cloud/language/v1beta2.rb"
+Style/ModuleFunction:
+  Enabled: false

--- a/shared/output/cloud/noservice/.rubocop.yml
+++ b/shared/output/cloud/noservice/.rubocop.yml
@@ -26,3 +26,5 @@ Naming/FileName:
 Style/CaseEquality:
   Exclude:
     - "lib/google/garbage/noservice.rb"
+Style/ModuleFunction:
+  Enabled: false

--- a/shared/output/cloud/secretmanager_v1beta1/.rubocop.yml
+++ b/shared/output/cloud/secretmanager_v1beta1/.rubocop.yml
@@ -33,3 +33,5 @@ Style/CaseEquality:
   Exclude:
     - "lib/google/cloud/secret_manager/v1beta1/secret_manager_service/*.rb"
     - "lib/google/cloud/secret_manager/v1beta1.rb"
+Style/ModuleFunction:
+  Enabled: false

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/paths.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/paths.rb
@@ -73,6 +73,8 @@ module Google
 
               "projects/#{project}/secrets/#{secret}/versions/#{secret_version}"
             end
+
+            extend self
           end
         end
       end

--- a/shared/output/cloud/speech_v1/.rubocop.yml
+++ b/shared/output/cloud/speech_v1/.rubocop.yml
@@ -33,3 +33,5 @@ Style/CaseEquality:
   Exclude:
     - "lib/google/cloud/speech/v1/speech/*.rb"
     - "lib/google/cloud/speech/v1.rb"
+Style/ModuleFunction:
+  Enabled: false

--- a/shared/output/cloud/vision_v1/.rubocop.yml
+++ b/shared/output/cloud/vision_v1/.rubocop.yml
@@ -40,3 +40,5 @@ Style/CaseEquality:
     - "lib/google/cloud/vision/v1/product_search/*.rb"
     - "lib/google/cloud/vision/v1/image_annotator/*.rb"
     - "lib/google/cloud/vision/v1.rb"
+Style/ModuleFunction:
+  Enabled: false

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/paths.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/paths.rb
@@ -42,6 +42,8 @@ module Google
 
               "projects/#{project}/locations/#{location}/productSets/#{product_set}"
             end
+
+            extend self
           end
         end
       end

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/paths.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/paths.rb
@@ -82,6 +82,8 @@ module Google
 
               "projects/#{project}/locations/#{location}/products/#{product}/referenceImages/#{reference_image}"
             end
+
+            extend self
           end
         end
       end

--- a/shared/output/gapic/templates/garbage/.rubocop.yml
+++ b/shared/output/gapic/templates/garbage/.rubocop.yml
@@ -28,3 +28,5 @@ Metrics/PerceivedComplexity:
 Style/CaseEquality:
   Exclude:
     - "lib/so/much/trash/garbage_service/*.rb"
+Style/ModuleFunction:
+  Enabled: false

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/paths.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/paths.rb
@@ -112,6 +112,8 @@ module So
 
             "projects/#{project}/simple_garbage/#{garbage}"
           end
+
+          extend self
         end
       end
     end

--- a/shared/output/gapic/templates/grpc_service_config/.rubocop.yml
+++ b/shared/output/gapic/templates/grpc_service_config/.rubocop.yml
@@ -35,3 +35,5 @@ Style/CaseEquality:
   Exclude:
     - "lib/testing/grpc_service_config/service_no_retry/*.rb"
     - "lib/testing/grpc_service_config/service_with_retries/*.rb"
+Style/ModuleFunction:
+  Enabled: false

--- a/shared/output/gapic/templates/showcase/.rubocop.yml
+++ b/shared/output/gapic/templates/showcase/.rubocop.yml
@@ -49,3 +49,5 @@ Style/CaseEquality:
     - "lib/google/showcase/v1beta1/identity/*.rb"
     - "lib/google/showcase/v1beta1/messaging/*.rb"
     - "lib/google/showcase/v1beta1/testing/*.rb"
+Style/ModuleFunction:
+  Enabled: false

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/paths.rb
@@ -44,6 +44,8 @@ module Google
           def user_path user_id:
             "users/#{user_id}"
           end
+
+          extend self
         end
       end
     end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/paths.rb
@@ -97,6 +97,8 @@ module Google
           def user_path user_id:
             "users/#{user_id}"
           end
+
+          extend self
         end
       end
     end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/paths.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/paths.rb
@@ -61,6 +61,8 @@ module Google
 
             "sessions/#{session}/tests/#{test}"
           end
+
+          extend self
         end
       end
     end


### PR DESCRIPTION
This lets users call `Google::Cloud::Blah::V1::MyService::Paths.my_path` without having to instantiate a client object. This is a workaround for cases where a service does not provide a particular path helper, but the helper is available on another service.