### PR TITLE
fix: Timeouts are in seconds rather than milliseconds

### DIFF
--- a/gapic-generator/templates/default/service/client/_client.erb
+++ b/gapic-generator/templates/default/service/client/_client.erb
@@ -29,7 +29,7 @@ class <%= service.client_name %>
   # To modify the configuration for all <%= service.name %> clients:
   #
   #     <%= service.client_name_full %>.configure do |config|
-  #       config.timeout = 10_000
+  #       config.timeout = 10.0
   #     end
   #
   # @yield [config] Configure the <%= service.client_name %> client.
@@ -75,7 +75,7 @@ class <%= service.client_name %>
   # configuration:
   #
   #     client = <%= service.client_name_full %>.new do |config|
-  #       config.timeout = 10_000
+  #       config.timeout = 10.0
   #     end
   #
   # @yield [config] Configure the <%= service.name %> client.

--- a/gapic-generator/templates/default/service/client/_config.erb
+++ b/gapic-generator/templates/default/service/client/_config.erb
@@ -20,15 +20,15 @@
 # to 20 seconds, and all remaining timeouts to 10 seconds:
 #
 #     <%= service.client_name_full %>.configure do |config|
-#       config.timeout = 10_000
-#       config.rpcs.<%= method_service.methods.first.name %>.timeout = 20_000
+#       config.timeout = 10.0
+#       config.rpcs.<%= method_service.methods.first.name %>.timeout = 20.0
 #     end
 #
 # To apply the above configuration only to a new client:
 #
 #     client = <%= service.client_name_full %>.new do |config|
-#       config.timeout = 10_000
-#       config.rpcs.<%= method_service.methods.first.name %>.timeout = 20_000
+#       config.timeout = 10.0
+#       config.rpcs.<%= method_service.methods.first.name %>.timeout = 20.0
 #     end
 #
 <%- end -%>
@@ -65,7 +65,7 @@
 #   An array of interceptors that are run before calls are executed.
 #   @return [::Array<::GRPC::ClientInterceptor>]
 # @!attribute [rw] timeout
-#   The call timeout in milliseconds.
+#   The call timeout in seconds.
 #   @return [::Numeric]
 # @!attribute [rw] metadata
 #   Additional gRPC headers to be sent with the call.

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
@@ -47,7 +47,7 @@ module Google
               # To modify the configuration for all CampaignService clients:
               #
               #     ::Google::Ads::GoogleAds::V1::Services::CampaignService::Client.configure do |config|
-              #       config.timeout = 10_000
+              #       config.timeout = 10.0
               #     end
               #
               # @yield [config] Configure the Client client.
@@ -99,7 +99,7 @@ module Google
               # configuration:
               #
               #     client = ::Google::Ads::GoogleAds::V1::Services::CampaignService::Client.new do |config|
-              #       config.timeout = 10_000
+              #       config.timeout = 10.0
               #     end
               #
               # @yield [config] Configure the CampaignService client.
@@ -298,15 +298,15 @@ module Google
               # to 20 seconds, and all remaining timeouts to 10 seconds:
               #
               #     ::Google::Ads::GoogleAds::V1::Services::CampaignService::Client.configure do |config|
-              #       config.timeout = 10_000
-              #       config.rpcs.get_campaign.timeout = 20_000
+              #       config.timeout = 10.0
+              #       config.rpcs.get_campaign.timeout = 20.0
               #     end
               #
               # To apply the above configuration only to a new client:
               #
               #     client = ::Google::Ads::GoogleAds::V1::Services::CampaignService::Client.new do |config|
-              #       config.timeout = 10_000
-              #       config.rpcs.get_campaign.timeout = 20_000
+              #       config.timeout = 10.0
+              #       config.rpcs.get_campaign.timeout = 20.0
               #     end
               #
               # @!attribute [rw] endpoint
@@ -342,7 +342,7 @@ module Google
               #   An array of interceptors that are run before calls are executed.
               #   @return [::Array<::GRPC::ClientInterceptor>]
               # @!attribute [rw] timeout
