### PR TITLE
fix: Prevent duplicate path helper methods

### DIFF
--- a/gapic-generator-cloud/Rakefile
+++ b/gapic-generator-cloud/Rakefile
@@ -85,6 +85,11 @@ namespace :gen do |gen_namespace|
     generate_cloud_templates :vision_v1
   end
 
+  desc "Generate the expected output for document_ai_v1beta3"
+  task :document_ai_v1beta3 do
+    generate_cloud_templates :document_ai_v1beta3
+  end
+
   desc "Generate the expected output for noservice"
   task :noservice do
     generate_cloud_templates :noservice

--- a/gapic-generator/lib/gapic/presenters/resource_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/resource_presenter.rb
@@ -33,6 +33,10 @@ module Gapic
         @patterns.filter!(&:useful_for_helpers?)
       end
 
+      def dup
+        ResourcePresenter.new @resource
+      end
+
       def name
         @resource.type.split("/").delete_if(&:empty?).last
       end
@@ -61,6 +65,10 @@ module Gapic
 
         attr_reader :pattern
         attr_reader :path_string
+
+        def pattern_template
+          @parsed_pattern.template
+        end
 
         def useful_for_helpers?
           !@parsed_pattern.positional_segments? && !@parsed_pattern.nontrivial_pattern_segments?

--- a/gapic-generator/templates/default/service/client/_paths.erb
+++ b/gapic-generator/templates/default/service/client/_paths.erb
@@ -1,7 +1,7 @@
 <%- assert_locals service -%>
 # Path helper methods for the <%= service.name %> API.
 module Paths
-<%- service.references.each do |resource| -%>
+<%- service.deduped_references.each do |resource| -%>
 <%= indent render(partial: "service/client/resource", locals: { resource: resource }), 2 %>
 
 <%- end %>

--- a/gapic-generator/templates/default/service/test/client_paths.erb
+++ b/gapic-generator/templates/default/service/test/client_paths.erb
@@ -7,7 +7,7 @@ require "gapic/grpc/service_stub"
 require "<%= service.service_require %>"
 
 class <%= service.client_name_full %>PathsTest < Minitest::Test
-<%- service.references.each do |resource| -%>
+<%- service.deduped_references.each do |resource| -%>
 <%= indent render(partial: "service/test/resource",
                   locals: { resource: resource, service: service }), 2 %>
 

--- a/gapic-generator/test/gapic/presenters/service_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/service_presenter_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+
+class ServicePresenterTest < PresenterTest
+  def test_deduped_resources
+    request = FakeRequest.new
+    request.add_file! "google.common.iam" do
+      request.add_message! "Request1" do
+        request.set_message_resource! "location.googleapis.com/Location",
+                                      ["projects/{project}/locations/{location}"]
+      end
+      request.add_message! "Request2" do
+        request.set_message_resource! "org.googleapis.com/Location",
+                                      ["organizations/{organization}/locations/{location}"]
+      end
+      request.add_service! "IamGroot" do
+        request.add_method! "Foo", "google.common.iam.Request1", "google.common.iam.Request1"
+        request.add_method! "Bar", "google.common.iam.Request2", "google.common.iam.Request2"
+      end
+    end
+    api = Gapic::Schema::Api.new request
+    presenter = Gapic::Presenters::GemPresenter.new api
+    service_presenter = presenter.services.first
+    assert_equal 2, service_presenter.references.size
+    assert_equal 1, service_presenter.deduped_references.size
+    patterns = service_presenter.deduped_references[0].patterns
+    assert_equal 2, patterns.size
+    assert_equal "projects/*/locations/*", patterns[0].pattern_template
+    assert_equal "organizations/*/locations/*", patterns[1].pattern_template
+  end
+
+  def test_deduped_resources_with_duplicated_patterns
+    request = FakeRequest.new
+    request.add_file! "google.common.iam" do
+      request.add_message! "Request1" do
+        request.set_message_resource! "location.googleapis.com/Location",
+                                      ["projects/{project}/locations/{location}"]
+      end
+      request.add_message! "Request2" do
+        request.set_message_resource! "org.googleapis.com/Location",
+                                      ["projects/{project}/locations/{where}"]
+      end
+      request.add_service! "IamGroot" do
+        request.add_method! "Foo", "google.common.iam.Request1", "google.common.iam.Request1"
+        request.add_method! "Bar", "google.common.iam.Request2", "google.common.iam.Request2"
+      end
+    end
+    api = Gapic::Schema::Api.new request
+    presenter = Gapic::Presenters::GemPresenter.new api
+    service_presenter = presenter.services.first
+    assert_equal 2, service_presenter.references.size
+    assert_equal 1, service_presenter.deduped_references.size
+    patterns = service_presenter.deduped_references[0].patterns
+    assert_equal 1, patterns.size
+    assert_equal "projects/*/locations/*", patterns[0].pattern_template
+  end
+end

--- a/gapic-generator/test/test_helper.rb
+++ b/gapic-generator/test/test_helper.rb
@@ -316,6 +316,15 @@ class FakeRequest < OpenStruct
     self
   end
 
+  def add_toplevel_resource! type, patterns
+    resources = @cur_descriptor.options[:".google.api.resource_definition"] ||= []
+    resource_descriptor = OpenStruct.new
+    resource_descriptor.type = type
+    resource_descriptor.pattern = Array(patterns)
+    resources << resource_descriptor
+    self
+  end
+
   def add_message! name
     outer_descriptor = @cur_descriptor
     @cur_descriptor = OpenStruct.new
@@ -332,6 +341,14 @@ class FakeRequest < OpenStruct
       outer_descriptor.message_type << @cur_descriptor
     end
     @cur_descriptor = outer_descriptor
+    self
+  end
+
+  def set_message_resource! type, patterns
+    resource_descriptor = OpenStruct.new
+    resource_descriptor.type = type
+    resource_descriptor.pattern = Array(patterns)
+    @cur_descriptor.options[:".google.api.resource"] = resource_descriptor
     self
   end
 
@@ -360,7 +377,7 @@ class FakeRequest < OpenStruct
     self
   end
 
-  def add_method! name
+  def add_method! name, input_type, output_type
     outer_descriptor = @cur_descriptor
     @cur_descriptor = OpenStruct.new
     @cur_descriptor.input_type = input_type

--- a/shared/Rakefile
+++ b/shared/Rakefile
@@ -59,6 +59,11 @@ namespace :gen do |gen_namespace|
     generate_input_file :vision_v1
   end
 
+  desc "Generate the binary input files for document_ai v1beta3"
+  task :document_ai_v1beta3 do
+    generate_input_file :document_ai_v1beta3
+  end
+
   desc "Generate the binary input files for showcase"
   task :showcase do
     generate_input_file :showcase

--- a/shared/config/document_ai_v1beta3.yml
+++ b/shared/config/document_ai_v1beta3.yml
@@ -1,0 +1,9 @@
+---
+:gem:
+  :name: "google-cloud-document_ai-v1beta3"
+:defaults:
+  :service:
+    :default_host: "documentai.googleapis.com"
+    :oauth_scopes:
+      - https://www.googleapis.com/auth/cloud-platform
+:generate_metadata: false


### PR DESCRIPTION
Prevents "duplicate" resources (i.e. resources with the same name but potentially different namespaces) from producing "duplicate" path helpers (e.g. https://github.com/googleapis/google-cloud-ruby/pull/12787)
