### PR TITLE
feat(gapic-common): The gRPC service stub supports default timeouts

### DIFF
--- a/gapic-common/lib/gapic/grpc/service_stub.rb
+++ b/gapic-common/lib/gapic/grpc/service_stub.rb
@@ -49,8 +49,9 @@ module Gapic
     #     provided as a `GRPC::Core::Channel`.)
     # @param interceptors [Array<GRPC::ClientInterceptor>] An array of {GRPC::ClientInterceptor} objects that will
     #   be used for intercepting calls before they are executed Interceptors are an EXPERIMENTAL API.
+    # @param timeout [Numeric] The default timeout for calls, in seconds, or `nil` (the default) for infinite.
     #
-    def initialize grpc_stub_class, endpoint:, credentials:, channel_args: nil, interceptors: nil
+    def initialize grpc_stub_class, endpoint:, credentials:, channel_args: nil, interceptors: nil, timeout: nil
       raise ArgumentError, "grpc_stub_class is required" if grpc_stub_class.nil?
       raise ArgumentError, "endpoint is required" if endpoint.nil?
       raise ArgumentError, "credentials is required" if credentials.nil?
@@ -61,10 +62,12 @@ module Gapic
       @grpc_stub = case credentials
                    when GRPC::Core::Channel
                      grpc_stub_class.new endpoint, nil, channel_override: credentials,
-                                                        interceptors:     interceptors
+                                                        interceptors:     interceptors,
+                                                        timeout:          timeout
                    when GRPC::Core::ChannelCredentials, Symbol
                      grpc_stub_class.new endpoint, credentials, channel_args: channel_args,
-                                                                interceptors: interceptors
+                                                                interceptors: interceptors,
+                                                                timeout:      timeout
                    else
                      updater_proc = credentials.updater_proc if credentials.respond_to? :updater_proc
                      updater_proc ||= credentials if credentials.is_a? Proc
@@ -73,7 +76,8 @@ module Gapic
                      call_creds = GRPC::Core::CallCredentials.new updater_proc
                      chan_creds = GRPC::Core::ChannelCredentials.new.compose call_creds
                      grpc_stub_class.new endpoint, chan_creds, channel_args: channel_args,
-                                                               interceptors: interceptors
+                                                               interceptors: interceptors,
+                                                               timeout:      timeout
                    end
     end
 

--- a/gapic-common/lib/gapic/operation.rb
+++ b/gapic-common/lib/gapic/operation.rb
@@ -253,7 +253,7 @@ module Gapic
     # @yield operation [Gapic::Operation] Yields the finished Operation.
     #
     def wait_until_done! retry_policy: nil
-      retry_policy = RetryPolicy.new retry_policy if retry_policy.is_a? Hash
+      retry_policy = RetryPolicy.new(**retry_policy) if retry_policy.is_a? Hash
       retry_policy ||= RetryPolicy.new
 
       until done?

--- a/gapic-common/test/gapic/grpc/stub_test.rb
+++ b/gapic-common/test/gapic/grpc/stub_test.rb
@@ -51,7 +51,7 @@ class GrpcStubTest < Minitest::Spec
 
     mock = Minitest::Mock.new
     mock.expect :nil?, false
-    mock.expect :new, nil, ["service:port", nil, channel_override: fake_channel, interceptors: []]
+    mock.expect :new, nil, ["service:port", nil, channel_override: fake_channel, interceptors: [], timeout: nil]
 
     Gapic::ServiceStub.new mock, endpoint: "service:port", credentials: fake_channel
 
@@ -63,7 +63,7 @@ class GrpcStubTest < Minitest::Spec
 
     mock = Minitest::Mock.new
     mock.expect :nil?, false
-    mock.expect :new, nil, ["service:port", fake_channel_creds, channel_args: {}, interceptors: []]
+    mock.expect :new, nil, ["service:port", fake_channel_creds, channel_args: {}, interceptors: [], timeout: nil]
 
     Gapic::ServiceStub.new mock, endpoint: "service:port", credentials: fake_channel_creds
 
@@ -75,9 +75,21 @@ class GrpcStubTest < Minitest::Spec
 
     mock = Minitest::Mock.new
     mock.expect :nil?, false
-    mock.expect :new, nil, ["service:port", creds, channel_args: {}, interceptors: []]
+    mock.expect :new, nil, ["service:port", creds, channel_args: {}, interceptors: [], timeout: nil]
 
     Gapic::ServiceStub.new mock, endpoint: "service:port", credentials: creds
+
+    mock.verify
+  end
+
+  def test_with_timeout
+    creds = :this_channel_is_insecure
+
+    mock = Minitest::Mock.new
+    mock.expect :nil?, false
+    mock.expect :new, nil, ["service:port", creds, channel_args: {}, interceptors: [], timeout: 10]
+
+    Gapic::ServiceStub.new mock, endpoint: "service:port", credentials: creds, timeout: 10
 
     mock.verify
   end
@@ -87,7 +99,7 @@ class GrpcStubTest < Minitest::Spec
       GRPC::Core::ChannelCredentials.stub :new, FakeChannelCredentials.method(:new) do
         mock = Minitest::Mock.new
         mock.expect :nil?, false
-        mock.expect :new, nil, ["service:port", FakeCallCredentials, channel_args: {}, interceptors: []]
+        mock.expect :new, nil, ["service:port", FakeCallCredentials, channel_args: {}, interceptors: [], timeout: nil]
 
         Gapic::ServiceStub.new mock, endpoint: "service:port", credentials: FakeCredentials.new
 
@@ -101,7 +113,7 @@ class GrpcStubTest < Minitest::Spec
       GRPC::Core::ChannelCredentials.stub :new, FakeChannelCredentials.method(:new) do
         mock = Minitest::Mock.new
         mock.expect :nil?, false
-        mock.expect :new, nil, ["service:port", FakeCallCredentials, channel_args: {}, interceptors: []]
+        mock.expect :new, nil, ["service:port", FakeCallCredentials, channel_args: {}, interceptors: [], timeout: nil]
 
         credentials_proc = ->{}
 


### PR DESCRIPTION
Part of the alternative to #639 