### PR TITLE
fix: small fixes for combined libraries and testing

### DIFF
--- a/gapic-common/lib/gapic/headers.rb
+++ b/gapic-common/lib/gapic/headers.rb
@@ -38,7 +38,7 @@ module Gapic
 
       ruby_version ||= ::RUBY_VERSION
       gax_version  ||= ::Gapic::Common::VERSION
-      grpc_version ||= ::GRPC::VERSION if defined? ::GRPC
+      grpc_version ||= ::GRPC::VERSION if defined? ::GRPC::VERSION
       rest_version ||= ::Faraday::VERSION if defined? ::Faraday
 
       x_goog_api_client_header = ["gl-ruby/#{ruby_version}"]

--- a/gapic-common/lib/gapic/rest/client_stub.rb
+++ b/gapic-common/lib/gapic/rest/client_stub.rb
@@ -37,13 +37,13 @@ module Gapic
       def initialize endpoint:, credentials:
         @endpoint = endpoint
         @endpoint = "https://#{endpoint}" unless /^https?:/.match? endpoint
-        @endpoint.sub! %r{/$}, ""
+        @endpoint = @endpoint.sub %r{/$}, ""
 
         @credentials = credentials
 
         @connection = Faraday.new url: @endpoint do |conn|
           conn.headers = { "Content-Type" => "application/json" }
-          conn.request :google_authorization, @credentials
+          conn.request :google_authorization, @credentials unless @credentials.is_a? ::Symbol
           conn.request :retry
           conn.response :raise_error
           conn.adapter :net_http


### PR DESCRIPTION
3 fixes that combined/rest libraries need in gapic-common

1. Combined libraries will load `grpc/error` (but not `grpc/version`) via `require 'gapic/common'`. Ideally the load of `grpc/error` should be moved to `gapic/grpc` but full impact of that move should be evaluated separately.
Meanwhile, having `::GRPC` but not `::GRPC::Error` will lead to exception in `gapic/headers.rb`. This fixes.

2. Passing a frozen string as an endpoint can happen in testing, and `gsub!` will fail. This does not need combined to happen, so in theory it affects Compute right now, but no one acceptance-tests compute against a local endpoint.

3. Similarly, passing a symbol as a credential in testing (`:this_channel_is_insecure`) should mean "don't try to do auth", just as it is in GRPC. This implements by disabling the Faraday middleware.