### PR TITLE
feat: Expanded readme for normal default clients and cloud clients

### DIFF
--- a/gapic-generator-cloud/templates/cloud/gem/readme.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/readme.erb
@@ -60,7 +60,7 @@ for general usage information.
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
 or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+that will write logs to [Cloud Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:

--- a/gapic-generator-cloud/templates/cloud/gem/readme.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/readme.erb
@@ -1,15 +1,15 @@
-# Ruby Client for the Google Cloud Speech V1 API
+# Ruby Client for the <%= gem.title %> API
 
-API Client library for the Google Cloud Speech V1 API
+<%= gem.summary %>
 
-google-cloud-speech-v1 is the official client library for the Google Cloud Speech V1 API.
+<%= gem.description %>
 
-https://github.com/googleapis/google-cloud-ruby
+<%= gem.homepage %>
 
 ## Installation
 
 ```
-$ gem install google-cloud-speech-v1
+$ gem install <%= gem.name %>
 ```
 
 ## Before You Begin
@@ -17,22 +17,44 @@ $ gem install google-cloud-speech-v1
 In order to use this library, you first need to go through the following steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
+<%- if gem.free_tier? -%>
+1. This API has a free tier. You may not need to
+   [enable billing](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
+   to get started.
+<%- else -%>
 1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
+<%- end -%>
+<%- if gem.api_id -%>
+1. [Enable the API.](https://console.cloud.google.com/apis/library/<%= gem.api_id %>.googleapis.com)
+<%- end -%>
 1. {file:AUTHENTICATION.md Set up authentication.}
 
 ## Quick Start
 
+<%- if gem.packages? -%>
 ```ruby
-require "google/cloud/speech/v1"
+require "<%= gem.entrypoint_require %>"
+<%- service = gem.packages.first.services.first -%>
+<%- method = service&.methods.first -%>
+<%- if service && method -%>
 
-client = Google::Cloud::Speech::V1::Speech::Client.new
+client = <%= service.create_client_call %>
 request = my_create_request
-response = client.recognize request
+response = client.<%= method.name %> request
+<%- end -%>
 ```
 
-View the [Client Library Documentation](https://googleapis.dev/ruby/google-cloud-speech-v1/latest)
+<%- end -%>
+<%- unless gem.library_documentation_url.to_s.empty? -%>
+View the [Client Library Documentation](<%= gem.library_documentation_url %>)
 for class and method documentation.
 
+<%- end -%>
+<%- if gem.product_documentation_url -%>
+See also the [Product Documentation](<%= gem.product_documentation_url %>)
+for general usage information.
+
+<%- end -%>
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.

--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/readme.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/readme.erb
@@ -62,7 +62,7 @@ See the {file:MIGRATING.md MIGRATING.md} document for more information.
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
 or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+that will write logs to [Cloud Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -37,6 +37,10 @@ module Gapic
         end
       end
 
+      def packages?
+        !packages.empty?
+      end
+
       def services
         @services ||= begin
           files = @api.generate_files

--- a/gapic-generator/templates/default/gem/readme.erb
+++ b/gapic-generator/templates/default/gem/readme.erb
@@ -1,4 +1,4 @@
-# <%= gem.title %>
+# Ruby Client for the <%= gem.title %> API
 
 <%= gem.summary %>
 
@@ -10,6 +10,20 @@
 
 ```
 $ gem install <%= gem.name %>
+```
+
+## Quick Start
+
+```ruby
+require "<%= gem.entrypoint_require %>"
+<%- service = gem.packages.first&.services.first -%>
+<%- method = service&.methods.first -%>
+<%- if service && method -%>
+
+client = <%= service.create_client_call %>
+request = my_create_request
+response = client.<%= method.name %> request
+<%- end -%>
 ```
 
 ## Supported Ruby Versions

--- a/shared/output/cloud/language_v1/README.md
+++ b/shared/output/cloud/language_v1/README.md
@@ -38,7 +38,7 @@ for class and method documentation.
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
 or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+that will write logs to [Cloud Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:

--- a/shared/output/cloud/language_v1/README.md
+++ b/shared/output/cloud/language_v1/README.md
@@ -1,4 +1,4 @@
-# Google Cloud Language V1
+# Ruby Client for the Google Cloud Language V1 API
 
 API Client library for the Google Cloud Language V1 API
 
@@ -10,6 +10,53 @@ https://github.com/googleapis/google-cloud-ruby
 
 ```
 $ gem install google-cloud-language-v1
+```
+
+## Before You Begin
+
+In order to use this library, you first need to go through the following steps:
+
+1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
+1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
+1. {file:AUTHENTICATION.md Set up authentication.}
+
+## Quick Start
+
+```ruby
+require "google/cloud/language/v1"
+
+client = Google::Cloud::Language::V1::LanguageService::Client.new
+request = my_create_request
+response = client.analyze_sentiment request
+```
+
+View the [Client Library Documentation](https://googleapis.dev/ruby/google-cloud-language-v1/latest)
+for class and method documentation.
+
+## Enabling Logging
+
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
+that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+
+Configuring a Ruby stdlib logger:
+
+```ruby
+require "logger"
+
+module MyLogger
+  LOGGER = Logger.new $stderr, level: Logger::WARN
+  def logger
+    LOGGER
+  end
+end
+
+# Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+module GRPC
+  extend MyLogger
+end
 ```
 
 ## Supported Ruby Versions

--- a/shared/output/cloud/language_v1beta1/README.md
+++ b/shared/output/cloud/language_v1beta1/README.md
@@ -38,7 +38,7 @@ for class and method documentation.
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
 or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+that will write logs to [Cloud Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:

--- a/shared/output/cloud/language_v1beta1/README.md
+++ b/shared/output/cloud/language_v1beta1/README.md
@@ -1,4 +1,4 @@
-# Google Cloud Language V1beta1
+# Ruby Client for the Google Cloud Language V1beta1 API
 
 API Client library for the Google Cloud Language V1beta1 API
 
@@ -10,6 +10,53 @@ https://github.com/googleapis/google-cloud-ruby
 
 ```
 $ gem install google-cloud-language-v1beta1
+```
+
+## Before You Begin
+
+In order to use this library, you first need to go through the following steps:
+
+1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
+1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
+1. {file:AUTHENTICATION.md Set up authentication.}
+
+## Quick Start
+
+```ruby
+require "google/cloud/language/v1beta1"
+
+client = Google::Cloud::Language::V1beta1::LanguageService::Client.new
+request = my_create_request
+response = client.analyze_sentiment request
+```
+
+View the [Client Library Documentation](https://googleapis.dev/ruby/google-cloud-language-v1beta1/latest)
+for class and method documentation.
+
+## Enabling Logging
+
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
+that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+
+Configuring a Ruby stdlib logger:
+
+```ruby
+require "logger"
+
+module MyLogger
+  LOGGER = Logger.new $stderr, level: Logger::WARN
+  def logger
+    LOGGER
+  end
+end
+
+# Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+module GRPC
+  extend MyLogger
+end
 ```
 
 ## Supported Ruby Versions

--- a/shared/output/cloud/language_v1beta2/README.md
+++ b/shared/output/cloud/language_v1beta2/README.md
@@ -1,4 +1,4 @@
-# Google Cloud Language V1beta2
+# Ruby Client for the Google Cloud Language V1beta2 API
 
 API Client library for the Google Cloud Language V1beta2 API
 
@@ -10,6 +10,53 @@ https://github.com/googleapis/google-cloud-ruby
 
 ```
 $ gem install google-cloud-language-v1beta2
+```
+
+## Before You Begin
+
+In order to use this library, you first need to go through the following steps:
+
+1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
+1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
+1. {file:AUTHENTICATION.md Set up authentication.}
+
+## Quick Start
+
+```ruby
+require "google/cloud/language/v1beta2"
+
+client = Google::Cloud::Language::V1beta2::LanguageService::Client.new
+request = my_create_request
+response = client.analyze_sentiment request
+```
+
+View the [Client Library Documentation](https://googleapis.dev/ruby/google-cloud-language-v1beta2/latest)
+for class and method documentation.
+
+## Enabling Logging
+
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
+that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+
+Configuring a Ruby stdlib logger:
+
+```ruby
+require "logger"
+
+module MyLogger
+  LOGGER = Logger.new $stderr, level: Logger::WARN
+  def logger
+    LOGGER
+  end
+end
+
+# Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+module GRPC
+  extend MyLogger
+end
 ```
 
 ## Supported Ruby Versions

--- a/shared/output/cloud/language_v1beta2/README.md
+++ b/shared/output/cloud/language_v1beta2/README.md
@@ -38,7 +38,7 @@ for class and method documentation.
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
 or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+that will write logs to [Cloud Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:

--- a/shared/output/cloud/noservice/README.md
+++ b/shared/output/cloud/noservice/README.md
@@ -1,4 +1,4 @@
-# Google Garbage Noservice
+# Ruby Client for the Google Garbage Noservice API
 
 API Client library for the Google Garbage Noservice API
 
@@ -10,6 +10,45 @@ https://github.com/googleapis/google-cloud-ruby
 
 ```
 $ gem install google-garbage-noservice
+```
+
+## Before You Begin
+
+In order to use this library, you first need to go through the following steps:
+
+1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
+1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
+1. {file:AUTHENTICATION.md Set up authentication.}
+
+## Quick Start
+
+View the [Client Library Documentation](https://googleapis.dev/ruby/google-garbage-noservice/latest)
+for class and method documentation.
+
+## Enabling Logging
+
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
+that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+
+Configuring a Ruby stdlib logger:
+
+```ruby
+require "logger"
+
+module MyLogger
+  LOGGER = Logger.new $stderr, level: Logger::WARN
+  def logger
+    LOGGER
+  end
+end
+
+# Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+module GRPC
+  extend MyLogger
+end
 ```
 
 ## Supported Ruby Versions

--- a/shared/output/cloud/noservice/README.md
+++ b/shared/output/cloud/noservice/README.md
@@ -30,7 +30,7 @@ for class and method documentation.
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
 or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+that will write logs to [Cloud Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:

--- a/shared/output/cloud/secretmanager_v1beta1/README.md
+++ b/shared/output/cloud/secretmanager_v1beta1/README.md
@@ -1,4 +1,4 @@
-# Secret Manager V1beta1
+# Ruby Client for the Secret Manager V1beta1 API
 
 Stores, manages, and secures access to application secrets.
 
@@ -10,6 +10,53 @@ https://github.com/googleapis/google-cloud-ruby
 
 ```
 $ gem install google-cloud-secret_manager-v1beta1
+```
+
+## Before You Begin
+
+In order to use this library, you first need to go through the following steps:
+
+1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
+1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
+1. {file:AUTHENTICATION.md Set up authentication.}
+
+## Quick Start
+
+```ruby
+require "google/cloud/secret_manager/v1beta1"
+
+client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+request = my_create_request
+response = client.list_secrets request
+```
+
+View the [Client Library Documentation](https://googleapis.dev/ruby/google-cloud-secret_manager-v1beta1/latest)
+for class and method documentation.
+
+## Enabling Logging
+
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
+that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+
+Configuring a Ruby stdlib logger:
+
+```ruby
+require "logger"
+
+module MyLogger
+  LOGGER = Logger.new $stderr, level: Logger::WARN
+  def logger
+    LOGGER
+  end
+end
+
+# Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+module GRPC
+  extend MyLogger
+end
 ```
 
 ## Supported Ruby Versions

--- a/shared/output/cloud/secretmanager_v1beta1/README.md
+++ b/shared/output/cloud/secretmanager_v1beta1/README.md
@@ -38,7 +38,7 @@ for class and method documentation.
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
 or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+that will write logs to [Cloud Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:

--- a/shared/output/cloud/secretmanager_wrapper/README.md
+++ b/shared/output/cloud/secretmanager_wrapper/README.md
@@ -47,7 +47,7 @@ See the {file:MIGRATING.md MIGRATING.md} document for more information.
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
 or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+that will write logs to [Cloud Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:

--- a/shared/output/cloud/speech_v1/README.md
+++ b/shared/output/cloud/speech_v1/README.md
@@ -38,7 +38,7 @@ for class and method documentation.
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
 or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+that will write logs to [Cloud Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:

--- a/shared/output/cloud/vision_v1/README.md
+++ b/shared/output/cloud/vision_v1/README.md
@@ -38,7 +38,7 @@ for class and method documentation.
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
 The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
 or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+that will write logs to [Cloud Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:

--- a/shared/output/cloud/vision_v1/README.md
+++ b/shared/output/cloud/vision_v1/README.md
@@ -1,4 +1,4 @@
-# Google Cloud Vision V1
+# Ruby Client for the Google Cloud Vision V1 API
 
 API Client library for the Google Cloud Vision V1 API
 
@@ -10,6 +10,53 @@ https://github.com/googleapis/google-cloud-ruby
 
 ```
 $ gem install google-cloud-vision-v1
+```
+
+## Before You Begin
+
+In order to use this library, you first need to go through the following steps:
+
+1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
+1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
+1. {file:AUTHENTICATION.md Set up authentication.}
+
+## Quick Start
+
+```ruby
+require "google/cloud/vision/v1"
+
+client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+request = my_create_request
+response = client.create_product_set request
+```
+
+View the [Client Library Documentation](https://googleapis.dev/ruby/google-cloud-vision-v1/latest)
+for class and method documentation.
+
+## Enabling Logging
+
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
+The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
+or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
+that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
+and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+
+Configuring a Ruby stdlib logger:
+
+```ruby
+require "logger"
+
+module MyLogger
+  LOGGER = Logger.new $stderr, level: Logger::WARN
+  def logger
+    LOGGER
+  end
+end
+
+# Define a gRPC module-level logger method before grpc/logconfig.rb loads.
+module GRPC
+  extend MyLogger
+end
 ```
 
 ## Supported Ruby Versions

--- a/shared/output/gapic/templates/garbage/README.md
+++ b/shared/output/gapic/templates/garbage/README.md
@@ -1,4 +1,4 @@
-# Google Garbage
+# Ruby Client for the Google Garbage API
 
 API Client library for the Google Garbage API
 
@@ -10,6 +10,16 @@ https://github.com/googleapis/googleapis
 
 ```
 $ gem install google-garbage
+```
+
+## Quick Start
+
+```ruby
+require "so/much/trash"
+
+client = So::Much::Trash::GarbageService::Client.new
+request = my_create_request
+response = client.get_empty_garbage request
 ```
 
 ## Supported Ruby Versions

--- a/shared/output/gapic/templates/grpc_service_config/README.md
+++ b/shared/output/gapic/templates/grpc_service_config/README.md
@@ -1,4 +1,4 @@
-# Testing GrpcServiceConfig
+# Ruby Client for the Testing GrpcServiceConfig API
 
 API Client library for the Testing GrpcServiceConfig API
 
@@ -10,6 +10,16 @@ https://github.com/googleapis/googleapis
 
 ```
 $ gem install testing-grpc_service_config
+```
+
+## Quick Start
+
+```ruby
+require "testing/grpc_service_config"
+
+client = Testing::GrpcServiceConfig::ServiceNoRetry::Client.new
+request = my_create_request
+response = client.no_retry_method request
 ```
 
 ## Supported Ruby Versions

--- a/shared/output/gapic/templates/showcase/README.md
+++ b/shared/output/gapic/templates/showcase/README.md
@@ -1,4 +1,4 @@
-# Google Showcase
+# Ruby Client for the Google Showcase API
 
 API Client library for the Google Showcase API
 
@@ -10,6 +10,16 @@ https://github.com/googleapis/googleapis
 
 ```
 $ gem install google-showcase
+```
+
+## Quick Start
+
+```ruby
+require "google/showcase/v1beta1"
+
+client = Google::Showcase::V1beta1::Echo::Client.new
+request = my_create_request
+response = client.echo request
 ```
 
 ## Supported Ruby Versions


### PR DESCRIPTION
Fixes #375.

This provides an expanded generated readme that includes a simple quickstart showing which file to require and generally how to create a client using one of the versioned gems.

It also includes an even more expanded readme for cloud clients that includes before-you-begin info on setting up projects, billing, auth, etc., as well as providing links to documentation.