### PR TITLE
feat: Unpin minitest in generated wrappers

### DIFF
--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/gemfile.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/gemfile.erb
@@ -9,9 +9,3 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 <%- gem.gem_version_dependencies.each do |name, _requirement| -%>
 gem "<%= name %>", path: "../<%= name %>"
 <%- end -%>
-
-gem "rake"
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"

--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/gemspec.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/gemspec.erb
@@ -30,10 +30,11 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "google-style", "~> 1.24.0"
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
+  gem.add_development_dependency "rake", ">= 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"

--- a/shared/output/cloud/secretmanager_wrapper/Gemfile
+++ b/shared/output/cloud/secretmanager_wrapper/Gemfile
@@ -7,9 +7,3 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "google-cloud-secret_manager-v1", path: "../google-cloud-secret_manager-v1"
 gem "google-cloud-secret_manager-v1beta1", path: "../google-cloud-secret_manager-v1beta1"
-
-gem "rake"
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"

--- a/shared/output/cloud/secretmanager_wrapper/google-cloud-secret_manager.gemspec
+++ b/shared/output/cloud/secretmanager_wrapper/google-cloud-secret_manager.gemspec
@@ -28,10 +28,11 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "google-style", "~> 1.24.0"
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
+  gem.add_development_dependency "rake", ">= 12.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"


### PR DESCRIPTION
The pinning is unnecessary because we don't use minitest/spec.