### PR TITLE
fix: Allow generation of libraries with no custom env prefix

### DIFF
--- a/gapic-generator-cloud/lib/gapic/presenters/cloud_gem_presenter.rb
+++ b/gapic-generator-cloud/lib/gapic/presenters/cloud_gem_presenter.rb
@@ -77,6 +77,10 @@ module Gapic
         desc
       end
 
+      def env_prefix!
+        env_prefix || "GOOGLE_CLOUD"
+      end
+
       ##
       # Returns a hash of extra generator arguments to be rendered into the
       # repo-metadata.json file.
@@ -84,7 +88,7 @@ module Gapic
       def generator_args_for_metadata
         result = {}
         result["ruby-cloud-description"] = description
-        result["ruby-cloud-env-prefix"] = env_prefix
+        result["ruby-cloud-env-prefix"] = env_prefix if env_prefix
         result["ruby-cloud-product-url"] = product_documentation_url if product_documentation_url
         path_overrides = @api.overrides_of(:file_path).map { |k, v| "#{k}=#{v}" }.join ";"
         result["ruby-cloud-path-override"] = path_overrides unless path_overrides.empty?

--- a/gapic-generator-cloud/lib/gapic/presenters/cloud_gem_presenter.rb
+++ b/gapic-generator-cloud/lib/gapic/presenters/cloud_gem_presenter.rb
@@ -77,7 +77,7 @@ module Gapic
         desc
       end
 
-      def env_prefix!
+      def cloud_env_prefix
         env_prefix || "GOOGLE_CLOUD"
       end
 

