### PR TITLE
feat: Various enhancements to LRO clients.

### DIFF
--- a/gapic-generator/templates/default/service/client/_client.erb
+++ b/gapic-generator/templates/default/service/client/_client.erb
@@ -105,6 +105,7 @@ class <%= service.client_name %>
     <%- if service.lro? -%>
     <%= service.lro_client_ivar %> = <%= service.operations_name %>.new do |config|
       config.credentials = credentials
+      config.endpoint = @config.endpoint
     end
 
     <%- end -%>
@@ -117,6 +118,15 @@ class <%= service.client_name %>
     )
   end
 
+<%- if service.lro? -%>
+  ##
+  # Get the associated client for long-running operations.
+  #
+  # @return [<%= service.operations_name_full %>]
+  #
+  attr_reader :<%= service.lro_client_var %>
+
+<%- end -%>
   # Service calls
   <%- service.methods.each do |method| -%>
 

--- a/gapic-generator/templates/default/service/test/client.erb
+++ b/gapic-generator/templates/default/service/test/client.erb
@@ -17,8 +17,22 @@ class <%= service.client_name_full %>Test < Minitest::Test
 <% service.methods.each do |method| %>
 <%= indent render(partial: "service/test/method/#{method.kind}",
                   locals: { method: method }), 2 %>
-<% if method != service.methods.last %>
 
 <% end %>
-<% end %>
+<%= indent render(partial: "service/test/method/configure", locals: { service: service }), 2 %>
+<%- if service.lro? -%>
+
+  def test_<%= service.lro_client_var %>
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = <%= service.client_name_full =%>.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    assert_kind_of <%= service.operations_name_full %>, client.<%= service.lro_client_var %>
+  end
+<%- end -%>
 end

--- a/gapic-generator/templates/default/service/test/client_operations.erb
+++ b/gapic-generator/templates/default/service/test/client_operations.erb
@@ -17,8 +17,8 @@ class <%= service.operations_name_full %>Test < Minitest::Test
 <% service.lro_service.methods.each do |method| %>
 <%= indent render(partial: "service/test/method/#{method.kind}",
                   locals: { client_name_full: service.operations_name_full, method: method }), 2 %>
-<% if method != service.lro_service.methods.last %>
 
 <% end %>
-<% end %>
+<%= indent render(partial: "service/test/method/configure",
+                  locals: { service: service, client_name_full: service.operations_name_full }), 2 %>
 end

--- a/gapic-generator/templates/default/service/test/method/_configure.erb
+++ b/gapic-generator/templates/default/service/test/method/_configure.erb
@@ -1,0 +1,19 @@
+<%- assert_locals service -%>
+<%- full_client_name = defined?(client_name_full) ? client_name_full : service.client_name_full -%>
+def test_configure
+  grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+  client = block_config = config = nil
+  Gapic::ServiceStub.stub :new, nil do
+    client = <%= full_client_name =%>.new do |config|
+      config.credentials = grpc_channel
+    end
+  end
+
+  config = client.configure do |c|
+    block_config = c
+  end
+
+  assert_same block_config, config
+  assert_kind_of <%= full_client_name %>::Configuration, config
+end

--- a/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
+++ b/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
@@ -405,4 +405,22 @@ class Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test
       assert_equal 5, annotate_text_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Cloud::Language::V1::LanguageService::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Cloud::Language::V1::LanguageService::Client::Configuration, config
+  end
 end

--- a/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
@@ -287,4 +287,22 @@ class Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest::
       assert_equal 5, annotate_text_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Cloud::Language::V1beta1::LanguageService::Client::Configuration, config
+  end
 end

--- a/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
@@ -405,4 +405,22 @@ class Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::
       assert_equal 5, annotate_text_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Cloud::Language::V1beta2::LanguageService::Client::Configuration, config
+  end
 end

--- a/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
@@ -945,4 +945,22 @@ class Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest < 
       assert_equal 5, test_iam_permissions_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client::Configuration, config
+  end
 end

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -132,6 +132,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.endpoint = @config.endpoint
               end
 
               @speech_stub = Gapic::ServiceStub.new(
@@ -142,6 +143,13 @@ module Google
                 interceptors: @config.interceptors
               )
             end
