### PR TITLE
feat: rewrap certain grpc errors

### DIFF
--- a/gapic-common/lib/gapic/call_options/retry_policy.rb
+++ b/gapic-common/lib/gapic/call_options/retry_policy.rb
@@ -132,7 +132,7 @@ module Gapic
       private
 
       def retry? error
-        error.is_a?(GRPC::BadStatus) && retry_codes.include?(error.code)
+        error.is_a?(::GRPC::BadStatus) && retry_codes.include?(error.code)
       end
 
       def delay!

--- a/gapic-common/lib/gapic/grpc.rb
+++ b/gapic-common/lib/gapic/grpc.rb
@@ -13,5 +13,6 @@
 # limitations under the License.
 
 require "grpc"
+require "gapic/grpc/errors"
 require "gapic/grpc/service_stub"
 require "gapic/grpc/status_details"

--- a/gapic-common/lib/gapic/grpc/errors.rb
+++ b/gapic-common/lib/gapic/grpc/errors.rb
@@ -1,0 +1,60 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "googleauth"
+require "gapic/common/error"
+
+module Gapic
+  module GRPC
+    ##
+    # An error class to represent the Authorization Error.
+    # The GRPC layer wraps auth plugin errors in ::GRPC::Unavailable.
+    # This class rewraps those GRPC layer errors, presenting a correct status code.
+    #
+    class AuthorizationError < ::GRPC::Unauthenticated
+    end
+
+    ##
+    # An error class that represents Deadline Exceeded error with an optional
+    # retry root cause.
+    #
+    # The GRPC layer throws ::GRPC::DeadlineExceeded without any context.
+    # If the deadline was exceeded while retrying another exception (e.g.
+    # ::GRPC::Unavailable), that exception could be useful for understanding
+    # the readon for the timeout.
+    #
+    # This exception rewraps ::GRPC::DeadlineExceeded, adding an exception
+    # that was being retried until the deadline was exceeded (if any) as a
+    # `root_cause` attribute.
+    #
+    # @!attribute [r] root_cause
+    #   @return [Object, nil] The exception that was being retried
+    #     when the DeadlineExceeded error occured.
+    #
+    class DeadlineExceededError < ::GRPC::DeadlineExceeded
+      attr_reader :root_cause
+
+      ##
+      # @param message [String] The error message.
+      #
+      # @param root_cause [Object, nil] The exception that was being retried
+      #   when the DeadlineExceeded error occured.
+      #
+      def initialize message, root_cause: nil
+        super message
+        @root_cause = root_cause
+      end
+    end
+  end
+end

--- a/gapic-common/lib/gapic/grpc/service_stub.rb
+++ b/gapic-common/lib/gapic/grpc/service_stub.rb
@@ -34,20 +34,20 @@ module Gapic
     # @param grpc_stub_class [Class] gRPC stub class to create a new instance of.
     # @param endpoint [String] The endpoint of the API.
     # @param credentials [Google::Auth::Credentials, Signet::OAuth2::Client, String, Hash, Proc,
-    #   GRPC::Core::Channel, GRPC::Core::ChannelCredentials] Provides the means for authenticating requests made by
+    #   ::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] Provides the means for authenticating requests made by
     #   the client. This parameter can be many types:
     #
     #   * A `Google::Auth::Credentials` uses a the properties of its represented keyfile for authenticating requests
     #     made by this client.
     #   * A `Signet::OAuth2::Client` object used to apply the OAuth credentials.
-    #   * A `GRPC::Core::Channel` will be used to make calls through.
-    #   * A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials should
-    #     already be composed with a `GRPC::Core::CallCredentials` object.
+    #   * A `::GRPC::Core::Channel` will be used to make calls through.
+    #   * A `::GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials should
+    #     already be composed with a `::GRPC::Core::CallCredentials` object.
     #   * A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the metadata for
     #     requests, generally, to give OAuth credentials.
     # @param channel_args [Hash] The channel arguments. (This argument is ignored when `credentials` is
-    #     provided as a `GRPC::Core::Channel`.)
-    # @param interceptors [Array<GRPC::ClientInterceptor>] An array of {GRPC::ClientInterceptor} objects that will
+    #     provided as a `::GRPC::Core::Channel`.)
+    # @param interceptors [Array<::GRPC::ClientInterceptor>] An array of {::GRPC::ClientInterceptor} objects that will
     #   be used for intercepting calls before they are executed Interceptors are an EXPERIMENTAL API.
     #
     def initialize grpc_stub_class, endpoint:, credentials:, channel_args: nil, interceptors: nil
@@ -59,10 +59,10 @@ module Gapic
       interceptors = Array interceptors
 
       @grpc_stub = case credentials
