### PR TITLE
chore: Update copyright year on sample outputs

### DIFF
--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v7/services.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v7/services.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v7/services/campaign_service.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v7/services/campaign_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v7/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v7/services/campaign_service/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v7/services/campaign_service/credentials.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v7/services/campaign_service/credentials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v7/services/campaign_service/paths.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v7/services/campaign_service/paths.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/version.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/common/bidding.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/common/bidding.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/common/custom_parameter.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/common/custom_parameter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/common/frequency_cap.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/common/frequency_cap.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/common/real_time_bidding_setting.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/common/real_time_bidding_setting.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/common/targeting_setting.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/common/targeting_setting.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/ad_serving_optimization_status.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/ad_serving_optimization_status.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/advertising_channel_sub_type.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/advertising_channel_sub_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/advertising_channel_type.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/advertising_channel_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/app_campaign_app_store.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/app_campaign_app_store.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/app_campaign_bidding_strategy_goal_type.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/app_campaign_bidding_strategy_goal_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/asset_field_type.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/asset_field_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/bidding_strategy_type.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/bidding_strategy_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/brand_safety_suitability.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/brand_safety_suitability.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/campaign_experiment_type.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/campaign_experiment_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/campaign_serving_status.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/campaign_serving_status.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/campaign_status.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/campaign_status.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/frequency_cap_event_type.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/frequency_cap_event_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/frequency_cap_level.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/frequency_cap_level.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/frequency_cap_time_unit.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/frequency_cap_time_unit.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/location_source_type.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/location_source_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/negative_geo_target_type.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/negative_geo_target_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/optimization_goal_type.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/optimization_goal_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/payment_mode.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/payment_mode.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/positive_geo_target_type.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/positive_geo_target_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/response_content_type.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/response_content_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/target_impression_share_location.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/target_impression_share_location.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/targeting_dimension.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/targeting_dimension.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/vanity_pharma_display_url_mode.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/vanity_pharma_display_url_mode.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/vanity_pharma_text.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/enums/vanity_pharma_text.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/resources/campaign.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/resources/campaign.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/services/campaign_service.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v7/services/campaign_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/api/field_behavior.rb
+++ b/shared/output/ads/googleads/proto_docs/google/api/field_behavior.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/api/resource.rb
+++ b/shared/output/ads/googleads/proto_docs/google/api/resource.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/protobuf/any.rb
+++ b/shared/output/ads/googleads/proto_docs/google/protobuf/any.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/protobuf/field_mask.rb
+++ b/shared/output/ads/googleads/proto_docs/google/protobuf/field_mask.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/ads/googleads/proto_docs/google/rpc/status.rb
+++ b/shared/output/ads/googleads/proto_docs/google/rpc/status.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/Rakefile
+++ b/shared/output/cloud/compute_small/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google-cloud-compute-v1.rb
+++ b/shared/output/cloud/compute_small/lib/google-cloud-compute-v1.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/credentials.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/credentials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/service_stub.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/service_stub.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/credentials.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/credentials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/rest.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/rest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/rest/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/rest/service_stub.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/rest/service_stub.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/credentials.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/credentials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/service_stub.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/service_stub.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/credentials.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/credentials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/service_stub.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/service_stub.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/credentials.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/credentials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest/service_stub.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest/service_stub.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/version.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/proto_docs/google/api/field_behavior.rb
+++ b/shared/output/cloud/compute_small/proto_docs/google/api/field_behavior.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/proto_docs/google/api/resource.rb
+++ b/shared/output/cloud/compute_small/proto_docs/google/api/resource.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/proto_docs/google/cloud/compute/v1/compute_small.rb
+++ b/shared/output/cloud/compute_small/proto_docs/google/cloud/compute/v1/compute_small.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/proto_docs/google/cloud/extended_operations.rb
+++ b/shared/output/cloud/compute_small/proto_docs/google/cloud/extended_operations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/Gemfile
+++ b/shared/output/cloud/compute_small/snippets/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/addresses/aggregated_list.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/aggregated_list.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/addresses/delete.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/delete.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/addresses/get.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/get.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/addresses/insert.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/insert.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/addresses/list.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/list.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/global_operations/delete.rb
+++ b/shared/output/cloud/compute_small/snippets/global_operations/delete.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/global_operations/get.rb
+++ b/shared/output/cloud/compute_small/snippets/global_operations/get.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/networks/list_peering_routes.rb
+++ b/shared/output/cloud/compute_small/snippets/networks/list_peering_routes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/networks/remove_peering.rb
+++ b/shared/output/cloud/compute_small/snippets/networks/remove_peering.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/region_instance_group_managers/resize.rb
+++ b/shared/output/cloud/compute_small/snippets/region_instance_group_managers/resize.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/region_operations/delete.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/delete.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/region_operations/get.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/get.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/region_operations/list.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/list.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/snippets/region_operations/wait.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/wait.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/addresses_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/addresses_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/global_operations_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/global_operations_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/networks_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/networks_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_instance_group_managers_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_instance_group_managers_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_operations_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_operations_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/compute_small/test/helper.rb
+++ b/shared/output/cloud/compute_small/test/helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/Rakefile
+++ b/shared/output/cloud/language_v1/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/lib/google-cloud-language-v1.rb
+++ b/shared/output/cloud/language_v1/lib/google-cloud-language-v1.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/credentials.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/credentials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/version.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/proto_docs/google/api/field_behavior.rb
+++ b/shared/output/cloud/language_v1/proto_docs/google/api/field_behavior.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/proto_docs/google/cloud/language/v1/language_service.rb
+++ b/shared/output/cloud/language_v1/proto_docs/google/cloud/language/v1/language_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/snippets/Gemfile
+++ b/shared/output/cloud/language_v1/snippets/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/snippets/language_service/analyze_entities.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/analyze_entities.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/snippets/language_service/analyze_entity_sentiment.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/analyze_entity_sentiment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/snippets/language_service/analyze_sentiment.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/analyze_sentiment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/snippets/language_service/analyze_syntax.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/analyze_syntax.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/snippets/language_service/annotate_text.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/annotate_text.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/snippets/language_service/classify_text.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/classify_text.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
+++ b/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1/test/helper.rb
+++ b/shared/output/cloud/language_v1/test/helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/Rakefile
+++ b/shared/output/cloud/language_v1beta1/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/lib/google-cloud-language-v1beta1.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google-cloud-language-v1beta1.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/credentials.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/credentials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/version.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/proto_docs/google/cloud/language/v1beta1/language_service.rb
+++ b/shared/output/cloud/language_v1beta1/proto_docs/google/cloud/language/v1beta1/language_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/snippets/Gemfile
+++ b/shared/output/cloud/language_v1beta1/snippets/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_entities.rb
+++ b/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_entities.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_sentiment.rb
+++ b/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_sentiment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_syntax.rb
+++ b/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_syntax.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/snippets/language_service/annotate_text.rb
+++ b/shared/output/cloud/language_v1beta1/snippets/language_service/annotate_text.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta1/test/helper.rb
+++ b/shared/output/cloud/language_v1beta1/test/helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/Rakefile
+++ b/shared/output/cloud/language_v1beta2/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/lib/google-cloud-language-v1beta2.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google-cloud-language-v1beta2.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/credentials.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/credentials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/version.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/proto_docs/google/api/field_behavior.rb
+++ b/shared/output/cloud/language_v1beta2/proto_docs/google/api/field_behavior.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/proto_docs/google/cloud/language/v1beta2/language_service.rb
+++ b/shared/output/cloud/language_v1beta2/proto_docs/google/cloud/language/v1beta2/language_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/proto_docs/google/protobuf/timestamp.rb
+++ b/shared/output/cloud/language_v1beta2/proto_docs/google/protobuf/timestamp.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/snippets/Gemfile
+++ b/shared/output/cloud/language_v1beta2/snippets/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_entities.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_entities.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_entity_sentiment.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_entity_sentiment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_sentiment.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_sentiment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_syntax.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_syntax.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/annotate_text.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/annotate_text.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/classify_text.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/classify_text.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/language_v1beta2/test/helper.rb
+++ b/shared/output/cloud/language_v1beta2/test/helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/Rakefile
+++ b/shared/output/cloud/secretmanager_v1beta1/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google-cloud-secret_manager-v1beta1.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google-cloud-secret_manager-v1beta1.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/credentials.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/credentials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/paths.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/paths.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/api/field_behavior.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/api/field_behavior.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/api/resource.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/api/resource.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/cloud/secrets/v1beta1/resources.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/cloud/secrets/v1beta1/resources.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/cloud/secrets/v1beta1/service.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/cloud/secrets/v1beta1/service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/iam/v1/iam_policy.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/iam/v1/iam_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/iam/v1/options.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/iam/v1/options.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/iam/v1/policy.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/iam/v1/policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/protobuf/empty.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/protobuf/empty.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/protobuf/field_mask.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/protobuf/field_mask.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/protobuf/timestamp.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/protobuf/timestamp.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/type/expr.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/type/expr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/Gemfile
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/access_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/access_secret_version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/add_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/add_secret_version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/create_secret.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/create_secret.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/delete_secret.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/delete_secret.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/destroy_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/destroy_secret_version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/disable_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/disable_secret_version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/enable_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/enable_secret_version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_iam_policy.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_iam_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_secret.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_secret.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_secret_version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secret_versions.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secret_versions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secrets.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secrets.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/set_iam_policy.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/set_iam_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/test_iam_permissions.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/test_iam_permissions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/update_secret.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/update_secret.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_paths_test.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_paths_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_v1beta1/test/helper.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/test/helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_wrapper/Rakefile
+++ b/shared/output/cloud/secretmanager_wrapper/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_wrapper/lib/google-cloud-secret_manager.rb
+++ b/shared/output/cloud/secretmanager_wrapper/lib/google-cloud-secret_manager.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_wrapper/lib/google/cloud/secret_manager.rb
+++ b/shared/output/cloud/secretmanager_wrapper/lib/google/cloud/secret_manager.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_wrapper/lib/google/cloud/secret_manager/version.rb
+++ b/shared/output/cloud/secretmanager_wrapper/lib/google/cloud/secret_manager/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_wrapper/test/google/cloud/secret_manager/client_test.rb
+++ b/shared/output/cloud/secretmanager_wrapper/test/google/cloud/secret_manager/client_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_wrapper/test/google/cloud/secret_manager/version_test.rb
+++ b/shared/output/cloud/secretmanager_wrapper/test/google/cloud/secret_manager/version_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/secretmanager_wrapper/test/helper.rb
+++ b/shared/output/cloud/secretmanager_wrapper/test/helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/Rakefile
+++ b/shared/output/cloud/speech_v1/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/lib/google-cloud-speech-v1.rb
+++ b/shared/output/cloud/speech_v1/lib/google-cloud-speech-v1.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/credentials.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/credentials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/version.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/proto_docs/google/api/field_behavior.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/api/field_behavior.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/proto_docs/google/cloud/speech/v1/cloud_speech.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/cloud/speech/v1/cloud_speech.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/longrunning/operations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/proto_docs/google/protobuf/any.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/protobuf/any.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/proto_docs/google/protobuf/duration.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/protobuf/duration.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/proto_docs/google/protobuf/empty.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/protobuf/empty.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/proto_docs/google/protobuf/timestamp.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/protobuf/timestamp.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/proto_docs/google/protobuf/wrappers.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/protobuf/wrappers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/proto_docs/google/rpc/status.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/rpc/status.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/snippets/Gemfile
+++ b/shared/output/cloud/speech_v1/snippets/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/snippets/speech/long_running_recognize.rb
+++ b/shared/output/cloud/speech_v1/snippets/speech/long_running_recognize.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/snippets/speech/recognize.rb
+++ b/shared/output/cloud/speech_v1/snippets/speech/recognize.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/snippets/speech/streaming_recognize.rb
+++ b/shared/output/cloud/speech_v1/snippets/speech/streaming_recognize.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/speech_v1/test/helper.rb
+++ b/shared/output/cloud/speech_v1/test/helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/Rakefile
+++ b/shared/output/cloud/vision_v1/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/lib/google-cloud-vision-v1.rb
+++ b/shared/output/cloud/vision_v1/lib/google-cloud-vision-v1.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/credentials.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/credentials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/paths.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/paths.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/credentials.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/credentials.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/paths.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/paths.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/version.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/api/field_behavior.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/api/field_behavior.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/api/resource.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/api/resource.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/geometry.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/geometry.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/image_annotator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/product_search.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/product_search.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/product_search_service.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/product_search_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/text_annotation.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/text_annotation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/web_detection.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/web_detection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/longrunning/operations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/protobuf/any.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/protobuf/any.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/protobuf/duration.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/protobuf/duration.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/protobuf/empty.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/protobuf/empty.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/protobuf/field_mask.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/protobuf/field_mask.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/protobuf/timestamp.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/protobuf/timestamp.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/protobuf/wrappers.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/protobuf/wrappers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/rpc/status.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/rpc/status.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/type/color.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/type/color.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/proto_docs/google/type/latlng.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/type/latlng.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/Gemfile
+++ b/shared/output/cloud/vision_v1/snippets/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_files.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_files.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_images.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_images.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/batch_annotate_files.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/batch_annotate_files.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/batch_annotate_images.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/batch_annotate_images.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/add_product_to_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/add_product_to_product_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/create_product.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/create_product.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/create_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/create_product_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/create_reference_image.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/create_reference_image.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/delete_product.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/delete_product.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/delete_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/delete_product_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/delete_reference_image.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/delete_reference_image.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/get_product.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/get_product.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/get_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/get_product_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/get_reference_image.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/get_reference_image.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/import_product_sets.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/import_product_sets.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_product_sets.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_product_sets.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_products.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_products.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_products_in_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_products_in_product_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_reference_images.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_reference_images.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/purge_products.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/purge_products.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/remove_product_from_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/remove_product_from_product_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/update_product.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/update_product.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/snippets/product_search/update_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/update_product_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_paths_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_paths_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_paths_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_paths_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/shared/output/cloud/vision_v1/test/helper.rb
+++ b/shared/output/cloud/vision_v1/test/helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Ensure that tests continue to pass in 2022.