### PR TITLE
fix: Disable module length metric

### DIFF
--- a/gapic-generator-cloud/templates/cloud/gem/rubocop.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/rubocop.erb
@@ -21,6 +21,8 @@ Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 Naming/FileName:

--- a/gapic-generator/templates/default/gem/rubocop.erb
+++ b/gapic-generator/templates/default/gem/rubocop.erb
@@ -18,6 +18,8 @@ Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 Naming/FileName:

--- a/shared/output/cloud/language_v1/.rubocop.yml
+++ b/shared/output/cloud/language_v1/.rubocop.yml
@@ -20,6 +20,8 @@ Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 Naming/FileName:

--- a/shared/output/cloud/language_v1beta1/.rubocop.yml
+++ b/shared/output/cloud/language_v1beta1/.rubocop.yml
@@ -20,6 +20,8 @@ Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 Naming/FileName:

--- a/shared/output/cloud/language_v1beta2/.rubocop.yml
+++ b/shared/output/cloud/language_v1beta2/.rubocop.yml
@@ -20,6 +20,8 @@ Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 Naming/FileName:

--- a/shared/output/cloud/noservice/.rubocop.yml
+++ b/shared/output/cloud/noservice/.rubocop.yml
@@ -20,6 +20,8 @@ Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 Naming/FileName:

--- a/shared/output/cloud/secretmanager_v1beta1/.rubocop.yml
+++ b/shared/output/cloud/secretmanager_v1beta1/.rubocop.yml
@@ -20,6 +20,8 @@ Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 Naming/FileName:

--- a/shared/output/cloud/speech_v1/.rubocop.yml
+++ b/shared/output/cloud/speech_v1/.rubocop.yml
@@ -20,6 +20,8 @@ Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 Naming/FileName:

--- a/shared/output/cloud/vision_v1/.rubocop.yml
+++ b/shared/output/cloud/vision_v1/.rubocop.yml
@@ -20,6 +20,8 @@ Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 Naming/FileName:

--- a/shared/output/gapic/templates/garbage/.rubocop.yml
+++ b/shared/output/gapic/templates/garbage/.rubocop.yml
@@ -17,6 +17,8 @@ Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 Naming/FileName:

--- a/shared/output/gapic/templates/grpc_service_config/.rubocop.yml
+++ b/shared/output/gapic/templates/grpc_service_config/.rubocop.yml
@@ -17,6 +17,8 @@ Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 Naming/FileName:

--- a/shared/output/gapic/templates/showcase/.rubocop.yml
+++ b/shared/output/gapic/templates/showcase/.rubocop.yml
@@ -17,6 +17,8 @@ Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 Naming/FileName:


### PR DESCRIPTION
DLP V2 generates lots of path helpers, causing `paths.rb` to violate `Metrics/ModuleLength`. Disable this metric for generated files.