### PR TITLE
feat(gapic-common): Support numeric_enums in the ClientStub

### DIFF
--- a/gapic-common/lib/gapic/rest/client_stub.rb
+++ b/gapic-common/lib/gapic/rest/client_stub.rb
@@ -130,7 +130,7 @@ module Gapic
       # @return [Faraday::Response]
       def make_http_request verb, uri:, body:, params:, options:
         if @numeric_enums && (!params.key?("$alt") || params["$alt"] == "json")
-          params = params.merge({"$alt" => "json;enum-encoding=int"})
+          params = params.merge({ "$alt" => "json;enum-encoding=int" })
         end
         options = ::Gapic::CallOptions.new(**options.to_h) unless options.is_a? ::Gapic::CallOptions
         @connection.send verb, uri do |req|

--- a/gapic-common/lib/gapic/rest/client_stub.rb
+++ b/gapic-common/lib/gapic/rest/client_stub.rb
@@ -60,8 +60,8 @@ module Gapic
       #
       # @param uri [String] uri to send this request to
       # @param params [Hash] query string parameters for the request
-      # @param options [::Gapic::CallOptions] gapic options to be applied to the REST call.
-      #   Currently only timeout and headers are supported.
+      # @param options [::Gapic::CallOptions,Hash] gapic options to be applied
+      #     to the REST call. Currently only timeout and headers are supported.
       # @return [Faraday::Response]
       def make_get_request uri:, params: {}, options: {}
         make_http_request :get, uri: uri, body: nil, params: params, options: options
@@ -72,8 +72,8 @@ module Gapic
       #
       # @param uri [String] uri to send this request to
       # @param params [Hash] query string parameters for the request
-      # @param options [::Gapic::CallOptions] gapic options to be applied to the REST call.
-      #   Currently only timeout and headers are supported.
+      # @param options [::Gapic::CallOptions,Hash] gapic options to be applied
+      #     to the REST call. Currently only timeout and headers are supported.
       # @return [Faraday::Response]
       def make_delete_request uri:, params: {}, options: {}
         make_http_request :delete, uri: uri, body: nil, params: params, options: options
@@ -85,8 +85,8 @@ module Gapic
       # @param uri [String] uri to send this request to
       # @param body [String] a body to send with the request, nil for requests without a body
       # @param params [Hash] query string parameters for the request
-      # @param options [::Gapic::CallOptions] gapic options to be applied to the REST call.
-      #   Currently only timeout and headers are supported.
+      # @param options [::Gapic::CallOptions,Hash] gapic options to be applied
+      #     to the REST call. Currently only timeout and headers are supported.
       # @return [Faraday::Response]
       def make_patch_request uri:, body:, params: {}, options: {}
         make_http_request :patch, uri: uri, body: body, params: params, options: options
@@ -98,8 +98,8 @@ module Gapic
       # @param uri [String] uri to send this request to
       # @param body [String] a body to send with the request, nil for requests without a body
       # @param params [Hash] query string parameters for the request
-      # @param options [::Gapic::CallOptions] gapic options to be applied to the REST call.
-      #   Currently only timeout and headers are supported.
+      # @param options [::Gapic::CallOptions,Hash] gapic options to be applied
+      #     to the REST call. Currently only timeout and headers are supported.
       # @return [Faraday::Response]
       def make_post_request uri:, body: nil, params: {}, options: {}
         make_http_request :post, uri: uri, body: body, params: params, options: options
@@ -111,8 +111,8 @@ module Gapic
       # @param uri [String] uri to send this request to
       # @param body [String] a body to send with the request, nil for requests without a body
       # @param params [Hash] query string parameters for the request
-      # @param options [::Gapic::CallOptions] gapic options to be applied to the REST call.
-      #   Currently only timeout and headers are supported.
+      # @param options [::Gapic::CallOptions,Hash] gapic options to be applied
+      #     to the REST call. Currently only timeout and headers are supported.
       # @return [Faraday::Response]
       def make_put_request uri:, body: nil, params: {}, options: {}
         make_http_request :put, uri: uri, body: body, params: params, options: options
@@ -125,8 +125,8 @@ module Gapic
       # @param uri [String] uri to send this request to
       # @param body [String, nil] a body to send with the request, nil for requests without a body
       # @param params [Hash] query string parameters for the request
