### PR TITLE
fix: Fix default env_prefix computation to avoid the version part of the namespace

### DIFF
--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -127,7 +127,11 @@ module Gapic
       end
 
       def env_prefix
-        (gem_config(:env_prefix) || name.split("-").last).upcase
+        prefix = gem_config(:env_prefix) || begin
+          segs = name.split("-").reverse
+          segs.find { |seg| seg !~ /^v\d/ } || segs.first || "UNKNOWN"
+        end
+        prefix.upcase
       end
 
       def iam_dependency?

--- a/shared/output/cloud/compute_small/AUTHENTICATION.md
+++ b/shared/output/cloud/compute_small/AUTHENTICATION.md
@@ -19,7 +19,7 @@ during development.
 2. Set the [environment variable](#environment-variables).
 
 ```sh
-export V1_CREDENTIALS=path/to/keyfile.json
+export COMPUTE_CREDENTIALS=path/to/keyfile.json
 ```
 
 3. Initialize the client.
@@ -66,8 +66,8 @@ The environment variables that google-cloud-compute-v1
 checks for credentials are configured on the service Credentials class (such as
 {::Google::Cloud::Compute::V1::Addresses::Credentials}):
 
-1. `V1_CREDENTIALS` - Path to JSON file, or JSON contents
-2. `V1_KEYFILE` - Path to JSON file, or JSON contents
+1. `COMPUTE_CREDENTIALS` - Path to JSON file, or JSON contents
+2. `COMPUTE_KEYFILE` - Path to JSON file, or JSON contents
 3. `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
 4. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
 5. `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
@@ -75,7 +75,7 @@ checks for credentials are configured on the service Credentials class (such as
 ```ruby
 require "google/cloud/compute/v1"
 
-ENV["V1_CREDENTIALS"] = "path/to/keyfile.json"
+ENV["COMPUTE_CREDENTIALS"] = "path/to/keyfile.json"
 
 client = ::Google::Cloud::Compute::V1::Addresses::Client.new
 ```

--- a/shared/output/cloud/compute_small/Rakefile
+++ b/shared/output/cloud/compute_small/Rakefile
@@ -69,29 +69,29 @@ desc "Run the google-cloud-compute-v1 acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||=
-    ENV["V1_TEST_PROJECT"] ||
+    ENV["COMPUTE_TEST_PROJECT"] ||
     ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||=
-    ENV["V1_TEST_KEYFILE"] ||
+    ENV["COMPUTE_TEST_KEYFILE"] ||
     ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
     keyfile ||=
-      ENV["V1_TEST_KEYFILE_JSON"] ||
+      ENV["COMPUTE_TEST_KEYFILE_JSON"] ||
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or V1_TEST_PROJECT=test123 V1_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or COMPUTE_TEST_PROJECT=test123 COMPUTE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   require "google/cloud/compute/v1/addresses/credentials"
   ::Google::Cloud::Compute::V1::Addresses::Credentials.env_vars.each do |path|
     ENV[path] = nil
   end
-  ENV["V1_PROJECT"] = project
-  ENV["V1_TEST_PROJECT"] = project
-  ENV["V1_KEYFILE_JSON"] = keyfile
+  ENV["COMPUTE_PROJECT"] = project
+  ENV["COMPUTE_TEST_PROJECT"] = project
+  ENV["COMPUTE_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
 end

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/credentials.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/credentials.rb
@@ -30,13 +30,13 @@ module Google
               "https://www.googleapis.com/auth/cloud-platform"
             ]
             self.env_vars = [
-              "V1_CREDENTIALS",
-              "V1_KEYFILE",
+              "COMPUTE_CREDENTIALS",
+              "COMPUTE_KEYFILE",
               "GOOGLE_CLOUD_CREDENTIALS",
               "GOOGLE_CLOUD_KEYFILE",
               "GCLOUD_KEYFILE",
-              "V1_CREDENTIALS_JSON",
-              "V1_KEYFILE_JSON",
+              "COMPUTE_CREDENTIALS_JSON",
+              "COMPUTE_KEYFILE_JSON",
               "GOOGLE_CLOUD_CREDENTIALS_JSON",
               "GOOGLE_CLOUD_KEYFILE_JSON",
               "GCLOUD_KEYFILE_JSON"

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/credentials.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/credentials.rb
@@ -30,13 +30,13 @@ module Google
               "https://www.googleapis.com/auth/cloud-platform"
             ]
             self.env_vars = [
-              "V1_CREDENTIALS",
-              "V1_KEYFILE",
+              "COMPUTE_CREDENTIALS",
+              "COMPUTE_KEYFILE",
               "GOOGLE_CLOUD_CREDENTIALS",
               "GOOGLE_CLOUD_KEYFILE",
               "GCLOUD_KEYFILE",
-              "V1_CREDENTIALS_JSON",
-              "V1_KEYFILE_JSON",
+              "COMPUTE_CREDENTIALS_JSON",
+              "COMPUTE_KEYFILE_JSON",
               "GOOGLE_CLOUD_CREDENTIALS_JSON",
               "GOOGLE_CLOUD_KEYFILE_JSON",
               "GCLOUD_KEYFILE_JSON"

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/credentials.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/credentials.rb
@@ -30,13 +30,13 @@ module Google
               "https://www.googleapis.com/auth/cloud-platform"
             ]
             self.env_vars = [
-              "V1_CREDENTIALS",
-              "V1_KEYFILE",
+              "COMPUTE_CREDENTIALS",
+              "COMPUTE_KEYFILE",
               "GOOGLE_CLOUD_CREDENTIALS",
               "GOOGLE_CLOUD_KEYFILE",
               "GCLOUD_KEYFILE",
-              "V1_CREDENTIALS_JSON",
-              "V1_KEYFILE_JSON",
+              "COMPUTE_CREDENTIALS_JSON",
+              "COMPUTE_KEYFILE_JSON",
               "GOOGLE_CLOUD_CREDENTIALS_JSON",
               "GOOGLE_CLOUD_KEYFILE_JSON",
               "GCLOUD_KEYFILE_JSON"

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/credentials.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/credentials.rb
@@ -30,13 +30,13 @@ module Google
               "https://www.googleapis.com/auth/cloud-platform"
             ]
             self.env_vars = [
-              "V1_CREDENTIALS",
-              "V1_KEYFILE",
+              "COMPUTE_CREDENTIALS",
+              "COMPUTE_KEYFILE",
               "GOOGLE_CLOUD_CREDENTIALS",
               "GOOGLE_CLOUD_KEYFILE",
               "GCLOUD_KEYFILE",
-              "V1_CREDENTIALS_JSON",
-              "V1_KEYFILE_JSON",
+              "COMPUTE_CREDENTIALS_JSON",
+              "COMPUTE_KEYFILE_JSON",
               "GOOGLE_CLOUD_CREDENTIALS_JSON",
               "GOOGLE_CLOUD_KEYFILE_JSON",
               "GCLOUD_KEYFILE_JSON"


### PR DESCRIPTION
Handles the case where `--env-prefix=` is not provided and the proto namespace includes a version.