### PR TITLE
fix: Set correct endpoint for LRO services

### DIFF
--- a/gapic-generator-cloud/Rakefile
+++ b/gapic-generator-cloud/Rakefile
@@ -82,39 +82,35 @@ namespace :image do
   end
 
   task :push do
-    require_relative "lib/gapic/generator/cloud/version.rb"
-    version = ENV["RELEASE_VERSION"] || Gapic::Generator::Cloud::VERSION
-    match = /^((\d+)\.\d+)\.\d+$/.match version
-    raise "Bad version format: #{version}" unless match
-    version_minor = match[1]
-    version_major = match[2]
-    project = ENV["PROJECT_ID"] || "gapic-images"
-    image_url = "gcr.io/#{project}/gapic-generator-ruby"
-    prepare_embedded_gapic_generator_directory
-    sh "gcloud builds submit --project=#{project} --config=cloudbuild.yaml" \
-       " --substitutions=_IMAGE_URL=#{image_url},_VERSION=#{version} ."
+    push_image
   end
 
   task :release do
-    require_relative "lib/gapic/generator/cloud/version.rb"
-    version = ENV["RELEASE_VERSION"] || Gapic::Generator::Cloud::VERSION
-    match = /^((\d+)\.\d+)\.\d+$/.match version
-    raise "Bad version format: #{version}" unless match
-    version_minor = match[1]
-    version_major = match[2]
-    project = ENV["PROJECT_ID"] || "gapic-images"
-    image_url = "gcr.io/#{project}/gapic-generator-ruby"
-    prepare_embedded_gapic_generator_directory
-    sh "gcloud builds submit --project=#{project} --config=cloudbuild.yaml" \
-       " --substitutions=_IMAGE_URL=#{image_url},_VERSION=#{version} ."
-    sh "gcloud container images add-tag --quiet #{image_url}:#{version}" \
-       " #{image_url}:#{version_minor} #{image_url}:#{version_major} #{image_url}:latest"
+    push_image tag_latest: true
   end
 end
 
 task :release_gem do
   Rake::Task["build"].invoke
   Rake::Task["release:rubygem_push"].invoke
+end
+
+def push_image tag_latest: false
+  require_relative "lib/gapic/generator/cloud/version.rb"
+  version = ENV["RELEASE_VERSION"] || Gapic::Generator::Cloud::VERSION
+  match = /^((\d+)\.\d+)\.\d+$/.match version
+  raise "Bad version format: #{version}" unless match
+  version_minor = match[1]
+  version_major = match[2]
+  project = ENV["PROJECT_ID"] || "gapic-images"
+  image_url = "gcr.io/#{project}/gapic-generator-ruby"
+  prepare_embedded_gapic_generator_directory
+  sh "gcloud builds submit --project=#{project} --config=cloudbuild.yaml" \
+     " --substitutions=_IMAGE_URL=#{image_url},_VERSION=#{version} ."
+  if tag_latest
+    sh "gcloud container images add-tag --quiet #{image_url}:#{version}" \
+       " #{image_url}:#{version_minor} #{image_url}:#{version_major} #{image_url}:latest"
+  end
 end
 
 def prepare_embedded_gapic_generator_directory

--- a/gapic-generator/lib/gapic/presenters/service_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_presenter.rb
@@ -268,15 +268,8 @@ module Gapic
       end
 
       def lro_service
-        unless defined? @lro_service
-          lro = @service.parent.parent.files.find { |file| file.name == "google/longrunning/operations.proto" }
-          if !lro.nil? && lro?
-            @lro_service = ServicePresenter.new @api, lro.services.first, parent_service: self
-          else
-            @lro_service = nil
-          end
-        end
-        @lro_service
+        lro = @service.parent.parent.files.find { |file| file.name == "google/longrunning/operations.proto" }
+        return ServicePresenter.new @api, lro.services.first, parent_service: self unless lro.nil?
       end
 
       def config_channel_args

--- a/gapic-generator/lib/gapic/presenters/service_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_presenter.rb
@@ -27,9 +27,10 @@ module Gapic
       include Gapic::Helpers::FilepathHelper
       include Gapic::Helpers::NamespaceHelper
 
-      def initialize api, service
+      def initialize api, service, parent_service: nil
         @api = api
         @service = service
+        @parent_service = parent_service
       end
 
       def gem
