### PR TITLE
fix: Eliminate Ruby 2.7 keyword arguments warning in generated tests

### DIFF
--- a/gapic-generator/templates/default/service/test/method/_setup.erb
+++ b/gapic-generator/templates/default/service/test/method/_setup.erb
@@ -9,10 +9,10 @@ class ClientStub
     @requests = []
   end
 
-  def call_rpc *args
+  def call_rpc *args, **kwargs
     @call_rpc_count += 1
 
-    @requests << @block&.call(*args)
+    @requests << @block&.call(*args, **kwargs)
 
     yield @response, @operation if block_given?
 

--- a/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
+++ b/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
@@ -36,10 +36,10 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
@@ -36,10 +36,10 @@ class ::Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
@@ -36,10 +36,10 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
@@ -36,10 +36,10 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -36,10 +36,10 @@ class ::Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
@@ -36,10 +36,10 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -36,10 +36,10 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -36,10 +36,10 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -36,10 +36,10 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
@@ -36,10 +36,10 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
@@ -44,10 +44,10 @@ class ::So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
@@ -44,10 +44,10 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/iam_policy_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/iam_policy_test.rb
@@ -44,10 +44,10 @@ class ::So::Much::Trash::IAMPolicy::ClientTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/really_renamed_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/really_renamed_service_test.rb
@@ -44,10 +44,10 @@ class ::So::Much::Trash::ReallyRenamedService::ClientTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_test.rb
@@ -44,10 +44,10 @@ class ::So::Much::Trash::ResourceNames::ClientTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/gapic/templates/grpc_service_config/test/testing/grpc_service_config/service_no_retry_test.rb
+++ b/shared/output/gapic/templates/grpc_service_config/test/testing/grpc_service_config/service_no_retry_test.rb
@@ -44,10 +44,10 @@ class ::Testing::GrpcServiceConfig::ServiceNoRetry::ClientTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/gapic/templates/grpc_service_config/test/testing/grpc_service_config/service_with_retries_test.rb
+++ b/shared/output/gapic/templates/grpc_service_config/test/testing/grpc_service_config/service_with_retries_test.rb
@@ -44,10 +44,10 @@ class ::Testing::GrpcServiceConfig::ServiceWithRetries::ClientTest < Minitest::T
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -44,10 +44,10 @@ class ::Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -44,10 +44,10 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -44,10 +44,10 @@ class ::Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -44,10 +44,10 @@ class ::Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -44,10 +44,10 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -44,10 +44,10 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
       @requests = []
     end
 
-    def call_rpc *args
+    def call_rpc *args, **kwargs
       @call_rpc_count += 1
 
-      @requests << @block&.call(*args)
+      @requests << @block&.call(*args, **kwargs)
 
       yield @response, @operation if block_given?
 


### PR DESCRIPTION
Eliminates a warning that is appearing in our CI runs on Ruby 2.7.