### PR TITLE
Several fixes for mixins (rebase-merge to get individual commit messages)

### DIFF
--- a/gapic-generator/lib/gapic/model/mixins.rb
+++ b/gapic-generator/lib/gapic/model/mixins.rb
@@ -55,9 +55,7 @@ module Gapic
 
       # @return [Enumerable<String>] Full proto names of the mix-in services
       def mixin_services
-        @mixin_services ||= services_in_config.select do |service|
-          service != LRO_SERVICE && !@api_services.include?(service)
-        end
+        @mixin_services ||= (services_in_config & SERVICE_TO_DEPENDENCY.keys)
       end
 
       # @return [Hash<String, String>]

--- a/gapic-generator/lib/gapic/model/mixins.rb
+++ b/gapic-generator/lib/gapic/model/mixins.rb
@@ -137,8 +137,8 @@ module Gapic
       # have these in lookup tables than to construct a ServicePresenter
 
       SERVICE_TO_DEPENDENCY = {
-        LOCATIONS_SERVICE => { "google-cloud-location" => "~> 0.1" },
-        IAM_SERVICE => { "google-iam-v1" => "~> 0.1" }
+        LOCATIONS_SERVICE => { "google-cloud-location" => [">= 0.0", "< 2.a"] },
+        IAM_SERVICE => { "google-iam-v1" => [">= 0.0", "< 2.a"] }
       }.freeze
 
       SERVICE_TO_REQUIRE_STR = {

--- a/gapic-generator/lib/gapic/model/mixins.rb
+++ b/gapic-generator/lib/gapic/model/mixins.rb
@@ -36,9 +36,12 @@ module Gapic
       #   List of services from the  Api model
       # @param service_config [Google::Api::Service]
       #   The service config
-      def initialize api_services, service_config
+      # @param gem_name [String]
+      #   The name of the gem.
+      def initialize api_services, service_config, gem_name
         @api_services = api_services
         @service_config = service_config
+        @gem_name = gem_name
       end
 
       # @return [Boolean] Whether there are any mix-in services
@@ -55,7 +58,10 @@ module Gapic
 
       # @return [Enumerable<String>] Full proto names of the mix-in services
       def mixin_services
-        @mixin_services ||= (services_in_config & SERVICE_TO_DEPENDENCY.keys)
+        @mixin_services ||= begin
+          candidates = services_in_config & SERVICE_TO_DEPENDENCY.keys
+          candidates.reject { |name| SERVICE_TO_DEPENDENCY[name].include? @gem_name }
+        end
       end
 
       # @return [Hash<String, String>]

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -30,7 +30,8 @@ module Gapic
 
       def initialize api
         @api = api
-        @mixins_model = Gapic::Model::Mixins.new api.services.map(&:full_name), api.service_config
+        service_config = api.configuration[:common_services] ? nil : api.service_config
+        @mixins_model = Gapic::Model::Mixins.new api.services.map(&:full_name), service_config, name
       end
 
       ##
@@ -212,6 +213,9 @@ module Gapic
           extra_deps = gem_config_dependencies
           deps.merge! extra_deps if extra_deps
           deps.merge! mixins_model.dependencies if mixins_model.mixins?
+          # google-iam-v1 is a superset of grpc-google-iam-v1, so if both are
+          # listed, use only google-iam-v1.
+          deps.delete "grpc-google-iam-v1" if deps.include? "google-iam-v1"
           deps
         end
       end

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -53,7 +53,10 @@ module Gapic
       def services
         @services ||= begin
           files = @api.generate_files
-          files.map(&:services).flatten.map { |s| ServicePresenter.new self, @api, s }
+          service_list = files.map(&:services).flatten
+          mixin_service_names = mixins_model.mixin_services
+          service_list.delete_if { |s| mixin_service_names.include? s.full_name }
+          service_list.map { |s| ServicePresenter.new self, @api, s }
         end
       end
 

--- a/gapic-generator/lib/gapic/presenters/package_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/package_presenter.rb
@@ -61,10 +61,12 @@ module Gapic
       def services
         @services ||= begin
           files = @api.generate_files.select { |f| f.package == @package }
-          services = files.map(&:services).flatten
+          service_list = files.map(&:services).flatten
+          mixin_service_names = gem.mixins_model.mixin_services
+          service_list.delete_if { |s| mixin_service_names.include? s.full_name }
           # Omit common services in this package. Common service clients do not
           # go into their own package.
-          normal_services = services.select { |s| @api.delegate_service_for(s).nil? }
+          normal_services = service_list.select { |s| @api.delegate_service_for(s).nil? }
           # But include common services that delegate to normal services in this package.
           common_services = normal_services.flat_map { |s| @api.common_services_for s }
           (normal_services + common_services).map { |s| ServicePresenter.new @gem_presenter, @api, s }

--- a/rules_ruby_gapic/private/ruby_gapic_library_internal.bzl
+++ b/rules_ruby_gapic/private/ruby_gapic_library_internal.bzl
@@ -59,6 +59,7 @@ def ruby_gapic_library_internal(
         extra_protoc_parameters,
         yml_configs,
         grpc_service_config,
+        service_yaml,
         **kwargs):
     srcjar_target_name = name
     srcjar_output_suffix = ".srcjar"
@@ -80,6 +81,8 @@ def ruby_gapic_library_internal(
     opt_file_args = {}
     if grpc_service_config:
         opt_file_args[grpc_service_config] = "grpc_service_config"
+    if service_yaml:
+        opt_file_args[service_yaml] = "service-yaml"
 
     if yml_configs:
         for file_label in yml_configs:

--- a/rules_ruby_gapic/ruby_gapic.bzl
+++ b/rules_ruby_gapic/ruby_gapic.bzl
@@ -32,6 +32,7 @@ load("@rules_gapic//:gapic.bzl", "proto_custom_library")
 #   (e.g. gem-name=a-gem-name-v1)
 # yml_configs: a list of labels of the yaml configs (or an empty list)
 # grpc_service_config: a label to the grpc service config
+# service_yaml: a label to the service yaml
 #
 def ruby_gapic_library(
   name,
@@ -39,6 +40,7 @@ def ruby_gapic_library(
   extra_protoc_parameters = [],
   yml_configs = [],
   grpc_service_config = None,
+  service_yaml = None,
   **kwargs):
   
   _ruby_gapic_library_internal(
@@ -47,7 +49,8 @@ def ruby_gapic_library(
     Label("//rules_ruby_gapic/gapic-generator:gapic_generator_ruby"),
     extra_protoc_parameters,
     yml_configs,
-    grpc_service_config
+    grpc_service_config,
+    service_yaml
   )
 
 ##
@@ -63,6 +66,7 @@ def ruby_gapic_library(
 # extra_protoc_parameters: a list of the generator parameters in the form of "key=value" strings
 #   (e.g. ruby-cloud-gem-name=google-cloud-gem-name-v1)
 # grpc_service_config: a label to the grpc service config
+# service_yaml: a label to the service yaml
 #
 def ruby_cloud_gapic_library(
   name,
@@ -71,6 +75,7 @@ def ruby_cloud_gapic_library(
   ruby_cloud_description = "",
   extra_protoc_parameters = [],
   grpc_service_config = None,
+  service_yaml = None,
   **kwargs):
   
   if extra_protoc_parameters:
@@ -96,7 +101,8 @@ def ruby_cloud_gapic_library(
     Label("//rules_ruby_gapic/gapic-generator-cloud:gapic_generator_cloud"),
     extra_protoc_parameters,
     [],
-    grpc_service_config
+    grpc_service_config,
+    service_yaml
   )
 
 ##
@@ -108,12 +114,14 @@ def ruby_cloud_gapic_library(
 # extra_protoc_parameters: a list of the generator parameters in the form of "key=value" strings
 #   (e.g. gem-name=google-ads-googleads)
 # grpc_service_config: a label to the grpc service config
+# service_yaml: a label to the service yaml
 #
 def ruby_ads_gapic_library(
   name,
   srcs,
   extra_protoc_parameters = [],
   grpc_service_config = None,
+  service_yaml = None,
   **kwargs):
   
   _ruby_gapic_library_internal(
@@ -122,7 +130,8 @@ def ruby_ads_gapic_library(
     Label("//rules_ruby_gapic/gapic-generator-ads:gapic_generator_ads"),
     extra_protoc_parameters,
     [],
-    grpc_service_config
+    grpc_service_config,
+    service_yaml
   )
 
 ##

--- a/shared/output/gapic/templates/testing/testing.gemspec
+++ b/shared/output/gapic/templates/testing/testing.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-common", "~>1.0"
-  gem.add_dependency "google-cloud-location", "~> 0.1"
+  gem.add_dependency "google-cloud-location", ">= 0.0", "< 2.a"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"


### PR DESCRIPTION
* Mixin dependencies were `"~> 0.1"` which precludes 1.x. Changed to `[">= 0.0", "< 2.a"]` to conform to how we're doing dependencies on other libraries that we intend to promote to 1.0.
* Mixins currently require passing in a service-yaml file, but the `service_yaml` field in the bazel config wasn't implemented as it is in other languages. This made it difficult to specify the service yaml path because it needs to be included as an argument and added implicitly to the depset. Fixed (I think).