### PR TITLE
fix: Show REST-specific examples in markdown docs for REST-only clients

### DIFF
--- a/gapic-generator-cloud/Rakefile
+++ b/gapic-generator-cloud/Rakefile
@@ -85,11 +85,6 @@ namespace :gen do |gen_namespace|
     generate_cloud_templates :vision_v1
   end
 
-  desc "Generate the expected output for document_ai_v1beta3"
-  task :document_ai_v1beta3 do
-    generate_cloud_templates :document_ai_v1beta3
-  end
-
   desc "Generate the expected output for noservice"
   task :noservice do
     generate_cloud_templates :noservice

--- a/gapic-generator-cloud/templates/cloud/gem/authentication.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/authentication.erb
@@ -1,5 +1,5 @@
 <%- assert_locals gem -%>
-<%- service = gem.first_non_common_service -%>
+<%- service = gem.first_non_common_service.usable_service_presenter -%>
 <%- assert_locals service -%>
 # Authentication
 

--- a/gapic-generator-cloud/templates/cloud/gem/readme.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/readme.erb
@@ -44,7 +44,7 @@ In order to use this library, you first need to go through the following steps:
 <%- if gem.packages? -%>
 ```ruby
 require "<%= gem.entrypoint_require %>"
-<%- service = gem.quick_start_service -%>
+<%- service = gem.quick_start_service.usable_service_presenter -%>
 <%- method = service&.quick_start_method -%>
 <%- if service && method -%>
 
@@ -65,6 +65,7 @@ See also the [Product Documentation](<%= gem.product_documentation_url %>)
 for general usage information.
 
 <%- end -%>
+<%- if gem.show_grpc_logging_docs? -%>
 ## Enabling Logging
 
 To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
@@ -91,6 +92,7 @@ module GRPC
 end
 ```
 
+<%- end -%>
 ## Supported Ruby Versions
 
 This library is supported on Ruby 2.5+.

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -239,6 +239,13 @@ module Gapic
         result || first_non_common_service
       end
 
+      ##
+      # Whether the "Enabling (gRPC) Logging" section of the readme should
+      # appear. This is true if there is a quick-start service displayed in the
+      # readme, AND it uses gRPC.
+      #
+      # @return [Boolean]
+      #
       def show_grpc_logging_docs?
         packages? && quick_start_service.usable_service_presenter.is_a?(ServicePresenter)
       end

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -239,6 +239,10 @@ module Gapic
         result || first_non_common_service
       end
 
+      def show_grpc_logging_docs?
+        packages? && quick_start_service.usable_service_presenter.is_a?(ServicePresenter)
+      end
+
       private
 
       def gem_config key

--- a/gapic-generator/lib/gapic/presenters/method_rest_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/method_rest_presenter.rb
@@ -187,7 +187,7 @@ module Gapic
       #
       # @return [String]
       def transcoding_helper_name
-        "transcode_#{@main_method.name}"
+        "transcode_#{name}"
       end
 
       ##

--- a/gapic-generator/lib/gapic/presenters/method_rest_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/method_rest_presenter.rb
@@ -189,6 +189,24 @@ module Gapic
       def transcoding_helper_name
         "transcode_#{@main_method.name}"
       end
+
+      ##
+      # Method name
+      #
+      # @return [String]
+      #
+      def name
+        @main_method.name
+      end
+
+      ##
+      # Full class name of the request type
+      #
+      # @return [String]
+      #
+      def request_type
+        @main_method.request_type
+      end
     end
   end
 end

--- a/gapic-generator/lib/gapic/presenters/service_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_presenter.rb
@@ -451,6 +451,22 @@ module Gapic
         result || methods.find { |meth| !meth.client_streaming? }
       end
 
+      ##
+      # Returns this service presenter if there is a grpc client. Otherwise,
+      # returns the corresponding rest service presenter if there isn't a grpc
+      # client but there is a rest client. Otherwise, returns nil if there is
+      # neither client.
+      #
+      # @return [ServicePresenter,ServiceRestPresenter,nil]
+      #
+      def usable_service_presenter
+        if @api.generate_grpc_clients?
+          self
+        elsif @api.generate_rest_clients? && methods_rest_bindings?
+          rest
+        end
+      end
+
       private
 
       def default_config key

--- a/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
@@ -146,7 +146,9 @@ module Gapic
       # first non-client-streaming method defined, but it can be overridden via
       # a gem config.
       #
-      # @return [Gapic::Presenters::MethodRestPresenter]
+      # @return [Gapic::Presenters::MethodRestPresenter] if there is a method
+      #     appropriatke for quick start
+      # @return [nil] if there is no method appropriate for quick start
       #
       def quick_start_method
         main_service.quick_start_method&.rest

--- a/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
@@ -127,6 +127,30 @@ module Gapic
         main_service.service_file_path.sub ".rb", "_test.rb"
       end
 
