### PR TITLE
chore: Configure GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: "CI tests"
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  tests:
+    if: ${{ github.repository == 'googleapis/gapic-generator-ruby' }}
+    runs-on: ubuntu-latest
+    services:
+      showcase:
+        image: gcr.io/gapic-images/gapic-showcase:0.12.0
+        ports:
+          - "7469:7469"
+    steps:
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.6"
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: |
+          git submodule set-url shared/googleapis https://github.com/googleapis/googleapis.git
+          git submodule set-url shared/api-common-protos https://github.com/googleapis/api-common-protos.git
+          git submodule update --init --recursive
+      - name: Install dependencies
+        run: |
+          bundle update
+          bundle exec rake update
+      - name: Run CI
+        run: |
+          bundle exec rake ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
           git submodule update --init --recursive
       - name: Install dependencies
         run: |
-          bundle update
-          bundle exec rake update
+          bundle install --retry=3
+          bundle exec rake bundle_install
       - name: Run CI
         run: |
           bundle exec rake ci

--- a/Rakefile
+++ b/Rakefile
@@ -149,7 +149,7 @@ task :ci do
 end
 
 desc "Runs bundle update for all gems."
-task :update do
+task :bundle_update do
   Dir.chdir "shared" do
     Bundler.with_unbundled_env do
       puts "Running bundle update for shared"
@@ -162,6 +162,26 @@ task :update do
       Bundler.with_unbundled_env do
         puts "Running bundle update for #{gem}"
         sh "bundle update"
+      end
+    end
+  end
+end
+task update: :bundle_update
+
+desc "Runs bundle install for all gems."
+task :bundle_install do
+  Dir.chdir "shared" do
+    Bundler.with_unbundled_env do
+      puts "Running bundle install for shared"
+      sh "bundle install --retry=3"
+    end
+  end
+
+  gem_dirs.each do |gem|
+    Dir.chdir gem do
+      Bundler.with_unbundled_env do
+        puts "Running bundle install for #{gem}"
+        sh "bundle install --retry=3"
       end
     end
   end

--- a/shared/.gitignore
+++ b/shared/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+/.bundle/


### PR DESCRIPTION
GitHub Actions config that replicates the current CircleCI config (with the difference that showcase is being updated from 0.5 to 0.12). This will let us turn down CircleCI for this repo.