### PR TITLE
feat: improve method docs

### DIFF
--- a/gapic-generator/lib/gapic/presenters/field_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/field_presenter.rb
@@ -95,7 +95,7 @@ module Gapic
         base_type =
           if field.message?
             type = message_ruby_type field.message
-            output ? type : "#{type} | Hash"
+            output ? type : "#{type}, Hash"
           elsif field.enum?
             # TODO: handle when arg message is nil and enum is the type
             message_ruby_type field.enum

--- a/gapic-generator/lib/gapic/presenters/method_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/method_presenter.rb
@@ -214,7 +214,7 @@ module Gapic
 
       def doc_types_for arg
         if arg.message?
-          "#{message_ruby_type arg.message} | Hash"
+          "#{message_ruby_type arg.message}, Hash"
         elsif arg.enum?
           # TODO: handle when arg message is nil and enum is the type
           message_ruby_type arg.enum

--- a/gapic-generator/templates/default/service/client/method/docs/_request_normal.erb
+++ b/gapic-generator/templates/default/service/client/method/docs/_request_normal.erb
@@ -1,15 +1,21 @@
 <%- assert_locals method -%>
 # @overload <%= method.name %>(request, options = nil)
-#   @param request [<%= method.request_type %> | Hash]
-<%- if method.doc_description -%>
-<%= indent method.doc_description, "#     " %>
-<%- end -%>
+#   Pass arguments to `<%= method.name %>` via a request object, either of type
+#   {<%= method.request_type %>} or an equivalent Hash.
+#
+#   @param request [<%= method.request_type %>, Hash]
+#     A request object representing the call parameters. Required. To specify no
+#     parameters, or to keep all the default parameter values, pass an empty Hash.
 #   @param options [Gapic::CallOptions, Hash]
 #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
 <%-if method.arguments.any?-%>
 #
 <%- arg_list = method.arguments.map { |arg| "#{arg.name}: nil"}.join ", " -%>
 # @overload <%= method.name %>(<%= arg_list %>)
+#   Pass arguments to `<%= method.name %>` via keyword arguments. Note that at
+#   least one keyword argument is required. To specify no parameters, or to keep all
+#   the default parameter values, pass an empty Hash as a request object (see above).
+#
 <%- method.arguments.each do |arg| -%>
 #   @param <%= arg.name %> [<%= arg.doc_types %>]
 <%- if arg.doc_description -%>
@@ -17,4 +23,3 @@
 <%- end -%>
 <%- end -%>
 <%- end -%>
-#

--- a/gapic-generator/templates/default/service/client/method/docs/_request_streaming.erb
+++ b/gapic-generator/templates/default/service/client/method/docs/_request_streaming.erb
@@ -1,5 +1,5 @@
 <%- assert_locals method -%>
-# @param request [Gapic::StreamInput, Enumerable<<%= method.request_type %> | Hash>]
+# @param request [Gapic::StreamInput, Enumerable<<%= method.request_type %>, Hash>]
 #   An enumerable of {<%= method.request_type %>} instances.
 # @param options [Gapic::CallOptions, Hash]
 #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
@@ -148,15 +148,22 @@ module Google
               # Returns the requested campaign in full detail.
               #
               # @overload get_campaign(request, options = nil)
-              #   @param request [Google::Ads::GoogleAds::V1::Services::GetCampaignRequest | Hash]
-              #     Returns the requested campaign in full detail.
+              #   Pass arguments to `get_campaign` via a request object, either of type
+              #   {Google::Ads::GoogleAds::V1::Services::GetCampaignRequest} or an equivalent Hash.
+              #
+              #   @param request [Google::Ads::GoogleAds::V1::Services::GetCampaignRequest, Hash]
+              #     A request object representing the call parameters. Required. To specify no
+              #     parameters, or to keep all the default parameter values, pass an empty Hash.
               #   @param options [Gapic::CallOptions, Hash]
               #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
               #
               # @overload get_campaign(resource_name: nil)
+              #   Pass arguments to `get_campaign` via keyword arguments. Note that at
+              #   least one keyword argument is required. To specify no parameters, or to keep all
+              #   the default parameter values, pass an empty Hash as a request object (see above).
+              #
               #   @param resource_name [String]
               #     Required. The resource name of the campaign to fetch.
-              #
               #
               # @yield [response, operation] Access the result along with the RPC operation
               # @yieldparam response [Google::Ads::GoogleAds::V1::Resources::Campaign]
@@ -207,15 +214,23 @@ module Google
               # Creates, updates, or removes campaigns. Operation statuses are returned.
               #
               # @overload mutate_campaigns(request, options = nil)
-              #   @param request [Google::Ads::GoogleAds::V1::Services::MutateCampaignsRequest | Hash]
-              #     Creates, updates, or removes campaigns. Operation statuses are returned.
+              #   Pass arguments to `mutate_campaigns` via a request object, either of type
+              #   {Google::Ads::GoogleAds::V1::Services::MutateCampaignsRequest} or an equivalent Hash.
+              #
+              #   @param request [Google::Ads::GoogleAds::V1::Services::MutateCampaignsRequest, Hash]
+              #     A request object representing the call parameters. Required. To specify no
+              #     parameters, or to keep all the default parameter values, pass an empty Hash.
               #   @param options [Gapic::CallOptions, Hash]
               #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
               #
               # @overload mutate_campaigns(customer_id: nil, operations: nil, partial_failure: nil, validate_only: nil)
+              #   Pass arguments to `mutate_campaigns` via keyword arguments. Note that at
+              #   least one keyword argument is required. To specify no parameters, or to keep all
+              #   the default parameter values, pass an empty Hash as a request object (see above).
+              #
               #   @param customer_id [String]
               #     Required. The ID of the customer whose campaigns are being modified.
-              #   @param operations [Array<Google::Ads::GoogleAds::V1::Services::CampaignOperation | Hash>]
+              #   @param operations [Array<Google::Ads::GoogleAds::V1::Services::CampaignOperation, Hash>]
               #     Required. The list of operations to perform on individual campaigns.
               #   @param partial_failure [Boolean]
               #     If true, successful operations will be carried out and invalid
@@ -225,7 +240,6 @@ module Google
               #   @param validate_only [Boolean]
               #     If true, the request is validated but not executed. Only errors are
               #     returned, not results.
-              #
               #
               # @yield [response, operation] Access the result along with the RPC operation
               # @yieldparam response [Google::Ads::GoogleAds::V1::Services::MutateCampaignsResponse]

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
@@ -200,17 +200,24 @@ module Google
             # Analyzes the sentiment of the provided text.
             #
             # @overload analyze_sentiment(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1::AnalyzeSentimentRequest | Hash]
-            #     Analyzes the sentiment of the provided text.
+            #   Pass arguments to `analyze_sentiment` via a request object, either of type
+            #   {Google::Cloud::Language::V1::AnalyzeSentimentRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1::AnalyzeSentimentRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload analyze_sentiment(document: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1::Document | Hash]
+            #   Pass arguments to `analyze_sentiment` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1::Document, Hash]
             #     Input document.
             #   @param encoding_type [Google::Cloud::Language::V1::EncodingType]
             #     The encoding type used by the API to calculate sentence offsets.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1::AnalyzeSentimentResponse]
@@ -336,19 +343,24 @@ module Google
             # other properties.
             #
             # @overload analyze_entities(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1::AnalyzeEntitiesRequest | Hash]
-            #     Finds named entities (currently proper names and common nouns) in the text
-            #     along with entity types, salience, mentions for each entity, and
-            #     other properties.
+            #   Pass arguments to `analyze_entities` via a request object, either of type
+            #   {Google::Cloud::Language::V1::AnalyzeEntitiesRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1::AnalyzeEntitiesRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload analyze_entities(document: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1::Document | Hash]
+            #   Pass arguments to `analyze_entities` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1::Document, Hash]
             #     Input document.
             #   @param encoding_type [Google::Cloud::Language::V1::EncodingType]
             #     The encoding type used by the API to calculate offsets.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1::AnalyzeEntitiesResponse]
@@ -497,18 +509,24 @@ module Google
             # sentiment associated with each entity and its mentions.
             #
             # @overload analyze_entity_sentiment(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest | Hash]
-            #     Finds entities, similar to {Google::Cloud::Language::V1::LanguageService::Client#analyze_entities AnalyzeEntities} in the text and analyzes
-            #     sentiment associated with each entity and its mentions.
+            #   Pass arguments to `analyze_entity_sentiment` via a request object, either of type
+            #   {Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload analyze_entity_sentiment(document: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1::Document | Hash]
+            #   Pass arguments to `analyze_entity_sentiment` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1::Document, Hash]
             #     Input document.
             #   @param encoding_type [Google::Cloud::Language::V1::EncodingType]
             #     The encoding type used by the API to calculate offsets.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1::AnalyzeEntitySentimentResponse]
@@ -666,19 +684,24 @@ module Google
             # properties.
             #
             # @overload analyze_syntax(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1::AnalyzeSyntaxRequest | Hash]
-            #     Analyzes the syntax of the text and provides sentence boundaries and
-            #     tokenization along with part of speech tags, dependency trees, and other
-            #     properties.
+            #   Pass arguments to `analyze_syntax` via a request object, either of type
+            #   {Google::Cloud::Language::V1::AnalyzeSyntaxRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1::AnalyzeSyntaxRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload analyze_syntax(document: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1::Document | Hash]
+            #   Pass arguments to `analyze_syntax` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1::Document, Hash]
             #     Input document.
             #   @param encoding_type [Google::Cloud::Language::V1::EncodingType]
             #     The encoding type used by the API to calculate offsets.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1::AnalyzeSyntaxResponse]
@@ -836,15 +859,22 @@ module Google
             # Classifies a document into categories.
             #
             # @overload classify_text(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1::ClassifyTextRequest | Hash]
-            #     Classifies a document into categories.
+            #   Pass arguments to `classify_text` via a request object, either of type
+            #   {Google::Cloud::Language::V1::ClassifyTextRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1::ClassifyTextRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload classify_text(document: nil)
-            #   @param document [Google::Cloud::Language::V1::Document | Hash]
-            #     Input document.
+            #   Pass arguments to `classify_text` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
             #
+            #   @param document [Google::Cloud::Language::V1::Document, Hash]
+            #     Input document.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1::ClassifyTextResponse]
@@ -954,20 +984,26 @@ module Google
             # analyzeEntities, and analyzeSyntax provide in one call.
             #
             # @overload annotate_text(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1::AnnotateTextRequest | Hash]
-            #     A convenience method that provides all the features that analyzeSentiment,
-            #     analyzeEntities, and analyzeSyntax provide in one call.
+            #   Pass arguments to `annotate_text` via a request object, either of type
+            #   {Google::Cloud::Language::V1::AnnotateTextRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1::AnnotateTextRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload annotate_text(document: nil, features: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1::Document | Hash]
+            #   Pass arguments to `annotate_text` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1::Document, Hash]
             #     Input document.
-            #   @param features [Google::Cloud::Language::V1::AnnotateTextRequest::Features | Hash]
+            #   @param features [Google::Cloud::Language::V1::AnnotateTextRequest::Features, Hash]
             #     The enabled features.
             #   @param encoding_type [Google::Cloud::Language::V1::EncodingType]
             #     The encoding type used by the API to calculate offsets.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1::AnnotateTextResponse]

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -152,18 +152,25 @@ module Google
             # Analyzes the sentiment of the provided text.
             #
             # @overload analyze_sentiment(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest | Hash]
-            #     Analyzes the sentiment of the provided text.
+            #   Pass arguments to `analyze_sentiment` via a request object, either of type
+            #   {Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload analyze_sentiment(document: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1beta1::Document | Hash]
+            #   Pass arguments to `analyze_sentiment` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1beta1::Document, Hash]
             #     Input document.
             #   @param encoding_type [Google::Cloud::Language::V1beta1::EncodingType]
             #     The encoding type used by the API to calculate sentence offsets for the
             #     sentence sentiment.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1beta1::AnalyzeSentimentResponse]
@@ -210,19 +217,24 @@ module Google
             # other properties.
             #
             # @overload analyze_entities(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest | Hash]
-            #     Finds named entities (currently proper names and common nouns) in the text
-            #     along with entity types, salience, mentions for each entity, and
-            #     other properties.
+            #   Pass arguments to `analyze_entities` via a request object, either of type
+            #   {Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload analyze_entities(document: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1beta1::Document | Hash]
+            #   Pass arguments to `analyze_entities` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1beta1::Document, Hash]
             #     Input document.
             #   @param encoding_type [Google::Cloud::Language::V1beta1::EncodingType]
             #     The encoding type used by the API to calculate offsets.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1beta1::AnalyzeEntitiesResponse]
@@ -269,19 +281,24 @@ module Google
             # properties.
             #
             # @overload analyze_syntax(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest | Hash]
-            #     Analyzes the syntax of the text and provides sentence boundaries and
-            #     tokenization along with part of speech tags, dependency trees, and other
-            #     properties.
+            #   Pass arguments to `analyze_syntax` via a request object, either of type
+            #   {Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload analyze_syntax(document: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1beta1::Document | Hash]
+            #   Pass arguments to `analyze_syntax` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1beta1::Document, Hash]
             #     Input document.
             #   @param encoding_type [Google::Cloud::Language::V1beta1::EncodingType]
             #     The encoding type used by the API to calculate offsets.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1beta1::AnalyzeSyntaxResponse]
@@ -327,20 +344,26 @@ module Google
             # analyzeEntities, and analyzeSyntax provide in one call.
             #
             # @overload annotate_text(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1beta1::AnnotateTextRequest | Hash]
-            #     A convenience method that provides all the features that analyzeSentiment,
-            #     analyzeEntities, and analyzeSyntax provide in one call.
+            #   Pass arguments to `annotate_text` via a request object, either of type
+            #   {Google::Cloud::Language::V1beta1::AnnotateTextRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1beta1::AnnotateTextRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload annotate_text(document: nil, features: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1beta1::Document | Hash]
+            #   Pass arguments to `annotate_text` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1beta1::Document, Hash]
             #     Input document.
-            #   @param features [Google::Cloud::Language::V1beta1::AnnotateTextRequest::Features | Hash]
+            #   @param features [Google::Cloud::Language::V1beta1::AnnotateTextRequest::Features, Hash]
             #     The enabled features.
             #   @param encoding_type [Google::Cloud::Language::V1beta1::EncodingType]
             #     The encoding type used by the API to calculate offsets.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1beta1::AnnotateTextResponse]

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -152,18 +152,25 @@ module Google
             # Analyzes the sentiment of the provided text.
             #
             # @overload analyze_sentiment(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest | Hash]
