### PR TITLE
feat: copy ads protos from latest and don't use cache when invoking build from Rakefile

### DIFF
--- a/gapic-generator-ads/Dockerfile
+++ b/gapic-generator-ads/Dockerfile
@@ -42,7 +42,7 @@ FROM ruby:2.6-stretch
 WORKDIR /workspace
 
 # Install common protos.
-COPY --from=gcr.io/gapic-images/api-common-protos:beta /protos/ /workspace/common-protos/
+COPY --from=gcr.io/gapic-images/api-common-protos:latest /protos/ /workspace/common-protos/
 
 # Copy gems from the builder.
 COPY --from=builder /workspace/*.gem /workspace/

--- a/gapic-generator-ads/Rakefile
+++ b/gapic-generator-ads/Rakefile
@@ -62,7 +62,7 @@ end
 desc "Build the docker image."
 task :image, :name do |_t, args|
   image_name = args[:name] || "ruby-gapic-generator-ads"
-  sh "docker build -t #{image_name}:$(git rev-parse HEAD) ."
+  sh "docker build --no-cache -t #{image_name}:$(git rev-parse HEAD) ."
 end
 namespace :image do
   desc "Build the docker image using the local base image code"
@@ -73,7 +73,7 @@ namespace :image do
     base_tmp_dir = File.join __dir__, "tmp", "gapic-generator"
     rm_rf base_tmp_dir
     cp_r base_source_dir, base_tmp_dir
-    sh "docker build -t #{image_name}:$(git rev-parse HEAD) ."
+    sh "docker build --no-cache -t #{image_name}:$(git rev-parse HEAD) ."
     rm_r base_tmp_dir
   end
 end


### PR DESCRIPTION
merging Penelope's improvements

CR #472
CR https://github.com/googleapis/gapic-generator-ruby/pull/472#issuecomment-648391338