### PR TITLE
feat: update shared IAM protos dependency

### DIFF
--- a/gapic-generator-cloud/templates/cloud/gem/gemspec.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/gemspec.erb
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "gapic-common", "~> 0.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   <%- if gem.iam_dependency? -%>
-  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
+  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
   <%- end -%>
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/gapic-generator/templates/default/gem/gemspec.erb
+++ b/gapic-generator/templates/default/gem/gemspec.erb
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", "~> 0.2"
   <%- if gem.iam_dependency? -%>
-  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
+  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
   <%- end -%>
 
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
+++ b/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", "~> 0.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
+  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"

--- a/shared/output/gapic/templates/garbage/google-garbage.gemspec
+++ b/shared/output/gapic/templates/garbage/google-garbage.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "gapic-common", "~> 0.2"
-  gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
+  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.10"


### PR DESCRIPTION
The common protos image embedded in the microgenerator docker releases was recently updated to include newer IAM protos with a slightly expanded interface (specifically, an extra `options` field on `GetIamPolicyRequest`). This is causing the microgenerator to generate documentation for that field, and tests that use that field, tests that were failing when run against the 0.6.9 release of the `grpc-google-iam-v1` shared protos gem. (See e.g. https://github.com/googleapis/google-cloud-ruby/pull/5356). I just built and pushed a version 0.6.10 update to the common gem with up to date protos. This PR updates the generated dependencies to call for at least that version.

The strange dependency `">= 0.6.10", "< 2.0"` is a hedge against future plans for the `grpc-google-iam-v1` library. It is a common protos library, so semver is kind of meaningless—there are _never_ supposed to be backward-incompatible changes (see https://aip.dev/213). As such, I want to promote it to 1.0 and treat it the same as our other two common libraries `googleapis-common-protos` and `googleapis-common-protos-type` (which are both at 1.x). However, before we can do that, we _must_ get _all_ libraries that depend on it to accept 1.x versions.