-                   when GRPC::Core::Channel
+                   when ::GRPC::Core::Channel
                      grpc_stub_class.new endpoint, nil, channel_override: credentials,
                                                         interceptors:     interceptors
-                   when GRPC::Core::ChannelCredentials, Symbol
+                   when ::GRPC::Core::ChannelCredentials, Symbol
                      grpc_stub_class.new endpoint, credentials, channel_args: channel_args,
                                                                 interceptors: interceptors
                    else
@@ -70,8 +70,8 @@ module Gapic
                      updater_proc ||= credentials if credentials.is_a? Proc
                      raise ArgumentError, "invalid credentials (#{credentials.class})" if updater_proc.nil?
 
-                     call_creds = GRPC::Core::CallCredentials.new updater_proc
-                     chan_creds = GRPC::Core::ChannelCredentials.new.compose call_creds
+                     call_creds = ::GRPC::Core::CallCredentials.new updater_proc
+                     chan_creds = ::GRPC::Core::ChannelCredentials.new.compose call_creds
                      grpc_stub_class.new endpoint, chan_creds, channel_args: channel_args,
                                                                interceptors: interceptors
                    end
@@ -88,7 +88,7 @@ module Gapic
     #
     # @yield [response, operation] Access the response along with the RPC operation.
     # @yieldparam response [Object] The response object.
-    # @yieldparam operation [GRPC::ActiveCall::Operation] The RPC operation for the response.
+    # @yieldparam operation [::GRPC::ActiveCall::Operation] The RPC operation for the response.
     #
     # @return [Object] The response object.
     #
@@ -98,7 +98,7 @@ module Gapic
     #   require "gapic"
     #   require "gapic/grpc"
     #
-    #   echo_channel = GRPC::Core::Channel.new(
+    #   echo_channel = ::GRPC::Core::Channel.new(
     #     "localhost:7469", nil, :this_channel_is_insecure
     #   )
     #   echo_stub = Gapic::ServiceStub.new(
@@ -115,7 +115,7 @@ module Gapic
     #   require "gapic"
     #   require "gapic/grpc"
     #
-    #   echo_channel = GRPC::Core::Channel.new(
+    #   echo_channel = ::GRPC::Core::Channel.new(
     #     "localhost:7469", nil, :this_channel_is_insecure
     #   )
     #   echo_stub = Gapic::ServiceStub.new(
@@ -126,7 +126,7 @@ module Gapic
     #   request = Google::Showcase::V1beta1::EchoRequest.new
     #   options = Gapic::CallOptions.new(
     #     retry_policy = {
-    #       retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE]
+    #       retry_codes: [::GRPC::Core::StatusCodes::UNAVAILABLE]
     #     }
     #   )
     #   response = echo_stub.call_rpc :echo, request
@@ -138,7 +138,7 @@ module Gapic
     #   require "gapic"
     #   require "gapic/grpc"
     #
-    #   echo_channel = GRPC::Core::Channel.new(
+    #   echo_channel = ::GRPC::Core::Channel.new(
     #     "localhost:7469", nil, :this_channel_is_insecure
     #   )
     #   echo_stub = Gapic::ServiceStub.new(

--- a/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
+++ b/gapic-common/lib/gapic/grpc/service_stub/rpc_call.rb
@@ -46,7 +46,7 @@ module Gapic
       #
       # @yield [response, operation] Access the response along with the RPC operation.
       # @yieldparam response [Object] The response object.
-      # @yieldparam operation [GRPC::ActiveCall::Operation] The RPC operation for the response.
+      # @yieldparam operation [::GRPC::ActiveCall::Operation] The RPC operation for the response.
       #
       # @return [Object] The response object.
       #
@@ -56,7 +56,7 @@ module Gapic
       #   require "gapic"
       #   require "gapic/grpc"
       #
-      #   echo_channel = GRPC::Core::Channel.new(
+      #   echo_channel = ::GRPC::Core::Channel.new(
       #     "localhost:7469", nil, :this_channel_is_insecure
       #   )
       #   echo_stub = Gapic::ServiceStub.new(
@@ -74,7 +74,7 @@ module Gapic
       #   require "gapic"
       #   require "gapic/grpc"
       #
-      #   echo_channel = GRPC::Core::Channel.new(
+      #   echo_channel = ::GRPC::Core::Channel.new(
       #     "localhost:7469", nil, :this_channel_is_insecure
       #   )
       #   echo_stub = Gapic::ServiceStub.new(
@@ -86,7 +86,7 @@ module Gapic
       #   request = Google::Showcase::V1beta1::EchoRequest.new
       #   options = Gapic::CallOptions.new(
       #     retry_policy = {