-            #     Analyzes the sentiment of the provided text.
+            #   Pass arguments to `analyze_sentiment` via a request object, either of type
+            #   {Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload analyze_sentiment(document: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1beta2::Document | Hash]
+            #   Pass arguments to `analyze_sentiment` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1beta2::Document, Hash]
             #     Required. Input document.
             #   @param encoding_type [Google::Cloud::Language::V1beta2::EncodingType]
             #     The encoding type used by the API to calculate sentence offsets for the
             #     sentence sentiment.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1beta2::AnalyzeSentimentResponse]
@@ -210,19 +217,24 @@ module Google
             # other properties.
             #
             # @overload analyze_entities(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest | Hash]
-            #     Finds named entities (currently proper names and common nouns) in the text
-            #     along with entity types, salience, mentions for each entity, and
-            #     other properties.
+            #   Pass arguments to `analyze_entities` via a request object, either of type
+            #   {Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload analyze_entities(document: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1beta2::Document | Hash]
+            #   Pass arguments to `analyze_entities` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1beta2::Document, Hash]
             #     Required. Input document.
             #   @param encoding_type [Google::Cloud::Language::V1beta2::EncodingType]
             #     The encoding type used by the API to calculate offsets.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1beta2::AnalyzeEntitiesResponse]
@@ -268,18 +280,24 @@ module Google
             # sentiment associated with each entity and its mentions.
             #
             # @overload analyze_entity_sentiment(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest | Hash]
-            #     Finds entities, similar to {Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_entities AnalyzeEntities} in the text and analyzes
-            #     sentiment associated with each entity and its mentions.
+            #   Pass arguments to `analyze_entity_sentiment` via a request object, either of type
+            #   {Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload analyze_entity_sentiment(document: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1beta2::Document | Hash]
+            #   Pass arguments to `analyze_entity_sentiment` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1beta2::Document, Hash]
             #     Required. Input document.
             #   @param encoding_type [Google::Cloud::Language::V1beta2::EncodingType]
             #     The encoding type used by the API to calculate offsets.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentResponse]
@@ -326,19 +344,24 @@ module Google
             # properties.
             #
             # @overload analyze_syntax(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest | Hash]
-            #     Analyzes the syntax of the text and provides sentence boundaries and
-            #     tokenization along with part-of-speech tags, dependency trees, and other
-            #     properties.
+            #   Pass arguments to `analyze_syntax` via a request object, either of type
+            #   {Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload analyze_syntax(document: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1beta2::Document | Hash]
+            #   Pass arguments to `analyze_syntax` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1beta2::Document, Hash]
             #     Required. Input document.
             #   @param encoding_type [Google::Cloud::Language::V1beta2::EncodingType]
             #     The encoding type used by the API to calculate offsets.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1beta2::AnalyzeSyntaxResponse]
@@ -383,15 +406,22 @@ module Google
             # Classifies a document into categories.
             #
             # @overload classify_text(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1beta2::ClassifyTextRequest | Hash]
-            #     Classifies a document into categories.
+            #   Pass arguments to `classify_text` via a request object, either of type
+            #   {Google::Cloud::Language::V1beta2::ClassifyTextRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1beta2::ClassifyTextRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload classify_text(document: nil)
-            #   @param document [Google::Cloud::Language::V1beta2::Document | Hash]
-            #     Required. Input document.
+            #   Pass arguments to `classify_text` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
             #
+            #   @param document [Google::Cloud::Language::V1beta2::Document, Hash]
+            #     Required. Input document.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1beta2::ClassifyTextResponse]
@@ -437,20 +467,26 @@ module Google
             # classification features in one call.
             #
             # @overload annotate_text(request, options = nil)
-            #   @param request [Google::Cloud::Language::V1beta2::AnnotateTextRequest | Hash]
-            #     A convenience method that provides all syntax, sentiment, entity, and
-            #     classification features in one call.
+            #   Pass arguments to `annotate_text` via a request object, either of type
+            #   {Google::Cloud::Language::V1beta2::AnnotateTextRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Language::V1beta2::AnnotateTextRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload annotate_text(document: nil, features: nil, encoding_type: nil)
-            #   @param document [Google::Cloud::Language::V1beta2::Document | Hash]
+            #   Pass arguments to `annotate_text` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param document [Google::Cloud::Language::V1beta2::Document, Hash]
             #     Required. Input document.
-            #   @param features [Google::Cloud::Language::V1beta2::AnnotateTextRequest::Features | Hash]
+            #   @param features [Google::Cloud::Language::V1beta2::AnnotateTextRequest::Features, Hash]
             #     Required. The enabled features.
             #   @param encoding_type [Google::Cloud::Language::V1beta2::EncodingType]
             #     The encoding type used by the API to calculate offsets.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Language::V1beta2::AnnotateTextResponse]

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -160,12 +160,20 @@ module Google
             # Lists {Google::Cloud::SecretManager::V1beta1::Secret Secrets}.
             #
             # @overload list_secrets(request, options = nil)
-            #   @param request [Google::Cloud::SecretManager::V1beta1::ListSecretsRequest | Hash]
-            #     Lists {Google::Cloud::SecretManager::V1beta1::Secret Secrets}.
+            #   Pass arguments to `list_secrets` via a request object, either of type
+            #   {Google::Cloud::SecretManager::V1beta1::ListSecretsRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::SecretManager::V1beta1::ListSecretsRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload list_secrets(parent: nil, page_size: nil, page_token: nil)
+            #   Pass arguments to `list_secrets` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param parent [String]
             #     Required. The resource name of the project associated with the
             #     {Google::Cloud::SecretManager::V1beta1::Secret Secrets}, in the format `projects/*`.
@@ -176,7 +184,6 @@ module Google
             #   @param page_token [String]
             #     Optional. Pagination token, returned earlier via
             #     {Google::Cloud::SecretManager::V1beta1::ListSecretsResponse#next_page_token ListSecretsResponse.next_page_token}.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::PagedEnumerable<Google::Cloud::SecretManager::V1beta1::Secret>]
@@ -228,12 +235,20 @@ module Google
             # Creates a new {Google::Cloud::SecretManager::V1beta1::Secret Secret} containing no {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions}.
             #
             # @overload create_secret(request, options = nil)
-            #   @param request [Google::Cloud::SecretManager::V1beta1::CreateSecretRequest | Hash]
-            #     Creates a new {Google::Cloud::SecretManager::V1beta1::Secret Secret} containing no {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions}.
+            #   Pass arguments to `create_secret` via a request object, either of type
+            #   {Google::Cloud::SecretManager::V1beta1::CreateSecretRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::SecretManager::V1beta1::CreateSecretRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload create_secret(parent: nil, secret_id: nil, secret: nil)
+            #   Pass arguments to `create_secret` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param parent [String]
             #     Required. The resource name of the project to associate with the
             #     {Google::Cloud::SecretManager::V1beta1::Secret Secret}, in the format `projects/*`.
@@ -243,9 +258,8 @@ module Google
             #     A secret ID is a string with a maximum length of 255 characters and can
             #     contain uppercase and lowercase letters, numerals, and the hyphen (`-`) and
             #     underscore (`_`) characters.
-            #   @param secret [Google::Cloud::SecretManager::V1beta1::Secret | Hash]
+            #   @param secret [Google::Cloud::SecretManager::V1beta1::Secret, Hash]
             #     A {Google::Cloud::SecretManager::V1beta1::Secret Secret} with initial field values.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::SecretManager::V1beta1::Secret]
@@ -297,19 +311,25 @@ module Google
             # it to an existing {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload add_secret_version(request, options = nil)
-            #   @param request [Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest | Hash]
-            #     Creates a new {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} containing secret data and attaches
-            #     it to an existing {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
+            #   Pass arguments to `add_secret_version` via a request object, either of type
+            #   {Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload add_secret_version(parent: nil, payload: nil)
+            #   Pass arguments to `add_secret_version` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param parent [String]
             #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} to associate with the
             #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format `projects/*/secrets/*`.
-            #   @param payload [Google::Cloud::SecretManager::V1beta1::SecretPayload | Hash]
+            #   @param payload [Google::Cloud::SecretManager::V1beta1::SecretPayload, Hash]
             #     Required. The secret payload of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::SecretManager::V1beta1::SecretVersion]
@@ -360,15 +380,22 @@ module Google
             # Gets metadata for a given {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload get_secret(request, options = nil)
-            #   @param request [Google::Cloud::SecretManager::V1beta1::GetSecretRequest | Hash]
-            #     Gets metadata for a given {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
+            #   Pass arguments to `get_secret` via a request object, either of type
+            #   {Google::Cloud::SecretManager::V1beta1::GetSecretRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::SecretManager::V1beta1::GetSecretRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload get_secret(name: nil)
+            #   Pass arguments to `get_secret` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret}, in the format `projects/*/secrets/*`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::SecretManager::V1beta1::Secret]
@@ -419,17 +446,24 @@ module Google
             # Updates metadata of an existing {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload update_secret(request, options = nil)
-            #   @param request [Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest | Hash]
-            #     Updates metadata of an existing {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
+            #   Pass arguments to `update_secret` via a request object, either of type
+            #   {Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload update_secret(secret: nil, update_mask: nil)
-            #   @param secret [Google::Cloud::SecretManager::V1beta1::Secret | Hash]
-            #     Required. {Google::Cloud::SecretManager::V1beta1::Secret Secret} with updated field values.
-            #   @param update_mask [Google::Protobuf::FieldMask | Hash]
-            #     Required. Specifies the fields to be updated.
+            #   Pass arguments to `update_secret` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
             #
+            #   @param secret [Google::Cloud::SecretManager::V1beta1::Secret, Hash]
+            #     Required. {Google::Cloud::SecretManager::V1beta1::Secret Secret} with updated field values.
+            #   @param update_mask [Google::Protobuf::FieldMask, Hash]
+            #     Required. Specifies the fields to be updated.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::SecretManager::V1beta1::Secret]
@@ -480,16 +514,23 @@ module Google
             # Deletes a {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload delete_secret(request, options = nil)
-            #   @param request [Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest | Hash]
-            #     Deletes a {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
+            #   Pass arguments to `delete_secret` via a request object, either of type
+            #   {Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload delete_secret(name: nil)
+            #   Pass arguments to `delete_secret` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} to delete in the format
             #     `projects/*/secrets/*`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -541,13 +582,20 @@ module Google
             # data.
             #
             # @overload list_secret_versions(request, options = nil)
-            #   @param request [Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest | Hash]
-            #     Lists {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions}. This call does not return secret
-            #     data.
+            #   Pass arguments to `list_secret_versions` via a request object, either of type
+            #   {Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload list_secret_versions(parent: nil, page_size: nil, page_token: nil)
+            #   Pass arguments to `list_secret_versions` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param parent [String]
             #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::Secret Secret} associated with the
             #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} to list, in the format
@@ -559,7 +607,6 @@ module Google
             #   @param page_token [String]
             #     Optional. Pagination token, returned earlier via
             #     ListSecretVersionsResponse.next_page_token][].
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::PagedEnumerable<Google::Cloud::SecretManager::V1beta1::SecretVersion>]
@@ -614,21 +661,25 @@ module Google
             # {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             # @overload get_secret_version(request, options = nil)
-            #   @param request [Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest | Hash]
-            #     Gets metadata for a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
+            #   Pass arguments to `get_secret_version` via a request object, either of type
+            #   {Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest} or an equivalent Hash.
             #
-            #     `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
+            #   @param request [Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload get_secret_version(name: nil)
+            #   Pass arguments to `get_secret_version` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format
             #     `projects/*/secrets/*/versions/*`.
             #     `projects/*/secrets/*/versions/latest` is an alias to the `latest`
             #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::SecretManager::V1beta1::SecretVersion]
@@ -682,19 +733,23 @@ module Google
             # {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
             #
             # @overload access_secret_version(request, options = nil)
-            #   @param request [Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest | Hash]
-            #     Accesses a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}. This call returns the secret data.
+            #   Pass arguments to `access_secret_version` via a request object, either of type
+            #   {Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest} or an equivalent Hash.
             #
-            #     `projects/*/secrets/*/versions/latest` is an alias to the `latest`
-            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
+            #   @param request [Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload access_secret_version(name: nil)
+            #   Pass arguments to `access_secret_version` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} in the format
             #     `projects/*/secrets/*/versions/*`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::SecretManager::V1beta1::AccessSecretVersionResponse]
@@ -748,19 +803,23 @@ module Google
             # {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::DISABLED DISABLED}.
             #
             # @overload disable_secret_version(request, options = nil)
-            #   @param request [Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest | Hash]
-            #     Disables a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
+            #   Pass arguments to `disable_secret_version` via a request object, either of type
+            #   {Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest} or an equivalent Hash.
             #
-            #     Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
-            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::DISABLED DISABLED}.
+            #   @param request [Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload disable_secret_version(name: nil)
+            #   Pass arguments to `disable_secret_version` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to disable in the format
             #     `projects/*/secrets/*/versions/*`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::SecretManager::V1beta1::SecretVersion]
@@ -814,19 +873,23 @@ module Google
             # {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::ENABLED ENABLED}.
             #
             # @overload enable_secret_version(request, options = nil)
-            #   @param request [Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest | Hash]
-            #     Enables a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
+            #   Pass arguments to `enable_secret_version` via a request object, either of type
+            #   {Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest} or an equivalent Hash.
             #
-            #     Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
-            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::ENABLED ENABLED}.
+            #   @param request [Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload enable_secret_version(name: nil)
+            #   Pass arguments to `enable_secret_version` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to enable in the format
             #     `projects/*/secrets/*/versions/*`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::SecretManager::V1beta1::SecretVersion]
@@ -881,20 +944,23 @@ module Google
             # secret data.
             #
             # @overload destroy_secret_version(request, options = nil)
-            #   @param request [Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest | Hash]
-            #     Destroys a {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion}.
+            #   Pass arguments to `destroy_secret_version` via a request object, either of type
+            #   {Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest} or an equivalent Hash.
             #
-            #     Sets the {Google::Cloud::SecretManager::V1beta1::SecretVersion#state state} of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to
-            #     {Google::Cloud::SecretManager::V1beta1::SecretVersion::State::DESTROYED DESTROYED} and irrevocably destroys the
-            #     secret data.
+            #   @param request [Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload destroy_secret_version(name: nil)
+            #   Pass arguments to `destroy_secret_version` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. The resource name of the {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersion} to destroy in the format
             #     `projects/*/secrets/*/versions/*`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::SecretManager::V1beta1::SecretVersion]
@@ -949,26 +1015,29 @@ module Google
             # to the policy set on the associated {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
             #
             # @overload set_iam_policy(request, options = nil)
-            #   @param request [Google::Iam::V1::SetIamPolicyRequest | Hash]
-            #     Sets the access control policy on the specified secret. Replaces any
-            #     existing policy.
+            #   Pass arguments to `set_iam_policy` via a request object, either of type
+            #   {Google::Iam::V1::SetIamPolicyRequest} or an equivalent Hash.
             #