-              #   The call timeout in milliseconds.
+              #   The call timeout in seconds.
               #   @return [::Numeric]
               # @!attribute [rw] metadata
               #   Additional gRPC headers to be sent with the call.

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
@@ -45,7 +45,7 @@ module Google
             # To modify the configuration for all LanguageService clients:
             #
             #     ::Google::Cloud::Language::V1::LanguageService::Client.configure do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the Client client.
@@ -152,7 +152,7 @@ module Google
             # configuration:
             #
             #     client = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the LanguageService client.
@@ -1057,15 +1057,15 @@ module Google
             # to 20 seconds, and all remaining timeouts to 10 seconds:
             #
             #     ::Google::Cloud::Language::V1::LanguageService::Client.configure do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.analyze_sentiment.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.analyze_sentiment.timeout = 20.0
             #     end
             #
             # To apply the above configuration only to a new client:
             #
             #     client = ::Google::Cloud::Language::V1::LanguageService::Client.new do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.analyze_sentiment.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.analyze_sentiment.timeout = 20.0
             #     end
             #
             # @!attribute [rw] endpoint
@@ -1101,7 +1101,7 @@ module Google
             #   An array of interceptors that are run before calls are executed.
             #   @return [::Array<::GRPC::ClientInterceptor>]
             # @!attribute [rw] timeout
-            #   The call timeout in milliseconds.
+            #   The call timeout in seconds.
             #   @return [::Numeric]
             # @!attribute [rw] metadata
             #   Additional gRPC headers to be sent with the call.

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -45,7 +45,7 @@ module Google
             # To modify the configuration for all LanguageService clients:
             #
             #     ::Google::Cloud::Language::V1beta1::LanguageService::Client.configure do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the Client client.
@@ -104,7 +104,7 @@ module Google
             # configuration:
             #
             #     client = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the LanguageService client.
@@ -417,15 +417,15 @@ module Google
             # to 20 seconds, and all remaining timeouts to 10 seconds:
             #
             #     ::Google::Cloud::Language::V1beta1::LanguageService::Client.configure do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.analyze_sentiment.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.analyze_sentiment.timeout = 20.0
             #     end
             #
             # To apply the above configuration only to a new client:
             #
             #     client = ::Google::Cloud::Language::V1beta1::LanguageService::Client.new do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.analyze_sentiment.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.analyze_sentiment.timeout = 20.0
             #     end
             #
             # @!attribute [rw] endpoint
@@ -461,7 +461,7 @@ module Google
             #   An array of interceptors that are run before calls are executed.
             #   @return [::Array<::GRPC::ClientInterceptor>]
             # @!attribute [rw] timeout
-            #   The call timeout in milliseconds.
+            #   The call timeout in seconds.
             #   @return [::Numeric]
             # @!attribute [rw] metadata
             #   Additional gRPC headers to be sent with the call.

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -45,7 +45,7 @@ module Google
             # To modify the configuration for all LanguageService clients:
             #
             #     ::Google::Cloud::Language::V1beta2::LanguageService::Client.configure do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the Client client.
@@ -104,7 +104,7 @@ module Google
             # configuration:
             #
             #     client = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the LanguageService client.
@@ -540,15 +540,15 @@ module Google
             # to 20 seconds, and all remaining timeouts to 10 seconds:
             #
             #     ::Google::Cloud::Language::V1beta2::LanguageService::Client.configure do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.analyze_sentiment.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.analyze_sentiment.timeout = 20.0
             #     end
             #
             # To apply the above configuration only to a new client:
             #
             #     client = ::Google::Cloud::Language::V1beta2::LanguageService::Client.new do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.analyze_sentiment.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.analyze_sentiment.timeout = 20.0
             #     end
             #
             # @!attribute [rw] endpoint
@@ -584,7 +584,7 @@ module Google
             #   An array of interceptors that are run before calls are executed.
             #   @return [::Array<::GRPC::ClientInterceptor>]
             # @!attribute [rw] timeout