@@ -146,6 +147,7 @@ module Gapic
       end
 
       def client_endpoint
+        return @parent_service.client_endpoint if @parent_service
         @service.host || default_config(:default_host) || "localhost"
       end
 
@@ -266,9 +268,15 @@ module Gapic
       end
 
       def lro_service
-        lro = @service.parent.parent.files.find { |file| file.name == "google/longrunning/operations.proto" }
-
-        return ServicePresenter.new @api, lro.services.first unless lro.nil?
+        unless defined? @lro_service
+          lro = @service.parent.parent.files.find { |file| file.name == "google/longrunning/operations.proto" }
+          if !lro.nil? && lro?
+            @lro_service = ServicePresenter.new @api, lro.services.first, parent_service: self
+          else
+            @lro_service = nil
+          end
+        end
+        @lro_service
       end
 
       def config_channel_args

--- a/shared/output/cloud/secretmanager_wrapper/Rakefile
+++ b/shared/output/cloud/secretmanager_wrapper/Rakefile
@@ -125,7 +125,7 @@ namespace :samples do
         Bundler.with_clean_env do
           ENV["GOOGLE_CLOUD_SAMPLES_TEST"] = "not_master"
           sh "bundle update"
-          sh "bundle exec rake test_master"
+          sh "bundle exec rake test"
         end
       end
     else
@@ -139,7 +139,7 @@ namespace :samples do
         Bundler.with_clean_env do
           ENV["GOOGLE_CLOUD_SAMPLES_TEST"] = "master"
           sh "bundle update"
-          sh "bundle exec rake test_master"
+          sh "bundle exec rake test"
         end
       end
     else

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -413,7 +413,7 @@ module So
           #
           # @!attribute [rw] endpoint
           #   The hostname or hostname:port of the service endpoint.
-          #   Defaults to `"localhost"`.
+          #   Defaults to `"endlesstrash.example.net"`.
           #   @return [String]
           # @!attribute [rw] credentials
           #   Credentials to send with calls. You may provide any of the following types:
@@ -461,7 +461,7 @@ module So
           class Configuration
             extend Gapic::Config
 
-            config_attr :endpoint,     "localhost", String
+            config_attr :endpoint,     "endlesstrash.example.net", String
             config_attr :credentials,  nil do |value|
               allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, ::Signet::OAuth2::Client, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -413,7 +413,7 @@ module Google
           #
           # @!attribute [rw] endpoint
           #   The hostname or hostname:port of the service endpoint.
-          #   Defaults to `"localhost"`.
+          #   Defaults to `"localhost:7469"`.
           #   @return [String]
           # @!attribute [rw] credentials
           #   Credentials to send with calls. You may provide any of the following types:
@@ -461,7 +461,7 @@ module Google
           class Configuration
             extend Gapic::Config
 
-            config_attr :endpoint,     "localhost", String
+            config_attr :endpoint,     "localhost:7469", String
             config_attr :credentials,  nil do |value|
               allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, ::Signet::OAuth2::Client, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -413,7 +413,7 @@ module Google
           #
           # @!attribute [rw] endpoint
           #   The hostname or hostname:port of the service endpoint.
-          #   Defaults to `"localhost"`.
+          #   Defaults to `"localhost:7469"`.
           #   @return [String]
           # @!attribute [rw] credentials
           #   Credentials to send with calls. You may provide any of the following types:
@@ -461,7 +461,7 @@ module Google
           class Configuration
             extend Gapic::Config
 
-            config_attr :endpoint,     "localhost", String
+            config_attr :endpoint,     "localhost:7469", String
             config_attr :credentials,  nil do |value|
               allowed = [::String, ::Hash, ::Proc, ::Google::Auth::Credentials, ::Signet::OAuth2::Client, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC


### PR DESCRIPTION
Previously, Operation services did not have the correct endpoint address configured because they were being generated from the generic `google.longrunning.Operations` proto, which of course doesn't have the service-specific endpoint set up. So the Operations clients were defaulting to `localhost` as the endpoint. Clearly, that won't work.

This PR fixes this by causing LRO service presenters to have a reference to the actual service they're attached to. Then the `client_endpoint` attribute uses the actual service's endpoint if that reference is present.

This PR also includes a couple of unrelated changes:
* DRY up the `image:push` and `image:release` tasks, which share almost all their logic.
* Regenerates the examples, which includes the results of #378.