-            #     Permissions on {Google::Cloud::SecretManager::V1beta1::SecretVersion SecretVersions} are enforced according
-            #     to the policy set on the associated {Google::Cloud::SecretManager::V1beta1::Secret Secret}.
+            #   @param request [Google::Iam::V1::SetIamPolicyRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload set_iam_policy(resource: nil, policy: nil)
+            #   Pass arguments to `set_iam_policy` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param resource [String]
             #     REQUIRED: The resource for which the policy is being specified.
             #     `resource` is usually specified as a path. For example, a Project
             #     resource is specified as `projects/{project}`.
-            #   @param policy [Google::Iam::V1::Policy | Hash]
+            #   @param policy [Google::Iam::V1::Policy, Hash]
             #     REQUIRED: The complete policy to be applied to the `resource`. The size of
             #     the policy is limited to a few 10s of KB. An empty policy is a
             #     valid policy but certain Cloud Platform services (such as Projects)
             #     might reject them.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Iam::V1::Policy]
@@ -1020,18 +1089,24 @@ module Google
             # Returns empty policy if the secret exists and does not have a policy set.
             #
             # @overload get_iam_policy(request, options = nil)
-            #   @param request [Google::Iam::V1::GetIamPolicyRequest | Hash]
-            #     Gets the access control policy for a secret.
-            #     Returns empty policy if the secret exists and does not have a policy set.
+            #   Pass arguments to `get_iam_policy` via a request object, either of type
+            #   {Google::Iam::V1::GetIamPolicyRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Iam::V1::GetIamPolicyRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload get_iam_policy(resource: nil)
+            #   Pass arguments to `get_iam_policy` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param resource [String]
             #     REQUIRED: The resource for which the policy is being requested.
             #     `resource` is usually specified as a path. For example, a Project
             #     resource is specified as `projects/{project}`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Iam::V1::Policy]
@@ -1088,18 +1163,20 @@ module Google
             # may "fail open" without warning.
             #
             # @overload test_iam_permissions(request, options = nil)
-            #   @param request [Google::Iam::V1::TestIamPermissionsRequest | Hash]
-            #     Returns permissions that a caller has for the specified secret.
-            #     If the secret does not exist, this call returns an empty set of
-            #     permissions, not a NOT_FOUND error.
+            #   Pass arguments to `test_iam_permissions` via a request object, either of type
+            #   {Google::Iam::V1::TestIamPermissionsRequest} or an equivalent Hash.
             #
-            #     Note: This operation is designed to be used for building permission-aware
-            #     UIs and command-line tools, not for authorization checking. This operation
-            #     may "fail open" without warning.
+            #   @param request [Google::Iam::V1::TestIamPermissionsRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload test_iam_permissions(resource: nil, permissions: nil)
+            #   Pass arguments to `test_iam_permissions` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param resource [String]
             #     REQUIRED: The resource for which the policy detail is being requested.
             #     `resource` is usually specified as a path. For example, a Project
@@ -1109,7 +1186,6 @@ module Google
             #     wildcards (such as '*' or 'storage.*') are not allowed. For more
             #     information see
             #     [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Iam::V1::TestIamPermissionsResponse]

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -157,19 +157,25 @@ module Google
             # has been sent and processed.
             #
             # @overload recognize(request, options = nil)
-            #   @param request [Google::Cloud::Speech::V1::RecognizeRequest | Hash]
-            #     Performs synchronous speech recognition: receive results after all audio
-            #     has been sent and processed.
+            #   Pass arguments to `recognize` via a request object, either of type
+            #   {Google::Cloud::Speech::V1::RecognizeRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Speech::V1::RecognizeRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload recognize(config: nil, audio: nil)
-            #   @param config [Google::Cloud::Speech::V1::RecognitionConfig | Hash]
+            #   Pass arguments to `recognize` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param config [Google::Cloud::Speech::V1::RecognitionConfig, Hash]
             #     Required. Provides information to the recognizer that specifies how to
             #     process the request.
-            #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
+            #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio, Hash]
             #     Required. The audio data to be recognized.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Speech::V1::RecognizeResponse]
@@ -426,23 +432,25 @@ module Google
             # [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
             #
             # @overload long_running_recognize(request, options = nil)
-            #   @param request [Google::Cloud::Speech::V1::LongRunningRecognizeRequest | Hash]
-            #     Performs asynchronous speech recognition: receive results via the
-            #     google.longrunning.Operations interface. Returns either an
-            #     `Operation.error` or an `Operation.response` which contains
-            #     a `LongRunningRecognizeResponse` message.
-            #     For more information on asynchronous speech recognition, see the
-            #     [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
+            #   Pass arguments to `long_running_recognize` via a request object, either of type
+            #   {Google::Cloud::Speech::V1::LongRunningRecognizeRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Speech::V1::LongRunningRecognizeRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload long_running_recognize(config: nil, audio: nil)
-            #   @param config [Google::Cloud::Speech::V1::RecognitionConfig | Hash]
+            #   Pass arguments to `long_running_recognize` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param config [Google::Cloud::Speech::V1::RecognitionConfig, Hash]
             #     Required. Provides information to the recognizer that specifies how to
             #     process the request.
-            #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio | Hash]
+            #   @param audio [Google::Cloud::Speech::V1::RecognitionAudio, Hash]
             #     Required. The audio data to be recognized.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::Operation]
@@ -588,7 +596,7 @@ module Google
             # Performs bidirectional streaming speech recognition: receive results while
             # sending audio. This method is only available via the gRPC API (not REST).
             #
-            # @param request [Gapic::StreamInput, Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeRequest | Hash>]
+            # @param request [Gapic::StreamInput, Enumerable<Google::Cloud::Speech::V1::StreamingRecognizeRequest, Hash>]
             #   An enumerable of {Google::Cloud::Speech::V1::StreamingRecognizeRequest} instances.
             # @param options [Gapic::CallOptions, Hash]
             #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -109,16 +109,20 @@ module Google
             # to use different resource name schemes, such as `users/*/operations`.
             #
             # @overload list_operations(request, options = nil)
-            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #     Lists operations that match the specified filter in the request. If the
-            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+            #   Pass arguments to `list_operations` via a request object, either of type
+            #   {Google::Longrunning::ListOperationsRequest} or an equivalent Hash.
             #
-            #     NOTE: the `name` binding below allows API services to override the binding
-            #     to use different resource name schemes, such as `users/*/operations`.
+            #   @param request [Google::Longrunning::ListOperationsRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+            #   Pass arguments to `list_operations` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     The name of the operation collection.
             #   @param filter [String]
@@ -127,7 +131,6 @@ module Google
             #     The standard list page size.
             #   @param page_token [String]
             #     The standard list page token.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::PagedEnumerable<Gapic::Operation>]
@@ -182,17 +185,22 @@ module Google
             # service.
             #
             # @overload get_operation(request, options = nil)
-            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #     Gets the latest state of a long-running operation.  Clients can use this
-            #     method to poll the operation result at intervals as recommended by the API
-            #     service.
+            #   Pass arguments to `get_operation` via a request object, either of type
+            #   {Google::Longrunning::GetOperationRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Longrunning::GetOperationRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload get_operation(name: nil)
+            #   Pass arguments to `get_operation` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     The name of the operation resource.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::Operation]
@@ -247,18 +255,22 @@ module Google
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
             # @overload delete_operation(request, options = nil)
-            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #     Deletes a long-running operation. This method indicates that the client is
-            #     no longer interested in the operation result. It does not cancel the
-            #     operation. If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.
+            #   Pass arguments to `delete_operation` via a request object, either of type
+            #   {Google::Longrunning::DeleteOperationRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Longrunning::DeleteOperationRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload delete_operation(name: nil)
+            #   Pass arguments to `delete_operation` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     The name of the operation resource to be deleted.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -318,24 +330,22 @@ module Google
             # corresponding to `Code.CANCELLED`.
             #
             # @overload cancel_operation(request, options = nil)
-            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #     Starts asynchronous cancellation on a long-running operation.  The server
-            #     makes a best effort to cancel the operation, but success is not
-            #     guaranteed.  If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     Operations.GetOperation or
-            #     other methods to check whether the cancellation succeeded or whether the
-            #     operation completed despite cancellation. On successful cancellation,
-            #     the operation is not deleted; instead, it becomes an operation with
-            #     an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
-            #     corresponding to `Code.CANCELLED`.
+            #   Pass arguments to `cancel_operation` via a request object, either of type
+            #   {Google::Longrunning::CancelOperationRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Longrunning::CancelOperationRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload cancel_operation(name: nil)
+            #   Pass arguments to `cancel_operation` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     The name of the operation resource to be cancelled.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -161,13 +161,21 @@ module Google
             # Run image detection and annotation for a batch of images.
             #
             # @overload batch_annotate_images(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest | Hash]
-            #     Run image detection and annotation for a batch of images.
+            #   Pass arguments to `batch_annotate_images` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::BatchAnnotateImagesRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Vision::V1::BatchAnnotateImagesRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload batch_annotate_images(requests: nil, parent: nil)
-            #   @param requests [Array<Google::Cloud::Vision::V1::AnnotateImageRequest | Hash>]
+            #   Pass arguments to `batch_annotate_images` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param requests [Array<Google::Cloud::Vision::V1::AnnotateImageRequest, Hash>]
             #     Required. Individual image annotation requests for this batch.
             #   @param parent [String]
             #     Optional. Target project and location to make a call.
@@ -182,7 +190,6 @@ module Google
             #         `eu`: The European Union.
             #
             #     Example: `projects/project-A/locations/eu`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
@@ -233,19 +240,21 @@ module Google
             # extracted.
             #
             # @overload batch_annotate_files(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::BatchAnnotateFilesRequest | Hash]
-            #     Service that performs image detection and annotation for a batch of files.
-            #     Now only "application/pdf", "image/tiff" and "image/gif" are supported.
+            #   Pass arguments to `batch_annotate_files` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::BatchAnnotateFilesRequest} or an equivalent Hash.
             #
-            #     This service will extract at most 5 (customers can specify which 5 in
-            #     AnnotateFileRequest.pages) frames (gif) or pages (pdf or tiff) from each
-            #     file provided and perform detection and annotation for each image
-            #     extracted.
+            #   @param request [Google::Cloud::Vision::V1::BatchAnnotateFilesRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload batch_annotate_files(requests: nil, parent: nil)
-            #   @param requests [Array<Google::Cloud::Vision::V1::AnnotateFileRequest | Hash>]
+            #   Pass arguments to `batch_annotate_files` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param requests [Array<Google::Cloud::Vision::V1::AnnotateFileRequest, Hash>]
             #     Required. The list of file annotation requests. Right now we support only one
             #     AnnotateFileRequest in BatchAnnotateFilesRequest.
             #   @param parent [String]
@@ -261,7 +270,6 @@ module Google
             #         `eu`: The European Union.
             #
             #     Example: `projects/project-A/locations/eu`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::BatchAnnotateFilesResponse]
@@ -314,23 +322,23 @@ module Google
             # GCS bucket, each json file containing BatchAnnotateImagesResponse proto.
             #
             # @overload async_batch_annotate_images(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest | Hash]
-            #     Run asynchronous image detection and annotation for a list of images.
+            #   Pass arguments to `async_batch_annotate_images` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest} or an equivalent Hash.
             #
-            #     Progress and results can be retrieved through the
-            #     `google.longrunning.Operations` interface.
-            #     `Operation.metadata` contains `OperationMetadata` (metadata).
-            #     `Operation.response` contains `AsyncBatchAnnotateImagesResponse` (results).
-            #
-            #     This service will write image annotation outputs to json files in customer
-            #     GCS bucket, each json file containing BatchAnnotateImagesResponse proto.
+            #   @param request [Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload async_batch_annotate_images(requests: nil, output_config: nil, parent: nil)
-            #   @param requests [Array<Google::Cloud::Vision::V1::AnnotateImageRequest | Hash>]
+            #   Pass arguments to `async_batch_annotate_images` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param requests [Array<Google::Cloud::Vision::V1::AnnotateImageRequest, Hash>]
             #     Required. Individual image annotation requests for this batch.
-            #   @param output_config [Google::Cloud::Vision::V1::OutputConfig | Hash]
+            #   @param output_config [Google::Cloud::Vision::V1::OutputConfig, Hash]
             #     Required. The desired output location and metadata (e.g. format).
             #   @param parent [String]
             #     Optional. Target project and location to make a call.
@@ -345,7 +353,6 @@ module Google
             #         `eu`: The European Union.
             #
             #     Example: `projects/project-A/locations/eu`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::Operation]
@@ -396,18 +403,21 @@ module Google
             # `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
             #
             # @overload async_batch_annotate_files(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest | Hash]
-            #     Run asynchronous image detection and annotation for a list of generic
-            #     files, such as PDF files, which may contain multiple pages and multiple
-            #     images per page. Progress and results can be retrieved through the
-            #     `google.longrunning.Operations` interface.
-            #     `Operation.metadata` contains `OperationMetadata` (metadata).
-            #     `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
+            #   Pass arguments to `async_batch_annotate_files` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload async_batch_annotate_files(requests: nil, parent: nil)
-            #   @param requests [Array<Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash>]
+            #   Pass arguments to `async_batch_annotate_files` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param requests [Array<Google::Cloud::Vision::V1::AsyncAnnotateFileRequest, Hash>]
             #     Required. Individual async file annotation requests for this batch.
             #   @param parent [String]
             #     Optional. Target project and location to make a call.
@@ -422,7 +432,6 @@ module Google
             #         `eu`: The European Union.
             #
             #     Example: `projects/project-A/locations/eu`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::Operation]

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -109,16 +109,20 @@ module Google
             # to use different resource name schemes, such as `users/*/operations`.
             #
             # @overload list_operations(request, options = nil)
-            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #     Lists operations that match the specified filter in the request. If the
-            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+            #   Pass arguments to `list_operations` via a request object, either of type
+            #   {Google::Longrunning::ListOperationsRequest} or an equivalent Hash.
             #
-            #     NOTE: the `name` binding below allows API services to override the binding
-            #     to use different resource name schemes, such as `users/*/operations`.
+            #   @param request [Google::Longrunning::ListOperationsRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+            #   Pass arguments to `list_operations` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     The name of the operation collection.
             #   @param filter [String]
@@ -127,7 +131,6 @@ module Google
             #     The standard list page size.
             #   @param page_token [String]
             #     The standard list page token.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::PagedEnumerable<Gapic::Operation>]
@@ -182,17 +185,22 @@ module Google
             # service.
             #
             # @overload get_operation(request, options = nil)
