### PR TITLE
fix: Loosen resource pattern checks

### DIFF
--- a/gapic-generator/lib/gapic/presenters/resource_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/resource_presenter.rb
@@ -38,15 +38,9 @@ module Gapic
           )
         end
 
-        @patterns.each do |pattern|
-          # URI path template verification for expected proto resource usage
-          if named_arg_patterns? pattern.segments
-            raise ArgumentError, "only resources without named patterns are supported, " \
-                                " not #{pattern.template}"
-          elsif positional_args? pattern.segments
-            raise ArgumentError, "only resources with named segments are supported, " \
-                                " not #{pattern.template}"
-          end
+        # Keep only patterns that can be used to create path helpers
+        @patterns.reject! do |pattern|
+          named_arg_patterns?(pattern.segments) || positional_args?(pattern.segments)
         end
       end
 

--- a/gapic-generator/templates/default/service/client/_resource.erb
+++ b/gapic-generator/templates/default/service/client/_resource.erb
@@ -1,6 +1,6 @@
 <%- assert_locals resource -%>
 <%- if resource.patterns.count == 1 -%>
 <%= render partial: "service/client/resource/single", locals: { resource: resource } %>
-<%- else -%>
+<%- elsif !resource.patterns.empty? -%>
 <%= render partial: "service/client/resource/multi", locals: { resource: resource } %>
 <%- end -%>


### PR DESCRIPTION
Currently, the resource presenter asserts that resource patterns follow its prescribed format and raises an exception if not. However, there are resources in the wild with legal patterns that do not conform (e.g. monitoring v3). Hence, we loosen the check, and instead just omit those patterns from the presenter (meaning they do not participate in the path generation options provided by the path helper). Along with this, we need to handle the case that a resource has _no_ conforming patterns.