### PR TITLE
chore: Release version 0.10.2

### DIFF
--- a/gapic-generator-ads/CHANGELOG.md
+++ b/gapic-generator-ads/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History for gapic-generator-ads
 
+### 0.10.2 / 2021-11-01
+
+* Includes changes from gapic-generator 0.10.2
+
 ### 0.10.1 / 2021-08-27
 
 * Includes changes from gapic-generator 0.10.1

--- a/gapic-generator-ads/Gemfile.lock
+++ b/gapic-generator-ads/Gemfile.lock
@@ -1,16 +1,16 @@
 PATH
   remote: ../gapic-generator
   specs:
-    gapic-generator (0.10.1)
+    gapic-generator (0.10.2)
       actionpack (~> 5.2)
       protobuf (~> 3.8)
 
 PATH
   remote: .
   specs:
-    gapic-generator-ads (0.10.1)
+    gapic-generator-ads (0.10.2)
       actionpack (~> 5.2)
-      gapic-generator (= 0.10.1)
+      gapic-generator (= 0.10.2)
       protobuf (~> 3.8)
 
 GEM
@@ -76,7 +76,7 @@ GEM
     rake (13.0.6)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rubocop (1.22.1)
+    rubocop (1.22.3)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -107,4 +107,4 @@ DEPENDENCIES
   rake (>= 12.0)
 
 BUNDLED WITH
-   2.2.22
+   2.2.30

--- a/gapic-generator-ads/lib/gapic/generator/ads/version.rb
+++ b/gapic-generator-ads/lib/gapic/generator/ads/version.rb
@@ -18,7 +18,7 @@
 module Gapic
   module Generator
     module Ads
-      VERSION = "0.10.1"
+      VERSION = "0.10.2"
     end
   end
 end

--- a/gapic-generator-cloud/CHANGELOG.md
+++ b/gapic-generator-cloud/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History for gapic-generator-cloud
 
+### 0.10.2 / 2021-11-01
+
+* Includes changes from gapic-generator 0.10.2
+
 ### 0.10.1 / 2021-08-27
 
 * Includes changes from gapic-generator 0.10.1

--- a/gapic-generator-cloud/Gemfile.lock
+++ b/gapic-generator-cloud/Gemfile.lock
@@ -1,16 +1,16 @@
 PATH
   remote: ../gapic-generator
   specs:
-    gapic-generator (0.10.1)
+    gapic-generator (0.10.2)
       actionpack (~> 5.2)
       protobuf (~> 3.8)
 
 PATH
   remote: .
   specs:
-    gapic-generator-cloud (0.10.1)
+    gapic-generator-cloud (0.10.2)
       actionpack (~> 5.2)
-      gapic-generator (= 0.10.1)
+      gapic-generator (= 0.10.2)
       google-style (~> 1.25.1)
       protobuf (~> 3.8)
 
@@ -83,7 +83,7 @@ GEM
     rake (13.0.6)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rubocop (1.22.1)
+    rubocop (1.22.3)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -114,4 +114,4 @@ DEPENDENCIES
   rake (>= 12.0)
 
 BUNDLED WITH
-   2.2.22
+   2.2.30

--- a/gapic-generator-cloud/lib/gapic/generator/cloud/version.rb
+++ b/gapic-generator-cloud/lib/gapic/generator/cloud/version.rb
@@ -18,7 +18,7 @@
 module Gapic
   module Generator
     module Cloud
-      VERSION = "0.10.1"
+      VERSION = "0.10.2"
     end
   end
 end

--- a/gapic-generator/CHANGELOG.md
+++ b/gapic-generator/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History for gapic-generator
 
+### 0.10.2 / 2021-11-01
+
+* New: Added support for service.yaml
+* New: New mixin implementation
+* New: Parse and generate explicit routing headers
+* New: Preliminary support for extended operations for REST LROs
+* Fixed: Potential failures in generated tests when routing headers reference sub-fields
+* Fixed: Renamed service_config to grpc_service_config
+
 ### 0.10.1 / 2021-08-27
 
 * New: Compute REST libraries are now generated with LRO wrappers

--- a/gapic-generator/Gemfile.lock
+++ b/gapic-generator/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gapic-generator (0.10.1)
+    gapic-generator (0.10.2)
       actionpack (~> 5.2)
       protobuf (~> 3.8)
 
@@ -82,7 +82,7 @@ GEM
     redcarpet (3.5.1)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rubocop (1.22.1)
+    rubocop (1.22.3)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -118,4 +118,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.2.6
+   2.2.30

--- a/gapic-generator/lib/gapic/generator/version.rb
+++ b/gapic-generator/lib/gapic/generator/version.rb
@@ -16,6 +16,6 @@
 
 module Gapic
   module Generator
-    VERSION = "0.10.1"
+    VERSION = "0.10.2"
   end
 end


### PR DESCRIPTION
I'm releasing the current set of changes (_not_ including the global enabling of snippet-gen) along with the results of running them on google-cloud-ruby (https://github.com/googleapis/google-cloud-ruby/pull/14492). This is to give us a clean slate for the next set of updates which will be more disruptive.