### PR TITLE
feat: Generate tests for resource path helpers

### DIFF
--- a/gapic-generator/lib/gapic/generators/default_generator.rb
+++ b/gapic-generator/lib/gapic/generators/default_generator.rb
@@ -58,6 +58,7 @@ module Gapic
             files << g("service/paths.erb",                  "lib/#{service.paths_file_path}",                   service: service) if service.paths?
             files << g("service/operations.erb",             "lib/#{service.operations_file_path}",              service: service) if service.lro?
             files << g("service/test/client.erb",            "test/#{service.test_client_file_path}",            service: service)
+            files << g("service/test/client_paths.erb",      "test/#{service.test_paths_file_path}",             service: service) if service.paths?
             files << g("service/test/client_operations.erb", "test/#{service.test_client_operations_file_path}", service: service) if service.lro?
           end
         end

--- a/gapic-generator/lib/gapic/presenters/resource_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/resource_presenter.rb
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 require "gapic/path_template"
-require "ostruct"
 require "active_support/inflector"
 
 module Gapic

--- a/gapic-generator/lib/gapic/presenters/resource_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/resource_presenter.rb
@@ -28,20 +28,10 @@ module Gapic
       def initialize resource
         @resource = resource
 
-        @patterns = resource.pattern.map do |template|
-          segments = Gapic::PathTemplate.parse template
-          OpenStruct.new(
-            template:    template,
-            segments:    segments,
-            arguments:   arguments_for(segments),
-            path_string: path_string_for(segments)
-          )
-        end
+        @patterns = resource.pattern.map { |template| PatternPresenter.new template }
 
         # Keep only patterns that can be used to create path helpers
-        @patterns.reject! do |pattern|
-          named_arg_patterns?(pattern.segments) || positional_args?(pattern.segments)
-        end
+        @patterns.filter!(&:useful_for_helpers?)
       end
 
       def name
@@ -60,33 +50,64 @@ module Gapic
         "#{ActiveSupport::Inflector.underscore name}_path"
       end
 
-      private
+      ##
+      # A presenter for a particular pattern
+      #
+      class PatternPresenter
+        def initialize template
+          @template = template
+          @segments = Gapic::PathTemplate.parse template
+          @arguments = arg_segments.map(&:name)
+          @path_string = build_path_string
+        end
 
-      def arguments_for segments
-        arg_segments(segments).map(&:name)
-      end
+        attr_reader :template, :segments, :arguments, :path_string
 
-      def arg_segments segments
-        segments.select { |segment| segment.is_a? Gapic::PathTemplate::Segment }
-      end
+        def useful_for_helpers?
+          arg_segments.none?(&:nontrivial_pattern?) && arg_segments.none?(&:positional?)
+        end
 
-      def path_string_for segments
-        segments.map do |segment|
-          if segment.is_a? Gapic::PathTemplate::Segment
-            "\#{#{segment.name}}"
-          else
-            # Should be a String
-            segment
-          end
-        end.join
-      end
+        def formal_arguments
+          arguments.map { |arg| "#{arg}:" }.join ", "
+        end
 
-      def positional_args? segments
-        arg_segments(segments).any?(&:positional?)
-      end
+        def arguments_key
+          arguments.sort.join ":"
+        end
 
-      def named_arg_patterns? segments
-        arg_segments(segments).any?(&:nontrivial_pattern?)
+        def arguments_with_dummy_values
+          arguments.each_with_index.map { |arg, index| "#{arg}: \"value#{index}\"" }.join ", "
+        end
+
+        def expected_path_for_dummy_values
+          index = -1
+          segments.map do |segment|
+            if segment.is_a? Gapic::PathTemplate::Segment
+              index += 1
+              "value#{index}"
+            else
+              # Should be a String
+              segment
+            end
+          end.join
+        end
+
+        private
+
+        def arg_segments
+          segments.select { |segment| segment.is_a? Gapic::PathTemplate::Segment }
+        end
+
+        def build_path_string
+          segments.map do |segment|
+            if segment.is_a? Gapic::PathTemplate::Segment
+              "\#{#{segment.name}}"
+            else
+              # Should be a String
+              segment
+            end
+          end.join
+        end
       end
     end
   end

--- a/gapic-generator/lib/gapic/presenters/service_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_presenter.rb
@@ -272,6 +272,10 @@ module Gapic
         service_file_path.sub ".rb", "_test.rb"
       end
 