+
+            ##
+            # Get the associated client for long-running operations.
+            #
+            # @return [Google::Cloud::Speech::V1::Speech::Operations]
+            #
+            attr_reader :operations_client
 
             # Service calls
 

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -293,4 +293,22 @@ class Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
       assert_equal 5, cancel_operation_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Cloud::Speech::V1::Speech::Operations.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Cloud::Speech::V1::Speech::Operations::Configuration, config
+  end
 end

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
@@ -258,4 +258,35 @@ class Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       end
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Cloud::Speech::V1::Speech::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Cloud::Speech::V1::Speech::Client::Configuration, config
+  end
+
+  def test_operations_client
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Cloud::Speech::V1::Speech::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    assert_kind_of Google::Cloud::Speech::V1::Speech::Operations, client.operations_client
+  end
 end

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -136,6 +136,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.endpoint = @config.endpoint
               end
 
               @image_annotator_stub = Gapic::ServiceStub.new(
@@ -146,6 +147,13 @@ module Google
                 interceptors: @config.interceptors
               )
             end
+
+            ##
+            # Get the associated client for long-running operations.
+            #
+            # @return [Google::Cloud::Vision::V1::ImageAnnotator::Operations]
+            #
+            attr_reader :operations_client
 
             # Service calls
 

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -147,6 +147,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.endpoint = @config.endpoint
               end
 
               @product_search_stub = Gapic::ServiceStub.new(
@@ -157,6 +158,13 @@ module Google
                 interceptors: @config.interceptors
               )
             end
+
+            ##
+            # Get the associated client for long-running operations.
+            #
+            # @return [Google::Cloud::Vision::V1::ProductSearch::Operations]
+            #
+            attr_reader :operations_client
 
             # Service calls
 

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -293,4 +293,22 @@ class Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Test
       assert_equal 5, cancel_operation_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Cloud::Vision::V1::ImageAnnotator::Operations::Configuration, config
+  end
 end

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -297,4 +297,35 @@ class Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
       assert_equal 5, async_batch_annotate_files_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Cloud::Vision::V1::ImageAnnotator::Client::Configuration, config
+  end
+
+  def test_operations_client
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    assert_kind_of Google::Cloud::Vision::V1::ImageAnnotator::Operations, client.operations_client
+  end
 end

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -293,4 +293,22 @@ class Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Test
       assert_equal 5, cancel_operation_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Cloud::Vision::V1::ProductSearch::Operations::Configuration, config
+  end
 end

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
@@ -1215,4 +1215,35 @@ class Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       assert_equal 5, purge_products_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Cloud::Vision::V1::ProductSearch::Client::Configuration, config
+  end
+
+  def test_operations_client
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    assert_kind_of Google::Cloud::Vision::V1::ProductSearch::Operations, client.operations_client
+  end
 end

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -133,6 +133,7 @@ module So
 
             @operations_client = Operations.new do |config|
               config.credentials = credentials
+              config.endpoint = @config.endpoint
             end
 
             @garbage_service_stub = Gapic::ServiceStub.new(
@@ -143,6 +144,13 @@ module So
               interceptors: @config.interceptors
             )
           end
+
+          ##
+          # Get the associated client for long-running operations.
+          #
+          # @return [So::Much::Trash::GarbageService::Operations]
+          #
+          attr_reader :operations_client
 
           # Service calls
 

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
@@ -301,4 +301,22 @@ class So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
       assert_equal 5, cancel_operation_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = So::Much::Trash::GarbageService::Operations.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of So::Much::Trash::GarbageService::Operations::Configuration, config
+  end
 end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
@@ -940,4 +940,35 @@ class So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       end
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = So::Much::Trash::GarbageService::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of So::Much::Trash::GarbageService::Client::Configuration, config
+  end
+
+  def test_operations_client
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = So::Much::Trash::GarbageService::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    assert_kind_of So::Much::Trash::GarbageService::Operations, client.operations_client
+  end
 end

--- a/shared/output/gapic/templates/grpc_service_config/test/testing/grpc_service_config/service_no_retry_test.rb
+++ b/shared/output/gapic/templates/grpc_service_config/test/testing/grpc_service_config/service_no_retry_test.rb
@@ -103,4 +103,22 @@ class Testing::GrpcServiceConfig::ServiceNoRetry::ClientTest < Minitest::Test
       assert_equal 4, no_retry_method_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Testing::GrpcServiceConfig::ServiceNoRetry::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Testing::GrpcServiceConfig::ServiceNoRetry::Client::Configuration, config
