### PR TITLE
feat: Update generated readmes to cover versioned vs wrapper clients

### DIFF
--- a/gapic-generator-cloud/lib/gapic/presenters/cloud_gem_presenter.rb
+++ b/gapic-generator-cloud/lib/gapic/presenters/cloud_gem_presenter.rb
@@ -37,6 +37,23 @@ module Gapic
         deps["google-cloud-errors"] = "~> 1.0"
         deps
       end
+
+      def wrapper_name
+        minfo = /^(.+)-v\w+$/.match name
+        minfo ? minfo[1] : nil
+      end
+
+      alias_method :readme_description, :description # rubocop:disable Style/Alias
+
+      def description
+        desc = readme_description
+        if wrapper_name
+          desc += " Note that #{name} is a version-specific client library." \
+            " For most uses, we recommend installing the main client library" \
+            " #{wrapper_name} instead. See the readme for more details."
+        end
+        desc
+      end
     end
 
     def self.cloud_gem_presenter api

--- a/gapic-generator-cloud/lib/gapic/presenters/cloud_gem_presenter.rb
+++ b/gapic-generator-cloud/lib/gapic/presenters/cloud_gem_presenter.rb
@@ -38,6 +38,10 @@ module Gapic
         deps
       end
 
+      ##
+      # The name of the wrapper gem corresponding to this versioned gem
+      # @return [String]
+      #
       def wrapper_name
         minfo = /^(.+)-v\w+$/.match name
         minfo ? minfo[1] : nil
@@ -45,6 +49,15 @@ module Gapic
 
       alias_method :readme_description, :description # rubocop:disable Style/Alias
 
+      ##
+      # Overrides the gemspec description including a note that users should
+      # consider installing the wrapper instead of this versioned gem.
+      #
+      # Note: The method `readme_description` was aliased to the superclass
+      # method because the description without this note is used in the readme.
+      #
+      # @return [String]
+      #
       def description
         desc = readme_description
         if wrapper_name

--- a/gapic-generator-cloud/lib/gapic/presenters/wrapper_gem_presenter.rb
+++ b/gapic-generator-cloud/lib/gapic/presenters/wrapper_gem_presenter.rb
@@ -101,6 +101,10 @@ module Gapic
         version_dependencies.first&.first
       end
 
+      def default_versioned_gem
+        versioned_gems.first
+      end
+
       def dependencies
         deps = { "google-cloud-core" => "~> 1.5" }
         version_dependencies.each do |version, requirement|

--- a/gapic-generator-cloud/templates/cloud/gem/readme.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/readme.erb
@@ -2,10 +2,18 @@
 
 <%= gem.summary %>
 
-<%= gem.description %>
+<%= gem.readme_description %>
 
 <%= gem.homepage %>
 
