### PR TITLE
fix: make rubocop run without caching for file formatting

### DIFF
--- a/gapic-generator/lib/gapic/file_formatter.rb
+++ b/gapic-generator/lib/gapic/file_formatter.rb
@@ -39,7 +39,7 @@ module Gapic
           write_file dir, file
         end
 
-        system "rubocop -x #{dir} -o #{dir}/rubocop.out -c #{configuration}"
+        system "rubocop --cache false -x #{dir} -o #{dir}/rubocop.out -c #{configuration}"
 
         files.each do |file|
           read_file dir, file


### PR DESCRIPTION
when ran from a sandbox environment (bazel) it helps to not try to leave side-effects and it does not seem to matter either way in other cases