-            #   The call timeout in milliseconds.
+            #   The call timeout in seconds.
             #   @return [::Numeric]
             # @!attribute [rw] metadata
             #   Additional gRPC headers to be sent with the call.

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -52,7 +52,7 @@ module Google
             # To modify the configuration for all SecretManagerService clients:
             #
             #     ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.configure do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the Client client.
@@ -111,7 +111,7 @@ module Google
             # configuration:
             #
             #     client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the SecretManagerService client.
@@ -1244,15 +1244,15 @@ module Google
             # to 20 seconds, and all remaining timeouts to 10 seconds:
             #
             #     ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.configure do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.list_secrets.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.list_secrets.timeout = 20.0
             #     end
             #
             # To apply the above configuration only to a new client:
             #
             #     client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.list_secrets.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.list_secrets.timeout = 20.0
             #     end
             #
             # @!attribute [rw] endpoint
@@ -1288,7 +1288,7 @@ module Google
             #   An array of interceptors that are run before calls are executed.
             #   @return [::Array<::GRPC::ClientInterceptor>]
             # @!attribute [rw] timeout
-            #   The call timeout in milliseconds.
+            #   The call timeout in seconds.
             #   @return [::Numeric]
             # @!attribute [rw] metadata
             #   Additional gRPC headers to be sent with the call.

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -44,7 +44,7 @@ module Google
             # To modify the configuration for all Speech clients:
             #
             #     ::Google::Cloud::Speech::V1::Speech::Client.configure do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the Client client.
@@ -103,7 +103,7 @@ module Google
             # configuration:
             #
             #     client = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the Speech client.
@@ -665,15 +665,15 @@ module Google
             # to 20 seconds, and all remaining timeouts to 10 seconds:
             #
             #     ::Google::Cloud::Speech::V1::Speech::Client.configure do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.recognize.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.recognize.timeout = 20.0
             #     end
             #
             # To apply the above configuration only to a new client:
             #
             #     client = ::Google::Cloud::Speech::V1::Speech::Client.new do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.recognize.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.recognize.timeout = 20.0
             #     end
             #
             # @!attribute [rw] endpoint
@@ -709,7 +709,7 @@ module Google
             #   An array of interceptors that are run before calls are executed.
             #   @return [::Array<::GRPC::ClientInterceptor>]
             # @!attribute [rw] timeout
-            #   The call timeout in milliseconds.
+            #   The call timeout in seconds.
             #   @return [::Numeric]
             # @!attribute [rw] metadata
             #   Additional gRPC headers to be sent with the call.

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -407,15 +407,15 @@ module Google
             # to 20 seconds, and all remaining timeouts to 10 seconds:
             #
             #     ::Google::Longrunning::Operations::Client.configure do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.list_operations.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.list_operations.timeout = 20.0
             #     end
             #
             # To apply the above configuration only to a new client:
             #
             #     client = ::Google::Longrunning::Operations::Client.new do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.list_operations.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.list_operations.timeout = 20.0
             #     end
             #
             # @!attribute [rw] endpoint
@@ -451,7 +451,7 @@ module Google
             #   An array of interceptors that are run before calls are executed.
             #   @return [::Array<::GRPC::ClientInterceptor>]
             # @!attribute [rw] timeout
-            #   The call timeout in milliseconds.
+            #   The call timeout in seconds.
             #   @return [::Numeric]
             # @!attribute [rw] metadata
             #   Additional gRPC headers to be sent with the call.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -48,7 +48,7 @@ module Google
             # To modify the configuration for all ImageAnnotator clients:
             #
             #     ::Google::Cloud::Vision::V1::ImageAnnotator::Client.configure do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the Client client.
@@ -107,7 +107,7 @@ module Google
             # configuration:
             #
             #     client = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the ImageAnnotator client.
