### PR TITLE
tweak samples tasks for wrapper-gem rakefiles

### DIFF
--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/rakefile.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/rakefile.erb
@@ -112,7 +112,7 @@ namespace :samples do
         Bundler.with_clean_env do
           ENV["GOOGLE_CLOUD_SAMPLES_TEST"] = "not_master"
           sh "bundle update"
-          sh "bundle exec rake test_master"
+          sh "bundle exec rake test"
         end
       end
     else
@@ -126,7 +126,7 @@ namespace :samples do
         Bundler.with_clean_env do
           ENV["GOOGLE_CLOUD_SAMPLES_TEST"] = "master"
           sh "bundle update"
-          sh "bundle exec rake test_master"
+          sh "bundle exec rake test"
         end
       end
     else


### PR DESCRIPTION
since we're using the same task for both latest and master, remove extra task in https://github.com/googleapis/google-cloud-ruby/pull/5141 and use clearer task name here.
