### PR TITLE
fix: Disable rubocop for sample tests in generated versioned libraries

### DIFF
--- a/gapic-generator-ads/Gemfile.lock
+++ b/gapic-generator-ads/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.3.0)
+    rails-html-sanitizer (1.4.1)
       loofah (~> 2.3)
     rainbow (3.0.0)
     rake (13.0.6)

--- a/gapic-generator-cloud/Gemfile.lock
+++ b/gapic-generator-cloud/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.3.0)
+    rails-html-sanitizer (1.4.1)
       loofah (~> 2.3)
     rainbow (3.0.0)
     rake (13.0.6)

--- a/gapic-generator-cloud/templates/cloud/gem/rubocop.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/rubocop.erb
@@ -9,6 +9,7 @@ AllCops:
     - "proto_docs/**/*"
     - "test/**/*"
     - "acceptance/**/*"
+    - "samples/acceptance/**/*"
     - "Rakefile"
 
 Layout/LineLength:

--- a/gapic-generator/Gemfile.lock
+++ b/gapic-generator/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.3.0)
+    rails-html-sanitizer (1.4.1)
       loofah (~> 2.3)
     rainbow (3.0.0)
     rake (13.0.6)

--- a/shared/output/cloud/compute_small/.rubocop.yml
+++ b/shared/output/cloud/compute_small/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "proto_docs/**/*"
     - "test/**/*"
     - "acceptance/**/*"
+    - "samples/acceptance/**/*"
     - "Rakefile"
 
 Layout/LineLength:

--- a/shared/output/cloud/language_v1/.rubocop.yml
+++ b/shared/output/cloud/language_v1/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "proto_docs/**/*"
     - "test/**/*"
     - "acceptance/**/*"
+    - "samples/acceptance/**/*"
     - "Rakefile"
 
 Layout/LineLength:

--- a/shared/output/cloud/language_v1beta1/.rubocop.yml
+++ b/shared/output/cloud/language_v1beta1/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "proto_docs/**/*"
     - "test/**/*"
     - "acceptance/**/*"
+    - "samples/acceptance/**/*"
     - "Rakefile"
 
 Layout/LineLength:

--- a/shared/output/cloud/language_v1beta2/.rubocop.yml
+++ b/shared/output/cloud/language_v1beta2/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "proto_docs/**/*"
     - "test/**/*"
     - "acceptance/**/*"
+    - "samples/acceptance/**/*"
     - "Rakefile"
 
 Layout/LineLength:

--- a/shared/output/cloud/secretmanager_v1beta1/.rubocop.yml
+++ b/shared/output/cloud/secretmanager_v1beta1/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "proto_docs/**/*"
     - "test/**/*"
     - "acceptance/**/*"
+    - "samples/acceptance/**/*"
     - "Rakefile"
 
 Layout/LineLength:

--- a/shared/output/cloud/speech_v1/.rubocop.yml
+++ b/shared/output/cloud/speech_v1/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "proto_docs/**/*"
     - "test/**/*"
     - "acceptance/**/*"
+    - "samples/acceptance/**/*"
     - "Rakefile"
 
 Layout/LineLength:

--- a/shared/output/cloud/vision_v1/.rubocop.yml
+++ b/shared/output/cloud/vision_v1/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "proto_docs/**/*"
     - "test/**/*"
     - "acceptance/**/*"
+    - "samples/acceptance/**/*"
     - "Rakefile"
 
 Layout/LineLength:


### PR DESCRIPTION
Prevents, e.g. https://github.com/googleapis/google-cloud-ruby/pull/13607/files