### PR TITLE
fix: LRO-wrapped methods of the internal Operations client not working

### DIFF
--- a/gapic-generator/templates/default/service/client/_operations.erb
+++ b/gapic-generator/templates/default/service/client/_operations.erb
@@ -74,6 +74,9 @@ class <%= service.operations_name %>
       channel_args: @config.channel_args,
       interceptors: @config.interceptors
     )
+
+    # Used by an LRO wrapper for some methods of this service
+    @operations_client = self
   end
 
   # Service calls

--- a/shared/output/cloud/compute_small_wrapper/lib/google/cloud/compute.rb
+++ b/shared/output/cloud/compute_small_wrapper/lib/google/cloud/compute.rb
@@ -54,8 +54,6 @@ module Google
       #
       # ## About Addresses
       #
-      # Services
-      #
       # The Addresses API.
       #
       # @param version [::String, ::Symbol] The API version to connect to. Optional.

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -102,6 +102,9 @@ module So
               channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
+
+            # Used by an LRO wrapper for some methods of this service
+            @operations_client = self
           end
 
           # Service calls

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -102,6 +102,9 @@ module Google
               channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
+
+            # Used by an LRO wrapper for some methods of this service
+            @operations_client = self
           end
 
           # Service calls

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -102,6 +102,9 @@ module Google
               channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
+
+            # Used by an LRO wrapper for some methods of this service
+            @operations_client = self
           end
 
           # Service calls

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/operations.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/operations.rb
@@ -101,6 +101,9 @@ module Testing
             channel_args: @config.channel_args,
             interceptors: @config.interceptors
           )
+
+          # Used by an LRO wrapper for some methods of this service
+          @operations_client = self
         end
 
         # Service calls


### PR DESCRIPTION
Fix the internal Operations clients referencing a nonexistent private field. See https://github.com/googleapis/google-cloud-ruby/pull/18340 for example of how things break.