### PR TITLE
fix: Ensure String and Hash are in the global scope

### DIFF
--- a/gapic-generator/templates/default/service/client/_client.erb
+++ b/gapic-generator/templates/default/service/client/_client.erb
@@ -104,7 +104,7 @@ class <%= service.client_name %>
                              !@config.endpoint.split(".").first.include?("-")
     credentials ||= Credentials.default scope: @config.scope,
                                         enable_self_signed_jwt: enable_self_signed_jwt
-    if credentials.is_a?(String) || credentials.is_a?(Hash)
+    if credentials.is_a?(::String) || credentials.is_a?(::Hash)
       credentials = Credentials.new credentials, scope: @config.scope
     end
     <%- end -%>

--- a/gapic-generator/templates/default/service/client/_operations.erb
+++ b/gapic-generator/templates/default/service/client/_operations.erb
@@ -61,7 +61,7 @@ class <%= service.operations_name %>
     # Create credentials
     credentials = @config.credentials
     credentials ||= Credentials.default scope: @config.scope
-    if credentials.is_a?(String) || credentials.is_a?(Hash)
+    if credentials.is_a?(::String) || credentials.is_a?(::Hash)
       credentials = Credentials.new credentials, scope: @config.scope
     end
     @quota_project_id = @config.quota_project

--- a/gapic-generator/templates/default/service/rest/client/_client.erb
+++ b/gapic-generator/templates/default/service/rest/client/_client.erb
@@ -97,7 +97,7 @@ class <%= service.rest.client_name %>
     credentials = @config.credentials
     <%- unless service.generic_endpoint? -%>
     credentials ||= Credentials.default scope: @config.scope
-    if credentials.is_a?(String) || credentials.is_a?(Hash)
+    if credentials.is_a?(::String) || credentials.is_a?(::Hash)
       credentials = Credentials.new credentials, scope: @config.scope
     end
     <%- end -%>

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/client.rb
@@ -127,7 +127,7 @@ module Google
                                          !@config.endpoint.split(".").first.include?("-")
                 credentials ||= Credentials.default scope: @config.scope,
                                                     enable_self_signed_jwt: enable_self_signed_jwt
-                if credentials.is_a?(String) || credentials.is_a?(Hash)
+                if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                   credentials = Credentials.new credentials, scope: @config.scope
                 end
                 @quota_project_id = @config.quota_project

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/client.rb
@@ -128,7 +128,7 @@ module Google
                 # Create credentials
                 credentials = @config.credentials
                 credentials ||= Credentials.default scope: @config.scope
-                if credentials.is_a?(String) || credentials.is_a?(Hash)
+                if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                   credentials = Credentials.new credentials, scope: @config.scope
                 end
 

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/client.rb
@@ -126,7 +126,7 @@ module Google
                 # Create credentials
                 credentials = @config.credentials
                 credentials ||= Credentials.default scope: @config.scope
-                if credentials.is_a?(String) || credentials.is_a?(Hash)
+                if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                   credentials = Credentials.new credentials, scope: @config.scope
                 end
 

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/client.rb
@@ -126,7 +126,7 @@ module Google
                 # Create credentials
                 credentials = @config.credentials
                 credentials ||= Credentials.default scope: @config.scope
-                if credentials.is_a?(String) || credentials.is_a?(Hash)
+                if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                   credentials = Credentials.new credentials, scope: @config.scope
                 end
 

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest/client.rb
@@ -126,7 +126,7 @@ module Google
                 # Create credentials
                 credentials = @config.credentials
                 credentials ||= Credentials.default scope: @config.scope
-                if credentials.is_a?(String) || credentials.is_a?(Hash)
+                if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                   credentials = Credentials.new credentials, scope: @config.scope
                 end
 

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
@@ -162,7 +162,7 @@ module Google
                                        !@config.endpoint.split(".").first.include?("-")
               credentials ||= Credentials.default scope: @config.scope,
                                                   enable_self_signed_jwt: enable_self_signed_jwt
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
+              if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
               @quota_project_id = @config.quota_project

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -132,7 +132,7 @@ module Google
                                        !@config.endpoint.split(".").first.include?("-")
               credentials ||= Credentials.default scope: @config.scope,
                                                   enable_self_signed_jwt: enable_self_signed_jwt
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
+              if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
               @quota_project_id = @config.quota_project

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -132,7 +132,7 @@ module Google
                                        !@config.endpoint.split(".").first.include?("-")
               credentials ||= Credentials.default scope: @config.scope,
                                                   enable_self_signed_jwt: enable_self_signed_jwt
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
+              if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
               @quota_project_id = @config.quota_project

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -139,7 +139,7 @@ module Google
                                        !@config.endpoint.split(".").first.include?("-")
               credentials ||= Credentials.default scope: @config.scope,
                                                   enable_self_signed_jwt: enable_self_signed_jwt
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
+              if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
               @quota_project_id = @config.quota_project

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -131,7 +131,7 @@ module Google
                                        !@config.endpoint.split(".").first.include?("-")
               credentials ||= Credentials.default scope: @config.scope,
                                                   enable_self_signed_jwt: enable_self_signed_jwt
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
+              if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
               @quota_project_id = @config.quota_project

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -82,7 +82,7 @@ module Google
               # Create credentials
               credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
+              if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
               @quota_project_id = @config.quota_project

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -135,7 +135,7 @@ module Google
                                        !@config.endpoint.split(".").first.include?("-")
               credentials ||= Credentials.default scope: @config.scope,
                                                   enable_self_signed_jwt: enable_self_signed_jwt
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
+              if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
               @quota_project_id = @config.quota_project

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -82,7 +82,7 @@ module Google
               # Create credentials
               credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
