### PR TITLE
feat: Save generation args in repo metadata

### DIFF
--- a/gapic-generator-cloud/lib/gapic/presenters/cloud_gem_presenter.rb
+++ b/gapic-generator-cloud/lib/gapic/presenters/cloud_gem_presenter.rb
@@ -76,6 +76,22 @@ module Gapic
         end
         desc
       end
+
+      ##
+      # Returns a hash of extra generator arguments to be rendered into the
+      # repo-metadata.json file.
+      #
+      def generator_args_for_metadata
+        result = {}
+        result["ruby-cloud-description"] = description
+        result["ruby-cloud-env-prefix"] = env_prefix
+        result["ruby-cloud-product-url"] = product_documentation_url if product_documentation_url
+        path_overrides = @api.overrides_of(:file_path).map { |k, v| "#{k}=#{v}" }.join ";"
+        result["ruby-cloud-path-override"] = path_overrides unless path_overrides.empty?
+        namespace_overrides = @api.overrides_of(:namespace).map { |k, v| "#{k}=#{v}" }.join ";"
+        result["ruby-cloud-namespace-override"] = namespace_overrides unless namespace_overrides.empty?
+        result
+      end
     end
 
     def self.cloud_gem_presenter api

--- a/gapic-generator-cloud/templates/cloud/gem/repo-metadata.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/repo-metadata.erb
@@ -18,5 +18,8 @@
 <%- end -%>
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": <%= !gem.free_tier? %>,
+<%- gem.generator_args_for_metadata.each do |key, val| -%>
+    <%= key.inspect %>: <%= val.inspect %>,
+<%- end -%>
     "library_type": "GAPIC_AUTO"
 }

--- a/gapic-generator/lib/gapic/schema/api.rb
+++ b/gapic-generator/lib/gapic/schema/api.rb
@@ -89,7 +89,7 @@ module Gapic
         matching_files.first
       end
 
-      def overrides_of(key)
+      def overrides_of key
         configuration&.fetch(:overrides, nil)&.fetch(key, nil) || {}
       end
 

--- a/gapic-generator/lib/gapic/schema/api.rb
+++ b/gapic-generator/lib/gapic/schema/api.rb
@@ -89,6 +89,10 @@ module Gapic
         matching_files.first
       end
 
+      def overrides_of(key)
+        configuration&.fetch(:overrides, nil)&.fetch(key, nil) || {}
+      end
+
       def fix_file_path str
         str = String str
         return str if configuration[:overrides].nil?

--- a/shared/output/cloud/compute_small/.repo-metadata.json
+++ b/shared/output/cloud/compute_small/.repo-metadata.json
@@ -5,5 +5,7 @@
     "name_pretty": "Google Cloud Compute V1 API",
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
+    "ruby-cloud-description": "google-cloud-compute-v1 is the official client library for the Google Cloud Compute V1 API. This library is considered to be in alpha. This means it is still a work-in-progress and under active development. Any release is subject to backwards-incompatible changes at any time.",
+    "ruby-cloud-env-prefix": "COMPUTE",
     "library_type": "GAPIC_AUTO"
 }

--- a/shared/output/cloud/language_v1/.repo-metadata.json
+++ b/shared/output/cloud/language_v1/.repo-metadata.json
@@ -5,5 +5,7 @@
     "name_pretty": "Google Cloud Language V1 API",
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
+    "ruby-cloud-description": "google-cloud-language-v1 is the official client library for the Google Cloud Language V1 API. Note that google-cloud-language-v1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-language instead. See the readme for more details.",
+    "ruby-cloud-env-prefix": "LANGUAGE",
     "library_type": "GAPIC_AUTO"
 }

--- a/shared/output/cloud/language_v1beta1/.repo-metadata.json
+++ b/shared/output/cloud/language_v1beta1/.repo-metadata.json
@@ -5,5 +5,7 @@
     "name_pretty": "Google Cloud Language V1beta1 API",
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
+    "ruby-cloud-description": "google-cloud-language-v1beta1 is the official client library for the Google Cloud Language V1beta1 API. Note that google-cloud-language-v1beta1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-language-wrapper-override instead. See the readme for more details.",
+    "ruby-cloud-env-prefix": "LANGUAGE",
     "library_type": "GAPIC_AUTO"
 }