-      #       retry_codes: [GRPC::Core::StatusCodes::UNAVAILABLE]
+      #       retry_codes: [::GRPC::Core::StatusCodes::UNAVAILABLE]
       #     }
       #   )
       #   response = echo_call.call request, options: options
@@ -97,7 +97,7 @@ module Gapic
       #   require "gapic"
       #   require "gapic/grpc"
       #
-      #   echo_channel = GRPC::Core::Channel.new(
+      #   echo_channel = ::GRPC::Core::Channel.new(
       #     "localhost:7469", nil, :this_channel_is_insecure
       #   )
       #   echo_stub = Gapic::ServiceStub.new(

--- a/gapic-common/lib/gapic/headers.rb
+++ b/gapic-common/lib/gapic/headers.rb
@@ -25,7 +25,7 @@ module Gapic
     # @param lib_version [String] The client library version.
     # @param gax_version [String] The Gapic version. Defaults to `Gapic::Common::VERSION`.
     # @param gapic_version [String] The Gapic version.
-    # @param grpc_version [String] The GRPC version. Defaults to `GRPC::VERSION`.
+    # @param grpc_version [String] The GRPC version. Defaults to `::GRPC::VERSION`.
     # @param rest_version [String] The Rest Library (Faraday) version. Defaults to `Faraday::VERSION`.
     # @param transports_version_send [Array] Which transports to send versions for.
     #   Allowed values to contain are:

--- a/gapic-common/lib/gapic/paged_enumerable.rb
+++ b/gapic-common/lib/gapic/paged_enumerable.rb
@@ -53,7 +53,7 @@ module Gapic
     # @param method_name [Symbol] The RPC method name.
     # @param request [Object] The request object.
     # @param response [Object] The response object.
-    # @param operation [GRPC::ActiveCall::Operation] The RPC operation for the response.
+    # @param operation [::GRPC::ActiveCall::Operation] The RPC operation for the response.
     # @param options [Gapic::CallOptions] The options for making the RPC call.
     # @param format_resource [Proc] A Proc object to format the resource object. The Proc should accept response as an
     #   argument, and return a formatted resource object. Optional.
@@ -195,7 +195,7 @@ module Gapic
     # @attribute [r] response
     #   @return [Object] the response object for the page.
     # @attribute [r] operation
-    #   @return [GRPC::ActiveCall::Operation] the RPC operation for the page.
+    #   @return [::GRPC::ActiveCall::Operation] the RPC operation for the page.
     class Page
       include Enumerable
       attr_reader :response
@@ -205,7 +205,7 @@ module Gapic
       # @private
       # @param response [Object] The response object for the page.
       # @param resource_field [String] The name of the field in response which holds the resources.
-      # @param operation [GRPC::ActiveCall::Operation] the RPC operation for the page.
+      # @param operation [::GRPC::ActiveCall::Operation] the RPC operation for the page.
       # @param format_resource [Proc] A Proc object to format the resource object. The Proc should accept response as an
       #   argument, and return a formatted resource object. Optional.
       #

--- a/gapic-common/test/gapic/grpc/rpc_call/raise_test.rb
+++ b/gapic-common/test/gapic/grpc/rpc_call/raise_test.rb
@@ -91,11 +91,11 @@ class RpcCallRaiseTest < Minitest::Test
   # it gets extracted and rewrapped into a G
   def test_will_rewrap_signet_errors
     signet_error_text = <<-SIGNET
-    #<Signet::AuthorizationError: Authorization failed.  Server message:
-    # {
-    #   "error": "invalid_grant",
-    #   "error_description": "Bad Request"
-    # }
+    <Signet::AuthorizationError: Authorization failed.  Server message:
+    {
+       "error": "invalid_grant",
+       "error_description": "Bad Request"
+    }>
     SIGNET
 
     unauth_error_text = "#{::GRPC::Core::StatusCodes::UNAUTHENTICATED}:#{signet_error_text}"


### PR DESCRIPTION
- Reclassifies `::GRPC::Unavailable` errors that contain `Signet::AuthorizationError` into `Gapic::GRPC::AuthorizationError` which is derived from `::GRPC::Unauthenticated`
- If an exception led to a retry, and then a deadline was exceeded, when `::GRPC::DeadlineExceeded` was thrown, it gets wrapped into the `Gapic::GRPC::DeadlineExceededError` which inherits from `::GRPC::DeadlineExceeded` but contains additional information about the retried exception.

Related to and will fix: https://github.com/googleads/google-ads-ruby/issues/246.

Internal re: go/cloudclibs-ruby-unavailable-auth