### PR TITLE
fix: Remove auth file from gemspec for generic wrappers

### DIFF
--- a/gapic-generator-cloud/lib/gapic/presenters/wrapper_gem_presenter.rb
+++ b/gapic-generator-cloud/lib/gapic/presenters/wrapper_gem_presenter.rb
@@ -79,8 +79,9 @@ module Gapic
       end
 
       def extra_files
-        files = ["README.md", "AUTHENTICATION.md", "LICENSE.md", ".yardopts"]
-        files << "MIGRATING.md" if migration?
+        files = ["README.md", "LICENSE.md", ".yardopts"]
+        files.insert 1, "AUTHENTICATION.md" unless generic_endpoint?
+        files.append "MIGRATING.md" if migration?
         files
       end
 


### PR DESCRIPTION
Remove `AUTHENTICATION.md` from the list of files in the gemspec of a generic (i.e. non-Google-specific) wrapper. Such wrappers have no `AUTHENTICATION.md` because it is a Google-specific file.

This is necessary to fix the `grafeas` gem.