### PR TITLE
fix: error code of 0 is not an error, body template field can be nil

### DIFF
--- a/gapic-common/lib/gapic/generic_lro/operation.rb
+++ b/gapic-common/lib/gapic/generic_lro/operation.rb
@@ -140,7 +140,8 @@ module Gapic
       # @return [Boolean] Whether an error has been returned.
       #
       def error?
-        done? && (!err.nil? || !error_code.nil?)
+        no_error_code = error_code.nil? || error_code.zero?
+        done? && !(err.nil? && no_error_code)
       end
 
       ##

--- a/gapic-common/lib/gapic/rest/grpc_transcoder.rb
+++ b/gapic-common/lib/gapic/rest/grpc_transcoder.rb
@@ -108,10 +108,10 @@ module Gapic
           uri_values = bind_uri_values! http_binding, request_hash
           next if uri_values.any? { |_, value| value.nil? }
 
-          if http_binding.body && http_binding.body != "*"
+          if http_binding.body && http_binding.body != "*" && !(request.respond_to? http_binding.body.to_sym)
             # Note that the body template can only point to a top-level field,
             # so there is no need to split the path.
-            next unless request.respond_to?(http_binding.body.to_sym)
+            next
           end
 
           method = http_binding.method

--- a/gapic-common/lib/gapic/rest/grpc_transcoder.rb
+++ b/gapic-common/lib/gapic/rest/grpc_transcoder.rb
@@ -108,11 +108,9 @@ module Gapic
           uri_values = bind_uri_values! http_binding, request_hash
           next if uri_values.any? { |_, value| value.nil? }
 
-          if http_binding.body && http_binding.body != "*" && !(request.respond_to? http_binding.body.to_sym)
-            # Note that the body template can only point to a top-level field,
-            # so there is no need to split the path.
-            next
-          end
+          # Note that the body template can only point to a top-level field,
+          # so there is no need to split the path.
+          next if http_binding.body && http_binding.body != "*" && !(request.respond_to? http_binding.body.to_sym)
 
           method = http_binding.method
           uri = expand_template http_binding.template, uri_values
@@ -184,9 +182,10 @@ module Gapic
           # Note 1: body template can only point to a top-level field.
           # Note 2: The field that body template points to can be null, in which case
           # an empty string should be sent. E.g. `Compute.Projects.SetUsageExportBucket`.
-          if request.respond_to?(body_template.to_sym) && request.send(body_template.to_sym)
+          request_body_field = request.send body_template.to_sym if request.respond_to? body_template.to_sym
+          if request_body_field
             request_hash_without_uri.delete camel_name_for body_template
-            body = request.send(body_template.to_sym).to_json(emit_defaults: true)
+            body = request_body_field.to_json emit_defaults: true
           end
 
           query_params = build_query_params request_hash_without_uri

--- a/gapic-common/test/gapic/generic_lro_test.rb
+++ b/gapic-common/test/gapic/generic_lro_test.rb
@@ -78,7 +78,7 @@ class GenericLROTest < Minitest::Test
   end
 
   # Testing errored-out object for message-type error
-  def test_errored_operation
+  def test_errored_operation_message
     error = OpenStruct.new(code: ERR_CODE, message: ERR_MSG)
     op = create_op MockOperation.new(status: :DONE, err: error), err_field: "err"
     assert op.done?
@@ -97,6 +97,16 @@ class GenericLROTest < Minitest::Test
     assert op.response?
     assert_nil op.error
     assert_equal NAME, op.name
+    refute_nil op.response
+  end
+
+  # Testing done object with error code set to 0
+  def test_done_operation_zeroerrcode
+    op = create_op MockOperation.new(status: :DONE, err_code: 0)
+    assert op.done?
+    refute op.error?
+    assert op.response?
+    assert_nil op.error
     refute_nil op.response
   end
 

--- a/gapic-common/test/gapic/rest/grpc_transcoder_test.rb
+++ b/gapic-common/test/gapic/rest/grpc_transcoder_test.rb
@@ -207,6 +207,7 @@ class GrpcTranscoderTest < Minitest::Test
         uri_template: "{name}/sub/{sub_request.name}",
         matches: [["name", %r{^v3/projects/[^/]+(?:/.*)?$}, true], ["sub_request.name", %r{^instances/[^/]+?$}, true]])
       .with_bindings(uri_method: :get, uri_template: "{name}", body: "IPProtocol", matches: [["name", %r{^v4/projects/[^/]+(?:/.*)?$}, true]])
+      .with_bindings(uri_method: :get, uri_template: "{name}", body: "sub_request", matches: [["name", %r{^v5/projects/[^/]+(?:/.*)?$}, true]])
 
     test_cases = [
       {
@@ -250,6 +251,16 @@ class GrpcTranscoderTest < Minitest::Test
           uri: "v4/projects/100",
           query_params: ["id=34","maybeNum=100"],
           body: '"TCP"'
+        }
+      },
+      {
+        # `body` is a nil message field.
+        request: example_request(id: 35, name: "v5/projects/100"),
+        expected: {
+          method: :get,
+          uri: "v5/projects/100",
+          query_params: ["id=35"],
+          body: ""
         }
       },
     ]


### PR DESCRIPTION
fix: error code of 0 is not an error for Generic LRO. Compute returns 0 in the error code field on success.
fix: body template field can be nil. This theoretically relaxes transcoding but there are no/should not be cases when somebody would use the nill-ness of a body field as a binding selector.