-            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #     Gets the latest state of a long-running operation.  Clients can use this
-            #     method to poll the operation result at intervals as recommended by the API
-            #     service.
+            #   Pass arguments to `get_operation` via a request object, either of type
+            #   {Google::Longrunning::GetOperationRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Longrunning::GetOperationRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload get_operation(name: nil)
+            #   Pass arguments to `get_operation` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     The name of the operation resource.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::Operation]
@@ -247,18 +255,22 @@ module Google
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
             # @overload delete_operation(request, options = nil)
-            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #     Deletes a long-running operation. This method indicates that the client is
-            #     no longer interested in the operation result. It does not cancel the
-            #     operation. If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.
+            #   Pass arguments to `delete_operation` via a request object, either of type
+            #   {Google::Longrunning::DeleteOperationRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Longrunning::DeleteOperationRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload delete_operation(name: nil)
+            #   Pass arguments to `delete_operation` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     The name of the operation resource to be deleted.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -318,24 +330,22 @@ module Google
             # corresponding to `Code.CANCELLED`.
             #
             # @overload cancel_operation(request, options = nil)
-            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #     Starts asynchronous cancellation on a long-running operation.  The server
-            #     makes a best effort to cancel the operation, but success is not
-            #     guaranteed.  If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     Operations.GetOperation or
-            #     other methods to check whether the cancellation succeeded or whether the
-            #     operation completed despite cancellation. On successful cancellation,
-            #     the operation is not deleted; instead, it becomes an operation with
-            #     an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
-            #     corresponding to `Code.CANCELLED`.
+            #   Pass arguments to `cancel_operation` via a request object, either of type
+            #   {Google::Longrunning::CancelOperationRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Longrunning::CancelOperationRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload cancel_operation(name: nil)
+            #   Pass arguments to `cancel_operation` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     The name of the operation resource to be cancelled.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -177,29 +177,31 @@ module Google
             #   4096 characters.
             #
             # @overload create_product_set(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::CreateProductSetRequest | Hash]
-            #     Creates and returns a new ProductSet resource.
+            #   Pass arguments to `create_product_set` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::CreateProductSetRequest} or an equivalent Hash.
             #
-            #     Possible errors:
-            #
-            #     * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
-            #       4096 characters.
+            #   @param request [Google::Cloud::Vision::V1::CreateProductSetRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload create_product_set(parent: nil, product_set: nil, product_set_id: nil)
+            #   Pass arguments to `create_product_set` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param parent [String]
             #     Required. The project in which the ProductSet should be created.
             #
             #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   @param product_set [Google::Cloud::Vision::V1::ProductSet | Hash]
+            #   @param product_set [Google::Cloud::Vision::V1::ProductSet, Hash]
             #     Required. The ProductSet to create.
             #   @param product_set_id [String]
             #     A user-supplied resource id for this ProductSet. If set, the server will
             #     attempt to use this value as the resource id. If it is already in use, an
             #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
             #     long. It cannot contain the character `/`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -255,17 +257,20 @@ module Google
             #   than 1.
             #
             # @overload list_product_sets(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::ListProductSetsRequest | Hash]
-            #     Lists ProductSets in an unspecified order.
+            #   Pass arguments to `list_product_sets` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::ListProductSetsRequest} or an equivalent Hash.
             #
-            #     Possible errors:
-            #
-            #     * Returns INVALID_ARGUMENT if page_size is greater than 100, or less
-            #       than 1.
+            #   @param request [Google::Cloud::Vision::V1::ListProductSetsRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload list_product_sets(parent: nil, page_size: nil, page_token: nil)
+            #   Pass arguments to `list_product_sets` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param parent [String]
             #     Required. The project from which ProductSets should be listed.
             #
@@ -274,7 +279,6 @@ module Google
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::PagedEnumerable<Google::Cloud::Vision::V1::ProductSet>]
@@ -330,22 +334,25 @@ module Google
             # * Returns NOT_FOUND if the ProductSet does not exist.
             #
             # @overload get_product_set(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::GetProductSetRequest | Hash]
-            #     Gets information associated with a ProductSet.
+            #   Pass arguments to `get_product_set` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::GetProductSetRequest} or an equivalent Hash.
             #
-            #     Possible errors:
-            #
-            #     * Returns NOT_FOUND if the ProductSet does not exist.
+            #   @param request [Google::Cloud::Vision::V1::GetProductSetRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload get_product_set(name: nil)
+            #   Pass arguments to `get_product_set` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. Resource name of the ProductSet to get.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOG_ID/productSets/PRODUCT_SET_ID`
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -403,27 +410,27 @@ module Google
             #   missing from the request or longer than 4096 characters.
             #
             # @overload update_product_set(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::UpdateProductSetRequest | Hash]
-            #     Makes changes to a ProductSet resource.
-            #     Only display_name can be updated currently.
+            #   Pass arguments to `update_product_set` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::UpdateProductSetRequest} or an equivalent Hash.
             #
-            #     Possible errors:
-            #
-            #     * Returns NOT_FOUND if the ProductSet does not exist.
-            #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but
-            #       missing from the request or longer than 4096 characters.
+            #   @param request [Google::Cloud::Vision::V1::UpdateProductSetRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload update_product_set(product_set: nil, update_mask: nil)
-            #   @param product_set [Google::Cloud::Vision::V1::ProductSet | Hash]
+            #   Pass arguments to `update_product_set` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param product_set [Google::Cloud::Vision::V1::ProductSet, Hash]
             #     Required. The ProductSet resource which replaces the one on the server.
-            #   @param update_mask [Google::Protobuf::FieldMask | Hash]
+            #   @param update_mask [Google::Protobuf::FieldMask, Hash]
             #     The {Google::Protobuf::FieldMask FieldMask} that specifies which fields to
             #     update.
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask path is `display_name`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ProductSet]
@@ -477,21 +484,25 @@ module Google
             # The actual image files are not deleted from Google Cloud Storage.
             #
             # @overload delete_product_set(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::DeleteProductSetRequest | Hash]
-            #     Permanently deletes a ProductSet. Products and ReferenceImages in the
-            #     ProductSet are not deleted.
+            #   Pass arguments to `delete_product_set` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::DeleteProductSetRequest} or an equivalent Hash.
             #
-            #     The actual image files are not deleted from Google Cloud Storage.
+            #   @param request [Google::Cloud::Vision::V1::DeleteProductSetRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload delete_product_set(name: nil)
+            #   Pass arguments to `delete_product_set` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. Resource name of the ProductSet to delete.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -549,32 +560,32 @@ module Google
             # * Returns INVALID_ARGUMENT if product_category is missing or invalid.
             #
             # @overload create_product(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::CreateProductRequest | Hash]
-            #     Creates and returns a new product resource.
+            #   Pass arguments to `create_product` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::CreateProductRequest} or an equivalent Hash.
             #
-            #     Possible errors:
-            #
-            #     * Returns INVALID_ARGUMENT if display_name is missing or longer than 4096
-            #       characters.
-            #     * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
-            #     * Returns INVALID_ARGUMENT if product_category is missing or invalid.
+            #   @param request [Google::Cloud::Vision::V1::CreateProductRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload create_product(parent: nil, product: nil, product_id: nil)
+            #   Pass arguments to `create_product` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param parent [String]
             #     Required. The project in which the Product should be created.
             #
             #     Format is
             #     `projects/PROJECT_ID/locations/LOC_ID`.
-            #   @param product [Google::Cloud::Vision::V1::Product | Hash]
+            #   @param product [Google::Cloud::Vision::V1::Product, Hash]
             #     Required. The product to create.
             #   @param product_id [String]
             #     A user-supplied resource id for this Product. If set, the server will
             #     attempt to use this value as the resource id. If it is already in use, an
             #     error is returned with code ALREADY_EXISTS. Must be at most 128 characters
             #     long. It cannot contain the character `/`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -629,16 +640,20 @@ module Google
             # * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #
             # @overload list_products(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::ListProductsRequest | Hash]
-            #     Lists products in an unspecified order.
+            #   Pass arguments to `list_products` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::ListProductsRequest} or an equivalent Hash.
             #
-            #     Possible errors:
-            #
-            #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #   @param request [Google::Cloud::Vision::V1::ListProductsRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload list_products(parent: nil, page_size: nil, page_token: nil)
+            #   Pass arguments to `list_products` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param parent [String]
             #     Required. The project OR ProductSet from which Products should be listed.
             #
@@ -648,7 +663,6 @@ module Google
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -704,22 +718,25 @@ module Google
             # * Returns NOT_FOUND if the Product does not exist.
             #
             # @overload get_product(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::GetProductRequest | Hash]
-            #     Gets information associated with a Product.
+            #   Pass arguments to `get_product` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::GetProductRequest} or an equivalent Hash.
             #
-            #     Possible errors:
-            #
-            #     * Returns NOT_FOUND if the Product does not exist.
+            #   @param request [Google::Cloud::Vision::V1::GetProductRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload get_product(name: nil)
+            #   Pass arguments to `get_product` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. Resource name of the Product to get.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -784,36 +801,29 @@ module Google
             # * Returns INVALID_ARGUMENT if product_category is present in update_mask.
             #
             # @overload update_product(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::UpdateProductRequest | Hash]
-            #     Makes changes to a Product resource.
-            #     Only the `display_name`, `description`, and `labels` fields can be updated
-            #     right now.
+            #   Pass arguments to `update_product` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::UpdateProductRequest} or an equivalent Hash.
             #
-            #     If labels are updated, the change will not be reflected in queries until
-            #     the next index time.
-            #
-            #     Possible errors:
-            #
-            #     * Returns NOT_FOUND if the Product does not exist.
-            #     * Returns INVALID_ARGUMENT if display_name is present in update_mask but is
-            #       missing from the request or longer than 4096 characters.
-            #     * Returns INVALID_ARGUMENT if description is present in update_mask but is
-            #       longer than 4096 characters.
-            #     * Returns INVALID_ARGUMENT if product_category is present in update_mask.
+            #   @param request [Google::Cloud::Vision::V1::UpdateProductRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload update_product(product: nil, update_mask: nil)
-            #   @param product [Google::Cloud::Vision::V1::Product | Hash]
+            #   Pass arguments to `update_product` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param product [Google::Cloud::Vision::V1::Product, Hash]
             #     Required. The Product resource which replaces the one on the server.
             #     product.name is immutable.
-            #   @param update_mask [Google::Protobuf::FieldMask | Hash]
+            #   @param update_mask [Google::Protobuf::FieldMask, Hash]
             #     The {Google::Protobuf::FieldMask FieldMask} that specifies which fields
             #     to update.
             #     If update_mask isn't specified, all mutable fields are to be updated.
             #     Valid mask paths include `product_labels`, `display_name`, and
             #     `description`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::Product]
@@ -868,22 +878,25 @@ module Google
             # until all related caches are refreshed.
             #
             # @overload delete_product(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::DeleteProductRequest | Hash]
-            #     Permanently deletes a product and its reference images.
+            #   Pass arguments to `delete_product` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::DeleteProductRequest} or an equivalent Hash.
             #
-            #     Metadata of the product and all its images will be deleted right away, but
-            #     search queries against ProductSets containing the product may still work
-            #     until all related caches are refreshed.
+            #   @param request [Google::Cloud::Vision::V1::DeleteProductRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload delete_product(name: nil)
+            #   Pass arguments to `delete_product` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. Resource name of product to delete.
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -952,36 +965,26 @@ module Google
             # * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
             #
             # @overload create_reference_image(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::CreateReferenceImageRequest | Hash]
-            #     Creates and returns a new ReferenceImage resource.
+            #   Pass arguments to `create_reference_image` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::CreateReferenceImageRequest} or an equivalent Hash.
             #
-            #     The `bounding_poly` field is optional. If `bounding_poly` is not specified,
-            #     the system will try to detect regions of interest in the image that are
-            #     compatible with the product_category on the parent product. If it is
-            #     specified, detection is ALWAYS skipped. The system converts polygons into
-            #     non-rotated rectangles.
-            #
-            #     Note that the pipeline will resize the image if the image resolution is too
-            #     large to process (above 50MP).
-            #
-            #     Possible errors:
-            #
-            #     * Returns INVALID_ARGUMENT if the image_uri is missing or longer than 4096
-            #       characters.
-            #     * Returns INVALID_ARGUMENT if the product does not exist.
-            #     * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
-            #       compatible with the parent product's product_category is detected.
-            #     * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
+            #   @param request [Google::Cloud::Vision::V1::CreateReferenceImageRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload create_reference_image(parent: nil, reference_image: nil, reference_image_id: nil)
+            #   Pass arguments to `create_reference_image` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param parent [String]
             #     Required. Resource name of the product in which to create the reference image.
             #
             #     Format is
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
-            #   @param reference_image [Google::Cloud::Vision::V1::ReferenceImage | Hash]
+            #   @param reference_image [Google::Cloud::Vision::V1::ReferenceImage, Hash]
             #     Required. The reference image to create.
             #     If an image ID is specified, it is ignored.
             #   @param reference_image_id [String]
@@ -989,7 +992,6 @@ module Google
             #     the server will attempt to use this value as the resource id. If it is
             #     already in use, an error is returned with code ALREADY_EXISTS. Must be at
             #     most 128 characters long. It cannot contain the character `/`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -1046,25 +1048,26 @@ module Google
             # The actual image files are not deleted from Google Cloud Storage.
             #
             # @overload delete_reference_image(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::DeleteReferenceImageRequest | Hash]
-            #     Permanently deletes a reference image.
+            #   Pass arguments to `delete_reference_image` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::DeleteReferenceImageRequest} or an equivalent Hash.
             #
-            #     The image metadata will be deleted right away, but search queries
-            #     against ProductSets containing the image may still work until all related
-            #     caches are refreshed.
-            #
-            #     The actual image files are not deleted from Google Cloud Storage.
+            #   @param request [Google::Cloud::Vision::V1::DeleteReferenceImageRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload delete_reference_image(name: nil)
+            #   Pass arguments to `delete_reference_image` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. The resource name of the reference image to delete.
             #
             #     Format is:
             #
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1121,18 +1124,20 @@ module Google
             #   than 1.
             #
             # @overload list_reference_images(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::ListReferenceImagesRequest | Hash]
-            #     Lists reference images.
+            #   Pass arguments to `list_reference_images` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::ListReferenceImagesRequest} or an equivalent Hash.
             #
-            #     Possible errors:
-            #
-            #     * Returns NOT_FOUND if the parent product does not exist.
-            #     * Returns INVALID_ARGUMENT if the page_size is greater than 100, or less
-            #       than 1.
+            #   @param request [Google::Cloud::Vision::V1::ListReferenceImagesRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload list_reference_images(parent: nil, page_size: nil, page_token: nil)
+            #   Pass arguments to `list_reference_images` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param parent [String]
             #     Required. Resource name of the product containing the reference images.
             #
