### PR TITLE
fix: the documentation for the timeout in the templates (change milliseconds and fix docs)

### DIFF
--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/_main.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/_main.erb
@@ -76,8 +76,8 @@ end
 #   The library version as recorded in instrumentation and logging.
 # * `interceptors` (*type:* `Array<GRPC::ClientInterceptor>`) -
 #   An array of interceptors that are run before calls are executed.
-# * `timeout` (*type:* `Integer`) -
-#   Default timeout in milliseconds.
+# * `timeout` (*type:* `Numeric`) -
+#   Default timeout in seconds.
 # * `metadata` (*type:* `Hash{Symbol=>String}`) -
 #   Additional gRPC headers to be sent with the call.
 # * `retry_policy` (*type:* `Hash`) -

--- a/gapic-generator/templates/default/service/client/_config.erb
+++ b/gapic-generator/templates/default/service/client/_config.erb
@@ -127,7 +127,7 @@ class Configuration
   # Each configuration object is of type `Gapic::Config::Method` and includes
   # the following configuration fields:
   #
-  #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+  #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
   #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
   #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
   #     include the following keys:

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
@@ -405,7 +405,7 @@ module Google
                 # Each configuration object is of type `Gapic::Config::Method` and includes
                 # the following configuration fields:
                 #
-                #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+                #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
                 #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
                 #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
                 #     include the following keys:

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
@@ -1164,7 +1164,7 @@ module Google
               # Each configuration object is of type `Gapic::Config::Method` and includes
               # the following configuration fields:
               #
-              #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+              #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
               #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
               #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
               #     include the following keys:

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -524,7 +524,7 @@ module Google
               # Each configuration object is of type `Gapic::Config::Method` and includes
               # the following configuration fields:
               #
-              #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+              #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
               #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
               #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
               #     include the following keys:

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -647,7 +647,7 @@ module Google
               # Each configuration object is of type `Gapic::Config::Method` and includes
               # the following configuration fields:
               #
-              #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+              #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
               #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
               #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
               #     include the following keys:

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -1351,7 +1351,7 @@ module Google
               # Each configuration object is of type `Gapic::Config::Method` and includes
               # the following configuration fields:
               #
-              #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+              #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
               #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
               #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
               #     include the following keys:

--- a/shared/output/cloud/secretmanager_wrapper/lib/google/cloud/secret_manager.rb
+++ b/shared/output/cloud/secretmanager_wrapper/lib/google/cloud/secret_manager.rb
@@ -94,8 +94,8 @@ module Google
       #   The library version as recorded in instrumentation and logging.
       # * `interceptors` (*type:* `Array<GRPC::ClientInterceptor>`) -
       #   An array of interceptors that are run before calls are executed.
-      # * `timeout` (*type:* `Integer`) -
-      #   Default timeout in milliseconds.
+      # * `timeout` (*type:* `Numeric`) -
+      #   Default timeout in seconds.
       # * `metadata` (*type:* `Hash{Symbol=>String}`) -
       #   Additional gRPC headers to be sent with the call.
       # * `retry_policy` (*type:* `Hash`) -

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -772,7 +772,7 @@ module Google
               # Each configuration object is of type `Gapic::Config::Method` and includes
               # the following configuration fields:
               #
-              #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+              #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
               #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
               #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
               #     include the following keys:

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -515,7 +515,7 @@ module Google
               # Each configuration object is of type `Gapic::Config::Method` and includes
               # the following configuration fields:
               #
-              #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+              #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
               #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
               #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
               #     include the following keys:

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -599,7 +599,7 @@ module Google
               # Each configuration object is of type `Gapic::Config::Method` and includes
               # the following configuration fields:
               #
-              #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+              #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
               #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
               #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
               #     include the following keys:

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -515,7 +515,7 @@ module Google
               # Each configuration object is of type `Gapic::Config::Method` and includes
               # the following configuration fields:
               #