@@ -492,15 +492,15 @@ module Google
             # to 20 seconds, and all remaining timeouts to 10 seconds:
             #
             #     ::Google::Cloud::Vision::V1::ImageAnnotator::Client.configure do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.batch_annotate_images.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.batch_annotate_images.timeout = 20.0
             #     end
             #
             # To apply the above configuration only to a new client:
             #
             #     client = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.batch_annotate_images.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.batch_annotate_images.timeout = 20.0
             #     end
             #
             # @!attribute [rw] endpoint
@@ -536,7 +536,7 @@ module Google
             #   An array of interceptors that are run before calls are executed.
             #   @return [::Array<::GRPC::ClientInterceptor>]
             # @!attribute [rw] timeout
-            #   The call timeout in milliseconds.
+            #   The call timeout in seconds.
             #   @return [::Numeric]
             # @!attribute [rw] metadata
             #   Additional gRPC headers to be sent with the call.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -407,15 +407,15 @@ module Google
             # to 20 seconds, and all remaining timeouts to 10 seconds:
             #
             #     ::Google::Longrunning::Operations::Client.configure do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.list_operations.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.list_operations.timeout = 20.0
             #     end
             #
             # To apply the above configuration only to a new client:
             #
             #     client = ::Google::Longrunning::Operations::Client.new do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.list_operations.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.list_operations.timeout = 20.0
             #     end
             #
             # @!attribute [rw] endpoint
@@ -451,7 +451,7 @@ module Google
             #   An array of interceptors that are run before calls are executed.
             #   @return [::Array<::GRPC::ClientInterceptor>]
             # @!attribute [rw] timeout
-            #   The call timeout in milliseconds.
+            #   The call timeout in seconds.
             #   @return [::Numeric]
             # @!attribute [rw] metadata
             #   Additional gRPC headers to be sent with the call.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -59,7 +59,7 @@ module Google
             # To modify the configuration for all ProductSearch clients:
             #
             #     ::Google::Cloud::Vision::V1::ProductSearch::Client.configure do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the Client client.
@@ -118,7 +118,7 @@ module Google
             # configuration:
             #
             #     client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
-            #       config.timeout = 10_000
+            #       config.timeout = 10.0
             #     end
             #
             # @yield [config] Configure the ProductSearch client.
@@ -1706,15 +1706,15 @@ module Google
             # to 20 seconds, and all remaining timeouts to 10 seconds:
             #
             #     ::Google::Cloud::Vision::V1::ProductSearch::Client.configure do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.create_product_set.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.create_product_set.timeout = 20.0
             #     end
             #
             # To apply the above configuration only to a new client:
             #
             #     client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.create_product_set.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.create_product_set.timeout = 20.0
             #     end
             #
             # @!attribute [rw] endpoint
@@ -1750,7 +1750,7 @@ module Google
             #   An array of interceptors that are run before calls are executed.
             #   @return [::Array<::GRPC::ClientInterceptor>]
             # @!attribute [rw] timeout
-            #   The call timeout in milliseconds.
+            #   The call timeout in seconds.
             #   @return [::Numeric]
             # @!attribute [rw] metadata
             #   Additional gRPC headers to be sent with the call.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -407,15 +407,15 @@ module Google
             # to 20 seconds, and all remaining timeouts to 10 seconds:
             #
             #     ::Google::Longrunning::Operations::Client.configure do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.list_operations.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.list_operations.timeout = 20.0
             #     end
             #
             # To apply the above configuration only to a new client:
             #
             #     client = ::Google::Longrunning::Operations::Client.new do |config|
-            #       config.timeout = 10_000
-            #       config.rpcs.list_operations.timeout = 20_000
+            #       config.timeout = 10.0
+            #       config.rpcs.list_operations.timeout = 20.0
             #     end
             #
             # @!attribute [rw] endpoint
@@ -451,7 +451,7 @@ module Google
             #   An array of interceptors that are run before calls are executed.
             #   @return [::Array<::GRPC::ClientInterceptor>]
             # @!attribute [rw] timeout
-            #   The call timeout in milliseconds.
+            #   The call timeout in seconds.
             #   @return [::Numeric]
             # @!attribute [rw] metadata
             #   Additional gRPC headers to be sent with the call.

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -52,7 +52,7 @@ module So
           # To modify the configuration for all GarbageService clients:
           #
           #     ::So::Much::Trash::GarbageService::Client.configure do |config|
