### PR TITLE
fix: Disable AsciiComments style rule

### DIFF
--- a/gapic-generator-cloud/templates/cloud/gem/rubocop.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/rubocop.erb
@@ -28,6 +28,8 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/<%= gem.name %>.rb"
+Style/AsciiComments:
+  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/IfUnlessModifier:

--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/rubocop.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/rubocop.erb
@@ -21,3 +21,6 @@ Metrics/BlockLength:
 Naming/FileName:
   Exclude:
     - "lib/<%= gem.name %>.rb"
+
+Style/AsciiComments:
+  Enabled: false

--- a/gapic-generator/templates/default/gem/rubocop.erb
+++ b/gapic-generator/templates/default/gem/rubocop.erb
@@ -25,6 +25,8 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/<%= gem.name %>.rb"
+Style/AsciiComments:
+  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/IfUnlessModifier:

--- a/shared/output/cloud/language_v1/.rubocop.yml
+++ b/shared/output/cloud/language_v1/.rubocop.yml
@@ -27,6 +27,8 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-language-v1.rb"
+Style/AsciiComments:
+  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/IfUnlessModifier:

--- a/shared/output/cloud/language_v1beta1/.rubocop.yml
+++ b/shared/output/cloud/language_v1beta1/.rubocop.yml
@@ -27,6 +27,8 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-language-v1beta1.rb"
+Style/AsciiComments:
+  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/IfUnlessModifier:

--- a/shared/output/cloud/language_v1beta2/.rubocop.yml
+++ b/shared/output/cloud/language_v1beta2/.rubocop.yml
@@ -27,6 +27,8 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-language-v1beta2.rb"
+Style/AsciiComments:
+  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/IfUnlessModifier:

--- a/shared/output/cloud/noservice/.rubocop.yml
+++ b/shared/output/cloud/noservice/.rubocop.yml
@@ -27,6 +27,8 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/google-garbage-noservice.rb"
+Style/AsciiComments:
+  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/IfUnlessModifier:

--- a/shared/output/cloud/secretmanager_v1beta1/.rubocop.yml
+++ b/shared/output/cloud/secretmanager_v1beta1/.rubocop.yml
@@ -27,6 +27,8 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-secret_manager-v1beta1.rb"
+Style/AsciiComments:
+  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/IfUnlessModifier:

--- a/shared/output/cloud/secretmanager_wrapper/.rubocop.yml
+++ b/shared/output/cloud/secretmanager_wrapper/.rubocop.yml
@@ -20,3 +20,6 @@ Metrics/BlockLength:
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-secret_manager.rb"
+
+Style/AsciiComments:
+  Enabled: false

--- a/shared/output/cloud/speech_v1/.rubocop.yml
+++ b/shared/output/cloud/speech_v1/.rubocop.yml
@@ -27,6 +27,8 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-speech-v1.rb"
+Style/AsciiComments:
+  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/IfUnlessModifier:

--- a/shared/output/cloud/vision_v1/.rubocop.yml
+++ b/shared/output/cloud/vision_v1/.rubocop.yml
@@ -27,6 +27,8 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-vision-v1.rb"
+Style/AsciiComments:
+  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/IfUnlessModifier:

--- a/shared/output/gapic/templates/garbage/.rubocop.yml
+++ b/shared/output/gapic/templates/garbage/.rubocop.yml
@@ -24,6 +24,8 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/google-garbage.rb"
+Style/AsciiComments:
+  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/IfUnlessModifier:

--- a/shared/output/gapic/templates/grpc_service_config/.rubocop.yml
+++ b/shared/output/gapic/templates/grpc_service_config/.rubocop.yml
@@ -24,6 +24,8 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/testing-grpc_service_config.rb"
+Style/AsciiComments:
+  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/IfUnlessModifier:

--- a/shared/output/gapic/templates/showcase/.rubocop.yml
+++ b/shared/output/gapic/templates/showcase/.rubocop.yml
@@ -24,6 +24,8 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/google-showcase.rb"
+Style/AsciiComments:
+  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/IfUnlessModifier:


### PR DESCRIPTION
Rubocop disallows non-ascii characters in comments by default (enforcing a Ruby style rule that comments should be in English). [AIP 192](https://google.aip.dev/192), which governs documentation, recommends that comments should be in American English but does not insist on it, and there are cases (e.g. examples) when it makes sense for non-ascii characters to appear. (This is already affecting at least one existing service.) So we're going to disable the Style/AsciiComments cop.