### PR TITLE
Make gapic-generator-ads a package and export its config.yml file.

### DIFF
--- a/gapic-generator-ads/BUILD.bazel
+++ b/gapic-generator-ads/BUILD.bazel
@@ -1,0 +1,2 @@
+# Export config file, allowing other packages to reference it.
+exports_files(["config.yml"])


### PR DESCRIPTION
This exports the ads `config.yml` file so that it can be referenced by a `ruby_gapic_ads_library` rules in another project (specifically, the googleads project's build files).  