-          #       config.timeout = 10_000
+          #       config.timeout = 10.0
           #     end
           #
           # @yield [config] Configure the Client client.
@@ -104,7 +104,7 @@ module So
           # configuration:
           #
           #     client = ::So::Much::Trash::GarbageService::Client.new do |config|
-          #       config.timeout = 10_000
+          #       config.timeout = 10.0
           #     end
           #
           # @yield [config] Configure the GarbageService client.
@@ -1198,15 +1198,15 @@ module So
           # to 20 seconds, and all remaining timeouts to 10 seconds:
           #
           #     ::So::Much::Trash::GarbageService::Client.configure do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.get_empty_garbage.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.get_empty_garbage.timeout = 20.0
           #     end
           #
           # To apply the above configuration only to a new client:
           #
           #     client = ::So::Much::Trash::GarbageService::Client.new do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.get_empty_garbage.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.get_empty_garbage.timeout = 20.0
           #     end
           #
           # @!attribute [rw] endpoint
@@ -1242,7 +1242,7 @@ module So
           #   An array of interceptors that are run before calls are executed.
           #   @return [::Array<::GRPC::ClientInterceptor>]
           # @!attribute [rw] timeout
-          #   The call timeout in milliseconds.
+          #   The call timeout in seconds.
           #   @return [::Numeric]
           # @!attribute [rw] metadata
           #   Additional gRPC headers to be sent with the call.

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -406,15 +406,15 @@ module So
           # to 20 seconds, and all remaining timeouts to 10 seconds:
           #
           #     ::Google::Longrunning::Operations::Client.configure do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.list_operations.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.list_operations.timeout = 20.0
           #     end
           #
           # To apply the above configuration only to a new client:
           #
           #     client = ::Google::Longrunning::Operations::Client.new do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.list_operations.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.list_operations.timeout = 20.0
           #     end
           #
           # @!attribute [rw] endpoint
@@ -450,7 +450,7 @@ module So
           #   An array of interceptors that are run before calls are executed.
           #   @return [::Array<::GRPC::ClientInterceptor>]
           # @!attribute [rw] timeout
-          #   The call timeout in milliseconds.
+          #   The call timeout in seconds.
           #   @return [::Numeric]
           # @!attribute [rw] metadata
           #   Additional gRPC headers to be sent with the call.

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/client.rb
@@ -74,7 +74,7 @@ module So
           # To modify the configuration for all IAMPolicy clients:
           #
           #     ::So::Much::Trash::IAMPolicy::Client.configure do |config|
-          #       config.timeout = 10_000
+          #       config.timeout = 10.0
           #     end
           #
           # @yield [config] Configure the Client client.
@@ -126,7 +126,7 @@ module So
           # configuration:
           #
           #     client = ::So::Much::Trash::IAMPolicy::Client.new do |config|
-          #       config.timeout = 10_000
+          #       config.timeout = 10.0
           #     end
           #
           # @yield [config] Configure the IAMPolicy client.
@@ -396,15 +396,15 @@ module So
           # to 20 seconds, and all remaining timeouts to 10 seconds:
           #
           #     ::So::Much::Trash::IAMPolicy::Client.configure do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.set_iam_policy.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.set_iam_policy.timeout = 20.0
           #     end
           #
           # To apply the above configuration only to a new client:
           #
           #     client = ::So::Much::Trash::IAMPolicy::Client.new do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.set_iam_policy.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.set_iam_policy.timeout = 20.0
           #     end
           #
           # @!attribute [rw] endpoint
@@ -440,7 +440,7 @@ module So
           #   An array of interceptors that are run before calls are executed.
           #   @return [::Array<::GRPC::ClientInterceptor>]
           # @!attribute [rw] timeout
