### PR TITLE
fix: Pin protobuf dependency on old rubies

### DIFF
--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/gemfile.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/gemfile.erb
@@ -9,3 +9,6 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 <%- gem.gem_version_dependencies.each do |name, _requirement| -%>
 gem "<%= name %>", path: "../<%= name %>"
 <%- end -%>
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/gapic-generator/templates/default/gem/gemfile.erb
+++ b/gapic-generator/templates/default/gem/gemfile.erb
@@ -2,3 +2,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/shared/output/cloud/language_v1/Gemfile
+++ b/shared/output/cloud/language_v1/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/shared/output/cloud/language_v1beta1/Gemfile
+++ b/shared/output/cloud/language_v1beta1/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/shared/output/cloud/language_v1beta2/Gemfile
+++ b/shared/output/cloud/language_v1beta2/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/shared/output/cloud/noservice/Gemfile
+++ b/shared/output/cloud/noservice/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/shared/output/cloud/secretmanager_v1beta1/Gemfile
+++ b/shared/output/cloud/secretmanager_v1beta1/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/shared/output/cloud/secretmanager_wrapper/Gemfile
+++ b/shared/output/cloud/secretmanager_wrapper/Gemfile
@@ -7,3 +7,6 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "google-cloud-secret_manager-v1", path: "../google-cloud-secret_manager-v1"
 gem "google-cloud-secret_manager-v1beta1", path: "../google-cloud-secret_manager-v1beta1"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/shared/output/cloud/speech_v1/Gemfile
+++ b/shared/output/cloud/speech_v1/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/shared/output/cloud/vision_v1/Gemfile
+++ b/shared/output/cloud/vision_v1/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/shared/output/gapic/templates/garbage/Gemfile
+++ b/shared/output/gapic/templates/garbage/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/shared/output/gapic/templates/grpc_service_config/Gemfile
+++ b/shared/output/gapic/templates/grpc_service_config/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/shared/output/gapic/templates/showcase/Gemfile
+++ b/shared/output/gapic/templates/showcase/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")


### PR DESCRIPTION
Version 3.12.0 of the `google-protobuf` gem will not install on Ruby 2.4. This change updates the generated Gemfiles to pin `google-protobuf` to 3.11.x on older Rubies.