### PR TITLE
fix: remove circular symlinks that serve no purpose

### DIFF
--- a/shared/input/proto_input
+++ b/shared/input/proto_input
@@ -1,1 +1,0 @@
-proto_input

--- a/shared/output/cloud/expected_output
+++ b/shared/output/cloud/expected_output
@@ -1,1 +1,0 @@
-expected_output

--- a/shared/output/gapic/expected_output
+++ b/shared/output/gapic/expected_output
@@ -1,1 +1,0 @@
-expected_output


### PR DESCRIPTION
why do we even have these