### PR TITLE
feat(gapic-common): Support faraday 2.0

### DIFF
--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -1,0 +1,44 @@
+name: CI gapic-common
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  CI:
+    if: ${{ github.repository == 'googleapis/gapic-generator-ruby' }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            ruby: "2.6"
+          - os: ubuntu-latest
+            ruby: "2.7"
+          - os: ubuntu-latest
+            ruby: "3.0"
+          - os: ubuntu-latest
+            ruby: "3.1"
+          - os: macos-latest
+            ruby: "3.0"
+          - os: windows-latest
+            ruby: "3.0"
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Install Ruby ${{ matrix.ruby }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "${{ matrix.ruby }}"
+    - name: Install tools
+      shell: bash
+      run: |
+        cd gapic-common && bundle install && gem install --no-document toys
+    - name: Test ${{ matrix.task }}
+      shell: bash
+      run: |
+        cd gapic-common && bundle exec rake ci

--- a/gapic-common/README.md
+++ b/gapic-common/README.md
@@ -15,11 +15,11 @@ convenient and idiomatic API surface to callers.
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.4+.
+This library is supported on Ruby 2.6+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.4 and
+security maintenance, and not end of life. Currently, this means Ruby 2.6 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/gapic-common/gapic-common.gemspec
+++ b/gapic-common/gapic-common.gemspec
@@ -33,17 +33,18 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.platform =      Gem::Platform::RUBY
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.6"
 
-  spec.add_dependency "faraday", "~> 1.3"
-  spec.add_dependency "googleapis-common-protos", ">= 1.3.11", "< 2.a"
-  spec.add_dependency "googleapis-common-protos-types", ">= 1.0.6", "< 2.a"
-  spec.add_dependency "googleauth", ">= 0.17.0", "< 2.a"
+  spec.add_dependency "faraday", ">= 1.9", "< 3.a"
+  spec.add_dependency "faraday-retry", ">= 1.0", "< 3.a"
+  spec.add_dependency "googleapis-common-protos", ">= 1.3.12", "< 2.a"
+  spec.add_dependency "googleapis-common-protos-types", ">= 1.3.1", "< 2.a"
+  spec.add_dependency "googleauth", "~> 1.0"
   spec.add_dependency "google-protobuf", "~> 3.14"
   spec.add_dependency "grpc", "~> 1.36"
 
   spec.add_development_dependency "google-cloud-core", "~> 1.5"
-  spec.add_development_dependency "google-style", "~> 1.25.1"
+  spec.add_development_dependency "google-style", "~> 1.26.0"
   spec.add_development_dependency "minitest", "~> 5.14"
   spec.add_development_dependency "minitest-autotest", "~> 1.0"
   spec.add_development_dependency "minitest-focus", "~> 1.1"

--- a/gapic-common/lib/gapic/generic_lro/operation.rb
+++ b/gapic-common/lib/gapic/generic_lro/operation.rb
@@ -198,7 +198,7 @@ module Gapic
       # @yield operation [Gapic::GenericLRO::Operation] Yields the finished Operation.
       #
       def wait_until_done! retry_policy: nil
-        retry_policy = ::Gapic::Operation::RetryPolicy.new retry_policy if retry_policy.is_a? Hash
+        retry_policy = ::Gapic::Operation::RetryPolicy.new(**retry_policy) if retry_policy.is_a? Hash
         retry_policy ||= ::Gapic::Operation::RetryPolicy.new
 
         until done?

--- a/gapic-common/lib/gapic/operation.rb
+++ b/gapic-common/lib/gapic/operation.rb
@@ -253,7 +253,7 @@ module Gapic
     # @yield operation [Gapic::Operation] Yields the finished Operation.
     #
     def wait_until_done! retry_policy: nil
-      retry_policy = RetryPolicy.new retry_policy if retry_policy.is_a? Hash
+      retry_policy = RetryPolicy.new(**retry_policy) if retry_policy.is_a? Hash
       retry_policy ||= RetryPolicy.new
 
       until done?

--- a/gapic-common/lib/gapic/paged_enumerable.rb
+++ b/gapic-common/lib/gapic/paged_enumerable.rb
@@ -181,8 +181,7 @@ module Gapic
 
       min_repeated_field_number = fields.map(&:number).min
       if min_repeated_field_number != repeated_field.number
-        raise ArgumentError, "#{@response.class} must have one primary repeated field " \
-          "by both position and number"
+        raise ArgumentError, "#{@response.class} must have one primary repeated field by both position and number"
       end
 
       # We have the correct repeated field, save the field's name

--- a/gapic-common/lib/gapic/protobuf.rb
+++ b/gapic-common/lib/gapic/protobuf.rb
@@ -134,7 +134,7 @@ module Gapic
     #
     # @return [Time] The converted Time.
     def self.timestamp_to_time timestamp
-      Time.at timestamp.nanos * 10**-9 + timestamp.seconds
+      Time.at timestamp.seconds, timestamp.nanos, :nanosecond
     end
 
     ##

--- a/gapic-common/lib/gapic/rest/client_stub.rb
+++ b/gapic-common/lib/gapic/rest/client_stub.rb
@@ -14,6 +14,7 @@
 
 require "googleauth"
 require "gapic/rest/faraday_middleware"
+require "faraday/retry"
 
 module Gapic
   module Rest

--- a/gapic-common/lib/gapic/rest/grpc_transcoder.rb
+++ b/gapic-common/lib/gapic/rest/grpc_transcoder.rb
@@ -140,7 +140,7 @@ module Gapic
       #   Name to value hash of the variables for the uri template expansion.
       #   The values are percent-escaped with slashes potentially preserved.
       def bind_uri_values! http_binding, request_hash
-        http_binding.field_bindings.map do |field_binding|
+        http_binding.field_bindings.to_h do |field_binding|
           field_path_camel = field_binding.field_path.split(".").map { |part| camel_name_for part }.join(".")
           field_value = extract_scalar_value! request_hash, field_path_camel, field_binding.regex
 
@@ -153,7 +153,7 @@ module Gapic
           end
 
           [field_binding.field_path, field_value]
-        end.to_h
+        end
       end
 
       # Percent-escapes a string.
@@ -289,7 +289,7 @@ module Gapic
       def camel_name_for attr_name
         parts = attr_name.split "_"
         first_part = parts[0]
-        other_parts = parts[1..-1]
+        other_parts = parts[1..]
         other_parts_pascal = other_parts.map(&:capitalize).join
         "#{first_part}#{other_parts_pascal}"
       end

--- a/gapic-common/test/gapic/config/errors_test.rb
+++ b/gapic-common/test/gapic/config/errors_test.rb
@@ -25,7 +25,7 @@ class ConfigErrorsTest < Minitest::Test
         config_attr "some method", nil, String
       end
     end
-    assert_equal "invalid config name some method", error.message
+    assert_includes error.message, "invalid config name some method"
   end
 
   def test_parent_config
@@ -36,7 +36,7 @@ class ConfigErrorsTest < Minitest::Test
         config_attr "parent_config", nil, String
       end
     end
-    assert_equal "invalid config name parent_config", error.message
+    assert_includes error.message, "invalid config name parent_config"
   end
 
   def test_existing_method
@@ -47,7 +47,7 @@ class ConfigErrorsTest < Minitest::Test
         config_attr "methods", nil, String
       end
     end
-    assert_equal "method methods already exists", error.message
+    assert_includes error.message, "method methods already exists"
   end
 
   def test_missing_validation
@@ -58,6 +58,6 @@ class ConfigErrorsTest < Minitest::Test
         config_attr "missing_validation", nil
       end
     end
-    assert_equal "validation must be provided", error.message
+    assert_includes error.message, "validation must be provided"
   end
 end

--- a/gapic-common/test/gapic/protobuf/coerce_test.rb
+++ b/gapic-common/test/gapic/protobuf/coerce_test.rb
@@ -90,7 +90,7 @@ class ProtobufCoerceTest < Minitest::Spec
     file = File.new "test/fixtures/fixture_file.txt"
     request_hash = { bytes_field: file }
     user = Gapic::Protobuf.coerce request_hash, to: Gapic::Examples::User
-    _(user.bytes_field).must_equal "This is a text file.\n"
+    _(user.bytes_field).must_match(/^This is a text file.\r?\n/)
   end
 
   it "handles StringIO instances" do

--- a/gapic-common/test/gapic/protobuf/time_test.rb
+++ b/gapic-common/test/gapic/protobuf/time_test.rb
@@ -20,7 +20,7 @@ require "stringio"
 class ProtobufTimeTest < Minitest::Spec
   SECONDS = 271_828_182
   NANOS = 845_904_523
-  A_TIME = Time.at SECONDS + NANOS * 10**-9
+  A_TIME = Time.at SECONDS, NANOS, :nanosecond
   A_TIMESTAMP =
     Google::Protobuf::Timestamp.new seconds: SECONDS, nanos: NANOS
 


### PR DESCRIPTION
This PR adds support for both Faraday `~> 1.9` and `~> 2.0`, to avoid causing diamond dependency issues for clients. Note that since we use the request-retry middleware, we require a version of Faraday (`>= 1.9`) that uses the faraday-retry gem. If the user is using Faraday 1.x, Faraday itself will depend on faraday-retry 1.x. If the user is using Faraday 2.x, gapic-common will bring in faraday-retry 2.x as a dependency. Hence, the "permissive" faraday-retry dependency that allows both 1.x and 2.x.

Also includes the following:

* feat(gapic-common): Require at least Ruby 2.6
* fix(gapic-common): Fix some Ruby 3.0 keyword argument usage errors
* fix(gapic-common): Fix precision issues in protobuf timestamp conversion
* chore: Add a CI job for gapic-common CI against a matrix of Ruby versions