+<%- if gem.wrapper_name -%>
+This gem is a _versioned_ client. It provides basic client classes for a
+specific version of the <%= gem.title %> API. Most users should consider the
+[<%= gem.wrapper_name %>](https://rubygems.org/gems/<%= gem.wrapper_name %>)
+gem, a convenience wrapper that may also include higher-level interface classes.
+See the section below titled *Which client should I use?* for more information.
+
+<%- end -%>
 ## Installation
 
 ```
@@ -93,3 +101,45 @@ in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
+<%- if gem.wrapper_name -%>
+
+## Which client should I use?
+
+Most modern Ruby client libraries for Google APIs come in two flavors:
+lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
+for _most_ cases, you should install the main client.
+
+A _versioned client_ has a name such as `<%= gem.name %>`,
+and provides a basic set of client classes for a _single version_ of a specific
+service. Some services publish multiple versions of their API, with potentially
+different interfaces including differences in field names, types, or method
+calls. For such services, there may be a separate versioned client library for
+each service version. Most versioned clients are created and maintained by a
+code generator, based on the service's published interface descriptions.
+
+The _main client_ for a service has a name such as `<%= gem.wrapper_name %>`.
+There will be only one main client for any given service, even a service with
+multiple versions. For most services, the main client does not directly include
+API client classes. Instead, it lists the service's versioned client(s) as
+dependencies, and provides convenient factory methods for constructing client
+classes provided by the underlying versioned client libraries. It will choose
+which service version to use by default (although it will generally let you
+override its recommendation if you need to talk to a specific version of the
+service.) For some services, the main client also provides a higher-level
+interface with additional features, convenience methods, or best practices
+built in.
+
+In _most_ cases, we recommend installing the main client gem rather than a
+versioned client gem. This is because the main client will embody the best
+practices for accessing the service, and may also be easier to use. In
+addition, documentation and samples published by Google will generally use the
+main client. However, alternately, if you need to access a specific version of
+a service, and you want to use a lower-level interface, you can bypass the main
+client and instead install a versioned client directly.
+
+Note that some services may not yet have a modern client library (neither a
+main nor a versioned client) available. For these services, there might be a
+_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
+Legacy client libraries have wide coverage across Google services, but may be
+more difficult to use or lack features provided by modern clients.
+<%- end -%>

--- a/gapic-generator-cloud/templates/cloud/gem/readme.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/readme.erb
@@ -8,9 +8,9 @@
 
 <%- if gem.wrapper_name -%>
 This gem is a _versioned_ client. It provides basic client classes for a
-specific version of the <%= gem.title %> API. Most users should consider the
-[<%= gem.wrapper_name %>](https://rubygems.org/gems/<%= gem.wrapper_name %>)
-gem, a convenience wrapper that may also include higher-level interface classes.
+specific version of the <%= gem.title %> API. Most users should consider using
+the main client gem,
+[<%= gem.wrapper_name %>](https://rubygems.org/gems/<%= gem.wrapper_name %>).
 See the section below titled *Which client should I use?* for more information.
 
 <%- end -%>
@@ -105,41 +105,59 @@ about the Ruby support schedule.
 
 ## Which client should I use?
 
-Most modern Ruby client libraries for Google APIs come in two flavors:
-lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
-for _most_ cases, you should install the main client.
+Most modern Ruby client libraries for Google APIs come in two flavors: the main
+client library with a name such as `<%= gem.wrapper_name %>`,
+and lower-level _versioned_ client libraries with names such as
+`<%= gem.name %>`.
+_In most cases, you should install the main client._
 
-A _versioned client_ has a name such as `<%= gem.name %>`,
-and provides a basic set of client classes for a _single version_ of a specific
-service. Some services publish multiple versions of their API, with potentially
-different interfaces including differences in field names, types, or method
-calls. For such services, there may be a separate versioned client library for
-each service version. Most versioned clients are created and maintained by a
-code generator, based on the service's published interface descriptions.
+### What's the difference between the main client and a versioned client?
 
-The _main client_ for a service has a name such as `<%= gem.wrapper_name %>`.
-There will be only one main client for any given service, even a service with
-multiple versions. For most services, the main client does not directly include
-API client classes. Instead, it lists the service's versioned client(s) as
-dependencies, and provides convenient factory methods for constructing client
-classes provided by the underlying versioned client libraries. It will choose
-which service version to use by default (although it will generally let you
-override its recommendation if you need to talk to a specific version of the
-service.) For some services, the main client also provides a higher-level
-interface with additional features, convenience methods, or best practices
-built in.
+A _versioned client_ provides a basic set of data types and client classes for
+a _single version_ of a specific service. (That is, for a service with multiple
+versions, there might be a separate versioned client for each service version.)
+Most versioned clients are written and maintained by a code generator.
 
-In _most_ cases, we recommend installing the main client gem rather than a
-versioned client gem. This is because the main client will embody the best
-practices for accessing the service, and may also be easier to use. In
-addition, documentation and samples published by Google will generally use the
-main client. However, alternately, if you need to access a specific version of
-a service, and you want to use a lower-level interface, you can bypass the main
-client and instead install a versioned client directly.
+The _main client_ is designed to provide you with the _recommended_ client
+interfaces for the service. There will be only one main client for any given
+service, even a service with multiple versions. The main client includes
+factory methods for constructing the client objects we recommend for most
+users. In some cases, those will be classes provided by an underlying versioned
+client; in other cases, they will be handwritten higher-level client objects
+with additional capabilities, convenience methods, or best practices built in.
+Generally, the main client will default to a recommended service version,
+although in some cases you can override this if you need to talk to a specific
+service version.
 
-Note that some services may not yet have a modern client library (neither a
-main nor a versioned client) available. For these services, there might be a
-_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
-Legacy client libraries have wide coverage across Google services, but may be
-more difficult to use or lack features provided by modern clients.
+### Why would I want to use the main client?
+
+We recommend that most users install the main client gem for a service. You can
+identify this gem as the one _without_ a version in its name, e.g.
+`<%= gem.wrapper_name %>`.
+The main client is recommended because it will embody the best practices for
+accessing the service, and may also provide more convenient interfaces or
+tighter integration into frameworks and third-party libraries. In addition, the
+documentation and samples published by Google will generally demonstrate use of
+the main client.
+
+### Why would I want to use a versioned client?
+
+You can use a versioned client if you are content with a possibly lower-level
+class interface, you explicitly want to avoid features provided by the main
+client, or you want to access a specific service version not be covered by the
+main client. You can identify versioned client gems because the service version
+is part of the name, e.g. `<%= gem.name %>`.
+
+### What about the google-apis-<name> clients?
+
+Client library gems with names that begin with `google-apis-` are based on an
+older code generation technology. They talk to a REST/JSON backend (whereas
+most modern clients talk to a [gRPC](https://grpc.io/) backend) and they may
+not offer the same performance, features, and ease of use provided by more
+modern clients.
+
+The `google-apis-` clients have wide coverage across Google services, so you
+might need to use one if there is no modern client available for the service.
+However, if a modern client is available, we generally recommend it over the
+older `google-apis-` clients.
 <%- end -%>

--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/readme.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/readme.erb
@@ -8,7 +8,8 @@ Actual client classes for the various versions of this API are defined in
 _versioned_ client gems, with names of the form `<%= gem.name %>-v*`.
 The gem `<%= gem.name %>` is a convenience wrapper library that brings the
 verisoned gems in as dependencies, and provides high-level methods for
-constructing clients.
+constructing clients. More information on versioned clients can be found below
+in the section titled *Which client should I use?*.
 
 View the [Client Library Documentation](<%= gem.library_documentation_url %>)
 for this library, <%= gem.name %>, to see the convenience methods for
@@ -95,3 +96,43 @@ in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
+
+## Which client should I use?
+
+Most modern Ruby client libraries for Google APIs come in two flavors:
+lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
+for _most_ cases, you should install the main client.
+
+A _versioned client_ has a name such as `<%= gem.default_versioned_gem %>`,
+and provides a basic set of client classes for a _single version_ of a specific
+service. Some services publish multiple versions of their API, with potentially
+different interfaces including differences in field names, types, or method
+calls. For such services, there may be a separate versioned client library for
+each service version. Most versioned clients are created and maintained by a
+code generator, based on the service's published interface descriptions.
+
+The _main client_ for a service has a name such as `<%= gem.name %>`.
+There will be only one main client for any given service, even a service with
+multiple versions. For most services, the main client does not directly include
+API client classes. Instead, it lists the service's versioned client(s) as
+dependencies, and provides convenient factory methods for constructing client
+classes provided by the underlying versioned client libraries. It will choose
+which service version to use by default (although it will generally let you
+override its recommendation if you need to talk to a specific version of the
+service.) For some services, the main client also provides a higher-level
+interface with additional features, convenience methods, or best practices
+built in.
+
+In _most_ cases, we recommend installing the main client gem rather than a
+versioned client gem. This is because the main client will embody the best
+practices for accessing the service, and may also be easier to use. In
+addition, documentation and samples published by Google will generally use the
+main client. However, alternately, if you need to access a specific version of
+a service, and you want to use a lower-level interface, you can bypass the main
+client and instead install a versioned client directly.
+
+Note that some services may not yet have a modern client library (neither a
+main nor a versioned client) available. For these services, there might be a
+_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
+Legacy client libraries have wide coverage across Google services, but may be
+more difficult to use or lack features provided by modern clients.

--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/readme.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/readme.erb
@@ -6,7 +6,7 @@
 
 Actual client classes for the various versions of this API are defined in
 _versioned_ client gems, with names of the form `<%= gem.name %>-v*`.
-The gem `<%= gem.name %>` is a convenience wrapper library that brings the
+The gem `<%= gem.name %>` is the main client library that brings the
 verisoned gems in as dependencies, and provides high-level methods for
 constructing clients. More information on versioned clients can be found below
 in the section titled *Which client should I use?*.
@@ -99,40 +99,58 @@ about the Ruby support schedule.
 
 ## Which client should I use?
 
-Most modern Ruby client libraries for Google APIs come in two flavors:
-lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
-for _most_ cases, you should install the main client.
+Most modern Ruby client libraries for Google APIs come in two flavors: the main
+client library with a name such as `<%= gem.name %>`,
+and lower-level _versioned_ client libraries with names such as
+`<%= gem.default_versioned_gem %>`.
+_In most cases, you should install the main client._
 
-A _versioned client_ has a name such as `<%= gem.default_versioned_gem %>`,
-and provides a basic set of client classes for a _single version_ of a specific
-service. Some services publish multiple versions of their API, with potentially
-different interfaces including differences in field names, types, or method
-calls. For such services, there may be a separate versioned client library for
-each service version. Most versioned clients are created and maintained by a
-code generator, based on the service's published interface descriptions.
+### What's the difference between the main client and a versioned client?
 
-The _main client_ for a service has a name such as `<%= gem.name %>`.
-There will be only one main client for any given service, even a service with
-multiple versions. For most services, the main client does not directly include
-API client classes. Instead, it lists the service's versioned client(s) as
-dependencies, and provides convenient factory methods for constructing client
-classes provided by the underlying versioned client libraries. It will choose
-which service version to use by default (although it will generally let you
-override its recommendation if you need to talk to a specific version of the
-service.) For some services, the main client also provides a higher-level
-interface with additional features, convenience methods, or best practices
-built in.
+A _versioned client_ provides a basic set of data types and client classes for
+a _single version_ of a specific service. (That is, for a service with multiple
+versions, there might be a separate versioned client for each service version.)
+Most versioned clients are written and maintained by a code generator.
 
-In _most_ cases, we recommend installing the main client gem rather than a
-versioned client gem. This is because the main client will embody the best
-practices for accessing the service, and may also be easier to use. In
-addition, documentation and samples published by Google will generally use the
-main client. However, alternately, if you need to access a specific version of
-a service, and you want to use a lower-level interface, you can bypass the main
-client and instead install a versioned client directly.
+The _main client_ is designed to provide you with the _recommended_ client
+interfaces for the service. There will be only one main client for any given
+service, even a service with multiple versions. The main client includes
+factory methods for constructing the client objects we recommend for most
+users. In some cases, those will be classes provided by an underlying versioned
+client; in other cases, they will be handwritten higher-level client objects
+with additional capabilities, convenience methods, or best practices built in.
+Generally, the main client will default to a recommended service version,
+although in some cases you can override this if you need to talk to a specific
+service version.
 
-Note that some services may not yet have a modern client library (neither a
-main nor a versioned client) available. For these services, there might be a
-_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
-Legacy client libraries have wide coverage across Google services, but may be
-more difficult to use or lack features provided by modern clients.
+### Why would I want to use the main client?
+
+We recommend that most users install the main client gem for a service. You can
+identify this gem as the one _without_ a version in its name, e.g.
+`<%= gem.name %>`.
+The main client is recommended because it will embody the best practices for
+accessing the service, and may also provide more convenient interfaces or
+tighter integration into frameworks and third-party libraries. In addition, the
+documentation and samples published by Google will generally demonstrate use of
+the main client.
+
+### Why would I want to use a versioned client?
+
+You can use a versioned client if you are content with a possibly lower-level
+class interface, you explicitly want to avoid features provided by the main
+client, or you want to access a specific service version not be covered by the
+main client. You can identify versioned client gems because the service version
+is part of the name, e.g. `<%= gem.default_versioned_gem %>`.
+
+### What about the google-apis-<name> clients?
+
+Client library gems with names that begin with `google-apis-` are based on an
+older code generation technology. They talk to a REST/JSON backend (whereas
+most modern clients talk to a [gRPC](https://grpc.io/) backend) and they may
+not offer the same performance, features, and ease of use provided by more
+modern clients.
+
+The `google-apis-` clients have wide coverage across Google services, so you
+might need to use one if there is no modern client available for the service.
+However, if a modern client is available, we generally recommend it over the
+older `google-apis-` clients.

--- a/shared/output/cloud/language_v1/README.md
+++ b/shared/output/cloud/language_v1/README.md
@@ -6,6 +6,12 @@ google-cloud-language-v1 is the official client library for the Google Cloud Lan
 
 https://github.com/googleapis/google-cloud-ruby
 
+This gem is a _versioned_ client. It provides basic client classes for a
+specific version of the Google Cloud Language V1 API. Most users should consider the
+[google-cloud-language](https://rubygems.org/gems/google-cloud-language)
+gem, a convenience wrapper that may also include higher-level interface classes.
+See the section below titled *Which client should I use?* for more information.
+
 ## Installation
 
 ```
@@ -69,3 +75,43 @@ in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
+
+## Which client should I use?
+
+Most modern Ruby client libraries for Google APIs come in two flavors:
+lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
+for _most_ cases, you should install the main client.
+
+A _versioned client_ has a name such as `google-cloud-language-v1`,
+and provides a basic set of client classes for a _single version_ of a specific
+service. Some services publish multiple versions of their API, with potentially
+different interfaces including differences in field names, types, or method
+calls. For such services, there may be a separate versioned client library for
+each service version. Most versioned clients are created and maintained by a
+code generator, based on the service's published interface descriptions.
+
+The _main client_ for a service has a name such as `google-cloud-language`.
+There will be only one main client for any given service, even a service with
+multiple versions. For most services, the main client does not directly include
+API client classes. Instead, it lists the service's versioned client(s) as
+dependencies, and provides convenient factory methods for constructing client
+classes provided by the underlying versioned client libraries. It will choose
+which service version to use by default (although it will generally let you
+override its recommendation if you need to talk to a specific version of the
+service.) For some services, the main client also provides a higher-level
+interface with additional features, convenience methods, or best practices
+built in.
+
+In _most_ cases, we recommend installing the main client gem rather than a
+versioned client gem. This is because the main client will embody the best
+practices for accessing the service, and may also be easier to use. In
+addition, documentation and samples published by Google will generally use the
+main client. However, alternately, if you need to access a specific version of
+a service, and you want to use a lower-level interface, you can bypass the main
+client and instead install a versioned client directly.
+
+Note that some services may not yet have a modern client library (neither a
+main nor a versioned client) available. For these services, there might be a
+_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
+Legacy client libraries have wide coverage across Google services, but may be
+more difficult to use or lack features provided by modern clients.

--- a/shared/output/cloud/language_v1/README.md
+++ b/shared/output/cloud/language_v1/README.md
@@ -7,9 +7,9 @@ google-cloud-language-v1 is the official client library for the Google Cloud Lan
 https://github.com/googleapis/google-cloud-ruby
 
 This gem is a _versioned_ client. It provides basic client classes for a
-specific version of the Google Cloud Language V1 API. Most users should consider the
-[google-cloud-language](https://rubygems.org/gems/google-cloud-language)
-gem, a convenience wrapper that may also include higher-level interface classes.
+specific version of the Google Cloud Language V1 API. Most users should consider using
+the main client gem,
+[google-cloud-language](https://rubygems.org/gems/google-cloud-language).
 See the section below titled *Which client should I use?* for more information.
 
 ## Installation
@@ -78,40 +78,58 @@ about the Ruby support schedule.
 
 ## Which client should I use?
 
-Most modern Ruby client libraries for Google APIs come in two flavors:
-lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
-for _most_ cases, you should install the main client.
+Most modern Ruby client libraries for Google APIs come in two flavors: the main
+client library with a name such as `google-cloud-language`,
+and lower-level _versioned_ client libraries with names such as
+`google-cloud-language-v1`.
+_In most cases, you should install the main client._
 
-A _versioned client_ has a name such as `google-cloud-language-v1`,
-and provides a basic set of client classes for a _single version_ of a specific
-service. Some services publish multiple versions of their API, with potentially
-different interfaces including differences in field names, types, or method
-calls. For such services, there may be a separate versioned client library for
-each service version. Most versioned clients are created and maintained by a
-code generator, based on the service's published interface descriptions.
+### What's the difference between the main client and a versioned client?
 
-The _main client_ for a service has a name such as `google-cloud-language`.
-There will be only one main client for any given service, even a service with
-multiple versions. For most services, the main client does not directly include
-API client classes. Instead, it lists the service's versioned client(s) as
-dependencies, and provides convenient factory methods for constructing client
-classes provided by the underlying versioned client libraries. It will choose
-which service version to use by default (although it will generally let you
-override its recommendation if you need to talk to a specific version of the
-service.) For some services, the main client also provides a higher-level
-interface with additional features, convenience methods, or best practices
-built in.
+A _versioned client_ provides a basic set of data types and client classes for
+a _single version_ of a specific service. (That is, for a service with multiple
+versions, there might be a separate versioned client for each service version.)
+Most versioned clients are written and maintained by a code generator.
 
-In _most_ cases, we recommend installing the main client gem rather than a
-versioned client gem. This is because the main client will embody the best
-practices for accessing the service, and may also be easier to use. In
-addition, documentation and samples published by Google will generally use the
-main client. However, alternately, if you need to access a specific version of
-a service, and you want to use a lower-level interface, you can bypass the main
-client and instead install a versioned client directly.
+The _main client_ is designed to provide you with the _recommended_ client
+interfaces for the service. There will be only one main client for any given
+service, even a service with multiple versions. The main client includes
+factory methods for constructing the client objects we recommend for most
+users. In some cases, those will be classes provided by an underlying versioned
+client; in other cases, they will be handwritten higher-level client objects
+with additional capabilities, convenience methods, or best practices built in.
+Generally, the main client will default to a recommended service version,
+although in some cases you can override this if you need to talk to a specific
+service version.
 
-Note that some services may not yet have a modern client library (neither a
-main nor a versioned client) available. For these services, there might be a
-_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
-Legacy client libraries have wide coverage across Google services, but may be
-more difficult to use or lack features provided by modern clients.
+### Why would I want to use the main client?
+
+We recommend that most users install the main client gem for a service. You can
+identify this gem as the one _without_ a version in its name, e.g.
+`google-cloud-language`.
+The main client is recommended because it will embody the best practices for
+accessing the service, and may also provide more convenient interfaces or
+tighter integration into frameworks and third-party libraries. In addition, the
+documentation and samples published by Google will generally demonstrate use of
+the main client.
+
+### Why would I want to use a versioned client?
+
+You can use a versioned client if you are content with a possibly lower-level
+class interface, you explicitly want to avoid features provided by the main
+client, or you want to access a specific service version not be covered by the
+main client. You can identify versioned client gems because the service version
+is part of the name, e.g. `google-cloud-language-v1`.
+
+### What about the google-apis-<name> clients?
+
+Client library gems with names that begin with `google-apis-` are based on an
+older code generation technology. They talk to a REST/JSON backend (whereas
+most modern clients talk to a [gRPC](https://grpc.io/) backend) and they may
+not offer the same performance, features, and ease of use provided by more
+modern clients.
+
+The `google-apis-` clients have wide coverage across Google services, so you
+might need to use one if there is no modern client available for the service.
+However, if a modern client is available, we generally recommend it over the
+older `google-apis-` clients.

--- a/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
+++ b/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
-  gem.description   = "google-cloud-language-v1 is the official client library for the Google Cloud Language V1 API."
+  gem.description   = "google-cloud-language-v1 is the official client library for the Google Cloud Language V1 API. Note that google-cloud-language-v1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-language instead. See the readme for more details."
   gem.summary       = "API Client library for the Google Cloud Language V1 API"
   gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"

--- a/shared/output/cloud/language_v1beta1/README.md
+++ b/shared/output/cloud/language_v1beta1/README.md
@@ -6,6 +6,12 @@ google-cloud-language-v1beta1 is the official client library for the Google Clou
 
 https://github.com/googleapis/google-cloud-ruby
 
+This gem is a _versioned_ client. It provides basic client classes for a
+specific version of the Google Cloud Language V1beta1 API. Most users should consider the
+[google-cloud-language](https://rubygems.org/gems/google-cloud-language)
+gem, a convenience wrapper that may also include higher-level interface classes.
+See the section below titled *Which client should I use?* for more information.
+
 ## Installation
 
 ```
@@ -69,3 +75,43 @@ in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
+
+## Which client should I use?
+
+Most modern Ruby client libraries for Google APIs come in two flavors:
+lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
+for _most_ cases, you should install the main client.
+
+A _versioned client_ has a name such as `google-cloud-language-v1beta1`,
+and provides a basic set of client classes for a _single version_ of a specific
+service. Some services publish multiple versions of their API, with potentially
+different interfaces including differences in field names, types, or method
+calls. For such services, there may be a separate versioned client library for
+each service version. Most versioned clients are created and maintained by a
+code generator, based on the service's published interface descriptions.
+
+The _main client_ for a service has a name such as `google-cloud-language`.
+There will be only one main client for any given service, even a service with
+multiple versions. For most services, the main client does not directly include
+API client classes. Instead, it lists the service's versioned client(s) as
+dependencies, and provides convenient factory methods for constructing client
+classes provided by the underlying versioned client libraries. It will choose
+which service version to use by default (although it will generally let you
+override its recommendation if you need to talk to a specific version of the
+service.) For some services, the main client also provides a higher-level
+interface with additional features, convenience methods, or best practices
+built in.
+
+In _most_ cases, we recommend installing the main client gem rather than a
+versioned client gem. This is because the main client will embody the best
+practices for accessing the service, and may also be easier to use. In
+addition, documentation and samples published by Google will generally use the
+main client. However, alternately, if you need to access a specific version of
+a service, and you want to use a lower-level interface, you can bypass the main
+client and instead install a versioned client directly.
+
+Note that some services may not yet have a modern client library (neither a
+main nor a versioned client) available. For these services, there might be a
+_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
+Legacy client libraries have wide coverage across Google services, but may be
+more difficult to use or lack features provided by modern clients.

--- a/shared/output/cloud/language_v1beta1/README.md
+++ b/shared/output/cloud/language_v1beta1/README.md
@@ -7,9 +7,9 @@ google-cloud-language-v1beta1 is the official client library for the Google Clou
 https://github.com/googleapis/google-cloud-ruby
 
 This gem is a _versioned_ client. It provides basic client classes for a
-specific version of the Google Cloud Language V1beta1 API. Most users should consider the
-[google-cloud-language](https://rubygems.org/gems/google-cloud-language)
-gem, a convenience wrapper that may also include higher-level interface classes.
+specific version of the Google Cloud Language V1beta1 API. Most users should consider using
+the main client gem,
+[google-cloud-language](https://rubygems.org/gems/google-cloud-language).
 See the section below titled *Which client should I use?* for more information.
 
 ## Installation
@@ -78,40 +78,58 @@ about the Ruby support schedule.
 
 ## Which client should I use?
 
-Most modern Ruby client libraries for Google APIs come in two flavors:
-lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
-for _most_ cases, you should install the main client.
+Most modern Ruby client libraries for Google APIs come in two flavors: the main
+client library with a name such as `google-cloud-language`,
+and lower-level _versioned_ client libraries with names such as
+`google-cloud-language-v1beta1`.
+_In most cases, you should install the main client._
 
-A _versioned client_ has a name such as `google-cloud-language-v1beta1`,
-and provides a basic set of client classes for a _single version_ of a specific
-service. Some services publish multiple versions of their API, with potentially
-different interfaces including differences in field names, types, or method
-calls. For such services, there may be a separate versioned client library for
-each service version. Most versioned clients are created and maintained by a
-code generator, based on the service's published interface descriptions.
+### What's the difference between the main client and a versioned client?
 
-The _main client_ for a service has a name such as `google-cloud-language`.
-There will be only one main client for any given service, even a service with
-multiple versions. For most services, the main client does not directly include
-API client classes. Instead, it lists the service's versioned client(s) as
-dependencies, and provides convenient factory methods for constructing client
-classes provided by the underlying versioned client libraries. It will choose
-which service version to use by default (although it will generally let you
-override its recommendation if you need to talk to a specific version of the
-service.) For some services, the main client also provides a higher-level
-interface with additional features, convenience methods, or best practices
-built in.
+A _versioned client_ provides a basic set of data types and client classes for
+a _single version_ of a specific service. (That is, for a service with multiple
+versions, there might be a separate versioned client for each service version.)
+Most versioned clients are written and maintained by a code generator.
 
-In _most_ cases, we recommend installing the main client gem rather than a
-versioned client gem. This is because the main client will embody the best
-practices for accessing the service, and may also be easier to use. In
-addition, documentation and samples published by Google will generally use the
-main client. However, alternately, if you need to access a specific version of
-a service, and you want to use a lower-level interface, you can bypass the main
-client and instead install a versioned client directly.
+The _main client_ is designed to provide you with the _recommended_ client
+interfaces for the service. There will be only one main client for any given
+service, even a service with multiple versions. The main client includes
+factory methods for constructing the client objects we recommend for most
+users. In some cases, those will be classes provided by an underlying versioned
+client; in other cases, they will be handwritten higher-level client objects
+with additional capabilities, convenience methods, or best practices built in.
+Generally, the main client will default to a recommended service version,
+although in some cases you can override this if you need to talk to a specific
+service version.
 
-Note that some services may not yet have a modern client library (neither a
-main nor a versioned client) available. For these services, there might be a
-_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
-Legacy client libraries have wide coverage across Google services, but may be
-more difficult to use or lack features provided by modern clients.
+### Why would I want to use the main client?
+
+We recommend that most users install the main client gem for a service. You can
+identify this gem as the one _without_ a version in its name, e.g.
+`google-cloud-language`.
+The main client is recommended because it will embody the best practices for
+accessing the service, and may also provide more convenient interfaces or
+tighter integration into frameworks and third-party libraries. In addition, the
+documentation and samples published by Google will generally demonstrate use of
+the main client.
+
+### Why would I want to use a versioned client?
+
+You can use a versioned client if you are content with a possibly lower-level
+class interface, you explicitly want to avoid features provided by the main
+client, or you want to access a specific service version not be covered by the
+main client. You can identify versioned client gems because the service version
+is part of the name, e.g. `google-cloud-language-v1beta1`.
+
+### What about the google-apis-<name> clients?
+
+Client library gems with names that begin with `google-apis-` are based on an
+older code generation technology. They talk to a REST/JSON backend (whereas
+most modern clients talk to a [gRPC](https://grpc.io/) backend) and they may
+not offer the same performance, features, and ease of use provided by more
+modern clients.
+
+The `google-apis-` clients have wide coverage across Google services, so you
+might need to use one if there is no modern client available for the service.
+However, if a modern client is available, we generally recommend it over the
+older `google-apis-` clients.

--- a/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
+++ b/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
-  gem.description   = "google-cloud-language-v1beta1 is the official client library for the Google Cloud Language V1beta1 API."
+  gem.description   = "google-cloud-language-v1beta1 is the official client library for the Google Cloud Language V1beta1 API. Note that google-cloud-language-v1beta1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-language instead. See the readme for more details."
   gem.summary       = "API Client library for the Google Cloud Language V1beta1 API"
   gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"

--- a/shared/output/cloud/language_v1beta2/README.md
+++ b/shared/output/cloud/language_v1beta2/README.md
@@ -6,6 +6,12 @@ google-cloud-language-v1beta2 is the official client library for the Google Clou
 
 https://github.com/googleapis/google-cloud-ruby
 
+This gem is a _versioned_ client. It provides basic client classes for a
+specific version of the Google Cloud Language V1beta2 API. Most users should consider the
+[google-cloud-language](https://rubygems.org/gems/google-cloud-language)
+gem, a convenience wrapper that may also include higher-level interface classes.
+See the section below titled *Which client should I use?* for more information.
+
 ## Installation
 
 ```
@@ -69,3 +75,43 @@ in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
+
+## Which client should I use?
+
+Most modern Ruby client libraries for Google APIs come in two flavors:
+lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
+for _most_ cases, you should install the main client.
+
+A _versioned client_ has a name such as `google-cloud-language-v1beta2`,
+and provides a basic set of client classes for a _single version_ of a specific
+service. Some services publish multiple versions of their API, with potentially
+different interfaces including differences in field names, types, or method
+calls. For such services, there may be a separate versioned client library for
+each service version. Most versioned clients are created and maintained by a
+code generator, based on the service's published interface descriptions.
+
+The _main client_ for a service has a name such as `google-cloud-language`.
+There will be only one main client for any given service, even a service with
+multiple versions. For most services, the main client does not directly include
+API client classes. Instead, it lists the service's versioned client(s) as
+dependencies, and provides convenient factory methods for constructing client
+classes provided by the underlying versioned client libraries. It will choose
+which service version to use by default (although it will generally let you
+override its recommendation if you need to talk to a specific version of the
+service.) For some services, the main client also provides a higher-level
+interface with additional features, convenience methods, or best practices
+built in.
+
+In _most_ cases, we recommend installing the main client gem rather than a
+versioned client gem. This is because the main client will embody the best
+practices for accessing the service, and may also be easier to use. In
+addition, documentation and samples published by Google will generally use the
+main client. However, alternately, if you need to access a specific version of
+a service, and you want to use a lower-level interface, you can bypass the main
+client and instead install a versioned client directly.
+
+Note that some services may not yet have a modern client library (neither a
+main nor a versioned client) available. For these services, there might be a
+_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
+Legacy client libraries have wide coverage across Google services, but may be
+more difficult to use or lack features provided by modern clients.

--- a/shared/output/cloud/language_v1beta2/README.md
+++ b/shared/output/cloud/language_v1beta2/README.md
@@ -7,9 +7,9 @@ google-cloud-language-v1beta2 is the official client library for the Google Clou
 https://github.com/googleapis/google-cloud-ruby
 
 This gem is a _versioned_ client. It provides basic client classes for a
-specific version of the Google Cloud Language V1beta2 API. Most users should consider the
-[google-cloud-language](https://rubygems.org/gems/google-cloud-language)
-gem, a convenience wrapper that may also include higher-level interface classes.
+specific version of the Google Cloud Language V1beta2 API. Most users should consider using
+the main client gem,
+[google-cloud-language](https://rubygems.org/gems/google-cloud-language).
 See the section below titled *Which client should I use?* for more information.
 
 ## Installation
@@ -78,40 +78,58 @@ about the Ruby support schedule.
 
 ## Which client should I use?
 
-Most modern Ruby client libraries for Google APIs come in two flavors:
-lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
-for _most_ cases, you should install the main client.
+Most modern Ruby client libraries for Google APIs come in two flavors: the main
+client library with a name such as `google-cloud-language`,
+and lower-level _versioned_ client libraries with names such as
+`google-cloud-language-v1beta2`.
+_In most cases, you should install the main client._
 
-A _versioned client_ has a name such as `google-cloud-language-v1beta2`,
-and provides a basic set of client classes for a _single version_ of a specific
-service. Some services publish multiple versions of their API, with potentially
-different interfaces including differences in field names, types, or method
-calls. For such services, there may be a separate versioned client library for
-each service version. Most versioned clients are created and maintained by a
-code generator, based on the service's published interface descriptions.
+### What's the difference between the main client and a versioned client?
 
-The _main client_ for a service has a name such as `google-cloud-language`.
-There will be only one main client for any given service, even a service with
-multiple versions. For most services, the main client does not directly include
-API client classes. Instead, it lists the service's versioned client(s) as
-dependencies, and provides convenient factory methods for constructing client
-classes provided by the underlying versioned client libraries. It will choose
-which service version to use by default (although it will generally let you
-override its recommendation if you need to talk to a specific version of the
-service.) For some services, the main client also provides a higher-level
-interface with additional features, convenience methods, or best practices
-built in.
+A _versioned client_ provides a basic set of data types and client classes for
+a _single version_ of a specific service. (That is, for a service with multiple
+versions, there might be a separate versioned client for each service version.)
+Most versioned clients are written and maintained by a code generator.
 
-In _most_ cases, we recommend installing the main client gem rather than a
-versioned client gem. This is because the main client will embody the best
-practices for accessing the service, and may also be easier to use. In
-addition, documentation and samples published by Google will generally use the
-main client. However, alternately, if you need to access a specific version of
-a service, and you want to use a lower-level interface, you can bypass the main
-client and instead install a versioned client directly.
+The _main client_ is designed to provide you with the _recommended_ client
+interfaces for the service. There will be only one main client for any given
+service, even a service with multiple versions. The main client includes
+factory methods for constructing the client objects we recommend for most
+users. In some cases, those will be classes provided by an underlying versioned
+client; in other cases, they will be handwritten higher-level client objects
+with additional capabilities, convenience methods, or best practices built in.
+Generally, the main client will default to a recommended service version,
+although in some cases you can override this if you need to talk to a specific
+service version.
 
-Note that some services may not yet have a modern client library (neither a
-main nor a versioned client) available. For these services, there might be a
-_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
-Legacy client libraries have wide coverage across Google services, but may be
-more difficult to use or lack features provided by modern clients.
+### Why would I want to use the main client?
+
+We recommend that most users install the main client gem for a service. You can
+identify this gem as the one _without_ a version in its name, e.g.
+`google-cloud-language`.
+The main client is recommended because it will embody the best practices for
+accessing the service, and may also provide more convenient interfaces or
+tighter integration into frameworks and third-party libraries. In addition, the
+documentation and samples published by Google will generally demonstrate use of
+the main client.
+
+### Why would I want to use a versioned client?
+
+You can use a versioned client if you are content with a possibly lower-level
+class interface, you explicitly want to avoid features provided by the main
+client, or you want to access a specific service version not be covered by the
+main client. You can identify versioned client gems because the service version
+is part of the name, e.g. `google-cloud-language-v1beta2`.
+
+### What about the google-apis-<name> clients?
+
+Client library gems with names that begin with `google-apis-` are based on an
+older code generation technology. They talk to a REST/JSON backend (whereas
+most modern clients talk to a [gRPC](https://grpc.io/) backend) and they may
+not offer the same performance, features, and ease of use provided by more
+modern clients.
+
+The `google-apis-` clients have wide coverage across Google services, so you
+might need to use one if there is no modern client available for the service.
+However, if a modern client is available, we generally recommend it over the
+older `google-apis-` clients.

--- a/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
+++ b/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
-  gem.description   = "google-cloud-language-v1beta2 is the official client library for the Google Cloud Language V1beta2 API."
+  gem.description   = "google-cloud-language-v1beta2 is the official client library for the Google Cloud Language V1beta2 API. Note that google-cloud-language-v1beta2 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-language instead. See the readme for more details."
   gem.summary       = "API Client library for the Google Cloud Language V1beta2 API"
   gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"

--- a/shared/output/cloud/secretmanager_v1beta1/README.md
+++ b/shared/output/cloud/secretmanager_v1beta1/README.md
@@ -6,6 +6,12 @@ google-cloud-secret_manager-v1beta1 is the official client library for the Secre
 
 https://github.com/googleapis/google-cloud-ruby
 
+This gem is a _versioned_ client. It provides basic client classes for a
+specific version of the Secret Manager V1beta1 API. Most users should consider the
+[google-cloud-secret_manager](https://rubygems.org/gems/google-cloud-secret_manager)
+gem, a convenience wrapper that may also include higher-level interface classes.
+See the section below titled *Which client should I use?* for more information.
+
 ## Installation
 
 ```
@@ -69,3 +75,43 @@ in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
+
+## Which client should I use?
+
+Most modern Ruby client libraries for Google APIs come in two flavors:
+lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
+for _most_ cases, you should install the main client.
+
+A _versioned client_ has a name such as `google-cloud-secret_manager-v1beta1`,
+and provides a basic set of client classes for a _single version_ of a specific
+service. Some services publish multiple versions of their API, with potentially
+different interfaces including differences in field names, types, or method
+calls. For such services, there may be a separate versioned client library for
+each service version. Most versioned clients are created and maintained by a
+code generator, based on the service's published interface descriptions.
+
+The _main client_ for a service has a name such as `google-cloud-secret_manager`.
+There will be only one main client for any given service, even a service with
+multiple versions. For most services, the main client does not directly include
+API client classes. Instead, it lists the service's versioned client(s) as
+dependencies, and provides convenient factory methods for constructing client
+classes provided by the underlying versioned client libraries. It will choose
+which service version to use by default (although it will generally let you
+override its recommendation if you need to talk to a specific version of the
+service.) For some services, the main client also provides a higher-level
+interface with additional features, convenience methods, or best practices
+built in.
+
+In _most_ cases, we recommend installing the main client gem rather than a
+versioned client gem. This is because the main client will embody the best
+practices for accessing the service, and may also be easier to use. In
+addition, documentation and samples published by Google will generally use the
+main client. However, alternately, if you need to access a specific version of
+a service, and you want to use a lower-level interface, you can bypass the main
+client and instead install a versioned client directly.
+
+Note that some services may not yet have a modern client library (neither a
+main nor a versioned client) available. For these services, there might be a
+_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
+Legacy client libraries have wide coverage across Google services, but may be
+more difficult to use or lack features provided by modern clients.

--- a/shared/output/cloud/secretmanager_v1beta1/README.md
+++ b/shared/output/cloud/secretmanager_v1beta1/README.md
@@ -7,9 +7,9 @@ google-cloud-secret_manager-v1beta1 is the official client library for the Secre
 https://github.com/googleapis/google-cloud-ruby
 
 This gem is a _versioned_ client. It provides basic client classes for a
-specific version of the Secret Manager V1beta1 API. Most users should consider the
-[google-cloud-secret_manager](https://rubygems.org/gems/google-cloud-secret_manager)
-gem, a convenience wrapper that may also include higher-level interface classes.
+specific version of the Secret Manager V1beta1 API. Most users should consider using
+the main client gem,
+[google-cloud-secret_manager](https://rubygems.org/gems/google-cloud-secret_manager).
 See the section below titled *Which client should I use?* for more information.
 
 ## Installation
@@ -78,40 +78,58 @@ about the Ruby support schedule.
 
 ## Which client should I use?
 
-Most modern Ruby client libraries for Google APIs come in two flavors:
-lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
-for _most_ cases, you should install the main client.
+Most modern Ruby client libraries for Google APIs come in two flavors: the main
+client library with a name such as `google-cloud-secret_manager`,
+and lower-level _versioned_ client libraries with names such as
+`google-cloud-secret_manager-v1beta1`.
+_In most cases, you should install the main client._
 
-A _versioned client_ has a name such as `google-cloud-secret_manager-v1beta1`,
-and provides a basic set of client classes for a _single version_ of a specific
-service. Some services publish multiple versions of their API, with potentially
-different interfaces including differences in field names, types, or method
-calls. For such services, there may be a separate versioned client library for
-each service version. Most versioned clients are created and maintained by a
-code generator, based on the service's published interface descriptions.
+### What's the difference between the main client and a versioned client?
 
-The _main client_ for a service has a name such as `google-cloud-secret_manager`.
-There will be only one main client for any given service, even a service with
-multiple versions. For most services, the main client does not directly include
-API client classes. Instead, it lists the service's versioned client(s) as
-dependencies, and provides convenient factory methods for constructing client
-classes provided by the underlying versioned client libraries. It will choose
-which service version to use by default (although it will generally let you
-override its recommendation if you need to talk to a specific version of the
-service.) For some services, the main client also provides a higher-level
-interface with additional features, convenience methods, or best practices
-built in.
+A _versioned client_ provides a basic set of data types and client classes for
+a _single version_ of a specific service. (That is, for a service with multiple
+versions, there might be a separate versioned client for each service version.)
+Most versioned clients are written and maintained by a code generator.
 
-In _most_ cases, we recommend installing the main client gem rather than a
-versioned client gem. This is because the main client will embody the best
-practices for accessing the service, and may also be easier to use. In
-addition, documentation and samples published by Google will generally use the
-main client. However, alternately, if you need to access a specific version of
-a service, and you want to use a lower-level interface, you can bypass the main
-client and instead install a versioned client directly.
+The _main client_ is designed to provide you with the _recommended_ client
+interfaces for the service. There will be only one main client for any given
+service, even a service with multiple versions. The main client includes
+factory methods for constructing the client objects we recommend for most
+users. In some cases, those will be classes provided by an underlying versioned
+client; in other cases, they will be handwritten higher-level client objects
+with additional capabilities, convenience methods, or best practices built in.
+Generally, the main client will default to a recommended service version,
+although in some cases you can override this if you need to talk to a specific
+service version.
 
-Note that some services may not yet have a modern client library (neither a
-main nor a versioned client) available. For these services, there might be a
-_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
-Legacy client libraries have wide coverage across Google services, but may be
-more difficult to use or lack features provided by modern clients.
+### Why would I want to use the main client?
+
+We recommend that most users install the main client gem for a service. You can
+identify this gem as the one _without_ a version in its name, e.g.
+`google-cloud-secret_manager`.
+The main client is recommended because it will embody the best practices for
+accessing the service, and may also provide more convenient interfaces or
+tighter integration into frameworks and third-party libraries. In addition, the
+documentation and samples published by Google will generally demonstrate use of
+the main client.
+
+### Why would I want to use a versioned client?
+
+You can use a versioned client if you are content with a possibly lower-level
+class interface, you explicitly want to avoid features provided by the main
+client, or you want to access a specific service version not be covered by the
+main client. You can identify versioned client gems because the service version
+is part of the name, e.g. `google-cloud-secret_manager-v1beta1`.
+
+### What about the google-apis-<name> clients?
+
+Client library gems with names that begin with `google-apis-` are based on an
+older code generation technology. They talk to a REST/JSON backend (whereas
+most modern clients talk to a [gRPC](https://grpc.io/) backend) and they may
+not offer the same performance, features, and ease of use provided by more
+modern clients.
+
+The `google-apis-` clients have wide coverage across Google services, so you
+might need to use one if there is no modern client available for the service.
+However, if a modern client is available, we generally recommend it over the
+older `google-apis-` clients.

--- a/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
+++ b/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
-  gem.description   = "google-cloud-secret_manager-v1beta1 is the official client library for the Secret Manager V1beta1 API."
+  gem.description   = "google-cloud-secret_manager-v1beta1 is the official client library for the Secret Manager V1beta1 API. Note that google-cloud-secret_manager-v1beta1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-secret_manager instead. See the readme for more details."
   gem.summary       = "Stores, manages, and secures access to application secrets."
   gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"

--- a/shared/output/cloud/secretmanager_wrapper/README.md
+++ b/shared/output/cloud/secretmanager_wrapper/README.md
@@ -8,7 +8,8 @@ Actual client classes for the various versions of this API are defined in
 _versioned_ client gems, with names of the form `google-cloud-secret_manager-v*`.
 The gem `google-cloud-secret_manager` is a convenience wrapper library that brings the
 verisoned gems in as dependencies, and provides high-level methods for
-constructing clients.
+constructing clients. More information on versioned clients can be found below
+in the section titled *Which client should I use?*.
 
 View the [Client Library Documentation](https://googleapis.dev/ruby/google-cloud-secret_manager/latest)
 for this library, google-cloud-secret_manager, to see the convenience methods for
@@ -78,3 +79,43 @@ in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
+
+## Which client should I use?
+
+Most modern Ruby client libraries for Google APIs come in two flavors:
+lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
+for _most_ cases, you should install the main client.
+
+A _versioned client_ has a name such as `google-cloud-secret_manager-v1`,
+and provides a basic set of client classes for a _single version_ of a specific
+service. Some services publish multiple versions of their API, with potentially
+different interfaces including differences in field names, types, or method
+calls. For such services, there may be a separate versioned client library for
+each service version. Most versioned clients are created and maintained by a
+code generator, based on the service's published interface descriptions.
+
+The _main client_ for a service has a name such as `google-cloud-secret_manager`.
+There will be only one main client for any given service, even a service with
+multiple versions. For most services, the main client does not directly include
+API client classes. Instead, it lists the service's versioned client(s) as
+dependencies, and provides convenient factory methods for constructing client
+classes provided by the underlying versioned client libraries. It will choose
+which service version to use by default (although it will generally let you
+override its recommendation if you need to talk to a specific version of the
+service.) For some services, the main client also provides a higher-level
+interface with additional features, convenience methods, or best practices
+built in.
+
+In _most_ cases, we recommend installing the main client gem rather than a
+versioned client gem. This is because the main client will embody the best
+practices for accessing the service, and may also be easier to use. In
+addition, documentation and samples published by Google will generally use the
+main client. However, alternately, if you need to access a specific version of
+a service, and you want to use a lower-level interface, you can bypass the main
+client and instead install a versioned client directly.
+
+Note that some services may not yet have a modern client library (neither a
+main nor a versioned client) available. For these services, there might be a
+_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
+Legacy client libraries have wide coverage across Google services, but may be
+more difficult to use or lack features provided by modern clients.

--- a/shared/output/cloud/secretmanager_wrapper/README.md
+++ b/shared/output/cloud/secretmanager_wrapper/README.md
@@ -6,7 +6,7 @@ google-cloud-secret_manager is the official client library for the Secret Manage
 
 Actual client classes for the various versions of this API are defined in
 _versioned_ client gems, with names of the form `google-cloud-secret_manager-v*`.
-The gem `google-cloud-secret_manager` is a convenience wrapper library that brings the
+The gem `google-cloud-secret_manager` is the main client library that brings the
 verisoned gems in as dependencies, and provides high-level methods for
 constructing clients. More information on versioned clients can be found below
 in the section titled *Which client should I use?*.
@@ -82,40 +82,58 @@ about the Ruby support schedule.
 
 ## Which client should I use?
 
-Most modern Ruby client libraries for Google APIs come in two flavors:
-lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
-for _most_ cases, you should install the main client.
+Most modern Ruby client libraries for Google APIs come in two flavors: the main
+client library with a name such as `google-cloud-secret_manager`,
+and lower-level _versioned_ client libraries with names such as
+`google-cloud-secret_manager-v1`.
+_In most cases, you should install the main client._
 
-A _versioned client_ has a name such as `google-cloud-secret_manager-v1`,
-and provides a basic set of client classes for a _single version_ of a specific
-service. Some services publish multiple versions of their API, with potentially
-different interfaces including differences in field names, types, or method
-calls. For such services, there may be a separate versioned client library for
-each service version. Most versioned clients are created and maintained by a
-code generator, based on the service's published interface descriptions.
+### What's the difference between the main client and a versioned client?
 
-The _main client_ for a service has a name such as `google-cloud-secret_manager`.
-There will be only one main client for any given service, even a service with
-multiple versions. For most services, the main client does not directly include
-API client classes. Instead, it lists the service's versioned client(s) as
-dependencies, and provides convenient factory methods for constructing client
-classes provided by the underlying versioned client libraries. It will choose
-which service version to use by default (although it will generally let you
-override its recommendation if you need to talk to a specific version of the
-service.) For some services, the main client also provides a higher-level
-interface with additional features, convenience methods, or best practices
-built in.
+A _versioned client_ provides a basic set of data types and client classes for
+a _single version_ of a specific service. (That is, for a service with multiple
+versions, there might be a separate versioned client for each service version.)
+Most versioned clients are written and maintained by a code generator.
 
-In _most_ cases, we recommend installing the main client gem rather than a
-versioned client gem. This is because the main client will embody the best
-practices for accessing the service, and may also be easier to use. In
-addition, documentation and samples published by Google will generally use the
-main client. However, alternately, if you need to access a specific version of
-a service, and you want to use a lower-level interface, you can bypass the main
-client and instead install a versioned client directly.
+The _main client_ is designed to provide you with the _recommended_ client
+interfaces for the service. There will be only one main client for any given
+service, even a service with multiple versions. The main client includes
+factory methods for constructing the client objects we recommend for most
+users. In some cases, those will be classes provided by an underlying versioned
+client; in other cases, they will be handwritten higher-level client objects
+with additional capabilities, convenience methods, or best practices built in.
+Generally, the main client will default to a recommended service version,
+although in some cases you can override this if you need to talk to a specific
+service version.
 
-Note that some services may not yet have a modern client library (neither a
-main nor a versioned client) available. For these services, there might be a
-_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
-Legacy client libraries have wide coverage across Google services, but may be
-more difficult to use or lack features provided by modern clients.
+### Why would I want to use the main client?
+
+We recommend that most users install the main client gem for a service. You can
+identify this gem as the one _without_ a version in its name, e.g.
+`google-cloud-secret_manager`.
+The main client is recommended because it will embody the best practices for
+accessing the service, and may also provide more convenient interfaces or
+tighter integration into frameworks and third-party libraries. In addition, the
+documentation and samples published by Google will generally demonstrate use of
+the main client.
+
+### Why would I want to use a versioned client?
+
+You can use a versioned client if you are content with a possibly lower-level
+class interface, you explicitly want to avoid features provided by the main
+client, or you want to access a specific service version not be covered by the
+main client. You can identify versioned client gems because the service version
+is part of the name, e.g. `google-cloud-secret_manager-v1`.
+
+### What about the google-apis-<name> clients?
+
+Client library gems with names that begin with `google-apis-` are based on an
+older code generation technology. They talk to a REST/JSON backend (whereas
+most modern clients talk to a [gRPC](https://grpc.io/) backend) and they may
+not offer the same performance, features, and ease of use provided by more
+modern clients.
+
+The `google-apis-` clients have wide coverage across Google services, so you
+might need to use one if there is no modern client available for the service.
+However, if a modern client is available, we generally recommend it over the
+older `google-apis-` clients.

--- a/shared/output/cloud/speech_v1/README.md
+++ b/shared/output/cloud/speech_v1/README.md
@@ -6,6 +6,12 @@ google-cloud-speech-v1 is the official client library for the Google Cloud Speec
 
 https://github.com/googleapis/google-cloud-ruby
 
+This gem is a _versioned_ client. It provides basic client classes for a
+specific version of the Google Cloud Speech V1 API. Most users should consider the
+[google-cloud-speech](https://rubygems.org/gems/google-cloud-speech)
+gem, a convenience wrapper that may also include higher-level interface classes.
+See the section below titled *Which client should I use?* for more information.
+
 ## Installation
 
 ```
@@ -69,3 +75,43 @@ in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
+
+## Which client should I use?
+
+Most modern Ruby client libraries for Google APIs come in two flavors:
+lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
+for _most_ cases, you should install the main client.
+
+A _versioned client_ has a name such as `google-cloud-speech-v1`,
+and provides a basic set of client classes for a _single version_ of a specific
+service. Some services publish multiple versions of their API, with potentially
+different interfaces including differences in field names, types, or method
+calls. For such services, there may be a separate versioned client library for
+each service version. Most versioned clients are created and maintained by a
+code generator, based on the service's published interface descriptions.
+
+The _main client_ for a service has a name such as `google-cloud-speech`.
+There will be only one main client for any given service, even a service with
+multiple versions. For most services, the main client does not directly include
+API client classes. Instead, it lists the service's versioned client(s) as
+dependencies, and provides convenient factory methods for constructing client
+classes provided by the underlying versioned client libraries. It will choose
+which service version to use by default (although it will generally let you
+override its recommendation if you need to talk to a specific version of the
+service.) For some services, the main client also provides a higher-level
+interface with additional features, convenience methods, or best practices
+built in.
+
+In _most_ cases, we recommend installing the main client gem rather than a
+versioned client gem. This is because the main client will embody the best
+practices for accessing the service, and may also be easier to use. In
+addition, documentation and samples published by Google will generally use the
+main client. However, alternately, if you need to access a specific version of
+a service, and you want to use a lower-level interface, you can bypass the main
+client and instead install a versioned client directly.
+
+Note that some services may not yet have a modern client library (neither a
+main nor a versioned client) available. For these services, there might be a
+_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
+Legacy client libraries have wide coverage across Google services, but may be
+more difficult to use or lack features provided by modern clients.

--- a/shared/output/cloud/speech_v1/README.md
+++ b/shared/output/cloud/speech_v1/README.md
@@ -7,9 +7,9 @@ google-cloud-speech-v1 is the official client library for the Google Cloud Speec
 https://github.com/googleapis/google-cloud-ruby
 
 This gem is a _versioned_ client. It provides basic client classes for a
-specific version of the Google Cloud Speech V1 API. Most users should consider the
-[google-cloud-speech](https://rubygems.org/gems/google-cloud-speech)
-gem, a convenience wrapper that may also include higher-level interface classes.
+specific version of the Google Cloud Speech V1 API. Most users should consider using
+the main client gem,
+[google-cloud-speech](https://rubygems.org/gems/google-cloud-speech).
 See the section below titled *Which client should I use?* for more information.
 
 ## Installation
@@ -78,40 +78,58 @@ about the Ruby support schedule.
 
 ## Which client should I use?
 
-Most modern Ruby client libraries for Google APIs come in two flavors:
-lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
-for _most_ cases, you should install the main client.
+Most modern Ruby client libraries for Google APIs come in two flavors: the main
+client library with a name such as `google-cloud-speech`,
+and lower-level _versioned_ client libraries with names such as
+`google-cloud-speech-v1`.
+_In most cases, you should install the main client._
 
-A _versioned client_ has a name such as `google-cloud-speech-v1`,
-and provides a basic set of client classes for a _single version_ of a specific
-service. Some services publish multiple versions of their API, with potentially
-different interfaces including differences in field names, types, or method
-calls. For such services, there may be a separate versioned client library for
-each service version. Most versioned clients are created and maintained by a
-code generator, based on the service's published interface descriptions.
+### What's the difference between the main client and a versioned client?
 
-The _main client_ for a service has a name such as `google-cloud-speech`.
-There will be only one main client for any given service, even a service with
-multiple versions. For most services, the main client does not directly include
-API client classes. Instead, it lists the service's versioned client(s) as
-dependencies, and provides convenient factory methods for constructing client
-classes provided by the underlying versioned client libraries. It will choose
-which service version to use by default (although it will generally let you
-override its recommendation if you need to talk to a specific version of the
-service.) For some services, the main client also provides a higher-level
-interface with additional features, convenience methods, or best practices
-built in.
+A _versioned client_ provides a basic set of data types and client classes for
+a _single version_ of a specific service. (That is, for a service with multiple
+versions, there might be a separate versioned client for each service version.)
+Most versioned clients are written and maintained by a code generator.
 
-In _most_ cases, we recommend installing the main client gem rather than a
-versioned client gem. This is because the main client will embody the best
-practices for accessing the service, and may also be easier to use. In
-addition, documentation and samples published by Google will generally use the
-main client. However, alternately, if you need to access a specific version of
-a service, and you want to use a lower-level interface, you can bypass the main
-client and instead install a versioned client directly.
+The _main client_ is designed to provide you with the _recommended_ client
+interfaces for the service. There will be only one main client for any given
+service, even a service with multiple versions. The main client includes
+factory methods for constructing the client objects we recommend for most
+users. In some cases, those will be classes provided by an underlying versioned
+client; in other cases, they will be handwritten higher-level client objects
+with additional capabilities, convenience methods, or best practices built in.
+Generally, the main client will default to a recommended service version,
+although in some cases you can override this if you need to talk to a specific
+service version.
 
-Note that some services may not yet have a modern client library (neither a
-main nor a versioned client) available. For these services, there might be a
-_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
-Legacy client libraries have wide coverage across Google services, but may be
-more difficult to use or lack features provided by modern clients.
+### Why would I want to use the main client?
+
+We recommend that most users install the main client gem for a service. You can
+identify this gem as the one _without_ a version in its name, e.g.
+`google-cloud-speech`.
+The main client is recommended because it will embody the best practices for
+accessing the service, and may also provide more convenient interfaces or
+tighter integration into frameworks and third-party libraries. In addition, the
+documentation and samples published by Google will generally demonstrate use of
+the main client.
+
+### Why would I want to use a versioned client?
+
+You can use a versioned client if you are content with a possibly lower-level
+class interface, you explicitly want to avoid features provided by the main
+client, or you want to access a specific service version not be covered by the
+main client. You can identify versioned client gems because the service version
+is part of the name, e.g. `google-cloud-speech-v1`.
+
+### What about the google-apis-<name> clients?
+
+Client library gems with names that begin with `google-apis-` are based on an
+older code generation technology. They talk to a REST/JSON backend (whereas
+most modern clients talk to a [gRPC](https://grpc.io/) backend) and they may
+not offer the same performance, features, and ease of use provided by more
+modern clients.
+
+The `google-apis-` clients have wide coverage across Google services, so you
+might need to use one if there is no modern client available for the service.
+However, if a modern client is available, we generally recommend it over the
+older `google-apis-` clients.

--- a/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
+++ b/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
-  gem.description   = "google-cloud-speech-v1 is the official client library for the Google Cloud Speech V1 API."
+  gem.description   = "google-cloud-speech-v1 is the official client library for the Google Cloud Speech V1 API. Note that google-cloud-speech-v1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-speech instead. See the readme for more details."
   gem.summary       = "API Client library for the Google Cloud Speech V1 API"
   gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"

--- a/shared/output/cloud/vision_v1/README.md
+++ b/shared/output/cloud/vision_v1/README.md
@@ -6,6 +6,12 @@ google-cloud-vision-v1 is the official client library for the Google Cloud Visio
 
 https://github.com/googleapis/google-cloud-ruby
 
+This gem is a _versioned_ client. It provides basic client classes for a
+specific version of the Google Cloud Vision V1 API. Most users should consider the
+[google-cloud-vision](https://rubygems.org/gems/google-cloud-vision)
+gem, a convenience wrapper that may also include higher-level interface classes.
+See the section below titled *Which client should I use?* for more information.
+
 ## Installation
 
 ```
@@ -69,3 +75,43 @@ in security maintenance, and not end of life. Currently, this means Ruby 2.4
 and later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
+
+## Which client should I use?
+
+Most modern Ruby client libraries for Google APIs come in two flavors:
+lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
+for _most_ cases, you should install the main client.
+
+A _versioned client_ has a name such as `google-cloud-vision-v1`,
+and provides a basic set of client classes for a _single version_ of a specific
+service. Some services publish multiple versions of their API, with potentially
+different interfaces including differences in field names, types, or method
+calls. For such services, there may be a separate versioned client library for
+each service version. Most versioned clients are created and maintained by a
+code generator, based on the service's published interface descriptions.
+
+The _main client_ for a service has a name such as `google-cloud-vision`.
+There will be only one main client for any given service, even a service with
+multiple versions. For most services, the main client does not directly include
+API client classes. Instead, it lists the service's versioned client(s) as
+dependencies, and provides convenient factory methods for constructing client
+classes provided by the underlying versioned client libraries. It will choose
+which service version to use by default (although it will generally let you
+override its recommendation if you need to talk to a specific version of the
+service.) For some services, the main client also provides a higher-level
+interface with additional features, convenience methods, or best practices
+built in.
+
+In _most_ cases, we recommend installing the main client gem rather than a
+versioned client gem. This is because the main client will embody the best
+practices for accessing the service, and may also be easier to use. In
+addition, documentation and samples published by Google will generally use the
+main client. However, alternately, if you need to access a specific version of
+a service, and you want to use a lower-level interface, you can bypass the main
+client and instead install a versioned client directly.
+
+Note that some services may not yet have a modern client library (neither a
+main nor a versioned client) available. For these services, there might be a
+_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
+Legacy client libraries have wide coverage across Google services, but may be
+more difficult to use or lack features provided by modern clients.

--- a/shared/output/cloud/vision_v1/README.md
+++ b/shared/output/cloud/vision_v1/README.md
@@ -7,9 +7,9 @@ google-cloud-vision-v1 is the official client library for the Google Cloud Visio
 https://github.com/googleapis/google-cloud-ruby
 
 This gem is a _versioned_ client. It provides basic client classes for a
-specific version of the Google Cloud Vision V1 API. Most users should consider the
-[google-cloud-vision](https://rubygems.org/gems/google-cloud-vision)
-gem, a convenience wrapper that may also include higher-level interface classes.
+specific version of the Google Cloud Vision V1 API. Most users should consider using
+the main client gem,
+[google-cloud-vision](https://rubygems.org/gems/google-cloud-vision).
 See the section below titled *Which client should I use?* for more information.
 
 ## Installation
@@ -78,40 +78,58 @@ about the Ruby support schedule.
 
 ## Which client should I use?
 
-Most modern Ruby client libraries for Google APIs come in two flavors:
-lower-level _versioned clients_ and higher-level _main clients_. As a TL;DR,
-for _most_ cases, you should install the main client.
+Most modern Ruby client libraries for Google APIs come in two flavors: the main
+client library with a name such as `google-cloud-vision`,
+and lower-level _versioned_ client libraries with names such as
+`google-cloud-vision-v1`.
+_In most cases, you should install the main client._
 
-A _versioned client_ has a name such as `google-cloud-vision-v1`,
-and provides a basic set of client classes for a _single version_ of a specific
-service. Some services publish multiple versions of their API, with potentially
-different interfaces including differences in field names, types, or method
-calls. For such services, there may be a separate versioned client library for
-each service version. Most versioned clients are created and maintained by a
-code generator, based on the service's published interface descriptions.
+### What's the difference between the main client and a versioned client?
 
-The _main client_ for a service has a name such as `google-cloud-vision`.
-There will be only one main client for any given service, even a service with
-multiple versions. For most services, the main client does not directly include
-API client classes. Instead, it lists the service's versioned client(s) as
-dependencies, and provides convenient factory methods for constructing client
-classes provided by the underlying versioned client libraries. It will choose
-which service version to use by default (although it will generally let you
-override its recommendation if you need to talk to a specific version of the
-service.) For some services, the main client also provides a higher-level
-interface with additional features, convenience methods, or best practices
-built in.
+A _versioned client_ provides a basic set of data types and client classes for
+a _single version_ of a specific service. (That is, for a service with multiple
+versions, there might be a separate versioned client for each service version.)
+Most versioned clients are written and maintained by a code generator.
 
-In _most_ cases, we recommend installing the main client gem rather than a
-versioned client gem. This is because the main client will embody the best
-practices for accessing the service, and may also be easier to use. In
-addition, documentation and samples published by Google will generally use the
-main client. However, alternately, if you need to access a specific version of
-a service, and you want to use a lower-level interface, you can bypass the main
-client and instead install a versioned client directly.
+The _main client_ is designed to provide you with the _recommended_ client
+interfaces for the service. There will be only one main client for any given
+service, even a service with multiple versions. The main client includes
+factory methods for constructing the client objects we recommend for most
+users. In some cases, those will be classes provided by an underlying versioned
+client; in other cases, they will be handwritten higher-level client objects
+with additional capabilities, convenience methods, or best practices built in.
+Generally, the main client will default to a recommended service version,
+although in some cases you can override this if you need to talk to a specific
+service version.
 
-Note that some services may not yet have a modern client library (neither a
-main nor a versioned client) available. For these services, there might be a
-_legacy client_ (with a name of the form `google-apis-<service>_<version>`).
-Legacy client libraries have wide coverage across Google services, but may be
-more difficult to use or lack features provided by modern clients.
+### Why would I want to use the main client?
+
+We recommend that most users install the main client gem for a service. You can
+identify this gem as the one _without_ a version in its name, e.g.
+`google-cloud-vision`.
+The main client is recommended because it will embody the best practices for
+accessing the service, and may also provide more convenient interfaces or
+tighter integration into frameworks and third-party libraries. In addition, the
+documentation and samples published by Google will generally demonstrate use of
+the main client.
+
+### Why would I want to use a versioned client?
+
+You can use a versioned client if you are content with a possibly lower-level
+class interface, you explicitly want to avoid features provided by the main
+client, or you want to access a specific service version not be covered by the
+main client. You can identify versioned client gems because the service version
+is part of the name, e.g. `google-cloud-vision-v1`.
+
+### What about the google-apis-<name> clients?
+
+Client library gems with names that begin with `google-apis-` are based on an
+older code generation technology. They talk to a REST/JSON backend (whereas
+most modern clients talk to a [gRPC](https://grpc.io/) backend) and they may
+not offer the same performance, features, and ease of use provided by more
+modern clients.
+
+The `google-apis-` clients have wide coverage across Google services, so you
+might need to use one if there is no modern client available for the service.
+However, if a modern client is available, we generally recommend it over the
+older `google-apis-` clients.

--- a/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
+++ b/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
-  gem.description   = "google-cloud-vision-v1 is the official client library for the Google Cloud Vision V1 API."
+  gem.description   = "google-cloud-vision-v1 is the official client library for the Google Cloud Vision V1 API. Note that google-cloud-vision-v1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-vision instead. See the readme for more details."
   gem.summary       = "API Client library for the Google Cloud Vision V1 API"
   gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"


### PR DESCRIPTION
This adds content to gem descriptions that tries to clarify the difference between versioned and wrapper clients, and directs users to install the wrapper. Specifically:

* Updates the description field in the gemspec for versioned clients, directing users to consider installing the wrapper instead.
* Adds a section to every generated readme entitled "Which client should I use?" that details the difference between versioned and wrapper clients.
* Adds a brief note at the top of the readme for versioned clients, directing users to consider installing the wrapper.