-          #   The call timeout in milliseconds.
+          #   The call timeout in seconds.
           #   @return [::Numeric]
           # @!attribute [rw] metadata
           #   Additional gRPC headers to be sent with the call.

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/client.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/client.rb
@@ -47,7 +47,7 @@ module Testing
         # To modify the configuration for all ServiceNoRetry clients:
         #
         #     ::Testing::GrpcServiceConfig::ServiceNoRetry::Client.configure do |config|
-        #       config.timeout = 10_000
+        #       config.timeout = 10.0
         #     end
         #
         # @yield [config] Configure the Client client.
@@ -99,7 +99,7 @@ module Testing
         # configuration:
         #
         #     client = ::Testing::GrpcServiceConfig::ServiceNoRetry::Client.new do |config|
-        #       config.timeout = 10_000
+        #       config.timeout = 10.0
         #     end
         #
         # @yield [config] Configure the ServiceNoRetry client.
@@ -204,15 +204,15 @@ module Testing
         # to 20 seconds, and all remaining timeouts to 10 seconds:
         #
         #     ::Testing::GrpcServiceConfig::ServiceNoRetry::Client.configure do |config|
-        #       config.timeout = 10_000
-        #       config.rpcs.no_retry_method.timeout = 20_000
+        #       config.timeout = 10.0
+        #       config.rpcs.no_retry_method.timeout = 20.0
         #     end
         #
         # To apply the above configuration only to a new client:
         #
         #     client = ::Testing::GrpcServiceConfig::ServiceNoRetry::Client.new do |config|
-        #       config.timeout = 10_000
-        #       config.rpcs.no_retry_method.timeout = 20_000
+        #       config.timeout = 10.0
+        #       config.rpcs.no_retry_method.timeout = 20.0
         #     end
         #
         # @!attribute [rw] endpoint
@@ -248,7 +248,7 @@ module Testing
         #   An array of interceptors that are run before calls are executed.
         #   @return [::Array<::GRPC::ClientInterceptor>]
         # @!attribute [rw] timeout
-        #   The call timeout in milliseconds.
+        #   The call timeout in seconds.
         #   @return [::Numeric]
         # @!attribute [rw] metadata
         #   Additional gRPC headers to be sent with the call.

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
@@ -47,7 +47,7 @@ module Testing
         # To modify the configuration for all ServiceWithRetries clients:
         #
         #     ::Testing::GrpcServiceConfig::ServiceWithRetries::Client.configure do |config|
-        #       config.timeout = 10_000
+        #       config.timeout = 10.0
         #     end
         #
         # @yield [config] Configure the Client client.
@@ -115,7 +115,7 @@ module Testing
         # configuration:
         #
         #     client = ::Testing::GrpcServiceConfig::ServiceWithRetries::Client.new do |config|
-        #       config.timeout = 10_000
+        #       config.timeout = 10.0
         #     end
         #
         # @yield [config] Configure the ServiceWithRetries client.
@@ -268,15 +268,15 @@ module Testing
         # to 20 seconds, and all remaining timeouts to 10 seconds:
         #
         #     ::Testing::GrpcServiceConfig::ServiceWithRetries::Client.configure do |config|
-        #       config.timeout = 10_000
-        #       config.rpcs.service_level_retry_method.timeout = 20_000
+        #       config.timeout = 10.0
+        #       config.rpcs.service_level_retry_method.timeout = 20.0
         #     end
         #
         # To apply the above configuration only to a new client:
         #
         #     client = ::Testing::GrpcServiceConfig::ServiceWithRetries::Client.new do |config|
-        #       config.timeout = 10_000
-        #       config.rpcs.service_level_retry_method.timeout = 20_000
+        #       config.timeout = 10.0
+        #       config.rpcs.service_level_retry_method.timeout = 20.0
         #     end
         #
         # @!attribute [rw] endpoint
@@ -312,7 +312,7 @@ module Testing
         #   An array of interceptors that are run before calls are executed.
         #   @return [::Array<::GRPC::ClientInterceptor>]
         # @!attribute [rw] timeout