--- a/gapic-generator-cloud/templates/cloud/gem/authentication.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/authentication.erb
@@ -22,7 +22,7 @@ during development.
 2. Set the [environment variable](#environment-variables).
 
 ```sh
-export <%= gem.env_prefix %>_CREDENTIALS=path/to/keyfile.json
+export <%= gem.env_prefix! %>_CREDENTIALS=path/to/keyfile.json
 ```
 
 3. Initialize the client.
@@ -69,16 +69,18 @@ The environment variables that <%= gem.name %>
 checks for credentials are configured on the service Credentials class (such as
 <%= service.credentials_class_xref %>):
 
-1. `<%= gem.env_prefix %>_CREDENTIALS` - Path to JSON file, or JSON contents
-2. `<%= gem.env_prefix %>_KEYFILE` - Path to JSON file, or JSON contents
-3. `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
-4. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
-5. `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
+<%- if gem.env_prefix -%>
+* `<%= gem.env_prefix %>_CREDENTIALS` - Path to JSON file, or JSON contents
+* `<%= gem.env_prefix %>_KEYFILE` - Path to JSON file, or JSON contents
+<%- end -%>
+* `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
 
 ```ruby
 require "<%= gem.entrypoint_require %>"
 
-ENV["<%= gem.env_prefix %>_CREDENTIALS"] = "path/to/keyfile.json"
+ENV["<%= gem.env_prefix! %>_CREDENTIALS"] = "path/to/keyfile.json"
 
 client = <%= service.create_client_call %>
 ```

--- a/gapic-generator-cloud/templates/cloud/gem/authentication.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/authentication.erb
@@ -22,7 +22,7 @@ during development.
 2. Set the [environment variable](#environment-variables).
 
 ```sh
-export <%= gem.env_prefix! %>_CREDENTIALS=path/to/keyfile.json
+export <%= gem.cloud_env_prefix %>_CREDENTIALS=path/to/keyfile.json
 ```
 
 3. Initialize the client.
@@ -80,7 +80,7 @@ checks for credentials are configured on the service Credentials class (such as
 ```ruby
 require "<%= gem.entrypoint_require %>"
 
-ENV["<%= gem.env_prefix! %>_CREDENTIALS"] = "path/to/keyfile.json"
+ENV["<%= gem.cloud_env_prefix %>_CREDENTIALS"] = "path/to/keyfile.json"
 
 client = <%= service.create_client_call %>
 ```

--- a/gapic-generator-cloud/templates/cloud/gem/rakefile.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/rakefile.erb
@@ -56,29 +56,29 @@ task :acceptance, :project, :keyfile do |t, args|
   <%- if service && !gem.generic_endpoint? -%>
   project = args[:project]
   project ||=
-    ENV["<%= gem.env_prefix! %>_TEST_PROJECT"] ||
+    ENV["<%= gem.cloud_env_prefix %>_TEST_PROJECT"] ||
     ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||=
-    ENV["<%= gem.env_prefix! %>_TEST_KEYFILE"] ||
+    ENV["<%= gem.cloud_env_prefix %>_TEST_KEYFILE"] ||
     ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
     keyfile ||=
-      ENV["<%= gem.env_prefix! %>_TEST_KEYFILE_JSON"] ||
+      ENV["<%= gem.cloud_env_prefix %>_TEST_KEYFILE_JSON"] ||
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or <%= gem.env_prefix! %>_TEST_PROJECT=test123 <%= gem.env_prefix! %>_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or <%= gem.cloud_env_prefix %>_TEST_PROJECT=test123 <%= gem.cloud_env_prefix %>_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   require "<%= service.credentials_require %>"
   <%= service.credentials_name_full %>.env_vars.each do |path|
     ENV[path] = nil
   end
-  ENV["<%= gem.env_prefix! %>_PROJECT"] = project
-  ENV["<%= gem.env_prefix! %>_TEST_PROJECT"] = project
-  ENV["<%= gem.env_prefix! %>_KEYFILE_JSON"] = keyfile
+  ENV["<%= gem.cloud_env_prefix %>_PROJECT"] = project
+  ENV["<%= gem.cloud_env_prefix %>_TEST_PROJECT"] = project
+  ENV["<%= gem.cloud_env_prefix %>_KEYFILE_JSON"] = keyfile
 
   <%- end -%>
   Rake::Task["acceptance:run"].invoke

--- a/gapic-generator-cloud/templates/cloud/gem/rakefile.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/rakefile.erb
@@ -56,29 +56,29 @@ task :acceptance, :project, :keyfile do |t, args|
   <%- if service && !gem.generic_endpoint? -%>
   project = args[:project]
   project ||=
-    ENV["<%= gem.env_prefix %>_TEST_PROJECT"] ||
+    ENV["<%= gem.env_prefix! %>_TEST_PROJECT"] ||
     ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||=
-    ENV["<%= gem.env_prefix %>_TEST_KEYFILE"] ||
+    ENV["<%= gem.env_prefix! %>_TEST_KEYFILE"] ||
     ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
     keyfile ||=
-      ENV["<%= gem.env_prefix %>_TEST_KEYFILE_JSON"] ||
+      ENV["<%= gem.env_prefix! %>_TEST_KEYFILE_JSON"] ||
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or <%= gem.env_prefix %>_TEST_PROJECT=test123 <%= gem.env_prefix %>_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or <%= gem.env_prefix! %>_TEST_PROJECT=test123 <%= gem.env_prefix! %>_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   require "<%= service.credentials_require %>"
   <%= service.credentials_name_full %>.env_vars.each do |path|
     ENV[path] = nil
   end
-  ENV["<%= gem.env_prefix %>_PROJECT"] = project
-  ENV["<%= gem.env_prefix %>_TEST_PROJECT"] = project
-  ENV["<%= gem.env_prefix %>_KEYFILE_JSON"] = keyfile
+  ENV["<%= gem.env_prefix! %>_PROJECT"] = project
+  ENV["<%= gem.env_prefix! %>_TEST_PROJECT"] = project
+  ENV["<%= gem.env_prefix! %>_KEYFILE_JSON"] = keyfile
 
   <%- end -%>
   Rake::Task["acceptance:run"].invoke

--- a/gapic-generator-cloud/templates/cloud/service/client/_credentials.erb
+++ b/gapic-generator-cloud/templates/cloud/service/client/_credentials.erb
@@ -13,13 +13,17 @@ class <%= service.credentials_name %> < ::Google::Auth::Credentials
   ]
   <%- end -%>
   self.env_vars = [
+    <%- if service.gem.env_prefix -%>
     "<%= service.gem.env_prefix %>_CREDENTIALS",
     "<%= service.gem.env_prefix %>_KEYFILE",
+    <%- end -%>
     "GOOGLE_CLOUD_CREDENTIALS",
     "GOOGLE_CLOUD_KEYFILE",
     "GCLOUD_KEYFILE",
+    <%- if service.gem.env_prefix -%>
     "<%= service.gem.env_prefix %>_CREDENTIALS_JSON",
     "<%= service.gem.env_prefix %>_KEYFILE_JSON",
+    <%- end -%>
     "GOOGLE_CLOUD_CREDENTIALS_JSON",
     "GOOGLE_CLOUD_KEYFILE_JSON",
     "GCLOUD_KEYFILE_JSON"

--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/rakefile.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/rakefile.erb
@@ -56,29 +56,29 @@ desc "Run the <%= gem.name %> acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||=
-    ENV["<%= gem.env_prefix %>_TEST_PROJECT"] ||
+    ENV["<%= gem.env_prefix! %>_TEST_PROJECT"] ||
     ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||=
-    ENV["<%= gem.env_prefix %>_TEST_KEYFILE"] ||
+    ENV["<%= gem.env_prefix! %>_TEST_KEYFILE"] ||
     ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
     keyfile ||=
-      ENV["<%= gem.env_prefix %>_TEST_KEYFILE_JSON"] ||
+      ENV["<%= gem.env_prefix! %>_TEST_KEYFILE_JSON"] ||
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or <%= gem.env_prefix %>_TEST_PROJECT=test123 <%= gem.env_prefix %>_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or <%= gem.env_prefix! %>_TEST_PROJECT=test123 <%= gem.env_prefix! %>_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   require "<%= service.credentials_require %>"
   <%= service.credentials_name_full %>.env_vars.each do |path|
     ENV[path] = nil
   end
-  ENV["<%= gem.env_prefix %>_PROJECT"] = project
-  ENV["<%= gem.env_prefix %>_TEST_PROJECT"] = project
-  ENV["<%= gem.env_prefix %>_KEYFILE_JSON"] = keyfile
+  ENV["<%= gem.env_prefix! %>_PROJECT"] = project
+  ENV["<%= gem.env_prefix! %>_TEST_PROJECT"] = project
+  ENV["<%= gem.env_prefix! %>_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
 end

--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/rakefile.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/rakefile.erb
@@ -56,29 +56,29 @@ desc "Run the <%= gem.name %> acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||=
-    ENV["<%= gem.env_prefix! %>_TEST_PROJECT"] ||
+    ENV["<%= gem.cloud_env_prefix %>_TEST_PROJECT"] ||
     ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||=
-    ENV["<%= gem.env_prefix! %>_TEST_KEYFILE"] ||
+    ENV["<%= gem.cloud_env_prefix %>_TEST_KEYFILE"] ||
     ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
     keyfile ||=
-      ENV["<%= gem.env_prefix! %>_TEST_KEYFILE_JSON"] ||
+      ENV["<%= gem.cloud_env_prefix %>_TEST_KEYFILE_JSON"] ||
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or <%= gem.env_prefix! %>_TEST_PROJECT=test123 <%= gem.env_prefix! %>_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or <%= gem.cloud_env_prefix %>_TEST_PROJECT=test123 <%= gem.cloud_env_prefix %>_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   require "<%= service.credentials_require %>"
   <%= service.credentials_name_full %>.env_vars.each do |path|
     ENV[path] = nil
   end
-  ENV["<%= gem.env_prefix! %>_PROJECT"] = project
-  ENV["<%= gem.env_prefix! %>_TEST_PROJECT"] = project
-  ENV["<%= gem.env_prefix! %>_KEYFILE_JSON"] = keyfile
+  ENV["<%= gem.cloud_env_prefix %>_PROJECT"] = project
+  ENV["<%= gem.cloud_env_prefix %>_TEST_PROJECT"] = project
+  ENV["<%= gem.cloud_env_prefix %>_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
 end

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -127,11 +127,7 @@ module Gapic
       end
 
       def env_prefix
-        prefix = gem_config(:env_prefix) || begin
-          segs = name.split("-").reverse
-          segs.find { |seg| seg !~ /^v\d/ } || segs.first || "UNKNOWN"
-        end
-        prefix.upcase
+        gem_config(:env_prefix)&.upcase
       end
 
       def iam_dependency?

--- a/gapic-generator/templates/default/service/client/_credentials.erb
+++ b/gapic-generator/templates/default/service/client/_credentials.erb
@@ -12,10 +12,12 @@ class <%= service.credentials_name %> < ::Google::Auth::Credentials
   <%- end -%>
   ]
   <%- end -%>
+  <%- if service.gem.env_prefix -%>
   self.env_vars = [
     "<%= service.gem.env_prefix %>_CREDENTIALS",
     "<%= service.gem.env_prefix %>_KEYFILE",
     "<%= service.gem.env_prefix %>_CREDENTIALS_JSON",
     "<%= service.gem.env_prefix %>_KEYFILE_JSON"
   ]
+  <%- end -%>
 end

--- a/gapic-generator/test/gapic/presenters/gem/garbage_test.rb
+++ b/gapic-generator/test/gapic/presenters/gem/garbage_test.rb
@@ -35,7 +35,7 @@ class GarbageGemPresenterTest < PresenterTest
     assert_equal "google-garbage is the official client library for the Google Garbage API.", presenter.description
     assert_equal "API Client library for the Google Garbage API", presenter.summary
     assert_equal "https://github.com/googleapis/googleapis", presenter.homepage
-    assert_equal "GARBAGE", presenter.env_prefix
+    assert_nil presenter.env_prefix
 
     assert_equal ["endless.trash.forever"], presenter.packages.map(&:name)
     presenter.packages.each { |pp| assert_kind_of Gapic::Presenters::PackagePresenter, pp }

--- a/shared/config/language_v1.yml
+++ b/shared/config/language_v1.yml
@@ -1,7 +1,6 @@
 ---
 :gem:
   :name: "google-cloud-language-v1"
-  :env_prefix: LANGUAGE
 :defaults:
   :service:
     :default_host: "language.googleapis.com"

--- a/shared/config/showcase.yml
+++ b/shared/config/showcase.yml
@@ -1,5 +1,6 @@
 ---
 :gem:
   :name: google-showcase
+  :env_prefix: SHOWCASE
 :generate_metadata: true
 :generate_standalone_snippets: true

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/credentials.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v1/services/campaign_service/credentials.rb
@@ -26,12 +26,6 @@ module Google
           module CampaignService
             # Credentials for the CampaignService API.
             class Credentials < ::Google::Auth::Credentials
-              self.env_vars = [
-                "GOOGLEADS_CREDENTIALS",
-                "GOOGLEADS_KEYFILE",
-                "GOOGLEADS_CREDENTIALS_JSON",
-                "GOOGLEADS_KEYFILE_JSON"
-              ]
             end
           end
         end

--- a/shared/output/cloud/compute_small/.repo-metadata.json
+++ b/shared/output/cloud/compute_small/.repo-metadata.json
@@ -6,6 +6,5 @@
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
     "ruby-cloud-description": "google-cloud-compute-v1 is the official client library for the Google Cloud Compute V1 API. This library is considered to be in alpha. This means it is still a work-in-progress and under active development. Any release is subject to backwards-incompatible changes at any time.",
-    "ruby-cloud-env-prefix": "COMPUTE",
     "library_type": "GAPIC_AUTO"
 }

--- a/shared/output/cloud/compute_small/AUTHENTICATION.md
+++ b/shared/output/cloud/compute_small/AUTHENTICATION.md
@@ -19,7 +19,7 @@ during development.
 2. Set the [environment variable](#environment-variables).
 
 ```sh
-export COMPUTE_CREDENTIALS=path/to/keyfile.json
+export GOOGLE_CLOUD_CREDENTIALS=path/to/keyfile.json
 ```
 
 3. Initialize the client.
@@ -66,16 +66,14 @@ The environment variables that google-cloud-compute-v1
 checks for credentials are configured on the service Credentials class (such as
 {::Google::Cloud::Compute::V1::Addresses::Credentials}):
 
-1. `COMPUTE_CREDENTIALS` - Path to JSON file, or JSON contents
-2. `COMPUTE_KEYFILE` - Path to JSON file, or JSON contents
-3. `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
-4. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
-5. `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
+* `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
 
 ```ruby
 require "google/cloud/compute/v1"
 
-ENV["COMPUTE_CREDENTIALS"] = "path/to/keyfile.json"
+ENV["GOOGLE_CLOUD_CREDENTIALS"] = "path/to/keyfile.json"
 
 client = ::Google::Cloud::Compute::V1::Addresses::Client.new
 ```

--- a/shared/output/cloud/compute_small/Rakefile
+++ b/shared/output/cloud/compute_small/Rakefile
@@ -69,29 +69,29 @@ desc "Run the google-cloud-compute-v1 acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||=
-    ENV["COMPUTE_TEST_PROJECT"] ||
+    ENV["GOOGLE_CLOUD_TEST_PROJECT"] ||
     ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||=
-    ENV["COMPUTE_TEST_KEYFILE"] ||
+    ENV["GOOGLE_CLOUD_TEST_KEYFILE"] ||
     ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
     keyfile ||=
-      ENV["COMPUTE_TEST_KEYFILE_JSON"] ||
+      ENV["GOOGLE_CLOUD_TEST_KEYFILE_JSON"] ||
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or COMPUTE_TEST_PROJECT=test123 COMPUTE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or GOOGLE_CLOUD_TEST_PROJECT=test123 GOOGLE_CLOUD_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   require "google/cloud/compute/v1/addresses/credentials"
   ::Google::Cloud::Compute::V1::Addresses::Credentials.env_vars.each do |path|
     ENV[path] = nil
   end
-  ENV["COMPUTE_PROJECT"] = project
-  ENV["COMPUTE_TEST_PROJECT"] = project
-  ENV["COMPUTE_KEYFILE_JSON"] = keyfile
+  ENV["GOOGLE_CLOUD_PROJECT"] = project
+  ENV["GOOGLE_CLOUD_TEST_PROJECT"] = project
+  ENV["GOOGLE_CLOUD_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
 end

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/credentials.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/credentials.rb
@@ -30,13 +30,9 @@ module Google
               "https://www.googleapis.com/auth/cloud-platform"
             ]
             self.env_vars = [
-              "COMPUTE_CREDENTIALS",
-              "COMPUTE_KEYFILE",
               "GOOGLE_CLOUD_CREDENTIALS",
               "GOOGLE_CLOUD_KEYFILE",
               "GCLOUD_KEYFILE",
-              "COMPUTE_CREDENTIALS_JSON",
-              "COMPUTE_KEYFILE_JSON",
               "GOOGLE_CLOUD_CREDENTIALS_JSON",
               "GOOGLE_CLOUD_KEYFILE_JSON",
               "GCLOUD_KEYFILE_JSON"

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/credentials.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/credentials.rb
@@ -30,13 +30,9 @@ module Google
               "https://www.googleapis.com/auth/cloud-platform"
             ]
             self.env_vars = [
-              "COMPUTE_CREDENTIALS",
-              "COMPUTE_KEYFILE",
               "GOOGLE_CLOUD_CREDENTIALS",
               "GOOGLE_CLOUD_KEYFILE",
               "GCLOUD_KEYFILE",
-              "COMPUTE_CREDENTIALS_JSON",
-              "COMPUTE_KEYFILE_JSON",
               "GOOGLE_CLOUD_CREDENTIALS_JSON",
               "GOOGLE_CLOUD_KEYFILE_JSON",
               "GCLOUD_KEYFILE_JSON"

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/credentials.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/credentials.rb
@@ -30,13 +30,9 @@ module Google
               "https://www.googleapis.com/auth/cloud-platform"
             ]
             self.env_vars = [
-              "COMPUTE_CREDENTIALS",
-              "COMPUTE_KEYFILE",
               "GOOGLE_CLOUD_CREDENTIALS",
               "GOOGLE_CLOUD_KEYFILE",
               "GCLOUD_KEYFILE",
-              "COMPUTE_CREDENTIALS_JSON",
-              "COMPUTE_KEYFILE_JSON",
               "GOOGLE_CLOUD_CREDENTIALS_JSON",
               "GOOGLE_CLOUD_KEYFILE_JSON",
               "GCLOUD_KEYFILE_JSON"

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/credentials.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/credentials.rb
@@ -30,13 +30,9 @@ module Google
               "https://www.googleapis.com/auth/cloud-platform"
             ]
             self.env_vars = [
-              "COMPUTE_CREDENTIALS",
-              "COMPUTE_KEYFILE",
               "GOOGLE_CLOUD_CREDENTIALS",
               "GOOGLE_CLOUD_KEYFILE",
               "GCLOUD_KEYFILE",
-              "COMPUTE_CREDENTIALS_JSON",
-              "COMPUTE_KEYFILE_JSON",
               "GOOGLE_CLOUD_CREDENTIALS_JSON",
               "GOOGLE_CLOUD_KEYFILE_JSON",
               "GCLOUD_KEYFILE_JSON"

--- a/shared/output/cloud/language_v1/.repo-metadata.json
+++ b/shared/output/cloud/language_v1/.repo-metadata.json
@@ -6,6 +6,5 @@
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
     "ruby-cloud-description": "google-cloud-language-v1 is the official client library for the Google Cloud Language V1 API. Note that google-cloud-language-v1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-language instead. See the readme for more details.",
-    "ruby-cloud-env-prefix": "LANGUAGE",
     "library_type": "GAPIC_AUTO"
 }

--- a/shared/output/cloud/language_v1/AUTHENTICATION.md
+++ b/shared/output/cloud/language_v1/AUTHENTICATION.md
@@ -19,7 +19,7 @@ during development.
 2. Set the [environment variable](#environment-variables).
 
 ```sh
-export LANGUAGE_CREDENTIALS=path/to/keyfile.json
+export GOOGLE_CLOUD_CREDENTIALS=path/to/keyfile.json
 ```
 
 3. Initialize the client.
@@ -66,16 +66,14 @@ The environment variables that google-cloud-language-v1
 checks for credentials are configured on the service Credentials class (such as
 {::Google::Cloud::Language::V1::LanguageService::Credentials}):
 
-1. `LANGUAGE_CREDENTIALS` - Path to JSON file, or JSON contents
-2. `LANGUAGE_KEYFILE` - Path to JSON file, or JSON contents
-3. `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
-4. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
-5. `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
+* `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
 
 ```ruby
 require "google/cloud/language/v1"
 
-ENV["LANGUAGE_CREDENTIALS"] = "path/to/keyfile.json"
+ENV["GOOGLE_CLOUD_CREDENTIALS"] = "path/to/keyfile.json"
 
 client = ::Google::Cloud::Language::V1::LanguageService::Client.new
 ```

--- a/shared/output/cloud/language_v1/Rakefile
+++ b/shared/output/cloud/language_v1/Rakefile
@@ -69,29 +69,29 @@ desc "Run the google-cloud-language-v1 acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||=
-    ENV["LANGUAGE_TEST_PROJECT"] ||
+    ENV["GOOGLE_CLOUD_TEST_PROJECT"] ||
     ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||=
-    ENV["LANGUAGE_TEST_KEYFILE"] ||
+    ENV["GOOGLE_CLOUD_TEST_KEYFILE"] ||
     ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
     keyfile ||=
-      ENV["LANGUAGE_TEST_KEYFILE_JSON"] ||
+      ENV["GOOGLE_CLOUD_TEST_KEYFILE_JSON"] ||
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or LANGUAGE_TEST_PROJECT=test123 LANGUAGE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or GOOGLE_CLOUD_TEST_PROJECT=test123 GOOGLE_CLOUD_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   require "google/cloud/language/v1/language_service/credentials"
   ::Google::Cloud::Language::V1::LanguageService::Credentials.env_vars.each do |path|
     ENV[path] = nil
   end
-  ENV["LANGUAGE_PROJECT"] = project
-  ENV["LANGUAGE_TEST_PROJECT"] = project
-  ENV["LANGUAGE_KEYFILE_JSON"] = keyfile
+  ENV["GOOGLE_CLOUD_PROJECT"] = project
+  ENV["GOOGLE_CLOUD_TEST_PROJECT"] = project
+  ENV["GOOGLE_CLOUD_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
 end

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/credentials.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/credentials.rb
@@ -30,13 +30,9 @@ module Google
               "https://www.googleapis.com/auth/cloud-platform"
             ]
             self.env_vars = [
-              "LANGUAGE_CREDENTIALS",
-              "LANGUAGE_KEYFILE",
               "GOOGLE_CLOUD_CREDENTIALS",
               "GOOGLE_CLOUD_KEYFILE",
               "GCLOUD_KEYFILE",
-              "LANGUAGE_CREDENTIALS_JSON",
-              "LANGUAGE_KEYFILE_JSON",
               "GOOGLE_CLOUD_CREDENTIALS_JSON",
               "GOOGLE_CLOUD_KEYFILE_JSON",
               "GCLOUD_KEYFILE_JSON"

--- a/shared/output/cloud/language_v1beta1/AUTHENTICATION.md
+++ b/shared/output/cloud/language_v1beta1/AUTHENTICATION.md
@@ -66,11 +66,11 @@ The environment variables that google-cloud-language-v1beta1
 checks for credentials are configured on the service Credentials class (such as
 {::Google::Cloud::Language::V1beta1::LanguageService::Credentials}):
 
-1. `LANGUAGE_CREDENTIALS` - Path to JSON file, or JSON contents
-2. `LANGUAGE_KEYFILE` - Path to JSON file, or JSON contents
-3. `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
-4. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
-5. `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
+* `LANGUAGE_CREDENTIALS` - Path to JSON file, or JSON contents
+* `LANGUAGE_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
 
 ```ruby
 require "google/cloud/language/v1beta1"

--- a/shared/output/cloud/language_v1beta2/AUTHENTICATION.md
+++ b/shared/output/cloud/language_v1beta2/AUTHENTICATION.md
@@ -66,11 +66,11 @@ The environment variables that google-cloud-language-v1beta2
 checks for credentials are configured on the service Credentials class (such as
 {::Google::Cloud::Language::V1beta2::LanguageService::Credentials}):
 
-1. `LANGUAGE_CREDENTIALS` - Path to JSON file, or JSON contents
-2. `LANGUAGE_KEYFILE` - Path to JSON file, or JSON contents
-3. `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
-4. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
-5. `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
+* `LANGUAGE_CREDENTIALS` - Path to JSON file, or JSON contents
+* `LANGUAGE_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
 
 ```ruby
 require "google/cloud/language/v1beta2"

--- a/shared/output/cloud/noservice/.repo-metadata.json
+++ b/shared/output/cloud/noservice/.repo-metadata.json
@@ -6,6 +6,5 @@
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
     "ruby-cloud-description": "google-garbage-noservice is the official client library for the Google Garbage Noservice API. Note that google-garbage-noservice is a version-specific client library. For most uses, we recommend installing the main client library google-garbage-noservice-wrapper instead. See the readme for more details.",
-    "ruby-cloud-env-prefix": "NOSERVICE",
     "library_type": "GAPIC_AUTO"
 }

--- a/shared/output/cloud/secretmanager_v1beta1/AUTHENTICATION.md
+++ b/shared/output/cloud/secretmanager_v1beta1/AUTHENTICATION.md
@@ -66,11 +66,11 @@ The environment variables that google-cloud-secret_manager-v1beta1
 checks for credentials are configured on the service Credentials class (such as
 {::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Credentials}):
 
-1. `SECRET_MANAGER_CREDENTIALS` - Path to JSON file, or JSON contents
-2. `SECRET_MANAGER_KEYFILE` - Path to JSON file, or JSON contents
-3. `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
-4. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
-5. `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
+* `SECRET_MANAGER_CREDENTIALS` - Path to JSON file, or JSON contents
+* `SECRET_MANAGER_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
 
 ```ruby
 require "google/cloud/secret_manager/v1beta1"

--- a/shared/output/cloud/secretmanager_wrapper/AUTHENTICATION.md
+++ b/shared/output/cloud/secretmanager_wrapper/AUTHENTICATION.md
@@ -66,11 +66,11 @@ The environment variables that google-cloud-secret_manager
 checks for credentials are configured on the service Credentials class (such as
 `::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Credentials`):
 
-1. `SECRET_MANAGER_CREDENTIALS` - Path to JSON file, or JSON contents
-2. `SECRET_MANAGER_KEYFILE` - Path to JSON file, or JSON contents
-3. `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
-4. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
-5. `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
+* `SECRET_MANAGER_CREDENTIALS` - Path to JSON file, or JSON contents
+* `SECRET_MANAGER_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
 
 ```ruby
 require "google/cloud/secret_manager"

--- a/shared/output/cloud/speech_v1/AUTHENTICATION.md
+++ b/shared/output/cloud/speech_v1/AUTHENTICATION.md
@@ -66,11 +66,11 @@ The environment variables that google-cloud-speech-v1
 checks for credentials are configured on the service Credentials class (such as
 {::Google::Cloud::Speech::V1::Speech::Credentials}):
 
-1. `SPEECH_CREDENTIALS` - Path to JSON file, or JSON contents
-2. `SPEECH_KEYFILE` - Path to JSON file, or JSON contents
-3. `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
-4. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
-5. `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
+* `SPEECH_CREDENTIALS` - Path to JSON file, or JSON contents
+* `SPEECH_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
 
 ```ruby
 require "google/cloud/speech/v1"

--- a/shared/output/cloud/vision_v1/AUTHENTICATION.md
+++ b/shared/output/cloud/vision_v1/AUTHENTICATION.md
@@ -66,11 +66,11 @@ The environment variables that google-cloud-vision-v1
 checks for credentials are configured on the service Credentials class (such as
 {::Google::Cloud::Vision::V1::ProductSearch::Credentials}):
 
-1. `VISION_CREDENTIALS` - Path to JSON file, or JSON contents
-2. `VISION_KEYFILE` - Path to JSON file, or JSON contents
-3. `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
-4. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
-5. `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
+* `VISION_CREDENTIALS` - Path to JSON file, or JSON contents
+* `VISION_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
+* `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
+* `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
 
 ```ruby
 require "google/cloud/vision/v1"

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/credentials.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/credentials.rb
@@ -37,12 +37,6 @@ module So
             "https://endlesstrash.example.net/garbage-read",
             "https://endlesstrash.example.net/garbage-write"
           ]
-          self.env_vars = [
-            "GARBAGE_CREDENTIALS",
-            "GARBAGE_KEYFILE",
-            "GARBAGE_CREDENTIALS_JSON",
-            "GARBAGE_KEYFILE_JSON"
-          ]
         end
       end
     end

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/credentials.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/credentials.rb
@@ -37,12 +37,6 @@ module So
             "https://endlesstrash.example.net/garbage-read",
             "https://endlesstrash.example.net/garbage-write"
           ]
-          self.env_vars = [
-            "GARBAGE_CREDENTIALS",
-            "GARBAGE_KEYFILE",
-            "GARBAGE_CREDENTIALS_JSON",
-            "GARBAGE_KEYFILE_JSON"
-          ]
         end
       end
     end

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/really_renamed_service/credentials.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/really_renamed_service/credentials.rb
@@ -37,12 +37,6 @@ module So
             "https://endlesstrash.example.net/garbage-read",
             "https://endlesstrash.example.net/garbage-write"
           ]
-          self.env_vars = [
-            "GARBAGE_CREDENTIALS",
-            "GARBAGE_KEYFILE",
-            "GARBAGE_CREDENTIALS_JSON",
-            "GARBAGE_KEYFILE_JSON"
-          ]
         end
       end
     end

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/credentials.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/credentials.rb
@@ -32,12 +32,6 @@ module So
       module ResourceNames
         # Credentials for the ResourceNames API.
         class Credentials < ::Google::Auth::Credentials
-          self.env_vars = [
-            "GARBAGE_CREDENTIALS",
-            "GARBAGE_KEYFILE",
-            "GARBAGE_CREDENTIALS_JSON",
-            "GARBAGE_KEYFILE_JSON"
-          ]
         end
       end
     end

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/credentials.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_no_retry/credentials.rb
@@ -31,12 +31,6 @@ module Testing
     module ServiceNoRetry
       # Credentials for the ServiceNoRetry API.
       class Credentials < ::Google::Auth::Credentials
-        self.env_vars = [
-          "GRPC_SERVICE_CONFIG_CREDENTIALS",
-          "GRPC_SERVICE_CONFIG_KEYFILE",
-          "GRPC_SERVICE_CONFIG_CREDENTIALS_JSON",
-          "GRPC_SERVICE_CONFIG_KEYFILE_JSON"
-        ]
       end
     end
   end

--- a/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/credentials.rb
+++ b/shared/output/gapic/templates/grpc_service_config/lib/testing/grpc_service_config/service_with_retries/credentials.rb
@@ -31,12 +31,6 @@ module Testing
     module ServiceWithRetries
       # Credentials for the ServiceWithRetries API.
       class Credentials < ::Google::Auth::Credentials
-        self.env_vars = [
-          "GRPC_SERVICE_CONFIG_CREDENTIALS",
-          "GRPC_SERVICE_CONFIG_KEYFILE",
-          "GRPC_SERVICE_CONFIG_CREDENTIALS_JSON",
-          "GRPC_SERVICE_CONFIG_KEYFILE_JSON"
-        ]
       end
     end
   end


### PR DESCRIPTION
Years ago when we had only a few libraries, we had the practice of providing service-specific credential environment variables for every service (e.g. `STORAGE_CREDENTIALS`). However, as we continue to create lots of new libraries, this practice has become problematic. Environment variables are in a global namespace shared with the rest of the application, and if we try to read credentials from lots of different names, the chances of collisions gets high. Moving forward, we will not provide service-specific environment variables for new clients. This PR ensures that if we do not set `env_prefix` when generating a client, then no service-specific environment variable name will be established, and it also makes sure the rest of the generated code and documentation handles that case. In some cases, we omit generating code that references the service-specific environment variables. In other cases, we fall back to the global `GOOGLE_CLOUD_CREDENTIALS` environment variable that is recognized by every client.