### PR TITLE
Fix: add the loading path to the gapic-generator-adc

### DIFF
--- a/gapic-generator-ads/bin/protoc-gen-ruby_ads
+++ b/gapic-generator-ads/bin/protoc-gen-ruby_ads
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+$LOAD_PATH.unshift ::File.expand_path("../lib", __dir__)
 gem "gapic-generator"
 require "gapic/generator/version"
 require "gapic/runner"


### PR DESCRIPTION
need to have this when executing the entrypoint from e.g. bazel