-        #   The call timeout in milliseconds.
+        #   The call timeout in seconds.
         #   @return [::Numeric]
         # @!attribute [rw] metadata
         #   Additional gRPC headers to be sent with the call.

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -53,7 +53,7 @@ module Google
           # To modify the configuration for all Echo clients:
           #
           #     ::Google::Showcase::V1beta1::Echo::Client.configure do |config|
-          #       config.timeout = 10_000
+          #       config.timeout = 10.0
           #     end
           #
           # @yield [config] Configure the Client client.
@@ -105,7 +105,7 @@ module Google
           # configuration:
           #
           #     client = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
-          #       config.timeout = 10_000
+          #       config.timeout = 10.0
           #     end
           #
           # @yield [config] Configure the Echo client.
@@ -595,15 +595,15 @@ module Google
           # to 20 seconds, and all remaining timeouts to 10 seconds:
           #
           #     ::Google::Showcase::V1beta1::Echo::Client.configure do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.echo.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.echo.timeout = 20.0
           #     end
           #
           # To apply the above configuration only to a new client:
           #
           #     client = ::Google::Showcase::V1beta1::Echo::Client.new do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.echo.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.echo.timeout = 20.0
           #     end
           #
           # @!attribute [rw] endpoint
@@ -639,7 +639,7 @@ module Google
           #   An array of interceptors that are run before calls are executed.
           #   @return [::Array<::GRPC::ClientInterceptor>]
           # @!attribute [rw] timeout
-          #   The call timeout in milliseconds.
+          #   The call timeout in seconds.
           #   @return [::Numeric]
           # @!attribute [rw] metadata
           #   Additional gRPC headers to be sent with the call.

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -406,15 +406,15 @@ module Google
           # to 20 seconds, and all remaining timeouts to 10 seconds:
           #
           #     ::Google::Longrunning::Operations::Client.configure do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.list_operations.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.list_operations.timeout = 20.0
           #     end
           #
           # To apply the above configuration only to a new client:
           #
           #     client = ::Google::Longrunning::Operations::Client.new do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.list_operations.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.list_operations.timeout = 20.0
           #     end
           #
           # @!attribute [rw] endpoint
@@ -450,7 +450,7 @@ module Google
           #   An array of interceptors that are run before calls are executed.
           #   @return [::Array<::GRPC::ClientInterceptor>]
           # @!attribute [rw] timeout
-          #   The call timeout in milliseconds.
+          #   The call timeout in seconds.
           #   @return [::Numeric]
           # @!attribute [rw] metadata
           #   Additional gRPC headers to be sent with the call.

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -52,7 +52,7 @@ module Google
           # To modify the configuration for all Identity clients:
           #
           #     ::Google::Showcase::V1beta1::Identity::Client.configure do |config|
-          #       config.timeout = 10_000
+          #       config.timeout = 10.0
           #     end
           #
           # @yield [config] Configure the Client client.
@@ -104,7 +104,7 @@ module Google
           # configuration:
           #
           #     client = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
-          #       config.timeout = 10_000
+          #       config.timeout = 10.0
           #     end
           #
           # @yield [config] Configure the Identity client.
@@ -478,15 +478,15 @@ module Google
           # to 20 seconds, and all remaining timeouts to 10 seconds:
           #
           #     ::Google::Showcase::V1beta1::Identity::Client.configure do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.create_user.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.create_user.timeout = 20.0
           #     end
           #
           # To apply the above configuration only to a new client:
           #
           #     client = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.create_user.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.create_user.timeout = 20.0
           #     end
           #
           # @!attribute [rw] endpoint
@@ -522,7 +522,7 @@ module Google
           #   An array of interceptors that are run before calls are executed.
           #   @return [::Array<::GRPC::ClientInterceptor>]
           # @!attribute [rw] timeout
-          #   The call timeout in milliseconds.
+          #   The call timeout in seconds.
           #   @return [::Numeric]
           # @!attribute [rw] metadata
           #   Additional gRPC headers to be sent with the call.

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -55,7 +55,7 @@ module Google
           # To modify the configuration for all Messaging clients:
           #
           #     ::Google::Showcase::V1beta1::Messaging::Client.configure do |config|
