### PR TITLE
feat: add showcase library to the noncloud examples

### DIFF
--- a/bazel_example/WORKSPACE.bazel
+++ b/bazel_example/WORKSPACE.bazel
@@ -117,3 +117,13 @@ local_repository(
 load("@gapic_generator_ruby//rules_ruby_gapic:repositories.bzl", "gapic_generator_ruby_repositories")
 
 gapic_generator_ruby_repositories()
+
+##
+# showcase for vanilla examples
+#
+http_archive(
+    name = "com_gapic_showcase",
+    sha256 = "043ac36c4444479f8bd197f33fb54df25ea448219249652697b11766c06ea9c8",
+    strip_prefix = "gapic-showcase-466f2d57422377a03e5d883c3f3da9cbcbaffe36",
+    urls = ["https://github.com/googleapis/gapic-showcase/archive/466f2d57422377a03e5d883c3f3da9cbcbaffe36.zip"],
+)

--- a/bazel_example/gapic-generator/BUILD.bazel
+++ b/bazel_example/gapic-generator/BUILD.bazel
@@ -28,6 +28,10 @@ load("@gapic_generator_ruby//rules_ruby_gapic:ruby_gapic_pkg.bzl",
   "ruby_gapic_assembly_pkg")
 
 ##
+# "example.proto" example rules
+##
+
+##
 # the proto files wrapped with dependencies
 #
 proto_library(
@@ -76,3 +80,59 @@ ruby_gapic_assembly_pkg(
     ":example_ruby_grpc",
   ],
 )
+##
+# End of the "example.proto" example rules
+##
+
+##
+# Showcase example rules below
+##
+
+##
+# just the protoc ruby output
+#
+ruby_proto_library(
+  name = "showcase_ruby_proto",
+  deps = ["@com_gapic_showcase//schema/google/showcase/v1beta1:showcase_proto"],
+)
+
+##
+# just the grpc-ruby plugin output
+#
+ruby_grpc_library(
+  name = "showcase_ruby_grpc",
+  srcs = ["@com_gapic_showcase//schema/google/showcase/v1beta1:showcase_proto"],
+  deps = ["@com_gapic_showcase//schema/google/showcase/v1beta1:showcase_proto"]
+)
+
+##
+# just the gapic-generator-ruby vanilla flavor output
+#
+ruby_gapic_library(
+  name = "showcase_ruby_gapic",
+  srcs = ["@com_gapic_showcase//schema/google/showcase/v1beta1:showcase_proto",],
+  extra_protoc_parameters = [
+    "gem-name=google-showcase-v1beta1",
+    "file-path-override=v1_beta1=v1beta1"
+  ],
+  grpc_service_config = "@com_gapic_showcase//schema/google/showcase/v1beta1:showcase_grpc_service_config.json",
+)
+
+##
+# completed example client library combined from
+# * protoc ruby output
+# * grpc-ruby protoc plugin output
+# * gapic-generator-ruby vanilla flavor output
+#
+ruby_gapic_assembly_pkg(
+  name = "google_showcase_v1beta1",
+  deps = [
+    ":showcase_ruby_gapic",
+    ":showcase_ruby_proto",
+    ":showcase_ruby_grpc",
+  ],
+)
+
+##
+# End of showcase example rules
+##


### PR DESCRIPTION
noncloud example can benefit from having a real library in it, now that showcase Bazel bindings are there