@@ -1145,7 +1150,6 @@ module Google
             #     of `nextPageToken` returned in a previous reference image list request.
             #
             #     Defaults to the first page if not specified.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::PagedEnumerable<Google::Cloud::Vision::V1::ReferenceImage>]
@@ -1201,23 +1205,26 @@ module Google
             # * Returns NOT_FOUND if the specified image does not exist.
             #
             # @overload get_reference_image(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::GetReferenceImageRequest | Hash]
-            #     Gets information associated with a ReferenceImage.
+            #   Pass arguments to `get_reference_image` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::GetReferenceImageRequest} or an equivalent Hash.
             #
-            #     Possible errors:
-            #
-            #     * Returns NOT_FOUND if the specified image does not exist.
+            #   @param request [Google::Cloud::Vision::V1::GetReferenceImageRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload get_reference_image(name: nil)
+            #   Pass arguments to `get_reference_image` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. The resource name of the ReferenceImage to get.
             #
             #     Format is:
             #
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Cloud::Vision::V1::ReferenceImage]
@@ -1275,19 +1282,20 @@ module Google
             # * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
             #
             # @overload add_product_to_product_set(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::AddProductToProductSetRequest | Hash]
-            #     Adds a Product to the specified ProductSet. If the Product is already
-            #     present, no change is made.
+            #   Pass arguments to `add_product_to_product_set` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::AddProductToProductSetRequest} or an equivalent Hash.
             #
-            #     One Product can be added to at most 100 ProductSets.
-            #
-            #     Possible errors:
-            #
-            #     * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
+            #   @param request [Google::Cloud::Vision::V1::AddProductToProductSetRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload add_product_to_product_set(name: nil, product: nil)
+            #   Pass arguments to `add_product_to_product_set` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. The resource name for the ProductSet to modify.
             #
@@ -1298,7 +1306,6 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1349,12 +1356,20 @@ module Google
             # Removes a Product from the specified ProductSet.
             #
             # @overload remove_product_from_product_set(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest | Hash]
-            #     Removes a Product from the specified ProductSet.
+            #   Pass arguments to `remove_product_from_product_set` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload remove_product_from_product_set(name: nil, product: nil)
+            #   Pass arguments to `remove_product_from_product_set` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. The resource name for the ProductSet to modify.
             #
@@ -1365,7 +1380,6 @@ module Google
             #
             #     Format is:
             #     `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -1422,18 +1436,20 @@ module Google
             # * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
             #
             # @overload list_products_in_product_set(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::ListProductsInProductSetRequest | Hash]
-            #     Lists the Products in a ProductSet, in an unspecified order. If the
-            #     ProductSet does not exist, the products field of the response will be
-            #     empty.
+            #   Pass arguments to `list_products_in_product_set` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::ListProductsInProductSetRequest} or an equivalent Hash.
             #
-            #     Possible errors:
-            #
-            #     * Returns INVALID_ARGUMENT if page_size is greater than 100 or less than 1.
+            #   @param request [Google::Cloud::Vision::V1::ListProductsInProductSetRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload list_products_in_product_set(name: nil, page_size: nil, page_token: nil)
+            #   Pass arguments to `list_products_in_product_set` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     Required. The ProductSet resource for which to retrieve Products.
             #
@@ -1443,7 +1459,6 @@ module Google
             #     The maximum number of items to return. Default 10, maximum 100.
             #   @param page_token [String]
             #     The next_page_token returned from a previous List request, if any.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::PagedEnumerable<Google::Cloud::Vision::V1::Product>]
@@ -1505,29 +1520,26 @@ module Google
             # {Google::Cloud::Vision::V1::ImportProductSetsGcsSource#csv_file_uri ImportProductSetsGcsSource.csv_file_uri}.
             #
             # @overload import_product_sets(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::ImportProductSetsRequest | Hash]
-            #     Asynchronous API that imports a list of reference images to specified
-            #     product sets based on a list of image information.
+            #   Pass arguments to `import_product_sets` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::ImportProductSetsRequest} or an equivalent Hash.
             #
-            #     The {Google::Longrunning::Operation google.longrunning.Operation} API can be used to keep track of the
-            #     progress and results of the request.
-            #     `Operation.metadata` contains `BatchOperationMetadata`. (progress)
-            #     `Operation.response` contains `ImportProductSetsResponse`. (results)
-            #
-            #     The input source of this method is a csv file on Google Cloud Storage.
-            #     For the format of the csv file please see
-            #     {Google::Cloud::Vision::V1::ImportProductSetsGcsSource#csv_file_uri ImportProductSetsGcsSource.csv_file_uri}.
+            #   @param request [Google::Cloud::Vision::V1::ImportProductSetsRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload import_product_sets(parent: nil, input_config: nil)
+            #   Pass arguments to `import_product_sets` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param parent [String]
             #     Required. The project in which the ProductSets should be imported.
             #
             #     Format is `projects/PROJECT_ID/locations/LOC_ID`.
-            #   @param input_config [Google::Cloud::Vision::V1::ImportProductSetsInputConfig | Hash]
+            #   @param input_config [Google::Cloud::Vision::V1::ImportProductSetsInputConfig, Hash]
             #     Required. The input content for the list of requests.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::Operation]
@@ -1602,36 +1614,21 @@ module Google
             # `Operation.metadata` contains `BatchOperationMetadata`. (progress)
             #
             # @overload purge_products(request, options = nil)
-            #   @param request [Google::Cloud::Vision::V1::PurgeProductsRequest | Hash]
-            #     Asynchronous API to delete all Products in a ProductSet or all Products
-            #     that are in no ProductSet.
+            #   Pass arguments to `purge_products` via a request object, either of type
+            #   {Google::Cloud::Vision::V1::PurgeProductsRequest} or an equivalent Hash.
             #
-            #     If a Product is a member of the specified ProductSet in addition to other
-            #     ProductSets, the Product will still be deleted.
-            #
-            #     It is recommended to not delete the specified ProductSet until after this
-            #     operation has completed. It is also recommended to not add any of the
-            #     Products involved in the batch delete to a new ProductSet while this
-            #     operation is running because those Products may still end up deleted.
-            #
-            #     It's not possible to undo the PurgeProducts operation. Therefore, it is
-            #     recommended to keep the csv files used in ImportProductSets (if that was
-            #     how you originally built the Product Set) before starting PurgeProducts, in
-            #     case you need to re-import the data after deletion.
-            #
-            #     If the plan is to purge all of the Products from a ProductSet and then
-            #     re-use the empty ProductSet to re-import new Products into the empty
-            #     ProductSet, you must wait until the PurgeProducts operation has finished
-            #     for that ProductSet.
-            #
-            #     The {Google::Longrunning::Operation google.longrunning.Operation} API can be used to keep track of the
-            #     progress and results of the request.
-            #     `Operation.metadata` contains `BatchOperationMetadata`. (progress)
+            #   @param request [Google::Cloud::Vision::V1::PurgeProductsRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload purge_products(product_set_purge_config: nil, delete_orphan_products: nil, parent: nil, force: nil)
-            #   @param product_set_purge_config [Google::Cloud::Vision::V1::ProductSetPurgeConfig | Hash]
+            #   Pass arguments to `purge_products` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
+            #   @param product_set_purge_config [Google::Cloud::Vision::V1::ProductSetPurgeConfig, Hash]
             #     Specify which ProductSet contains the Products to be deleted.
             #   @param delete_orphan_products [Boolean]
             #     If delete_orphan_products is true, all Products that are not in any
@@ -1643,7 +1640,6 @@ module Google
             #   @param force [Boolean]
             #     The default value is false. Override this value to true to actually perform
             #     the purge.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::Operation]

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -109,16 +109,20 @@ module Google
             # to use different resource name schemes, such as `users/*/operations`.
             #
             # @overload list_operations(request, options = nil)
-            #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-            #     Lists operations that match the specified filter in the request. If the
-            #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+            #   Pass arguments to `list_operations` via a request object, either of type
+            #   {Google::Longrunning::ListOperationsRequest} or an equivalent Hash.
             #
-            #     NOTE: the `name` binding below allows API services to override the binding
-            #     to use different resource name schemes, such as `users/*/operations`.
+            #   @param request [Google::Longrunning::ListOperationsRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+            #   Pass arguments to `list_operations` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     The name of the operation collection.
             #   @param filter [String]
@@ -127,7 +131,6 @@ module Google
             #     The standard list page size.
             #   @param page_token [String]
             #     The standard list page token.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::PagedEnumerable<Gapic::Operation>]
@@ -182,17 +185,22 @@ module Google
             # service.
             #
             # @overload get_operation(request, options = nil)
-            #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-            #     Gets the latest state of a long-running operation.  Clients can use this
-            #     method to poll the operation result at intervals as recommended by the API
-            #     service.
+            #   Pass arguments to `get_operation` via a request object, either of type
+            #   {Google::Longrunning::GetOperationRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Longrunning::GetOperationRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload get_operation(name: nil)
+            #   Pass arguments to `get_operation` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     The name of the operation resource.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Gapic::Operation]
@@ -247,18 +255,22 @@ module Google
             # `google.rpc.Code.UNIMPLEMENTED`.
             #
             # @overload delete_operation(request, options = nil)
-            #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-            #     Deletes a long-running operation. This method indicates that the client is
-            #     no longer interested in the operation result. It does not cancel the
-            #     operation. If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.
+            #   Pass arguments to `delete_operation` via a request object, either of type
+            #   {Google::Longrunning::DeleteOperationRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Longrunning::DeleteOperationRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload delete_operation(name: nil)
+            #   Pass arguments to `delete_operation` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     The name of the operation resource to be deleted.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]
@@ -318,24 +330,22 @@ module Google
             # corresponding to `Code.CANCELLED`.
             #
             # @overload cancel_operation(request, options = nil)
-            #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-            #     Starts asynchronous cancellation on a long-running operation.  The server
-            #     makes a best effort to cancel the operation, but success is not
-            #     guaranteed.  If the server doesn't support this method, it returns
-            #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-            #     Operations.GetOperation or
-            #     other methods to check whether the cancellation succeeded or whether the
-            #     operation completed despite cancellation. On successful cancellation,
-            #     the operation is not deleted; instead, it becomes an operation with
-            #     an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
-            #     corresponding to `Code.CANCELLED`.
+            #   Pass arguments to `cancel_operation` via a request object, either of type
+            #   {Google::Longrunning::CancelOperationRequest} or an equivalent Hash.
+            #
+            #   @param request [Google::Longrunning::CancelOperationRequest, Hash]
+            #     A request object representing the call parameters. Required. To specify no
+            #     parameters, or to keep all the default parameter values, pass an empty Hash.
             #   @param options [Gapic::CallOptions, Hash]
             #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
             #
             # @overload cancel_operation(name: nil)
+            #   Pass arguments to `cancel_operation` via keyword arguments. Note that at
+            #   least one keyword argument is required. To specify no parameters, or to keep all
+            #   the default parameter values, pass an empty Hash as a request object (see above).
+            #
             #   @param name [String]
             #     The name of the operation resource to be cancelled.
-            #
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -158,11 +158,14 @@ module So
           # Retrieves an EmptyGarbage resource
           #
           # @overload get_empty_garbage(request, options = nil)
-          #   @param request [So::Much::Trash::EmptyGarbage | Hash]
-          #     Retrieves an EmptyGarbage resource
+          #   Pass arguments to `get_empty_garbage` via a request object, either of type
+          #   {So::Much::Trash::EmptyGarbage} or an equivalent Hash.
+          #
+          #   @param request [So::Much::Trash::EmptyGarbage, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [So::Much::Trash::EmptyGarbage]
@@ -205,15 +208,22 @@ module So
           # Retrieves a SimpleGarbage resource.
           #
           # @overload get_simple_garbage(request, options = nil)
-          #   @param request [So::Much::Trash::SimpleGarbage | Hash]
-          #     Retrieves a SimpleGarbage resource.
+          #   Pass arguments to `get_simple_garbage` via a request object, either of type
+          #   {So::Much::Trash::SimpleGarbage} or an equivalent Hash.
+          #
+          #   @param request [So::Much::Trash::SimpleGarbage, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_simple_garbage(name: nil)
+          #   Pass arguments to `get_simple_garbage` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of this garbage.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [So::Much::Trash::SimpleGarbage]
@@ -305,12 +315,20 @@ module So
           # Retrieves a SpecificGarbage resource.
           #
           # @overload get_specific_garbage(request, options = nil)
-          #   @param request [So::Much::Trash::SpecificGarbage | Hash]
-          #     Retrieves a SpecificGarbage resource.
+          #   Pass arguments to `get_specific_garbage` via a request object, either of type
+          #   {So::Much::Trash::SpecificGarbage} or an equivalent Hash.
+          #
+          #   @param request [So::Much::Trash::SpecificGarbage, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_specific_garbage(name: nil, int32: nil, int64: nil, uint32: nil, uint64: nil, bool: nil, float: nil, double: nil, bytes: nil, enum: nil, nested: nil)
+          #   Pass arguments to `get_specific_garbage` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of this garbage.
           #   @param int32 [Integer]
@@ -331,9 +349,8 @@ module So
           #     The bytes of this garbage.
           #   @param enum [So::Much::Trash::GarbageEnum]
           #     The type of this garbage.
-          #   @param nested [So::Much::Trash::SpecificGarbage::NestedGarbage | Hash]
+          #   @param nested [So::Much::Trash::SpecificGarbage::NestedGarbage, Hash]
           #     The nested garbage resource of this garbage.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [So::Much::Trash::SpecificGarbage]
@@ -376,12 +393,20 @@ module So
           # Retrieves a NestedGarbage resource.
           #
           # @overload get_nested_garbage(request, options = nil)
-          #   @param request [So::Much::Trash::SpecificGarbage::NestedGarbage | Hash]
-          #     Retrieves a NestedGarbage resource.
+          #   Pass arguments to `get_nested_garbage` via a request object, either of type
+          #   {So::Much::Trash::SpecificGarbage::NestedGarbage} or an equivalent Hash.
+          #
+          #   @param request [So::Much::Trash::SpecificGarbage::NestedGarbage, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_nested_garbage(name: nil, int32: nil, int64: nil, uint32: nil, uint64: nil, bool: nil, float: nil, double: nil, bytes: nil, enum: nil)
+          #   Pass arguments to `get_nested_garbage` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of this garbage.
           #   @param int32 [Integer]
@@ -402,7 +427,6 @@ module So
           #     The bytes of this garbage.
           #   @param enum [So::Much::Trash::GarbageEnum]
           #     The type of this garbage.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [So::Much::Trash::SpecificGarbage::NestedGarbage]
@@ -445,12 +469,20 @@ module So
           # Retrieves a RepeatedGarbage resource.
           #
           # @overload get_repeated_garbage(request, options = nil)