-          #       config.timeout = 10_000
+          #       config.timeout = 10.0
           #     end
           #
           # @yield [config] Configure the Client client.
@@ -107,7 +107,7 @@ module Google
           # configuration:
           #
           #     client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
-          #       config.timeout = 10_000
+          #       config.timeout = 10.0
           #     end
           #
           # @yield [config] Configure the Messaging client.
@@ -1082,15 +1082,15 @@ module Google
           # to 20 seconds, and all remaining timeouts to 10 seconds:
           #
           #     ::Google::Showcase::V1beta1::Messaging::Client.configure do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.create_room.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.create_room.timeout = 20.0
           #     end
           #
           # To apply the above configuration only to a new client:
           #
           #     client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.create_room.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.create_room.timeout = 20.0
           #     end
           #
           # @!attribute [rw] endpoint
@@ -1126,7 +1126,7 @@ module Google
           #   An array of interceptors that are run before calls are executed.
           #   @return [::Array<::GRPC::ClientInterceptor>]
           # @!attribute [rw] timeout
-          #   The call timeout in milliseconds.
+          #   The call timeout in seconds.
           #   @return [::Numeric]
           # @!attribute [rw] metadata
           #   Additional gRPC headers to be sent with the call.

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -406,15 +406,15 @@ module Google
           # to 20 seconds, and all remaining timeouts to 10 seconds:
           #
           #     ::Google::Longrunning::Operations::Client.configure do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.list_operations.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.list_operations.timeout = 20.0
           #     end
           #
           # To apply the above configuration only to a new client:
           #
           #     client = ::Google::Longrunning::Operations::Client.new do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.list_operations.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.list_operations.timeout = 20.0
           #     end
           #
           # @!attribute [rw] endpoint
@@ -450,7 +450,7 @@ module Google
           #   An array of interceptors that are run before calls are executed.
           #   @return [::Array<::GRPC::ClientInterceptor>]
           # @!attribute [rw] timeout
-          #   The call timeout in milliseconds.
+          #   The call timeout in seconds.
           #   @return [::Numeric]
           # @!attribute [rw] metadata
           #   Additional gRPC headers to be sent with the call.

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -53,7 +53,7 @@ module Google
           # To modify the configuration for all Testing clients:
           #
           #     ::Google::Showcase::V1beta1::Testing::Client.configure do |config|
-          #       config.timeout = 10_000
+          #       config.timeout = 10.0
           #     end
           #
           # @yield [config] Configure the Client client.
@@ -105,7 +105,7 @@ module Google
           # configuration:
           #
           #     client = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
-          #       config.timeout = 10_000
+          #       config.timeout = 10.0
           #     end
           #
           # @yield [config] Configure the Testing client.
@@ -686,15 +686,15 @@ module Google
           # to 20 seconds, and all remaining timeouts to 10 seconds:
           #
           #     ::Google::Showcase::V1beta1::Testing::Client.configure do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.create_session.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.create_session.timeout = 20.0
           #     end
           #
           # To apply the above configuration only to a new client:
           #
           #     client = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
-          #       config.timeout = 10_000
-          #       config.rpcs.create_session.timeout = 20_000
+          #       config.timeout = 10.0
+          #       config.rpcs.create_session.timeout = 20.0
           #     end
           #
           # @!attribute [rw] endpoint
@@ -730,7 +730,7 @@ module Google
           #   An array of interceptors that are run before calls are executed.
           #   @return [::Array<::GRPC::ClientInterceptor>]
           # @!attribute [rw] timeout
-          #   The call timeout in milliseconds.
+          #   The call timeout in seconds.
           #   @return [::Numeric]
           # @!attribute [rw] metadata
           #   Additional gRPC headers to be sent with the call.


### PR DESCRIPTION
Timeouts in gapic-common are specified in seconds, not milliseconds. This PR fixes the documentation and examples in generated clients accordingly.