+      ##
+      # @return [String]
+      #
+      def credentials_class_xref
+        main_service.credentials_class_xref
+      end
+
+      ##
+      # @return [String]
+      #
+      def configure_client_call
+        "#{client_name_full}.configure"
+      end
+
+      ##
+      # The method to use for quick start samples. Normally this is simply the
+      # first non-client-streaming method defined, but it can be overridden via
+      # a gem config.
+      #
+      # @return [Gapic::Presenters::MethodRestPresenter]
+      #
+      def quick_start_method
+        main_service.quick_start_method&.rest
+      end
 
       private
 

--- a/shared/Rakefile
+++ b/shared/Rakefile
@@ -59,11 +59,6 @@ namespace :gen do |gen_namespace|
     generate_input_file :vision_v1
   end
 
-  desc "Generate the binary input files for document_ai v1beta3"
-  task :document_ai_v1beta3 do
-    generate_input_file :document_ai_v1beta3
-  end
-
   desc "Generate the binary input files for showcase"
   task :showcase do
     generate_input_file :showcase

--- a/shared/config/document_ai_v1beta3.yml
+++ b/shared/config/document_ai_v1beta3.yml
@@ -1,9 +1,0 @@
----
-:gem:
-  :name: "google-cloud-document_ai-v1beta3"
-:defaults:
-  :service:
-    :default_host: "documentai.googleapis.com"
-    :oauth_scopes:
-      - https://www.googleapis.com/auth/cloud-platform
-:generate_metadata: false

--- a/shared/output/cloud/compute_small/AUTHENTICATION.md
+++ b/shared/output/cloud/compute_small/AUTHENTICATION.md
@@ -27,7 +27,7 @@ export GOOGLE_CLOUD_CREDENTIALS=path/to/keyfile.json
 ```ruby
 require "google/cloud/compute/v1"
 
-client = ::Google::Cloud::Compute::V1::Addresses::Client.new
+client = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new
 ```
 
 ## Credential Lookup
@@ -75,7 +75,7 @@ require "google/cloud/compute/v1"
 
 ENV["GOOGLE_CLOUD_CREDENTIALS"] = "path/to/keyfile.json"
 
-client = ::Google::Cloud::Compute::V1::Addresses::Client.new
+client = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new
 ```
 
 ### Configuration
@@ -86,7 +86,7 @@ it in an environment variable. Either on an individual client initialization:
 ```ruby
 require "google/cloud/compute/v1"
 
-client = ::Google::Cloud::Compute::V1::Addresses::Client.new do |config|
+client = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new do |config|
   config.credentials = "path/to/keyfile.json"
 end
 ```
@@ -96,11 +96,11 @@ Or globally for all clients:
 ```ruby
 require "google/cloud/compute/v1"
 
-::Google::Cloud::Compute::V1::Addresses::Client.configure do |config|
+::Google::Cloud::Compute::V1::Addresses::Rest::Client.configure do |config|
   config.credentials = "path/to/keyfile.json"
 end
 
-client = ::Google::Cloud::Compute::V1::Addresses::Client.new
+client = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new
 ```
 
 ### Cloud SDK

--- a/shared/output/cloud/compute_small/README.md
+++ b/shared/output/cloud/compute_small/README.md
@@ -25,39 +25,13 @@ In order to use this library, you first need to go through the following steps:
 ```ruby
 require "google/cloud/compute/v1"
 
-client = ::Google::Cloud::Compute::V1::Addresses::Client.new
+client = ::Google::Cloud::Compute::V1::Addresses::Rest::Client.new
 request = ::Google::Cloud::Compute::V1::AggregatedListAddressesRequest.new # (request fields as keyword arguments...)
 response = client.aggregated_list request
 ```
 
 View the [Client Library Documentation](https://googleapis.dev/ruby/google-cloud-compute-v1/latest)
 for class and method documentation.
-
-## Enabling Logging
-
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
-The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Cloud Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
-and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
-
-Configuring a Ruby stdlib logger:
-
-```ruby
-require "logger"
-
-module MyLogger
-  LOGGER = Logger.new $stderr, level: Logger::WARN
-  def logger
-    LOGGER
-  end
-end
-
-# Define a gRPC module-level logger method before grpc/logconfig.rb loads.
-module GRPC
-  extend MyLogger
-end
-```
 
 ## Supported Ruby Versions
 

--- a/shared/output/cloud/noservice/README.md
+++ b/shared/output/cloud/noservice/README.md
@@ -31,32 +31,6 @@ In order to use this library, you first need to go through the following steps:
 View the [Client Library Documentation](https://googleapis.dev/ruby/google-garbage-noservice/latest)
 for class and method documentation.
 
-## Enabling Logging
-
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library.
-The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below,
-or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Cloud Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
-and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
-
-Configuring a Ruby stdlib logger:
-
-```ruby
-require "logger"
-
-module MyLogger
-  LOGGER = Logger.new $stderr, level: Logger::WARN
-  def logger
-    LOGGER
-  end
-end
-
-# Define a gRPC module-level logger method before grpc/logconfig.rb loads.
-module GRPC
-  extend MyLogger
-end
-```
-
 ## Supported Ruby Versions
 
 This library is supported on Ruby 2.5+.


### PR DESCRIPTION
Closes #622 