### PR TITLE
fix: error code of 0 is not an error for Generic LRO

### DIFF
--- a/gapic-common/lib/gapic/generic_lro/operation.rb
+++ b/gapic-common/lib/gapic/generic_lro/operation.rb
@@ -140,7 +140,7 @@ module Gapic
       # @return [Boolean] Whether an error has been returned.
       #
       def error?
-        done? && (!err.nil? || !error_code.nil?)
+        done? && !(err.nil? && (error_code.nil? || error_code == 0))
       end
 
       ##

--- a/gapic-common/lib/gapic/generic_lro/operation.rb
+++ b/gapic-common/lib/gapic/generic_lro/operation.rb
@@ -140,7 +140,7 @@ module Gapic
       # @return [Boolean] Whether an error has been returned.
       #
       def error?
-        done? && !(err.nil? && (error_code.nil? || error_code == 0))
+        done? && !(err.nil? && (error_code.nil? || error_code.zero?))
       end
 
       ##

--- a/gapic-common/lib/gapic/rest/grpc_transcoder.rb
+++ b/gapic-common/lib/gapic/rest/grpc_transcoder.rb
@@ -108,12 +108,12 @@ module Gapic
           uri_values = bind_uri_values! http_binding, request_hash
           next if uri_values.any? { |_, value| value.nil? }
 
-          if http_binding.body && http_binding.body != "*"
-            # Note that the body template can only point to a top-level field,
-            # so there is no need to split the path.
-            body_binding_camel = camel_name_for http_binding.body
-            next unless request_hash.key? body_binding_camel
-          end
+          # if http_binding.body && http_binding.body != "*"
+          #   # Note that the body template can only point to a top-level field,
+          #   # so there is no need to split the path.
+          #   body_binding_camel = camel_name_for http_binding.body
+          #   next unless request_hash.key? body_binding_camel
+          # end
 
           method = http_binding.method
           uri = expand_template http_binding.template, uri_values
@@ -182,9 +182,14 @@ module Gapic
           #
           # The `request_hash_without_uri` at this point was mutated to delete these fields.
           #
-          # Note that the body template can only point to a top-level field
-          request_hash_without_uri.delete camel_name_for body_template
-          body = request.send(body_template.to_sym).to_json(emit_defaults: true)
+          # Note 1: body template can only point to a top-level field.
+          # Note 2: The field that body template points to can be null, in which case
+          # an empty string should be sent. E.g. `Compute.Projects.SetUsageExportBucket`.
+          if request.send(body_template.to_sym)
+            request_hash_without_uri.delete camel_name_for body_template
+            body = request.send(body_template.to_sym).to_json(emit_defaults: true)
+          end
+
           query_params = build_query_params request_hash_without_uri
         else
           query_params = build_query_params request_hash_without_uri

--- a/gapic-common/lib/gapic/rest/grpc_transcoder.rb
+++ b/gapic-common/lib/gapic/rest/grpc_transcoder.rb
@@ -185,7 +185,7 @@ module Gapic
           # Note 1: body template can only point to a top-level field.
           # Note 2: The field that body template points to can be null, in which case
           # an empty string should be sent. E.g. `Compute.Projects.SetUsageExportBucket`.
-          if request.send(body_template.to_sym)
+          if request.send body_template.to_sym
             request_hash_without_uri.delete camel_name_for body_template
             body = request.send(body_template.to_sym).to_json(emit_defaults: true)
           end


### PR DESCRIPTION
also relaxes transcoding requirements by allowing a field directly specified in the `body` transcoding parameter to be nil. 