+              if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
               @quota_project_id = @config.quota_project

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -146,7 +146,7 @@ module Google
                                        !@config.endpoint.split(".").first.include?("-")
               credentials ||= Credentials.default scope: @config.scope,
                                                   enable_self_signed_jwt: enable_self_signed_jwt
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
+              if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
               @quota_project_id = @config.quota_project

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -82,7 +82,7 @@ module Google
               # Create credentials
               credentials = @config.credentials
               credentials ||= Credentials.default scope: @config.scope
-              if credentials.is_a?(String) || credentials.is_a?(Hash)
+              if credentials.is_a?(::String) || credentials.is_a?(::Hash)
                 credentials = Credentials.new credentials, scope: @config.scope
               end
               @quota_project_id = @config.quota_project

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -132,7 +132,7 @@ module So
                                      !@config.endpoint.split(".").first.include?("-")
             credentials ||= Credentials.default scope: @config.scope,
                                                 enable_self_signed_jwt: enable_self_signed_jwt
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
+            if credentials.is_a?(::String) || credentials.is_a?(::Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
             @quota_project_id = @config.quota_project

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -89,7 +89,7 @@ module So
             # Create credentials
             credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
+            if credentials.is_a?(::String) || credentials.is_a?(::Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
             @quota_project_id = @config.quota_project

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/client.rb
@@ -154,7 +154,7 @@ module So
                                      !@config.endpoint.split(".").first.include?("-")
             credentials ||= Credentials.default scope: @config.scope,
                                                 enable_self_signed_jwt: enable_self_signed_jwt
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
+            if credentials.is_a?(::String) || credentials.is_a?(::Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
             @quota_project_id = @config.quota_project

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/really_renamed_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/really_renamed_service/client.rb
@@ -128,7 +128,7 @@ module So
                                      !@config.endpoint.split(".").first.include?("-")
             credentials ||= Credentials.default scope: @config.scope,
                                                 enable_self_signed_jwt: enable_self_signed_jwt
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
+            if credentials.is_a?(::String) || credentials.is_a?(::Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
             @quota_project_id = @config.quota_project

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/client.rb
@@ -132,7 +132,7 @@ module So
                                      !@config.endpoint.split(".").first.include?("-")
             credentials ||= Credentials.default scope: @config.scope,
                                                 enable_self_signed_jwt: enable_self_signed_jwt
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
+            if credentials.is_a?(::String) || credentials.is_a?(::Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
             @quota_project_id = @config.quota_project

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/client.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/client.rb
@@ -127,7 +127,7 @@ module Testing
                                    !@config.endpoint.split(".").first.include?("-")
           credentials ||= Credentials.default scope: @config.scope,
                                               enable_self_signed_jwt: enable_self_signed_jwt
-          if credentials.is_a?(String) || credentials.is_a?(Hash)
+          if credentials.is_a?(::String) || credentials.is_a?(::Hash)
             credentials = Credentials.new credentials, scope: @config.scope
           end
           @quota_project_id = @config.quota_project

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/client.rb
@@ -137,7 +137,7 @@ module Testing
                                    !@config.endpoint.split(".").first.include?("-")
           credentials ||= Credentials.default scope: @config.scope,
                                               enable_self_signed_jwt: enable_self_signed_jwt
-          if credentials.is_a?(String) || credentials.is_a?(Hash)
+          if credentials.is_a?(::String) || credentials.is_a?(::Hash)
             credentials = Credentials.new credentials, scope: @config.scope
           end
           @quota_project_id = @config.quota_project

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -134,7 +134,7 @@ module Google
                                      !@config.endpoint.split(".").first.include?("-")
             credentials ||= Credentials.default scope: @config.scope,
                                                 enable_self_signed_jwt: enable_self_signed_jwt
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
+            if credentials.is_a?(::String) || credentials.is_a?(::Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
             @quota_project_id = @config.quota_project

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -89,7 +89,7 @@ module Google
             # Create credentials
             credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
+            if credentials.is_a?(::String) || credentials.is_a?(::Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
             @quota_project_id = @config.quota_project

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -132,7 +132,7 @@ module Google
                                      !@config.endpoint.split(".").first.include?("-")
             credentials ||= Credentials.default scope: @config.scope,
                                                 enable_self_signed_jwt: enable_self_signed_jwt
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
+            if credentials.is_a?(::String) || credentials.is_a?(::Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
             @quota_project_id = @config.quota_project

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -135,7 +135,7 @@ module Google
                                      !@config.endpoint.split(".").first.include?("-")
             credentials ||= Credentials.default scope: @config.scope,
                                                 enable_self_signed_jwt: enable_self_signed_jwt
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
+            if credentials.is_a?(::String) || credentials.is_a?(::Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
             @quota_project_id = @config.quota_project

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -89,7 +89,7 @@ module Google
             # Create credentials
             credentials = @config.credentials
             credentials ||= Credentials.default scope: @config.scope
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
+            if credentials.is_a?(::String) || credentials.is_a?(::Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
             @quota_project_id = @config.quota_project

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -133,7 +133,7 @@ module Google
                                      !@config.endpoint.split(".").first.include?("-")
             credentials ||= Credentials.default scope: @config.scope,
                                                 enable_self_signed_jwt: enable_self_signed_jwt
-            if credentials.is_a?(String) || credentials.is_a?(Hash)
+            if credentials.is_a?(::String) || credentials.is_a?(::Hash)
               credentials = Credentials.new credentials, scope: @config.scope
             end
             @quota_project_id = @config.quota_project


### PR DESCRIPTION
Fully qualifies some references to the standard `String` and `Hash` classes to handle the case where a generated client creates its own classes of one of those names. See https://github.com/googleapis/google-cloud-ruby/issues/11665