-          #   @param request [So::Much::Trash::RepeatedGarbage | Hash]
-          #     Retrieves a RepeatedGarbage resource.
+          #   Pass arguments to `get_repeated_garbage` via a request object, either of type
+          #   {So::Much::Trash::RepeatedGarbage} or an equivalent Hash.
+          #
+          #   @param request [So::Much::Trash::RepeatedGarbage, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_repeated_garbage(repeated_name: nil, repeated_int32: nil, repeated_int64: nil, repeated_uint32: nil, repeated_uint64: nil, repeated_bool: nil, repeated_float: nil, repeated_double: nil, repeated_bytes: nil, repeated_enum: nil)
+          #   Pass arguments to `get_repeated_garbage` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param repeated_name [Array<String>]
           #     The repeated name of this garbage.
           #   @param repeated_int32 [Array<Integer>]
@@ -471,7 +503,6 @@ module So
           #     The repeated bytes of this garbage.
           #   @param repeated_enum [Array<So::Much::Trash::GarbageEnum>]
           #     The repeated type of this garbage.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [So::Much::Trash::RepeatedGarbage]
@@ -514,12 +545,20 @@ module So
           # Retrieves a TypicalGarbage resource.
           #
           # @overload get_typical_garbage(request, options = nil)
-          #   @param request [So::Much::Trash::TypicalGarbage | Hash]
-          #     Retrieves a TypicalGarbage resource.
+          #   Pass arguments to `get_typical_garbage` via a request object, either of type
+          #   {So::Much::Trash::TypicalGarbage} or an equivalent Hash.
+          #
+          #   @param request [So::Much::Trash::TypicalGarbage, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_typical_garbage(name: nil, int32: nil, int64: nil, uint32: nil, uint64: nil, bool: nil, float: nil, double: nil, bytes: nil, timeout: nil, duration: nil, enum: nil, amap: nil)
+          #   Pass arguments to `get_typical_garbage` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of this garbage.
           #   @param int32 [Integer]
@@ -538,15 +577,14 @@ module So
           #     The double of this garbage.
           #   @param bytes [String]
           #     The bytes of this garbage.
-          #   @param timeout [Google::Protobuf::Timestamp | Hash]
+          #   @param timeout [Google::Protobuf::Timestamp, Hash]
           #     When the garbage was first activated.
-          #   @param duration [Google::Protobuf::Duration | Hash]
+          #   @param duration [Google::Protobuf::Duration, Hash]
           #     Time limit for this garbage. If not defined, the garbage endures forever.
           #   @param enum [So::Much::Trash::GarbageEnum]
           #     The type of this garbage.
           #   @param amap [Hash{String => String}]
           #     This is a map
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [So::Much::Trash::TypicalGarbage]
@@ -645,15 +683,22 @@ module So
           # Retrieves a ComplexGarbage resource.
           #
           # @overload get_complex_garbage(request, options = nil)
-          #   @param request [So::Much::Trash::ComplexGarbage | Hash]
-          #     Retrieves a ComplexGarbage resource.
+          #   Pass arguments to `get_complex_garbage` via a request object, either of type
+          #   {So::Much::Trash::ComplexGarbage} or an equivalent Hash.
+          #
+          #   @param request [So::Much::Trash::ComplexGarbage, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_complex_garbage(layer1: nil)
-          #   @param layer1 [So::Much::Trash::ComplexGarbage::Layer1Garbage | Hash]
-          #     The first step to total and complete garbage.
+          #   Pass arguments to `get_complex_garbage` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
           #
+          #   @param layer1 [So::Much::Trash::ComplexGarbage::Layer1Garbage, Hash]
+          #     The first step to total and complete garbage.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [So::Much::Trash::ComplexGarbage]
@@ -739,15 +784,22 @@ module So
           # Retrieves a GarbageNode resource.
           #
           # @overload get_garbage_node(request, options = nil)
-          #   @param request [So::Much::Trash::GarbageNode | Hash]
-          #     Retrieves a GarbageNode resource.
+          #   Pass arguments to `get_garbage_node` via a request object, either of type
+          #   {So::Much::Trash::GarbageNode} or an equivalent Hash.
+          #
+          #   @param request [So::Much::Trash::GarbageNode, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_garbage_node(data: nil, parent: nil)
-          #   @param data [String]
-          #   @param parent [So::Much::Trash::GarbageNode | Hash]
+          #   Pass arguments to `get_garbage_node` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
           #
+          #   @param data [String]
+          #   @param parent [So::Much::Trash::GarbageNode, Hash]
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [So::Much::Trash::GarbageNode]
@@ -790,19 +842,26 @@ module So
           # Performs paged garbage listing.
           #
           # @overload get_paged_garbage(request, options = nil)
-          #   @param request [So::Much::Trash::PagedGarbageRequest | Hash]
-          #     Performs paged garbage listing.
+          #   Pass arguments to `get_paged_garbage` via a request object, either of type
+          #   {So::Much::Trash::PagedGarbageRequest} or an equivalent Hash.
+          #
+          #   @param request [So::Much::Trash::PagedGarbageRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_paged_garbage(garbage: nil, page_size: nil, page_token: nil)
+          #   Pass arguments to `get_paged_garbage` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param garbage [String]
           #     The garbage to page.
           #   @param page_size [Integer]
           #     The amount of garbage items to returned in each page.
           #   @param page_token [String]
           #     The position of the page to be returned.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::PagedEnumerable<So::Much::Trash::GarbageItem>]
@@ -864,16 +923,22 @@ module So
           # google.longrunning.Operations interface.
           #
           # @overload long_running_garbage(request, options = nil)
-          #   @param request [So::Much::Trash::LongRunningGarbageRequest | Hash]
-          #     Performs asynchronous garbage listing. Garbage items are available via the
-          #     google.longrunning.Operations interface.
+          #   Pass arguments to `long_running_garbage` via a request object, either of type
+          #   {So::Much::Trash::LongRunningGarbageRequest} or an equivalent Hash.
+          #
+          #   @param request [So::Much::Trash::LongRunningGarbageRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload long_running_garbage(garbage: nil)
+          #   Pass arguments to `long_running_garbage` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param garbage [String]
           #     The name of the garbage this item belongs to.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::Operation]
@@ -916,7 +981,7 @@ module So
           ##
           # Performs client streaming garbage listing.
           #
-          # @param request [Gapic::StreamInput, Enumerable<So::Much::Trash::ListGarbageRequest | Hash>]
+          # @param request [Gapic::StreamInput, Enumerable<So::Much::Trash::ListGarbageRequest, Hash>]
           #   An enumerable of {So::Much::Trash::ListGarbageRequest} instances.
           # @param options [Gapic::CallOptions, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
@@ -967,15 +1032,22 @@ module So
           # Performs server streaming garbage listing.
           #
           # @overload server_garbage(request, options = nil)
-          #   @param request [So::Much::Trash::ListGarbageRequest | Hash]
-          #     Performs server streaming garbage listing.
+          #   Pass arguments to `server_garbage` via a request object, either of type
+          #   {So::Much::Trash::ListGarbageRequest} or an equivalent Hash.
+          #
+          #   @param request [So::Much::Trash::ListGarbageRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload server_garbage(garbage: nil)
+          #   Pass arguments to `server_garbage` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param garbage [String]
           #     The name of the garbage this item belongs to.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<So::Much::Trash::GarbageItem>]
@@ -1034,7 +1106,7 @@ module So
           ##
           # Performs bidirectional streaming garbage listing.
           #
-          # @param request [Gapic::StreamInput, Enumerable<So::Much::Trash::ListGarbageRequest | Hash>]
+          # @param request [Gapic::StreamInput, Enumerable<So::Much::Trash::ListGarbageRequest, Hash>]
           #   An enumerable of {So::Much::Trash::ListGarbageRequest} instances.
           # @param options [Gapic::CallOptions, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -116,16 +116,20 @@ module So
           # to use different resource name schemes, such as `users/*/operations`.
           #
           # @overload list_operations(request, options = nil)
-          #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-          #     Lists operations that match the specified filter in the request. If the
-          #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+          #   Pass arguments to `list_operations` via a request object, either of type
+          #   {Google::Longrunning::ListOperationsRequest} or an equivalent Hash.
           #
-          #     NOTE: the `name` binding below allows API services to override the binding
-          #     to use different resource name schemes, such as `users/*/operations`.
+          #   @param request [Google::Longrunning::ListOperationsRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+          #   Pass arguments to `list_operations` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of the operation collection.
           #   @param filter [String]
@@ -134,7 +138,6 @@ module So
           #     The standard list page size.
           #   @param page_token [String]
           #     The standard list page token.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::PagedEnumerable<Gapic::Operation>]
@@ -187,17 +190,22 @@ module So
           # service.
           #
           # @overload get_operation(request, options = nil)
-          #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-          #     Gets the latest state of a long-running operation.  Clients can use this
-          #     method to poll the operation result at intervals as recommended by the API
-          #     service.
+          #   Pass arguments to `get_operation` via a request object, either of type
+          #   {Google::Longrunning::GetOperationRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Longrunning::GetOperationRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_operation(name: nil)
+          #   Pass arguments to `get_operation` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of the operation resource.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::Operation]
@@ -250,18 +258,22 @@ module So
           # `google.rpc.Code.UNIMPLEMENTED`.
           #
           # @overload delete_operation(request, options = nil)
-          #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-          #     Deletes a long-running operation. This method indicates that the client is
-          #     no longer interested in the operation result. It does not cancel the
-          #     operation. If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.
+          #   Pass arguments to `delete_operation` via a request object, either of type
+          #   {Google::Longrunning::DeleteOperationRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Longrunning::DeleteOperationRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload delete_operation(name: nil)
+          #   Pass arguments to `delete_operation` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of the operation resource to be deleted.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -319,24 +331,22 @@ module So
           # corresponding to `Code.CANCELLED`.
           #
           # @overload cancel_operation(request, options = nil)
-          #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-          #     Starts asynchronous cancellation on a long-running operation.  The server
-          #     makes a best effort to cancel the operation, but success is not
-          #     guaranteed.  If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #     Operations.GetOperation or
-          #     other methods to check whether the cancellation succeeded or whether the
-          #     operation completed despite cancellation. On successful cancellation,
-          #     the operation is not deleted; instead, it becomes an operation with
-          #     an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
-          #     corresponding to `Code.CANCELLED`.
+          #   Pass arguments to `cancel_operation` via a request object, either of type
+          #   {Google::Longrunning::CancelOperationRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Longrunning::CancelOperationRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload cancel_operation(name: nil)
+          #   Pass arguments to `cancel_operation` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of the operation resource to be cancelled.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/client.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/client.rb
@@ -145,10 +145,14 @@ module Testing
 
         ##
         # @overload no_retry_method(request, options = nil)
-        #   @param request [Testing::GrpcServiceConfig::Request | Hash]
+        #   Pass arguments to `no_retry_method` via a request object, either of type
+        #   {Testing::GrpcServiceConfig::Request} or an equivalent Hash.
+        #
+        #   @param request [Testing::GrpcServiceConfig::Request, Hash]
+        #     A request object representing the call parameters. Required. To specify no
+        #     parameters, or to keep all the default parameter values, pass an empty Hash.
         #   @param options [Gapic::CallOptions, Hash]
         #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
-        #
         #
         # @yield [response, operation] Access the result along with the RPC operation
         # @yieldparam response [Testing::GrpcServiceConfig::Response]

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
@@ -161,10 +161,14 @@ module Testing
 
         ##
         # @overload service_level_retry_method(request, options = nil)
-        #   @param request [Testing::GrpcServiceConfig::Request | Hash]
+        #   Pass arguments to `service_level_retry_method` via a request object, either of type
+        #   {Testing::GrpcServiceConfig::Request} or an equivalent Hash.
+        #
+        #   @param request [Testing::GrpcServiceConfig::Request, Hash]
+        #     A request object representing the call parameters. Required. To specify no
+        #     parameters, or to keep all the default parameter values, pass an empty Hash.
         #   @param options [Gapic::CallOptions, Hash]
         #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
-        #
         #
         # @yield [response, operation] Access the result along with the RPC operation
         # @yieldparam response [Testing::GrpcServiceConfig::Response]
@@ -205,10 +209,14 @@ module Testing
 
         ##
         # @overload method_level_retry_method(request, options = nil)
-        #   @param request [Testing::GrpcServiceConfig::Request | Hash]
+        #   Pass arguments to `method_level_retry_method` via a request object, either of type
+        #   {Testing::GrpcServiceConfig::Request} or an equivalent Hash.
+        #
+        #   @param request [Testing::GrpcServiceConfig::Request, Hash]
+        #     A request object representing the call parameters. Required. To specify no
+        #     parameters, or to keep all the default parameter values, pass an empty Hash.
         #   @param options [Gapic::CallOptions, Hash]
         #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
-        #
         #
         # @yield [response, operation] Access the result along with the RPC operation
         # @yieldparam response [Testing::GrpcServiceConfig::Response]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -158,17 +158,24 @@ module Google
           # This method simply echos the request. This method is showcases unary rpcs.
           #
           # @overload echo(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::EchoRequest | Hash]
-          #     This method simply echos the request. This method is showcases unary rpcs.
+          #   Pass arguments to `echo` via a request object, either of type
+          #   {Google::Showcase::V1beta1::EchoRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::EchoRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload echo(content: nil, error: nil)
+          #   Pass arguments to `echo` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param content [String]
           #     The content to be echoed by the server.
-          #   @param error [Google::Rpc::Status | Hash]
+          #   @param error [Google::Rpc::Status, Hash]
           #     The error to be thrown by the server.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::EchoResponse]
@@ -212,18 +219,24 @@ module Google
           # through the stream. This method showcases server-side streaming rpcs.
           #
           # @overload expand(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::ExpandRequest | Hash]
-          #     This method split the given content into words and will pass each word back
-          #     through the stream. This method showcases server-side streaming rpcs.
+          #   Pass arguments to `expand` via a request object, either of type
+          #   {Google::Showcase::V1beta1::ExpandRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::ExpandRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload expand(content: nil, error: nil)
+          #   Pass arguments to `expand` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param content [String]
           #     The content that will be split into words and returned on the stream.
-          #   @param error [Google::Rpc::Status | Hash]
+          #   @param error [Google::Rpc::Status, Hash]
           #     The error that is thrown after all words are sent on the stream.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1beta1::EchoResponse>]
@@ -267,7 +280,7 @@ module Google
           # by the client, this method will return the a concatenation of the strings
           # passed to it. This method showcases client-side streaming rpcs.
           #
