### PR TITLE
Add utility methods to covert ruby/proto dates

### DIFF
--- a/gapic-common/lib/gapic/protobuf.rb
+++ b/gapic-common/lib/gapic/protobuf.rb
@@ -147,6 +147,16 @@ module Gapic
       Google::Protobuf::Timestamp.new seconds: time.to_i, nanos: time.nsec
     end
 
+    ##
+    # Utility for converting a Ruby Date instance to a Google::Type::Date.
+    #
+    # @param timestamp [Date] The Date to be converted.
+    #
+    # @return [Google::Type::Date] The converted Google::Type::Date.
+    def self.date_to_date_pb date
+      Google::Type::Date.new year: date.year, month: date.month, day: date.day
+    end
+
     private_class_method :coerce_submessages, :coerce_submessage, :coerce_array, :coerce_value, :map_field?
   end
 end

--- a/gapic-common/test/gapic/protobuf/date_test.rb
+++ b/gapic-common/test/gapic/protobuf/date_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+require "google/type/date_pb"
+
+class ProtobufDateTest < Minitest::Spec
+  it "date_to_date_pb converts ruby Date to proto Date" do
+    date = Date.new(2022, 8, 19)
+    datepb = Google::Type::Date.new(year: 2022, month: 8, day: 19)
+    _(Gapic::Protobuf.date_to_date_pb(date)).must_equal datepb
+  end
+end


### PR DESCRIPTION
This PR is not complete but I wanted to gather attention from maintainers as the issue has been ignored.

Close https://github.com/googleapis/gapic-generator-ruby/issues/706.