### PR TITLE
fix: Apply both namespace and service overrides to service names in yard links

### DIFF
--- a/gapic-generator/lib/gapic/formatting_utils.rb
+++ b/gapic-generator/lib/gapic/formatting_utils.rb
@@ -160,7 +160,8 @@ module Gapic
         last_index = address.size - 1 if service
         address.each_with_index.map do |node, index|
           node = node.camelize
-          index == last_index ? api.fix_service_name(node) : api.fix_namespace(node)
+          node = api.fix_service_name node if index == last_index
+          api.fix_namespace node
         end.join "::"
       end
     end

--- a/gapic-generator/test/gapic/formatting_utils_test.rb
+++ b/gapic-generator/test/gapic/formatting_utils_test.rb
@@ -290,7 +290,7 @@ class FormattingUtilsTest < Minitest::Test
     end
     result = Gapic::FormattingUtils.format_doc_lines api,
       ["Hello, [World][google.cloud.example.World] [Earth][google.cloud.example.Earth]!\n"]
-    assert_equal ["Hello, {::Google::Cloud::RealExample::World::Client World} {::Google::Cloud::RealExample::Earth Earth}!\n"], result
+    assert_equal ["Hello, {::Google::Cloud::RealExample::WorldService::Client World} {::Google::Cloud::RealExample::Earth Earth}!\n"], result
   end
 
   def test_xref_message_with_service_mapping


### PR DESCRIPTION
Apparently both AutoML and VMMigration depend on namespace overrides to update the capitalization of the service name.