### PR TITLE
fix: Wrapper gem dependencies on pre-ga versioned gems also allow 1.x versions

### DIFF
--- a/gapic-generator-cloud/lib/gapic/presenters/wrapper_gem_presenter.rb
+++ b/gapic-generator-cloud/lib/gapic/presenters/wrapper_gem_presenter.rb
@@ -109,6 +109,10 @@ module Gapic
         @dependencies ||= begin
           deps = { "google-cloud-core" => "~> 1.6" }
           version_dependencies.each do |version, requirement|
+            # For pre-release dependencies on versioned clients, support both
+            # 0.x and 1.x versions to ease the transition to 1.0 (GA) releases
+            # for those dependencies. (Note the 0.x->1.0 transition is
+            # generally not breaking.)
             deps["#{name}-#{version}"] =
               if requirement.start_with? "0."
                 [">= #{requirement}", "< 2.a"]

--- a/gapic-generator-cloud/lib/gapic/presenters/wrapper_gem_presenter.rb
+++ b/gapic-generator-cloud/lib/gapic/presenters/wrapper_gem_presenter.rb
@@ -107,9 +107,14 @@ module Gapic
 
       def dependencies
         @dependencies ||= begin
-          deps = { "google-cloud-core" => "~> 1.5" }
+          deps = { "google-cloud-core" => "~> 1.6" }
           version_dependencies.each do |version, requirement|
-            deps["#{name}-#{version}"] = "~> #{requirement}"
+            deps["#{name}-#{version}"] =
+              if requirement.start_with? "0."
+                [">= #{requirement}", "< 2.a"]
+              else
+                "~> #{requirement}"
+              end
           end
           extra_deps = gem_config_dependencies
           deps.merge! extra_deps if extra_deps

--- a/shared/output/cloud/secretmanager_wrapper/google-cloud-secret_manager.gemspec
+++ b/shared/output/cloud/secretmanager_wrapper/google-cloud-secret_manager.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "google-cloud-core", "~> 1.5"
+  gem.add_dependency "google-cloud-core", "~> 1.6"
   gem.add_dependency "google-cloud-secret_manager-v1", "~> 1.0"
-  gem.add_dependency "google-cloud-secret_manager-v1beta1", "~> 0.2"
+  gem.add_dependency "google-cloud-secret_manager-v1beta1", ">= 0.2", "< 2.a"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"


### PR DESCRIPTION
Currently most of our generated clients have versions in the 0.x range. This needs to change for GA services (e.g. services with versions like "v1" as opposed to "v1beta1"). We want to bump those library versions to 1.0 at some point soon. However, that could lead to diamond dependency issues with wrapper gems that still depend on `~> 0.x`. Here we implement the strategy we've been using for other libraries that we want to bump from 0.x to 1.0: Updating the dependencies so that they are of the form `">= 0.x", "< 2.a"` so they support both 0.x and 1.x. We can do this because in most cases, the 0.x to 1.0 version bump is not really a semver-major (backward incompatible) bump, but merely a promotion of the version from "prerelease" to "GA".