### PR TITLE
chore: Release v0.7.0

### DIFF
--- a/gapic-generator-ads/CHANGELOG.md
+++ b/gapic-generator-ads/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History for gapic-generator-ads
 
+### 0.7.0 / 2021-02-27
+
+* Includes changes from gapic-generator 0.7.0, notably dropping Ruby 2.4 support.
+
 ### 0.6.15 / 2021-02-22
 
 * Really fixed encoding arguments in executable entrypoints

--- a/gapic-generator-ads/Gemfile.lock
+++ b/gapic-generator-ads/Gemfile.lock
@@ -1,16 +1,16 @@
 PATH
   remote: ../gapic-generator
   specs:
-    gapic-generator (0.6.15)
+    gapic-generator (0.7.0)
       actionpack (~> 5.2)
       protobuf (~> 3.8)
 
 PATH
   remote: .
   specs:
-    gapic-generator-ads (0.6.15)
+    gapic-generator-ads (0.7.0)
       actionpack (~> 5.2)
-      gapic-generator (= 0.6.15)
+      gapic-generator (= 0.7.0)
       protobuf (~> 3.8)
 
 GEM

--- a/gapic-generator-ads/gapic-generator-ads.gemspec
+++ b/gapic-generator-ads/gapic-generator-ads.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "actionpack", "~> 5.2"
-  spec.add_dependency "gapic-generator", "= 0.6.15"
+  spec.add_dependency "gapic-generator", "= 0.7.0"
   spec.add_dependency "protobuf", "~> 3.8"
 
   spec.add_development_dependency "google-style", "~> 1.25.1"

--- a/gapic-generator-ads/lib/gapic/generator/ads/version.rb
+++ b/gapic-generator-ads/lib/gapic/generator/ads/version.rb
@@ -18,7 +18,7 @@
 module Gapic
   module Generator
     module Ads
-      VERSION = "0.6.15"
+      VERSION = "0.7.0"
     end
   end
 end

--- a/gapic-generator-cloud/CHANGELOG.md
+++ b/gapic-generator-cloud/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History for gapic-generator-cloud
 
+### 0.7.0 / 2021-02-27
+
+* Includes changes from gapic-generator 0.7.0, notably dropping Ruby 2.4 support.
+* Generate special Cloud RAD yardopts file for GAPIC generated clients.
+
 ### 0.6.15 / 2021-02-22
 
 * Really fixed encoding arguments in executable entrypoints

--- a/gapic-generator-cloud/Gemfile.lock
+++ b/gapic-generator-cloud/Gemfile.lock
@@ -1,16 +1,16 @@
 PATH
   remote: ../gapic-generator
   specs:
-    gapic-generator (0.6.15)
+    gapic-generator (0.7.0)
       actionpack (~> 5.2)
       protobuf (~> 3.8)
 
 PATH
   remote: .
   specs:
-    gapic-generator-cloud (0.6.15)
+    gapic-generator-cloud (0.7.0)
       actionpack (~> 5.2)
-      gapic-generator (= 0.6.15)
+      gapic-generator (= 0.7.0)
       google-style (~> 1.25.1)
       protobuf (~> 3.8)
 

--- a/gapic-generator-cloud/gapic-generator-cloud.gemspec
+++ b/gapic-generator-cloud/gapic-generator-cloud.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "actionpack", "~> 5.2"
-  spec.add_dependency "gapic-generator", "= 0.6.15"
+  spec.add_dependency "gapic-generator", "= 0.7.0"
   spec.add_dependency "google-style", "~> 1.25.1"
   spec.add_dependency "protobuf", "~> 3.8"
 

--- a/gapic-generator-cloud/lib/gapic/generator/cloud/version.rb
+++ b/gapic-generator-cloud/lib/gapic/generator/cloud/version.rb
@@ -18,7 +18,7 @@
 module Gapic
   module Generator
     module Cloud
-      VERSION = "0.6.15"
+      VERSION = "0.7.0"
     end
   end
 end

--- a/gapic-generator/CHANGELOG.md
+++ b/gapic-generator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History for gapic-generator
 
+### 0.7.0 / 2021-02-27
+
+* Update minimum Ruby version to 2.5 for generated libraries.
+* Update supported Rubocop to 1.x for generated libraries.
+
 ### 0.6.15 / 2021-02-22
 
 * Really fixed encoding arguments in executable entrypoints

--- a/gapic-generator/Gemfile.lock
+++ b/gapic-generator/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gapic-generator (0.6.15)
+    gapic-generator (0.7.0)
       actionpack (~> 5.2)
       protobuf (~> 3.8)
 

--- a/gapic-generator/lib/gapic/generator/version.rb
+++ b/gapic-generator/lib/gapic/generator/version.rb
@@ -16,6 +16,6 @@
 
 module Gapic
   module Generator
-    VERSION = "0.6.15"
+    VERSION = "0.7.0"
   end
 end


### PR DESCRIPTION
This release updates to google-style 1.25 and drops Ruby 2.4 support for generated libraries.