+      def test_paths_file_path
+        service_file_path.sub ".rb", "_paths_test.rb"
+      end
+
       def test_client_operations_file_path
         service_file_path.sub ".rb", "_operations_test.rb"
       end

--- a/gapic-generator/templates/default/service/client/resource/_multi.erb
+++ b/gapic-generator/templates/default/service/client/resource/_multi.erb
@@ -3,8 +3,7 @@
 # Create a fully-qualified <%= resource.name %> resource string.
 #
 <%- resource.patterns.each do |pattern| -%>
-<%- args_doc_sig = pattern.arguments.map { |arg| "#{arg}:" }.join ", " -%>
-# @overload <%= resource.path_helper %>(<%= args_doc_sig %>)
+# @overload <%= resource.path_helper %>(<%= pattern.formal_arguments %>)
 <%= indent render(partial: "service/client/resource/doc", locals: { pattern: pattern }), "#   " %>
 #
 <%- end -%>
@@ -14,9 +13,7 @@ def <%= resource.path_helper %> **args
 <%- last_pattern_index = resource.patterns.count - 1 -%>
 <%- resource.patterns.each_with_index do |pattern, index| -%>
 <%- comma = last_pattern_index == index ? "" : "," -%>
-<%- args_key = pattern.arguments.sort.join(":").inspect -%>
-<%- args_sig = pattern.arguments.map { |arg| "#{arg}:" }.join ", " -%>
-    <%= args_key %> => (proc do |<%= args_sig %>|
+    <%= pattern.arguments_key.inspect %> => (proc do |<%= pattern.formal_arguments %>|
 <%= indent render(partial: "service/client/resource/def", locals: { pattern: pattern }), 6 %>
     end)<%= comma %>
 <%- end -%>

--- a/gapic-generator/templates/default/service/client/resource/_single.erb
+++ b/gapic-generator/templates/default/service/client/resource/_single.erb
@@ -5,7 +5,6 @@
 <%= indent render(partial: "service/client/resource/doc", locals: { pattern: resource.patterns.first }), "# " %>
 #
 # @return [::String]
-<%- args = resource.patterns.first.arguments.map { |arg| "#{arg}:" }.join ", " -%>
-def <%= resource.path_helper %> <%= args %>
+def <%= resource.path_helper %> <%= resource.patterns.first.formal_arguments %>
 <%= indent render(partial: "service/client/resource/def", locals: { pattern: resource.patterns.first }), 2 %>
 end

--- a/gapic-generator/templates/default/service/test/_resource.erb
+++ b/gapic-generator/templates/default/service/test/_resource.erb
@@ -1,0 +1,16 @@
+<%- assert_locals resource -%>
+<%- assert_locals service -%>
+<%- full_client_name = defined?(client_name_full) ? client_name_full : service.client_name_full -%>
+def test_<%= resource.path_helper%>
+  grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+  ::Gapic::ServiceStub.stub :new, nil do
+    client = <%= full_client_name %>.new do |config|
+      config.credentials = grpc_channel
+    end
+<%- resource.patterns.each do |pattern| -%>
+
+    path = client.<%= resource.path_helper%> <%= pattern.arguments_with_dummy_values %>
+    assert_equal <%= pattern.expected_path_for_dummy_values.inspect %>, path
+<%- end -%>
+  end
+end

--- a/gapic-generator/templates/default/service/test/client_paths.erb
+++ b/gapic-generator/templates/default/service/test/client_paths.erb
@@ -1,0 +1,18 @@
+<%- assert_locals service -%>
+# frozen_string_literal: true
+
+<%= render partial: "shared/license" %>
+require "simplecov"
+require "minitest/autorun"
+
+require "gapic/grpc/service_stub"
+
+require "<%= service.service_require %>"
+
+class <%= service.client_name_full %>PathsTest < Minitest::Test
+<%- service.references.each do |resource| -%>
+<%= indent render(partial: "service/test/resource",
+                  locals: { resource: resource, service: service }), 2 %>
+
+<%- end %>
+end

--- a/gapic-generator/test/gapic/presenters/service/garbage_iam_test.rb
+++ b/gapic-generator/test/gapic/presenters/service/garbage_iam_test.rb
@@ -16,7 +16,7 @@
 
 require "test_helper"
 
-class GarbageServiceTest < PresenterTest
+class GarbageServiceIamTest < PresenterTest
   def presenter
     service_presenter :garbage, "IAMPolicy"
   end

--- a/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_paths_test.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_paths_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "simplecov"
+require "minitest/autorun"
+
+require "gapic/grpc/service_stub"
+
+require "google/cloud/secret_manager/v1beta1/secret_manager_service"
+
+class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientPathsTest < Minitest::Test
+  def test_project_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.project_path project: "value0"
+      assert_equal "projects/value0", path
+    end
+  end
+
+  def test_secret_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.secret_path project: "value0", secret: "value1"
+      assert_equal "projects/value0/secrets/value1", path
+    end
+  end
+
+  def test_secret_version_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.secret_version_path project: "value0", secret: "value1", secret_version: "value2"
+      assert_equal "projects/value0/secrets/value1/versions/value2", path
+    end
+  end
+end

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_paths_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_paths_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "simplecov"
+require "minitest/autorun"
+
+require "gapic/grpc/service_stub"
+
+require "google/cloud/vision/v1/image_annotator"
+
+class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientPathsTest < Minitest::Test
+  def test_product_set_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.product_set_path project: "value0", location: "value1", product_set: "value2"
+      assert_equal "projects/value0/locations/value1/productSets/value2", path
+    end
+  end
+end

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_paths_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_paths_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "simplecov"
+require "minitest/autorun"
+
+require "gapic/grpc/service_stub"
+
+require "google/cloud/vision/v1/product_search"
+
+class ::Google::Cloud::Vision::V1::ProductSearch::ClientPathsTest < Minitest::Test
+  def test_product_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.product_path project: "value0", location: "value1", product: "value2"
+      assert_equal "projects/value0/locations/value1/products/value2", path
+    end
+  end
+
+  def test_product_set_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.product_set_path project: "value0", location: "value1", product_set: "value2"
+      assert_equal "projects/value0/locations/value1/productSets/value2", path
+    end
+  end
+
+  def test_reference_image_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.reference_image_path project: "value0", location: "value1", product: "value2", reference_image: "value3"
+      assert_equal "projects/value0/locations/value1/products/value2/referenceImages/value3", path
+    end
+  end
+end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_paths_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_paths_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# The MIT License (MIT)
+#
+# Copyright <YEAR> <COPYRIGHT HOLDER>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require "simplecov"
+require "minitest/autorun"
+
+require "gapic/grpc/service_stub"
+
+require "so/much/trash/garbage_service"
+
+class ::So::Much::Trash::GarbageService::ClientPathsTest < Minitest::Test
+  def test_project_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.project_path project: "value0"
+      assert_equal "projects/value0", path
+    end
+  end
+
+  def test_simple_garbage_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.simple_garbage_path project: "value0", simple_garbage: "value1"
+      assert_equal "projects/value0/simple_garbage/value1", path
+    end
+  end
+
+  def test_specific_garbage_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.specific_garbage_path project: "value0", specific_garbage: "value1"
+      assert_equal "projects/value0/specific_garbage/value1", path
+    end
+  end
+
+  def test_typical_garbage_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::So::Much::Trash::GarbageService::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.typical_garbage_path project: "value0", typical_garbage_1: "value1"
+      assert_equal "projects/value0/typical_garbage_1/value1", path
+
+      path = client.typical_garbage_path project: "value0", typical_garbage_2: "value1"
+      assert_equal "projects/value0/typical_garbage_2/value1", path
+    end
+  end
+end

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_paths_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_paths_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# The MIT License (MIT)
+#
+# Copyright <YEAR> <COPYRIGHT HOLDER>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require "simplecov"
+require "minitest/autorun"
+
+require "gapic/grpc/service_stub"
+
+require "so/much/trash/resource_names"
+
+class ::So::Much::Trash::ResourceNames::ClientPathsTest < Minitest::Test
+  def test_complex_pattern_non_parent_resource_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::So::Much::Trash::ResourceNames::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.complex_pattern_non_parent_resource_path order_a: "value0", order_b: "value1"
+      assert_equal "orders/value0~value1", path
+    end
+  end
+
+  def test_complex_pattern_request_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::So::Much::Trash::ResourceNames::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.complex_pattern_request_path customer: "value0", item_a_id: "value1", item_b_id: "value2", items_c_id: "value3", details_a_id: "value4", details_b_id: "value5", details_c_id: "value6", extra_id: "value7"
+      assert_equal "customers/value0/items/value1.value2~value3/details/value4_value5-value6/extra/value7", path
+
+      path = client.complex_pattern_request_path customer: "value0", extra_id: "value1"
+      assert_equal "as/customers/value0/extras/value1", path
+    end
+  end
+
+  def test_complex_pattern_resource_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::So::Much::Trash::ResourceNames::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.complex_pattern_resource_path customer: "value0", item_a_id: "value1", item_b_id: "value2", items_c_id: "value3"
+      assert_equal "customers/value0/items/value1.value2~value3", path
+    end
+  end
+
+  def test_simple_pattern_non_parent_resource_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::So::Much::Trash::ResourceNames::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.simple_pattern_non_parent_resource_path location: "value0"
+      assert_equal "locations/value0", path
+    end
+  end
+
+  def test_simple_pattern_request_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::So::Much::Trash::ResourceNames::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.simple_pattern_request_path customer: "value0", thing: "value1"
+      assert_equal "customers/value0/things/value1", path
+    end
+  end
+
+  def test_simple_pattern_resource_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::So::Much::Trash::ResourceNames::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.simple_pattern_resource_path customer: "value0"
+      assert_equal "customers/value0", path
+    end
+  end
+
+  def test_star_pattern_request_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::So::Much::Trash::ResourceNames::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.star_pattern_request_path customer: "value0", path: "value1"
+      assert_equal "customers/value0/path/value1", path
+    end
+  end
+end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_paths_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_paths_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# The MIT License (MIT)
+#
+# Copyright <YEAR> <COPYRIGHT HOLDER>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require "simplecov"
+require "minitest/autorun"
+
+require "gapic/grpc/service_stub"
+
+require "google/showcase/v1beta1/identity"
+
+class ::Google::Showcase::V1beta1::Identity::ClientPathsTest < Minitest::Test
+  def test_user_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Showcase::V1beta1::Identity::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.user_path user_id: "value0"
+      assert_equal "users/value0", path
+    end
+  end
+end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_paths_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_paths_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# The MIT License (MIT)
+#
+# Copyright <YEAR> <COPYRIGHT HOLDER>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require "simplecov"
+require "minitest/autorun"
+
+require "gapic/grpc/service_stub"
+
+require "google/showcase/v1beta1/messaging"
+
+class ::Google::Showcase::V1beta1::Messaging::ClientPathsTest < Minitest::Test
+  def test_blurb_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.blurb_path room_id: "value0", blurb_id: "value1"
+      assert_equal "rooms/value0/blurbs/value1", path
+
+      path = client.blurb_path user_id: "value0", blurb_id: "value1"
+      assert_equal "user/value0/profile/blurbs/value1", path
+    end
+  end
+
+  def test_room_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.room_path room_id: "value0"
+      assert_equal "rooms/value0", path
+    end
+  end
+
+  def test_user_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Showcase::V1beta1::Messaging::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.user_path user_id: "value0"
+      assert_equal "users/value0", path
+    end
+  end
+end

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_paths_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_paths_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# The MIT License (MIT)
+#
+# Copyright <YEAR> <COPYRIGHT HOLDER>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require "simplecov"
+require "minitest/autorun"
+
+require "gapic/grpc/service_stub"
+
+require "google/showcase/v1beta1/testing"
+
+class ::Google::Showcase::V1beta1::Testing::ClientPathsTest < Minitest::Test
+  def test_session_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.session_path session: "value0"
+      assert_equal "sessions/value0", path
+    end
+  end
+
+  def test_test_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Showcase::V1beta1::Testing::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.test_path session: "value0", test: "value1"
+      assert_equal "sessions/value0/tests/value1", path
+    end
+  end
+end


### PR DESCRIPTION
Add generated tests for resource path helpers.

The main purpose of this is actually to address item 3 in #414 because if a collision occurs, the tests will fail.

ResourcePresenter has been refactored as part of this. The "pattern" object, which was originally an OpenStruct, has been given its own class so that we can define some convenience presenter methods on it. Not only does this support generating the path tests, but it simplified the templates for the paths module itself.

Also fixed the name of a test class that was colliding with another test class and causing warnings (and resulting in some tests not running.)