-              #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+              #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
               #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
               #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
               #     include the following keys:

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -1813,7 +1813,7 @@ module Google
               # Each configuration object is of type `Gapic::Config::Method` and includes
               # the following configuration fields:
               #
-              #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+              #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
               #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
               #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
               #     include the following keys:

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -515,7 +515,7 @@ module Google
               # Each configuration object is of type `Gapic::Config::Method` and includes
               # the following configuration fields:
               #
-              #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+              #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
               #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
               #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
               #     include the following keys:

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -1452,7 +1452,7 @@ module So
             # Each configuration object is of type `Gapic::Config::Method` and includes
             # the following configuration fields:
             #
-            #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+            #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
             #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
             #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
             #     include the following keys:

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -514,7 +514,7 @@ module So
             # Each configuration object is of type `Gapic::Config::Method` and includes
             # the following configuration fields:
             #
-            #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+            #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
             #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
             #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
             #     include the following keys:

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/client.rb
@@ -503,7 +503,7 @@ module So
             # Each configuration object is of type `Gapic::Config::Method` and includes
             # the following configuration fields:
             #
-            #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+            #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
             #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
             #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
             #     include the following keys:

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/really_renamed_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/really_renamed_service/client.rb
@@ -314,7 +314,7 @@ module So
             # Each configuration object is of type `Gapic::Config::Method` and includes
             # the following configuration fields:
             #
-            #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+            #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
             #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
             #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
             #     include the following keys:

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/client.rb
@@ -547,7 +547,7 @@ module So
             # Each configuration object is of type `Gapic::Config::Method` and includes
             # the following configuration fields:
             #
-            #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+            #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
             #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
             #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
             #     include the following keys:

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/client.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/client.rb
@@ -311,7 +311,7 @@ module Testing
           # Each configuration object is of type `Gapic::Config::Method` and includes
           # the following configuration fields:
           #
-          #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+          #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
           #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
           #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
           #     include the following keys:

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
@@ -375,7 +375,7 @@ module Testing
           # Each configuration object is of type `Gapic::Config::Method` and includes
           # the following configuration fields:
           #
-          #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+          #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
           #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
           #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
           #     include the following keys:

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -703,7 +703,7 @@ module Google
             # Each configuration object is of type `Gapic::Config::Method` and includes
             # the following configuration fields:
             #
-            #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+            #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
             #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
             #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
             #     include the following keys:

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -514,7 +514,7 @@ module Google
             # Each configuration object is of type `Gapic::Config::Method` and includes
             # the following configuration fields:
             #
-            #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+            #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
             #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
             #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
             #     include the following keys:

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -585,7 +585,7 @@ module Google
             # Each configuration object is of type `Gapic::Config::Method` and includes
             # the following configuration fields:
             #
-            #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+            #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
             #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
             #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
             #     include the following keys:

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -1189,7 +1189,7 @@ module Google
             # Each configuration object is of type `Gapic::Config::Method` and includes
             # the following configuration fields:
             #
-            #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+            #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
             #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
             #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
             #     include the following keys:

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -514,7 +514,7 @@ module Google
             # Each configuration object is of type `Gapic::Config::Method` and includes
             # the following configuration fields:
             #
-            #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+            #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
             #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
             #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
             #     include the following keys:

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -793,7 +793,7 @@ module Google
             # Each configuration object is of type `Gapic::Config::Method` and includes
             # the following configuration fields:
             #
-            #  *  `timeout` (*type:* `Numeric`) - The call timeout in milliseconds
+            #  *  `timeout` (*type:* `Numeric`) - The call timeout in seconds
             #  *  `metadata` (*type:* `Hash{Symbol=>String}`) - Additional gRPC headers
             #  *  `retry_policy (*type:* `Hash`) - The retry policy. The policy fields
             #     include the following keys:


### PR DESCRIPTION
closes https://github.com/googleapis/gapic-generator-ruby/issues/522