-          # @param request [Gapic::StreamInput, Enumerable<Google::Showcase::V1beta1::EchoRequest | Hash>]
+          # @param request [Gapic::StreamInput, Enumerable<Google::Showcase::V1beta1::EchoRequest, Hash>]
           #   An enumerable of {Google::Showcase::V1beta1::EchoRequest} instances.
           # @param options [Gapic::CallOptions, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
@@ -319,7 +332,7 @@ module Google
           # be passed  back on the stream. This method showcases bidirectional
           # streaming rpcs.
           #
-          # @param request [Gapic::StreamInput, Enumerable<Google::Showcase::V1beta1::EchoRequest | Hash>]
+          # @param request [Gapic::StreamInput, Enumerable<Google::Showcase::V1beta1::EchoRequest, Hash>]
           #   An enumerable of {Google::Showcase::V1beta1::EchoRequest} instances.
           # @param options [Gapic::CallOptions, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
@@ -371,20 +384,26 @@ module Google
           # expanded words, this method returns a paged list of expanded words.
           #
           # @overload paged_expand(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::PagedExpandRequest | Hash]
-          #     This is similar to the Expand method but instead of returning a stream of
-          #     expanded words, this method returns a paged list of expanded words.
+          #   Pass arguments to `paged_expand` via a request object, either of type
+          #   {Google::Showcase::V1beta1::PagedExpandRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::PagedExpandRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload paged_expand(content: nil, page_size: nil, page_token: nil)
+          #   Pass arguments to `paged_expand` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param content [String]
           #     The string to expand.
           #   @param page_size [Integer]
           #     The amount of words to returned in each page.
           #   @param page_token [String]
           #     The position of the page to be returned.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::PagedEnumerable<Google::Showcase::V1beta1::EchoResponse>]
@@ -429,23 +448,29 @@ module Google
           # This method showcases how a client handles a request timing out.
           #
           # @overload wait(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::WaitRequest | Hash]
-          #     This method will wait the requested amount of and then return.
-          #     This method showcases how a client handles a request timing out.
+          #   Pass arguments to `wait` via a request object, either of type
+          #   {Google::Showcase::V1beta1::WaitRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::WaitRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload wait(end_time: nil, ttl: nil, error: nil, success: nil)
-          #   @param end_time [Google::Protobuf::Timestamp | Hash]
+          #   Pass arguments to `wait` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
+          #   @param end_time [Google::Protobuf::Timestamp, Hash]
           #     The time that this operation will complete.
-          #   @param ttl [Google::Protobuf::Duration | Hash]
+          #   @param ttl [Google::Protobuf::Duration, Hash]
           #     The duration of this operation.
-          #   @param error [Google::Rpc::Status | Hash]
+          #   @param error [Google::Rpc::Status, Hash]
           #     The error that will be returned by the server. If this code is specified
           #     to be the OK rpc code, an empty response will be returned.
-          #   @param success [Google::Showcase::V1beta1::WaitResponse | Hash]
+          #   @param success [Google::Showcase::V1beta1::WaitResponse, Hash]
           #     The response to be returned on operation completion.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::Operation]
@@ -491,22 +516,27 @@ module Google
           # This method showcases how a client handles delays or retries.
           #
           # @overload block(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::BlockRequest | Hash]
-          #     This method will block (wait) for the requested amount of time
-          #     and then return the response or error.
-          #     This method showcases how a client handles delays or retries.
+          #   Pass arguments to `block` via a request object, either of type
+          #   {Google::Showcase::V1beta1::BlockRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::BlockRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload block(response_delay: nil, error: nil, success: nil)
-          #   @param response_delay [Google::Protobuf::Duration | Hash]
+          #   Pass arguments to `block` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
+          #   @param response_delay [Google::Protobuf::Duration, Hash]
           #     The amount of time to block before returning a response.
-          #   @param error [Google::Rpc::Status | Hash]
+          #   @param error [Google::Rpc::Status, Hash]
           #     The error that will be returned by the server. If this code is specified
           #     to be the OK rpc code, an empty response will be returned.
-          #   @param success [Google::Showcase::V1beta1::BlockResponse | Hash]
+          #   @param success [Google::Showcase::V1beta1::BlockResponse, Hash]
           #     The response to be returned that will signify successful method call.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::BlockResponse]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -116,16 +116,20 @@ module Google
           # to use different resource name schemes, such as `users/*/operations`.
           #
           # @overload list_operations(request, options = nil)
-          #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-          #     Lists operations that match the specified filter in the request. If the
-          #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+          #   Pass arguments to `list_operations` via a request object, either of type
+          #   {Google::Longrunning::ListOperationsRequest} or an equivalent Hash.
           #
-          #     NOTE: the `name` binding below allows API services to override the binding
-          #     to use different resource name schemes, such as `users/*/operations`.
+          #   @param request [Google::Longrunning::ListOperationsRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+          #   Pass arguments to `list_operations` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of the operation collection.
           #   @param filter [String]
@@ -134,7 +138,6 @@ module Google
           #     The standard list page size.
           #   @param page_token [String]
           #     The standard list page token.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::PagedEnumerable<Gapic::Operation>]
@@ -187,17 +190,22 @@ module Google
           # service.
           #
           # @overload get_operation(request, options = nil)
-          #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-          #     Gets the latest state of a long-running operation.  Clients can use this
-          #     method to poll the operation result at intervals as recommended by the API
-          #     service.
+          #   Pass arguments to `get_operation` via a request object, either of type
+          #   {Google::Longrunning::GetOperationRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Longrunning::GetOperationRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_operation(name: nil)
+          #   Pass arguments to `get_operation` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of the operation resource.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::Operation]
@@ -250,18 +258,22 @@ module Google
           # `google.rpc.Code.UNIMPLEMENTED`.
           #
           # @overload delete_operation(request, options = nil)
-          #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-          #     Deletes a long-running operation. This method indicates that the client is
-          #     no longer interested in the operation result. It does not cancel the
-          #     operation. If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.
+          #   Pass arguments to `delete_operation` via a request object, either of type
+          #   {Google::Longrunning::DeleteOperationRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Longrunning::DeleteOperationRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload delete_operation(name: nil)
+          #   Pass arguments to `delete_operation` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of the operation resource to be deleted.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -319,24 +331,22 @@ module Google
           # corresponding to `Code.CANCELLED`.
           #
           # @overload cancel_operation(request, options = nil)
-          #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-          #     Starts asynchronous cancellation on a long-running operation.  The server
-          #     makes a best effort to cancel the operation, but success is not
-          #     guaranteed.  If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #     Operations.GetOperation or
-          #     other methods to check whether the cancellation succeeded or whether the
-          #     operation completed despite cancellation. On successful cancellation,
-          #     the operation is not deleted; instead, it becomes an operation with
-          #     an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
-          #     corresponding to `Code.CANCELLED`.
+          #   Pass arguments to `cancel_operation` via a request object, either of type
+          #   {Google::Longrunning::CancelOperationRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Longrunning::CancelOperationRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload cancel_operation(name: nil)
+          #   Pass arguments to `cancel_operation` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of the operation resource to be cancelled.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -153,15 +153,22 @@ module Google
           # Creates a user.
           #
           # @overload create_user(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::CreateUserRequest | Hash]
-          #     Creates a user.
+          #   Pass arguments to `create_user` via a request object, either of type
+          #   {Google::Showcase::V1beta1::CreateUserRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::CreateUserRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload create_user(user: nil)
-          #   @param user [Google::Showcase::V1beta1::User | Hash]
-          #     The user to create.
+          #   Pass arguments to `create_user` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
           #
+          #   @param user [Google::Showcase::V1beta1::User, Hash]
+          #     The user to create.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::User]
@@ -204,15 +211,22 @@ module Google
           # Retrieves the User with the given uri.
           #
           # @overload get_user(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::GetUserRequest | Hash]
-          #     Retrieves the User with the given uri.
+          #   Pass arguments to `get_user` via a request object, either of type
+          #   {Google::Showcase::V1beta1::GetUserRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::GetUserRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_user(name: nil)
+          #   Pass arguments to `get_user` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The resource name of the requested user.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::User]
@@ -261,18 +275,25 @@ module Google
           # Updates a user.
           #
           # @overload update_user(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::UpdateUserRequest | Hash]
-          #     Updates a user.
+          #   Pass arguments to `update_user` via a request object, either of type
+          #   {Google::Showcase::V1beta1::UpdateUserRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::UpdateUserRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload update_user(user: nil, update_mask: nil)
-          #   @param user [Google::Showcase::V1beta1::User | Hash]
+          #   Pass arguments to `update_user` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
+          #   @param user [Google::Showcase::V1beta1::User, Hash]
           #     The user to update.
-          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
+          #   @param update_mask [Google::Protobuf::FieldMask, Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::User]
@@ -321,15 +342,22 @@ module Google
           # Deletes a user, their profile, and all of their authored messages.
           #
           # @overload delete_user(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::DeleteUserRequest | Hash]
-          #     Deletes a user, their profile, and all of their authored messages.
+          #   Pass arguments to `delete_user` via a request object, either of type
+          #   {Google::Showcase::V1beta1::DeleteUserRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::DeleteUserRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload delete_user(name: nil)
+          #   Pass arguments to `delete_user` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The resource name of the user to delete.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -378,12 +406,20 @@ module Google
           # Lists all users.
           #
           # @overload list_users(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::ListUsersRequest | Hash]
-          #     Lists all users.
+          #   Pass arguments to `list_users` via a request object, either of type
+          #   {Google::Showcase::V1beta1::ListUsersRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::ListUsersRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload list_users(page_size: nil, page_token: nil)
+          #   Pass arguments to `list_users` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param page_size [Integer]
           #     The maximum number of users to return. Server may return fewer users
           #     than requested. If unspecified, server will pick an appropriate default.
@@ -391,7 +427,6 @@ module Google
           #     The value of google.showcase.v1beta1.ListUsersResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1beta1.Identity\ListUsers` method.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::PagedEnumerable<Google::Showcase::V1beta1::User>]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -161,15 +161,22 @@ module Google
           # Creates a room.
           #
           # @overload create_room(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::CreateRoomRequest | Hash]
-          #     Creates a room.
+          #   Pass arguments to `create_room` via a request object, either of type
+          #   {Google::Showcase::V1beta1::CreateRoomRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::CreateRoomRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload create_room(room: nil)
-          #   @param room [Google::Showcase::V1beta1::Room | Hash]
-          #     The room to create.
+          #   Pass arguments to `create_room` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
           #
+          #   @param room [Google::Showcase::V1beta1::Room, Hash]
+          #     The room to create.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::Room]
@@ -212,15 +219,22 @@ module Google
           # Retrieves the Room with the given resource name.
           #
           # @overload get_room(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::GetRoomRequest | Hash]
-          #     Retrieves the Room with the given resource name.
+          #   Pass arguments to `get_room` via a request object, either of type
+          #   {Google::Showcase::V1beta1::GetRoomRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::GetRoomRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_room(name: nil)
+          #   Pass arguments to `get_room` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The resource name of the requested room.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::Room]
@@ -269,18 +283,25 @@ module Google
           # Updates a room.
           #
           # @overload update_room(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::UpdateRoomRequest | Hash]
-          #     Updates a room.
+          #   Pass arguments to `update_room` via a request object, either of type
+          #   {Google::Showcase::V1beta1::UpdateRoomRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::UpdateRoomRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload update_room(room: nil, update_mask: nil)
-          #   @param room [Google::Showcase::V1beta1::Room | Hash]
+          #   Pass arguments to `update_room` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
+          #   @param room [Google::Showcase::V1beta1::Room, Hash]
           #     The room to update.
-          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
+          #   @param update_mask [Google::Protobuf::FieldMask, Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::Room]
@@ -329,15 +350,22 @@ module Google
           # Deletes a room and all of its blurbs.
           #
           # @overload delete_room(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::DeleteRoomRequest | Hash]
-          #     Deletes a room and all of its blurbs.
+          #   Pass arguments to `delete_room` via a request object, either of type
+          #   {Google::Showcase::V1beta1::DeleteRoomRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::DeleteRoomRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload delete_room(name: nil)
+          #   Pass arguments to `delete_room` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The resource name of the requested room.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -386,12 +414,20 @@ module Google
           # Lists all chat rooms.
           #
           # @overload list_rooms(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::ListRoomsRequest | Hash]
-          #     Lists all chat rooms.
+          #   Pass arguments to `list_rooms` via a request object, either of type
+          #   {Google::Showcase::V1beta1::ListRoomsRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::ListRoomsRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload list_rooms(page_size: nil, page_token: nil)
+          #   Pass arguments to `list_rooms` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param page_size [Integer]
           #     The maximum number of rooms return. Server may return fewer rooms
           #     than requested. If unspecified, server will pick an appropriate default.
@@ -399,7 +435,6 @@ module Google
           #     The value of google.showcase.v1beta1.ListRoomsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1beta1.Messaging\ListRooms` method.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::PagedEnumerable<Google::Showcase::V1beta1::Room>]
@@ -445,20 +480,25 @@ module Google
           # to be a post on the profile.
           #
           # @overload create_blurb(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::CreateBlurbRequest | Hash]
-          #     Creates a blurb. If the parent is a room, the blurb is understood to be a
-          #     message in that room. If the parent is a profile, the blurb is understood
-          #     to be a post on the profile.
+          #   Pass arguments to `create_blurb` via a request object, either of type
+          #   {Google::Showcase::V1beta1::CreateBlurbRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::CreateBlurbRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload create_blurb(parent: nil, blurb: nil)
+          #   Pass arguments to `create_blurb` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param parent [String]
           #     The resource name of the chat room or user profile that this blurb will
           #     be tied to.
-          #   @param blurb [Google::Showcase::V1beta1::Blurb | Hash]
+          #   @param blurb [Google::Showcase::V1beta1::Blurb, Hash]
           #     The blurb to create.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::Blurb]
@@ -507,15 +547,22 @@ module Google
           # Retrieves the Blurb with the given resource name.
           #
           # @overload get_blurb(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::GetBlurbRequest | Hash]
-          #     Retrieves the Blurb with the given resource name.
+          #   Pass arguments to `get_blurb` via a request object, either of type
+          #   {Google::Showcase::V1beta1::GetBlurbRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::GetBlurbRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_blurb(name: nil)
+          #   Pass arguments to `get_blurb` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The resource name of the requested blurb.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::Blurb]
@@ -564,18 +611,25 @@ module Google
           # Updates a blurb.
           #
           # @overload update_blurb(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::UpdateBlurbRequest | Hash]
-          #     Updates a blurb.
+          #   Pass arguments to `update_blurb` via a request object, either of type
+          #   {Google::Showcase::V1beta1::UpdateBlurbRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::UpdateBlurbRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload update_blurb(blurb: nil, update_mask: nil)
-          #   @param blurb [Google::Showcase::V1beta1::Blurb | Hash]
+          #   Pass arguments to `update_blurb` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
+          #   @param blurb [Google::Showcase::V1beta1::Blurb, Hash]
           #     The blurb to update.
