### PR TITLE
feat: expand docker command line args, and include temporary hack for talent

### DIFF
--- a/gapic-generator-cloud/bin/ruby-cloud-docker-entrypoint
+++ b/gapic-generator-cloud/bin/ruby-cloud-docker-entrypoint
@@ -40,14 +40,19 @@ path_option_map = {
   "samples" => ["ruby-cloud-samples", "samples"],
   "grpc_service_config" => "ruby-cloud-grpc-service-config"
 }
+map_option_map = {
+  ":overrides.:file_path" => "ruby-cloud-path-override",
+  ":overrides.:namespace" => "ruby-cloud-namespace-override"
+}
 
 parameters = {}
 
 OptionParser.new do |op|
   bool_option_map.each do |key, flags|
-    flags = Array(flags).map { |f| "--#{f}" }
-    op.on(*flags) do
-      parameters[key] = "true"
+    flags = Array(flags).map { |f| "--#{f} BOOL" }
+    op.on(*flags) do |val|
+      val = val.downcase
+      parameters[key] = val if ["true", "false"].include? val
     end
   end
   value_option_map.each do |key, flags|
@@ -57,11 +62,18 @@ OptionParser.new do |op|
     end
   end
   path_option_map.each do |key, flags|
-    flags = Array(flags).map { |f| "--#{f} PATH" }
+    flags = Array(flags).map { |f| "--#{f} PATHS" }
     op.on(*flags) do |paths|
       parameters[key] = paths.split(";")
                              .map { |path| File.expand_path path, "/in" }
                              .join(";")
+    end
+  end
+  map_option_map.each do |key, flags|
+    flags = Array(flags).map { |f| "--#{f} MAPPING" }
+    op.on(*flags) do |mapping|
+      mapping_key, mapping_val = mapping.split("=", 2)
+      parameters["#{key}.#{mapping_key}"] = mapping_val if mapping_val
     end
   end
 end.parse! ARGV

--- a/gapic-generator-cloud/templates/cloud/gem/rakefile.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/rakefile.erb
@@ -104,7 +104,9 @@ end
 require "yard"
 require "yard/rake/yardoc_task"
 YARD::Rake::YardocTask.new do |y|
+<%- if gem.yard_strict? -%>
   y.options << "--fail-on-warning"
+<%- end -%>
 end
 
 desc "Run yard-doctest example tests."

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -134,11 +134,11 @@ module Gapic
       end
 
       def free_tier?
-        gem_config(:free_tier) ? true : false
+        gem_config(:free_tier) == "true"
       end
 
       def yard_strict?
-        gem_config(:yard_strict) ? true : false
+        gem_config(:yard_strict) != "false"
       end
 
       def entrypoint_require

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -134,10 +134,12 @@ module Gapic
       end
 
       def free_tier?
+        # Default to false unless the config is explicitly set to "true"
         gem_config(:free_tier) == "true"
       end
 
       def yard_strict?
+        # Default to true unless the config is explicitly set to "false"
         gem_config(:yard_strict) != "false"
       end
 

--- a/gapic-generator/lib/gapic/presenters/method_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/method_presenter.rb
@@ -160,6 +160,15 @@ module Gapic
 
       def paged?
         return false if server_streaming? # Cannot page a streaming response
+
+        # HACK: Two specific RPCs should not be paged.
+        # This is an intentionally hard-coded exception (and a temporary one,
+        # to be removed when these methods no longer conform to AIP-4233.) For
+        # detailed information, see internal link go/actools-talent-pagination.
+        address = @method.address.join "."
+        return false if address == "google.cloud.talent.v4beta1.SearchProfiles"
+        return false if address == "google.cloud.talent.v4beta1.SearchJobs"
+
         paged_request?(@method.input) && paged_response?(@method.output)
       end
 

--- a/gapic-generator/lib/gapic/presenters/method_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/method_presenter.rb
@@ -161,7 +161,7 @@ module Gapic
       def paged?
         return false if server_streaming? # Cannot page a streaming response
 
-        # HACK: Two specific RPCs should not be paged.
+        # HACK(dazuma, 2020-04-06): Two specific RPCs should not be paged.
         # This is an intentionally hard-coded exception (and a temporary one,
         # to be removed when these methods no longer conform to AIP-4233.) For
         # detailed information, see internal link go/actools-talent-pagination.

--- a/shared/output/cloud/secretmanager_wrapper/Rakefile
+++ b/shared/output/cloud/secretmanager_wrapper/Rakefile
@@ -151,6 +151,7 @@ end
 require "yard"
 require "yard/rake/yardoc_task"
 YARD::Rake::YardocTask.new do |y|
+  y.options << "--fail-on-warning"
 end
 
 desc "Run yard-doctest example tests."


### PR DESCRIPTION
This is a grab-bag of minor changes to support generating the automl and talent libraries. Specifically:

* Disable pagination for two specific RPCs in talent v4beta1. Fixes #342 
* Provide a way to set path and namespace overrides in the docker command line. These are necessary to generate automl properly because of the unusual naming convention used.
* Boolean options in the docker command line take an argument (either `true` or `false`) because synthtool assumes all options take an argument. This also makes it possible to disable `yard_strict` (which is necessary currently for automl since the docs are malformed).
* Made `yard_strict` enabled by default in wrappers, to match the fact that it is enabled by default in gapics.