### PR TITLE
fix: trigger iam dependency for iam v1 files other than iam_policy.proto

### DIFF
--- a/gapic-generator/templates/default/helpers/presenters/gem_presenter.rb
+++ b/gapic-generator/templates/default/helpers/presenters/gem_presenter.rb
@@ -114,7 +114,7 @@ class GemPresenter
   end
 
   def iam_dependency?
-    @api.files.map(&:name).include? "google/iam/v1/iam_policy.proto"
+    @api.files.map(&:name).any? { |f| f.start_with? "google/iam/v1/" }
   end
 
   private


### PR DESCRIPTION
Currently, the generator detects a dependency on the `grpc-google-iam-v1` only if a proto depends on the specific file `google/iam/v1/iam_policy.proto`. However, there are other files that should trigger the dependency, notably `google/iam/v1/policy.proto`. This is affecting the cloud asset library; without this fix, it fails to detect that it needs the `grpc-google-iam-v1` dependency, and thus the generated library fails to load.

Note: This was a long-running issue that affected the monolith as well. Currently, several libraries (including cloud asset) are fixing it with a synth hack.