-          #   @param update_mask [Google::Protobuf::FieldMask | Hash]
+          #   @param update_mask [Google::Protobuf::FieldMask, Hash]
           #     The field mask to determine wich fields are to be updated. If empty, the
           #     server will assume all fields are to be updated.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::Blurb]
@@ -624,15 +678,22 @@ module Google
           # Deletes a blurb.
           #
           # @overload delete_blurb(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::DeleteBlurbRequest | Hash]
-          #     Deletes a blurb.
+          #   Pass arguments to `delete_blurb` via a request object, either of type
+          #   {Google::Showcase::V1beta1::DeleteBlurbRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::DeleteBlurbRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload delete_blurb(name: nil)
+          #   Pass arguments to `delete_blurb` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The resource name of the requested blurb.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -682,13 +743,20 @@ module Google
           # parent resource name.
           #
           # @overload list_blurbs(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::ListBlurbsRequest | Hash]
-          #     Lists blurbs for a specific chat room or user profile depending on the
-          #     parent resource name.
+          #   Pass arguments to `list_blurbs` via a request object, either of type
+          #   {Google::Showcase::V1beta1::ListBlurbsRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::ListBlurbsRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload list_blurbs(parent: nil, page_size: nil, page_token: nil)
+          #   Pass arguments to `list_blurbs` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param parent [String]
           #     The resource name of the requested room or profile whos blurbs to list.
           #   @param page_size [Integer]
@@ -699,7 +767,6 @@ module Google
           #     The value of google.showcase.v1beta1.ListBlurbsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1beta1.Messaging\ListBlurbs` method.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::PagedEnumerable<Google::Showcase::V1beta1::Blurb>]
@@ -751,14 +818,20 @@ module Google
           # contain an exact match of a queried word will be returned.
           #
           # @overload search_blurbs(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::SearchBlurbsRequest | Hash]
-          #     This method searches through all blurbs across all rooms and profiles
-          #     for blurbs containing to words found in the query. Only posts that
-          #     contain an exact match of a queried word will be returned.
+          #   Pass arguments to `search_blurbs` via a request object, either of type
+          #   {Google::Showcase::V1beta1::SearchBlurbsRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::SearchBlurbsRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload search_blurbs(query: nil, parent: nil, page_size: nil, page_token: nil)
+          #   Pass arguments to `search_blurbs` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param query [String]
           #     The query used to search for blurbs containing to words of this string.
           #     Only posts that contain an exact match of a queried word will be returned.
@@ -774,7 +847,6 @@ module Google
           #     google.showcase.v1beta1.SearchBlurbsResponse.next_page_token
           #     returned from the previous call to
           #     `google.showcase.v1beta1.Messaging\SearchBlurbs` method.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::Operation]
@@ -825,18 +897,24 @@ module Google
           # particular chat room or user profile.
           #
           # @overload stream_blurbs(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::StreamBlurbsRequest | Hash]
-          #     This returns a stream that emits the blurbs that are created for a
-          #     particular chat room or user profile.
+          #   Pass arguments to `stream_blurbs` via a request object, either of type
+          #   {Google::Showcase::V1beta1::StreamBlurbsRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::StreamBlurbsRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload stream_blurbs(name: nil, expire_time: nil)
+          #   Pass arguments to `stream_blurbs` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The resource name of a chat room or user profile whose blurbs to stream.
-          #   @param expire_time [Google::Protobuf::Timestamp | Hash]
+          #   @param expire_time [Google::Protobuf::Timestamp, Hash]
           #     The time at which this stream will close.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Enumerable<Google::Showcase::V1beta1::StreamBlurbsResponse>]
@@ -885,7 +963,7 @@ module Google
           # This is a stream to create multiple blurbs. If an invalid blurb is
           # requested to be created, the stream will close with an error.
           #
-          # @param request [Gapic::StreamInput, Enumerable<Google::Showcase::V1beta1::CreateBlurbRequest | Hash>]
+          # @param request [Gapic::StreamInput, Enumerable<Google::Showcase::V1beta1::CreateBlurbRequest, Hash>]
           #   An enumerable of {Google::Showcase::V1beta1::CreateBlurbRequest} instances.
           # @param options [Gapic::CallOptions, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
@@ -938,7 +1016,7 @@ module Google
           # blurbs. If an invalid blurb is requested to be created, the stream will
           # close with an error.
           #
-          # @param request [Gapic::StreamInput, Enumerable<Google::Showcase::V1beta1::ConnectRequest | Hash>]
+          # @param request [Gapic::StreamInput, Enumerable<Google::Showcase::V1beta1::ConnectRequest, Hash>]
           #   An enumerable of {Google::Showcase::V1beta1::ConnectRequest} instances.
           # @param options [Gapic::CallOptions, Hash]
           #   Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -116,16 +116,20 @@ module Google
           # to use different resource name schemes, such as `users/*/operations`.
           #
           # @overload list_operations(request, options = nil)
-          #   @param request [Google::Longrunning::ListOperationsRequest | Hash]
-          #     Lists operations that match the specified filter in the request. If the
-          #     server doesn't support this method, it returns `UNIMPLEMENTED`.
+          #   Pass arguments to `list_operations` via a request object, either of type
+          #   {Google::Longrunning::ListOperationsRequest} or an equivalent Hash.
           #
-          #     NOTE: the `name` binding below allows API services to override the binding
-          #     to use different resource name schemes, such as `users/*/operations`.
+          #   @param request [Google::Longrunning::ListOperationsRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload list_operations(name: nil, filter: nil, page_size: nil, page_token: nil)
+          #   Pass arguments to `list_operations` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of the operation collection.
           #   @param filter [String]
@@ -134,7 +138,6 @@ module Google
           #     The standard list page size.
           #   @param page_token [String]
           #     The standard list page token.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::PagedEnumerable<Gapic::Operation>]
@@ -187,17 +190,22 @@ module Google
           # service.
           #
           # @overload get_operation(request, options = nil)
-          #   @param request [Google::Longrunning::GetOperationRequest | Hash]
-          #     Gets the latest state of a long-running operation.  Clients can use this
-          #     method to poll the operation result at intervals as recommended by the API
-          #     service.
+          #   Pass arguments to `get_operation` via a request object, either of type
+          #   {Google::Longrunning::GetOperationRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Longrunning::GetOperationRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_operation(name: nil)
+          #   Pass arguments to `get_operation` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of the operation resource.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::Operation]
@@ -250,18 +258,22 @@ module Google
           # `google.rpc.Code.UNIMPLEMENTED`.
           #
           # @overload delete_operation(request, options = nil)
-          #   @param request [Google::Longrunning::DeleteOperationRequest | Hash]
-          #     Deletes a long-running operation. This method indicates that the client is
-          #     no longer interested in the operation result. It does not cancel the
-          #     operation. If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.
+          #   Pass arguments to `delete_operation` via a request object, either of type
+          #   {Google::Longrunning::DeleteOperationRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Longrunning::DeleteOperationRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload delete_operation(name: nil)
+          #   Pass arguments to `delete_operation` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of the operation resource to be deleted.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -319,24 +331,22 @@ module Google
           # corresponding to `Code.CANCELLED`.
           #
           # @overload cancel_operation(request, options = nil)
-          #   @param request [Google::Longrunning::CancelOperationRequest | Hash]
-          #     Starts asynchronous cancellation on a long-running operation.  The server
-          #     makes a best effort to cancel the operation, but success is not
-          #     guaranteed.  If the server doesn't support this method, it returns
-          #     `google.rpc.Code.UNIMPLEMENTED`.  Clients can use
-          #     Operations.GetOperation or
-          #     other methods to check whether the cancellation succeeded or whether the
-          #     operation completed despite cancellation. On successful cancellation,
-          #     the operation is not deleted; instead, it becomes an operation with
-          #     an {Google::Longrunning::Operation#error Operation.error} value with a {Google::Rpc::Status#code google.rpc.Status.code} of 1,
-          #     corresponding to `Code.CANCELLED`.
+          #   Pass arguments to `cancel_operation` via a request object, either of type
+          #   {Google::Longrunning::CancelOperationRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Longrunning::CancelOperationRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload cancel_operation(name: nil)
+          #   Pass arguments to `cancel_operation` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The name of the operation resource to be cancelled.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -154,17 +154,24 @@ module Google
           # Creates a new testing session.
           #
           # @overload create_session(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::CreateSessionRequest | Hash]
-          #     Creates a new testing session.
+          #   Pass arguments to `create_session` via a request object, either of type
+          #   {Google::Showcase::V1beta1::CreateSessionRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::CreateSessionRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload create_session(session: nil)
-          #   @param session [Google::Showcase::V1beta1::Session | Hash]
+          #   Pass arguments to `create_session` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
+          #   @param session [Google::Showcase::V1beta1::Session, Hash]
           #     The session to be created.
           #     Sessions are immutable once they are created (although they can
           #     be deleted).
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::Session]
@@ -207,15 +214,22 @@ module Google
           # Gets a testing session.
           #
           # @overload get_session(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::GetSessionRequest | Hash]
-          #     Gets a testing session.
+          #   Pass arguments to `get_session` via a request object, either of type
+          #   {Google::Showcase::V1beta1::GetSessionRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::GetSessionRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload get_session(name: nil)
+          #   Pass arguments to `get_session` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The session to be retrieved.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::Session]
@@ -264,17 +278,24 @@ module Google
           # Lists the current test sessions.
           #
           # @overload list_sessions(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::ListSessionsRequest | Hash]
-          #     Lists the current test sessions.
+          #   Pass arguments to `list_sessions` via a request object, either of type
+          #   {Google::Showcase::V1beta1::ListSessionsRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::ListSessionsRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload list_sessions(page_size: nil, page_token: nil)
+          #   Pass arguments to `list_sessions` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param page_size [Integer]
           #     The maximum number of sessions to return per page.
           #   @param page_token [String]
           #     The page token, for retrieving subsequent pages.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::PagedEnumerable<Google::Showcase::V1beta1::Session>]
@@ -318,15 +339,22 @@ module Google
           # Delete a test session.
           #
           # @overload delete_session(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::DeleteSessionRequest | Hash]
-          #     Delete a test session.
+          #   Pass arguments to `delete_session` via a request object, either of type
+          #   {Google::Showcase::V1beta1::DeleteSessionRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::DeleteSessionRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload delete_session(name: nil)
+          #   Pass arguments to `delete_session` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The session to be deleted.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -377,17 +405,22 @@ module Google
           # and an overall rollup.
           #
           # @overload report_session(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::ReportSessionRequest | Hash]
-          #     Report on the status of a session.
-          #     This generates a report detailing which tests have been completed,
-          #     and an overall rollup.
+          #   Pass arguments to `report_session` via a request object, either of type
+          #   {Google::Showcase::V1beta1::ReportSessionRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::ReportSessionRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload report_session(name: nil)
+          #   Pass arguments to `report_session` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The session to be reported on.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::ReportSessionResponse]
@@ -436,19 +469,26 @@ module Google
           # List the tests of a sessesion.
           #
           # @overload list_tests(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::ListTestsRequest | Hash]
-          #     List the tests of a sessesion.
+          #   Pass arguments to `list_tests` via a request object, either of type
+          #   {Google::Showcase::V1beta1::ListTestsRequest} or an equivalent Hash.
+          #
+          #   @param request [Google::Showcase::V1beta1::ListTestsRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload list_tests(parent: nil, page_size: nil, page_token: nil)
+          #   Pass arguments to `list_tests` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param parent [String]
           #     The session.
           #   @param page_size [Integer]
           #     The maximum number of tests to return per page.
           #   @param page_token [String]
           #     The page token, for retrieving subsequent pages.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Gapic::PagedEnumerable<Google::Showcase::V1beta1::Test>]
@@ -503,20 +543,22 @@ module Google
           # This method will error if attempting to delete a required test.
           #
           # @overload delete_test(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::DeleteTestRequest | Hash]
-          #     Explicitly decline to implement a test.
+          #   Pass arguments to `delete_test` via a request object, either of type
+          #   {Google::Showcase::V1beta1::DeleteTestRequest} or an equivalent Hash.
           #
-          #     This removes the test from subsequent `ListTests` calls, and
-          #     attempting to do the test will error.
-          #
-          #     This method will error if attempting to delete a required test.
+          #   @param request [Google::Showcase::V1beta1::DeleteTestRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload delete_test(name: nil)
+          #   Pass arguments to `delete_test` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The test to be deleted.
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Protobuf::Empty]
@@ -568,22 +610,26 @@ module Google
           # end of the test, this method provides the means to do so.
           #
           # @overload verify_test(request, options = nil)
-          #   @param request [Google::Showcase::V1beta1::VerifyTestRequest | Hash]
-          #     Register a response to a test.
+          #   Pass arguments to `verify_test` via a request object, either of type
+          #   {Google::Showcase::V1beta1::VerifyTestRequest} or an equivalent Hash.
           #
-          #     In cases where a test involves registering a final answer at the
-          #     end of the test, this method provides the means to do so.
+          #   @param request [Google::Showcase::V1beta1::VerifyTestRequest, Hash]
+          #     A request object representing the call parameters. Required. To specify no
+          #     parameters, or to keep all the default parameter values, pass an empty Hash.
           #   @param options [Gapic::CallOptions, Hash]
           #     Overrides the default settings for this call, e.g, timeout, retries, etc. Optional.
           #
           # @overload verify_test(name: nil, answer: nil, answers: nil)
+          #   Pass arguments to `verify_test` via keyword arguments. Note that at
+          #   least one keyword argument is required. To specify no parameters, or to keep all
+          #   the default parameter values, pass an empty Hash as a request object (see above).
+          #
           #   @param name [String]
           #     The test to have an answer registered to it.
           #   @param answer [String]
           #     The answer from the test.
           #   @param answers [Array<String>]
           #     The answers from the test if multiple are to be checked
-          #
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [Google::Showcase::V1beta1::VerifyTestResponse]


### PR DESCRIPTION
This is a general cleanup of the documentation for method calling conventions. Specifically:

* In the "request object" overload, added a brief overview saying you can pass request proto objects or equivalent hashes.
* In the "request object" overload, the docs for the `request` parameter were a repeat of the overall method docs. This was not useful. Replaced it with a general description of a request object.
* In the "keyword arguments" overload, added a brief overview. Also noted here that at least one keyword argument is required, and that if a user wants to pass no arguments, they should pass an empty hash as a request object. (Fixes #390)
* Removed an extra newline that appeared in the comments between the params section and the yields section.
* Overall, replaced `|` with `,` as the delimiter for union types. There isn't a formal standard for this that I know of, but pretty much all the YARD examples I've seen always use `,`.