### PR TITLE
fix: provide a default value for the 'body' param in the post method

### DIFF
--- a/gapic-common/CHANGELOG.md
+++ b/gapic-common/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+### 0.4.1 / 2021-04-15
+* Provide a default value for the 'body' in the REST POST method in Gapic::Rest.
+
 ### 0.4.0 / 2021-02-23
 
 * Support for the REST calls via the Gapic::Rest::ClientStub and other classes in Gapic::Rest

--- a/gapic-common/lib/gapic/common/version.rb
+++ b/gapic-common/lib/gapic/common/version.rb
@@ -14,6 +14,6 @@
 
 module Gapic
   module Common
-    VERSION = "0.4.0".freeze
+    VERSION = "0.4.1".freeze
   end
 end

--- a/gapic-common/lib/gapic/rest/client_stub.rb
+++ b/gapic-common/lib/gapic/rest/client_stub.rb
@@ -85,7 +85,7 @@ module Gapic
       # @param options [::Gapic::CallOptions] gapic options to be applied to the REST call.
       #   Currently only timeout and headers are supported.
       # @return [Faraday::Response]
-      def make_post_request uri:, body:, params: {}, options: {}
+      def make_post_request uri:, body: nil, params: {}, options: {}
         make_http_request :post, uri: uri, body: body, params: params, options: options
       end
 


### PR DESCRIPTION
in recognition that POST requests with empty body are uncommon but not incorrect, and we generate them for REGAPIC
( https://lists.w3.org/Archives/Public/ietf-http-wg/2010JulSep/0273.html )