### PR TITLE
feat: Add CallOptions#merge and CallOptions equality checking

### DIFF
--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install tools
       shell: bash
       run: |
-        cd gapic-common && bundle install && gem install --no-document toys
+        cd gapic-common && gem install --no-document toys bundler && bundle install
     - name: Test ${{ matrix.task }}
       shell: bash
       run: |

--- a/gapic-common/lib/gapic/call_options.rb
+++ b/gapic-common/lib/gapic/call_options.rb
@@ -61,18 +61,50 @@ module Gapic
     # @param retry_policy [Hash] the policy for error retry.
     # @param retry_policy [Hash] The policy for error retry. keys must match the arguments for
     #   {RetryPolicy.new}.
+    #
     def apply_defaults timeout: nil, metadata: nil, retry_policy: nil
       @timeout ||= timeout
       @metadata = metadata.merge @metadata if metadata
       @retry_policy.apply_defaults retry_policy if @retry_policy.respond_to? :apply_defaults
     end
 
+    ##
+    # Convert to hash form.
+    #
+    # @return [Hash]
+    #
     def to_h
       {
         timeout:      timeout,
         metadata:     metadata,
         retry_policy: retry_policy
       }
+    end
+
+    ##
+    # Return a new CallOptions with the given modifications. The current object
+    # is not modified.
+    #
+    # @param kwargs [keywords] Updated fields. See {#initialize} for details.
+    # @return [CallOptions] A new CallOptions object.
+    #
+    def merge **kwargs
+      kwargs = to_h.merge kwargs
+      CallOptions.new(**kwargs)
+    end
+
+    # @private Equality test
+    def eql? other
+      other.is_a?(CallOptions) &&
+        other.timeout == timeout &&
+        other.metadata == metadata &&
+        other.retry_policy == retry_policy
+    end
+    alias == eql?
+
+    # @private Hash code
+    def hash
+      to_h.hash
     end
   end
 end

--- a/gapic-common/lib/gapic/call_options/retry_policy.rb
+++ b/gapic-common/lib/gapic/call_options/retry_policy.rb
@@ -74,6 +74,7 @@ module Gapic
       #
       # @param retry_policy [Hash] The policy for error retry. keys must match the arguments for
       #   {RpcCall::RetryPolicy.new}.
+      #
       def apply_defaults retry_policy
         return unless retry_policy.is_a? Hash
 
@@ -83,6 +84,21 @@ module Gapic
         @max_delay     ||= retry_policy[:max_delay]
 
         self
+      end
+
+      # @private Equality test
+      def eql? other
+        other.is_a?(RetryPolicy) &&
+          other.retry_codes == retry_codes &&
+          other.initial_delay == initial_delay &&
+          other.multiplier == multiplier &&
+          other.max_delay == max_delay
+      end
+      alias == eql?
+
+      # @private Hash code
+      def hash
+        [retry_codes, initial_delay, multiplier, max_delay].hash
       end
 
       # @private


### PR DESCRIPTION
Adds:
* Correct equality checking for `Gapic::CallOptions` and `Gapic::CallOptions::RetryPolicy`
* Corresponding hashcode computation
* `merge` method for `Gapic::CallOptions`

These are necessary for CallOptions to be used successfully in the mocks for the spanner client tests. We've had a bit of a challenge getting those tests working again with the changes to minitest 5.16, and my current solution is for the tests to use CallOptions objects rather than hashes to pass call options. This means CallOptions objects need proper equality checking so the mocks can recognize them. There are also a few tests that are calling `Hash#merge` on call options hashes, so this replicates that functionality on the CallOptions class.