-      # @param options [::Gapic::CallOptions] gapic options to be applied to the REST call.
-      #   Currently only timeout and headers are supported.
+      # @param options [::Gapic::CallOptions,Hash] gapic options to be applied
+      #     to the REST call. Currently only timeout and headers are supported.
       # @return [Faraday::Response]
       def make_http_request verb, uri:, body:, params:, options:
         if @numeric_enums && (!params.key?("$alt") || params["$alt"] == "json")

--- a/gapic-common/test/gapic/rest/client_stub_test.rb
+++ b/gapic-common/test/gapic/rest/client_stub_test.rb
@@ -54,8 +54,8 @@ class ClientStubTest < Minitest::Test
   def test_make_get_request_simple
     client_stub = make_client_stub
     expected_req = FakeRequest.default
-    mock = expect_connection client_stub, :get, "/blah", expected_req
-    client_stub.make_get_request uri: "/blah"
+    mock = expect_connection client_stub, :get, "/foo", expected_req
+    client_stub.make_get_request uri: "/foo"
     mock.verify
   end
 
@@ -63,8 +63,8 @@ class ClientStubTest < Minitest::Test
     client_stub = make_client_stub
     expected_req = FakeRequest.default
     expected_req.params = {"Foo" => "bar"}
-    mock = expect_connection client_stub, :get, "/blah", expected_req
-    client_stub.make_get_request uri: "/blah", params: {"Foo" => "bar"}
+    mock = expect_connection client_stub, :get, "/foo", expected_req
+    client_stub.make_get_request uri: "/foo", params: {"Foo" => "bar"}
     mock.verify
   end
 
@@ -72,16 +72,25 @@ class ClientStubTest < Minitest::Test
     client_stub = make_client_stub numeric_enums: true
     expected_req = FakeRequest.default
     expected_req.params = {"$alt" => "json;enum-encoding=int"}
-    mock = expect_connection client_stub, :get, "/blah", expected_req
-    client_stub.make_get_request uri: "/blah"
+    mock = expect_connection client_stub, :get, "/foo", expected_req
+    client_stub.make_get_request uri: "/foo"
+    mock.verify
+  end
+
+  def test_make_get_request_with_numeric_enums_and_existing_alt_param
+    client_stub = make_client_stub numeric_enums: true
+    expected_req = FakeRequest.default
+    expected_req.params = {"Foo" => "bar", "$alt" => "json;enum-encoding=int"}
+    mock = expect_connection client_stub, :get, "/foo", expected_req
+    client_stub.make_get_request uri: "/foo", params: {"Foo" => "bar", "$alt" => "json"}
     mock.verify
   end
 
   def test_make_delete_request_simple
     client_stub = make_client_stub
     expected_req = FakeRequest.default
-    mock = expect_connection client_stub, :delete, "/blah", expected_req
-    client_stub.make_delete_request uri: "/blah"
+    mock = expect_connection client_stub, :delete, "/foo", expected_req
+    client_stub.make_delete_request uri: "/foo"
     mock.verify
   end
 
@@ -89,8 +98,8 @@ class ClientStubTest < Minitest::Test
     client_stub = make_client_stub
     expected_req = FakeRequest.default
     expected_req.body = "hello"
-    mock = expect_connection client_stub, :patch, "/blah", expected_req
-    client_stub.make_patch_request uri: "/blah", body: "hello"
+    mock = expect_connection client_stub, :patch, "/foo", expected_req
+    client_stub.make_patch_request uri: "/foo", body: "hello"
     mock.verify
   end
 
@@ -98,8 +107,8 @@ class ClientStubTest < Minitest::Test
     client_stub = make_client_stub
     expected_req = FakeRequest.default
     expected_req.body = "hello"
-    mock = expect_connection client_stub, :post, "/blah", expected_req
-    client_stub.make_post_request uri: "/blah", body: "hello"
+    mock = expect_connection client_stub, :post, "/foo", expected_req
+    client_stub.make_post_request uri: "/foo", body: "hello"
     mock.verify
   end
 
@@ -107,8 +116,8 @@ class ClientStubTest < Minitest::Test
     client_stub = make_client_stub
     expected_req = FakeRequest.default
     expected_req.body = "hello"
-    mock = expect_connection client_stub, :put, "/blah", expected_req
-    client_stub.make_put_request uri: "/blah", body: "hello"
+    mock = expect_connection client_stub, :put, "/foo", expected_req
+    client_stub.make_put_request uri: "/foo", body: "hello"
     mock.verify
   end
 end

