### PR TITLE
fix: fix an issue when generating a service with no options would fail

### DIFF
--- a/gapic-generator/lib/gapic/presenters/service_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_presenter.rb
@@ -203,7 +203,8 @@ module Gapic
       def client_scopes
         common_service_delegate&.client_scopes ||
           @service.scopes ||
-          default_config(:oauth_scopes)
+          default_config(:oauth_scopes) || 
+          []
       end
 
       def credentials_name

--- a/gapic-generator/lib/gapic/presenters/service_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_presenter.rb
@@ -203,7 +203,7 @@ module Gapic
       def client_scopes
         common_service_delegate&.client_scopes ||
           @service.scopes ||
-          default_config(:oauth_scopes) || 
+          default_config(:oauth_scopes) ||
           []
       end
 


### PR DESCRIPTION
currently if a service has no options defined at all, the client_scopes for the ServicePresenter will be nil (absent a default config or a delegate provided). This leads to a nil exception later in the generation process. This change rectifies