### PR TITLE
fix: Use a reasonable service for examples

### DIFF
--- a/gapic-generator-cloud/templates/cloud/gem/authentication.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/authentication.erb
@@ -1,5 +1,5 @@
 <%- assert_locals gem -%>
-<%- service = gem.services.first -%>
+<%- service = gem.first_non_common_service -%>
 <%- assert_locals service -%>
 # Authentication
 

--- a/gapic-generator-cloud/templates/cloud/gem/rakefile.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/rakefile.erb
@@ -1,5 +1,5 @@
 <%- assert_locals gem -%>
-<%- service = gem.services.first -%>
+<%- service = gem.first_non_common_service -%>
 <%= render partial: "shared/header" -%>
 
 require "bundler/setup"

--- a/gapic-generator-cloud/templates/cloud/gem/readme.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/readme.erb
@@ -36,7 +36,7 @@ In order to use this library, you first need to go through the following steps:
 <%- if gem.packages? -%>
 ```ruby
 require "<%= gem.entrypoint_require %>"
-<%- service = gem.packages.first.services.first -%>
+<%- service = gem.first_non_common_service -%>
 <%- method = service&.methods.first -%>
 <%- if service && method -%>
 

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -48,6 +48,10 @@ module Gapic
         end
       end
 
+      def first_non_common_service
+        services.find { |service| service.common_service_delegate.nil? }
+      end
+
       def proto_files
         @proto_files ||= begin
           files = @api.files

--- a/gapic-generator/templates/default/gem/readme.erb
+++ b/gapic-generator/templates/default/gem/readme.erb
@@ -16,7 +16,7 @@ $ gem install <%= gem.name %>
 
 ```ruby
 require "<%= gem.entrypoint_require %>"
-<%- service = gem.packages.first&.services.first -%>
+<%- service = gem.first_non_common_service -%>
 <%- method = service&.methods.first -%>
 <%- if service && method -%>
 

--- a/gapic-generator/test/gapic/presenters/gem_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/gem_presenter_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+
+class GemPresenterTest < Minitest::Test
+  def test_first_non_common_service
+    request = FakeRequest.new
+    request.add_file! "google.common.iam" do
+      request.add_service! "IamGroot"
+    end
+    request.add_file! "google.cloud.example" do
+      request.add_service! "Hello"
+    end
+    configuration = {
+      common_services: {
+        "google.common.iam.IamGroot" => "google.cloud.example.Hello"
+      }
+    }
+    api = Gapic::Schema::Api.new request, configuration: configuration
+
+    presenter = Gapic::Presenters::GemPresenter.new api
+    assert_equal "IamGroot", presenter.services.first.address.last
+    assert_equal "Hello", presenter.first_non_common_service.address.last
+  end
+
+  def test_common_service_sanity_check
+    request = FakeRequest.new
+    request.add_file! "google.common.iam" do
+      request.add_service! "IamGroot"
+    end
+    request.add_file! "google.cloud.example" do
+      request.add_service! "Hello"
+    end
+    configuration = {
+      common_services: {
+        "google.common.iam.IamGroot" => "google.cloud.example.Hello",
+        "google.common.iam.IamGroot2" => "google.cloud.example.Hello2"
+      }
+    }
+    out, err = capture_subprocess_io do
+      Gapic::Schema::Api.new request, configuration: configuration
+    end
+    assert_equal "", out
+    err = err.split("\n")
+    assert_equal "WARNING: configured common service google.common.iam.IamGroot2 is not present", err[0]
+    assert_equal "WARNING: configured common service delegate google.cloud.example.Hello2 is not present", err[1]
+    assert_equal 2, err.size
+  end
+end


### PR DESCRIPTION
Fix two issues:
* Examples in auth, rakefile, and readme should pick a non-common service.
* We'd like to emit a warning if the `common_services` configuration references services that don't exist (in case we misspelled them).

Also started a test helper class `FakeRequest` that lets you create a "fake" request as input to the generator. This should be more useful as a test fixture than `FakeApi`, and indeed the eventual goal is to replace `FakeApi` with a real `Schema::Api` that uses `FakeRequest` as an input. The tests for these two fixes use `FakeRequest`.