--- a/gapic-common/test/gapic/rest/client_stub_test.rb
+++ b/gapic-common/test/gapic/rest/client_stub_test.rb
@@ -1,0 +1,114 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require "gapic/rest"
+
+class ClientStubTest < Minitest::Test
+  ENDPOINT = "google.example.com"
+  CREDENTIALS = :dummy_credentials
+  STANDARD_HEADER = { "Content-Type" => "application/json" }
+
+  FakeOptions = ::Struct.new :timeout
+
+  FakeRequest = ::Struct.new :params, :body, :headers, :options do
+    def initialize
+      self.options = FakeOptions.new
+      self.headers = {}
+    end
+
+    def self.default
+      req = FakeRequest.new
+      req.headers = STANDARD_HEADER.dup
+      req
+    end
+  end
+
+  def make_client_stub numeric_enums: false
+    ::Gapic::Rest::ClientStub.new endpoint: ENDPOINT,
+                                  credentials: CREDENTIALS,
+                                  numeric_enums: numeric_enums
+  end
+
+  def expect_connection client_stub, verb, uri, req
+    mock = ::Minitest::Mock.new
+    client_stub.instance_variable_set :@connection, mock
+    mock.expect verb, nil do |actual_uri, &block|
+      actual_req = FakeRequest.default
+      block.call actual_req
+      uri == actual_uri && req == actual_req
+    end
+  end
+
+  def test_make_get_request_simple
+    client_stub = make_client_stub
+    expected_req = FakeRequest.default
+    mock = expect_connection client_stub, :get, "/blah", expected_req
+    client_stub.make_get_request uri: "/blah"
+    mock.verify
+  end
+
+  def test_make_get_request_with_params
+    client_stub = make_client_stub
+    expected_req = FakeRequest.default
+    expected_req.params = {"Foo" => "bar"}
+    mock = expect_connection client_stub, :get, "/blah", expected_req
+    client_stub.make_get_request uri: "/blah", params: {"Foo" => "bar"}
+    mock.verify
+  end
+
+  def test_make_get_request_with_numeric_enums
+    client_stub = make_client_stub numeric_enums: true
+    expected_req = FakeRequest.default
+    expected_req.params = {"$alt" => "json;enum-encoding=int"}
+    mock = expect_connection client_stub, :get, "/blah", expected_req
+    client_stub.make_get_request uri: "/blah"
+    mock.verify
+  end
+
+  def test_make_delete_request_simple
+    client_stub = make_client_stub
+    expected_req = FakeRequest.default
+    mock = expect_connection client_stub, :delete, "/blah", expected_req
+    client_stub.make_delete_request uri: "/blah"
+    mock.verify
+  end
+
+  def test_make_patch_request_simple
+    client_stub = make_client_stub
+    expected_req = FakeRequest.default
+    expected_req.body = "hello"
+    mock = expect_connection client_stub, :patch, "/blah", expected_req
+    client_stub.make_patch_request uri: "/blah", body: "hello"
+    mock.verify
+  end
+
+  def test_make_post_request_simple
+    client_stub = make_client_stub
+    expected_req = FakeRequest.default
+    expected_req.body = "hello"
+    mock = expect_connection client_stub, :post, "/blah", expected_req
+    client_stub.make_post_request uri: "/blah", body: "hello"
+    mock.verify
+  end
+
+  def test_make_put_request_simple
+    client_stub = make_client_stub
+    expected_req = FakeRequest.default
+    expected_req.body = "hello"
+    mock = expect_connection client_stub, :put, "/blah", expected_req
+    client_stub.make_put_request uri: "/blah", body: "hello"
+    mock.verify
+  end
+end


### PR DESCRIPTION
This is part of the numeric enums work. It adds a feature to Gapic::Rest::ClientStub that lets you configure it as a service that supports the `enum-encoding=int` signal (see internal document go/cloudsdk-esf-json-enum-number). This will be released as a minor version update for gapic-common. (In a separate PR, the generator will be updated to pass the appropriate value to the ClientStub constructor in the ServiceStub template.)

This also:
* Adds tests for ClientStub
* Fixes exceptions if `nil` or a hash are passed in as the `options:` argument to `ClientStub#make_http_request`. These don't happen in the current generated compute client because the generated client class ensures that a true `Gapic::CallOptions` object is always passed for this argument. However, in the generated low-level `ServiceStub` classes, options defaults to `nil`, and at the `ClientStub` level, all the convenience methods such as `make_get_request` default options to a Hash. So you'd get NoMethodError if you used any of these documented lower-level interfaces and didn't set options explicitly to an actual `CallOptions` object.