### PR TITLE
Fix: add the loading path to the gapic-generator-cloud

### DIFF
--- a/gapic-generator-cloud/bin/protoc-gen-ruby_cloud
+++ b/gapic-generator-cloud/bin/protoc-gen-ruby_cloud
@@ -14,8 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-$LOAD_PATH.unshift ::File.expand_path("../../lib", __FILE__)
 
+$LOAD_PATH.unshift ::File.expand_path("../lib", __dir__)
 gem "gapic-generator"
 require "gapic/runner"
 require "google/protobuf/compiler/plugin.pb"

--- a/gapic-generator-cloud/bin/protoc-gen-ruby_cloud
+++ b/gapic-generator-cloud/bin/protoc-gen-ruby_cloud
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+$LOAD_PATH.unshift ::File.expand_path("../../lib", __FILE__)
 
 gem "gapic-generator"
 require "gapic/runner"


### PR DESCRIPTION
need to have this when executing the entrypoint from e.g. bazel