--- a/shared/output/cloud/language_v1beta2/.repo-metadata.json
+++ b/shared/output/cloud/language_v1beta2/.repo-metadata.json
@@ -5,5 +5,7 @@
     "name_pretty": "Google Cloud Language V1beta2 API",
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
+    "ruby-cloud-description": "google-cloud-language-v1beta2 is the official client library for the Google Cloud Language V1beta2 API.",
+    "ruby-cloud-env-prefix": "LANGUAGE",
     "library_type": "GAPIC_AUTO"
 }

--- a/shared/output/cloud/noservice/.repo-metadata.json
+++ b/shared/output/cloud/noservice/.repo-metadata.json
@@ -5,5 +5,7 @@
     "name_pretty": "Google Garbage Noservice API",
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
+    "ruby-cloud-description": "google-garbage-noservice is the official client library for the Google Garbage Noservice API. Note that google-garbage-noservice is a version-specific client library. For most uses, we recommend installing the main client library google-garbage-noservice-wrapper instead. See the readme for more details.",
+    "ruby-cloud-env-prefix": "NOSERVICE",
     "library_type": "GAPIC_AUTO"
 }

--- a/shared/output/cloud/secretmanager_v1beta1/.repo-metadata.json
+++ b/shared/output/cloud/secretmanager_v1beta1/.repo-metadata.json
@@ -5,5 +5,7 @@
     "name_pretty": "Secret Manager V1beta1 API",
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
+    "ruby-cloud-description": "google-cloud-secret_manager-v1beta1 is the official client library for the Secret Manager V1beta1 API. Note that google-cloud-secret_manager-v1beta1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-secret_manager instead. See the readme for more details.",
+    "ruby-cloud-env-prefix": "SECRET_MANAGER",
     "library_type": "GAPIC_AUTO"
 }

--- a/shared/output/cloud/secretmanager_wrapper/.repo-metadata.json
+++ b/shared/output/cloud/secretmanager_wrapper/.repo-metadata.json
@@ -7,5 +7,8 @@
     "product_documentation": "https://cloud.google.com/secret-manager/docs",
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
+    "ruby-cloud-description": "google-cloud-secret_manager is the official client library for the Secret Manager API.",
+    "ruby-cloud-env-prefix": "SECRET_MANAGER",
+    "ruby-cloud-product-url": "https://cloud.google.com/secret-manager/docs",
     "library_type": "GAPIC_AUTO"
 }

--- a/shared/output/cloud/speech_v1/.repo-metadata.json
+++ b/shared/output/cloud/speech_v1/.repo-metadata.json
@@ -5,5 +5,7 @@
     "name_pretty": "Google Cloud Speech V1 API",
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
+    "ruby-cloud-description": "google-cloud-speech-v1 is the official client library for the Google Cloud Speech V1 API. Note that google-cloud-speech-v1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-speech instead. See the readme for more details.",
+    "ruby-cloud-env-prefix": "SPEECH",
     "library_type": "GAPIC_AUTO"
 }

--- a/shared/output/cloud/vision_v1/.repo-metadata.json
+++ b/shared/output/cloud/vision_v1/.repo-metadata.json
@@ -5,5 +5,7 @@
     "name_pretty": "Google Cloud Vision V1 API",
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
+    "ruby-cloud-description": "google-cloud-vision-v1 is the official client library for the Google Cloud Vision V1 API. Note that google-cloud-vision-v1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-vision instead. See the readme for more details.",
+    "ruby-cloud-env-prefix": "VISION",
     "library_type": "GAPIC_AUTO"
 }


### PR DESCRIPTION
This will make it easier to generate the synth files for wrapper libraries, by ensuring that all the original gapic library's generator_args are present in one form or another in the repo-metadata file.

Note: depends on #607 . Tests will not pass until that PR is merged.