+  end
 end

--- a/shared/output/gapic/templates/grpc_service_config/test/testing/grpc_service_config/service_with_retries_test.rb
+++ b/shared/output/gapic/templates/grpc_service_config/test/testing/grpc_service_config/service_with_retries_test.rb
@@ -153,4 +153,22 @@ class Testing::GrpcServiceConfig::ServiceWithRetries::ClientTest < Minitest::Tes
       assert_equal 4, method_level_retry_method_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Testing::GrpcServiceConfig::ServiceWithRetries::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Testing::GrpcServiceConfig::ServiceWithRetries::Client::Configuration, config
+  end
 end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -134,6 +134,7 @@ module Google
 
             @operations_client = Operations.new do |config|
               config.credentials = credentials
+              config.endpoint = @config.endpoint
             end
 
             @echo_stub = Gapic::ServiceStub.new(
@@ -144,6 +145,13 @@ module Google
               interceptors: @config.interceptors
             )
           end
+
+          ##
+          # Get the associated client for long-running operations.
+          #
+          # @return [Google::Showcase::V1beta1::Echo::Operations]
+          #
+          attr_reader :operations_client
 
           # Service calls
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -136,6 +136,7 @@ module Google
 
             @operations_client = Operations.new do |config|
               config.credentials = credentials
+              config.endpoint = @config.endpoint
             end
 
             @messaging_stub = Gapic::ServiceStub.new(
@@ -146,6 +147,13 @@ module Google
               interceptors: @config.interceptors
             )
           end
+
+          ##
+          # Get the associated client for long-running operations.
+          #
+          # @return [Google::Showcase::V1beta1::Messaging::Operations]
+          #
+          attr_reader :operations_client
 
           # Service calls
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -301,4 +301,22 @@ class Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
       assert_equal 5, cancel_operation_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Showcase::V1beta1::Echo::Operations.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Showcase::V1beta1::Echo::Operations::Configuration, config
+  end
 end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -540,4 +540,35 @@ class Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       assert_equal 5, block_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Showcase::V1beta1::Echo::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Showcase::V1beta1::Echo::Client::Configuration, config
+  end
+
+  def test_operations_client
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Showcase::V1beta1::Echo::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    assert_kind_of Google::Showcase::V1beta1::Echo::Operations, client.operations_client
+  end
 end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -352,4 +352,22 @@ class Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
       assert_equal 5, list_users_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Showcase::V1beta1::Identity::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Showcase::V1beta1::Identity::Client::Configuration, config
+  end
 end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -301,4 +301,22 @@ class Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
       assert_equal 5, cancel_operation_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Showcase::V1beta1::Messaging::Operations.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Showcase::V1beta1::Messaging::Operations::Configuration, config
+  end
 end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -965,4 +965,35 @@ class Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       end
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Showcase::V1beta1::Messaging::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Showcase::V1beta1::Messaging::Client::Configuration, config
+  end
+
+  def test_operations_client
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Showcase::V1beta1::Messaging::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    assert_kind_of Google::Showcase::V1beta1::Messaging::Operations, client.operations_client
+  end
 end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -537,4 +537,22 @@ class Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       assert_equal 5, verify_test_client_stub.call_rpc_count
     end
   end
+
+  def test_configure
+    grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+
+    client = block_config = config = nil
+    Gapic::ServiceStub.stub :new, nil do
+      client = Google::Showcase::V1beta1::Testing::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+    end
+
+    config = client.configure do |c|
+      block_config = c
+    end
+
+    assert_same block_config, config
+    assert_kind_of Google::Showcase::V1beta1::Testing::Client::Configuration, config
+  end
 end


### PR DESCRIPTION
Several small items that have come up over the past week. I want to get these cleaned out before the next, larger PR related to "common" services.

Specifics:
* If the main client has a custom endpoint, the LRO client didn't inherit it. Fixed.
* There isn't currently a way to call `list_operations` because the LRO client object isn't accessible directly. Added an accessor.
* Generate tests for the `configure` method and the operations client accessor.