### PR TITLE
fix: Update snippetgen phase 1 to conform to standard sample style

### DIFF
--- a/gapic-generator-cloud/templates/cloud/gem/rubocop.erb
+++ b/gapic-generator-cloud/templates/cloud/gem/rubocop.erb
@@ -26,6 +26,9 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/AccessorMethodName:
+  Exclude:
+    - "snippets/**/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/<%= gem.name %>.rb"

--- a/gapic-generator/templates/default/gem/rubocop.erb
+++ b/gapic-generator/templates/default/gem/rubocop.erb
@@ -22,6 +22,9 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/AccessorMethodName:
+  Exclude:
+    - "snippets/**/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/<%= gem.name %>.rb"

--- a/gapic-generator/templates/default/service/client/method/docs/_snippets.erb
+++ b/gapic-generator/templates/default/service/client/method/docs/_snippets.erb
@@ -1,6 +1,6 @@
 <%- assert_locals method -%>
 <%- if method.generate_yardoc_snippets? -%>
 # @example Basic example
-<%= indent render(partial: "snippets/snippet/structure", locals: { snippet: method.snippet }), "#   " %>
+<%= indent render(partial: "snippets/snippet/inline", locals: { snippet: method.snippet }), "#   " %>
 #
 <%- end -%>

--- a/gapic-generator/templates/default/snippets/gemfile.erb
+++ b/gapic-generator/templates/default/snippets/gemfile.erb
@@ -10,8 +10,8 @@ else
 end
 
 group :test do
-  gem "google-style", "~> 1.25.1"
-  gem "minitest", "~> 5.14"
+  gem "google-style", "~> 1.26.1"
+  gem "minitest", "~> 5.16"
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~> 1.5"
 end

--- a/gapic-generator/templates/default/snippets/snippet/_body.erb
+++ b/gapic-generator/templates/default/snippets/snippet/_body.erb
@@ -1,6 +1,4 @@
 <%- assert_locals snippet -%>
-require "<%= snippet.require_path %>"
-
 # Create a client object. The client can be reused for multiple calls.
 client = <%= snippet.client_type %>.new
 

--- a/gapic-generator/templates/default/snippets/snippet/_inline.erb
+++ b/gapic-generator/templates/default/snippets/snippet/_inline.erb
@@ -1,0 +1,4 @@
+<%- assert_locals snippet -%>
+require "<%= snippet.require_path %>"
+
+<%= render partial: "snippets/snippet/body", locals: { snippet: snippet} -%>

--- a/gapic-generator/templates/default/snippets/snippet/_standalone.erb
+++ b/gapic-generator/templates/default/snippets/snippet/_standalone.erb
@@ -1,0 +1,10 @@
+<%- assert_locals snippet -%>
+require "<%= snippet.require_path %>"
+
+##
+# Example demonstrating basic usage of
+# <%= snippet.client_type %>#<%= snippet.method_name %>
+#
+def <%= snippet.method_name %>
+<%= indent render(partial: "snippets/snippet/body", locals: { snippet: snippet }), "  " %>
+end

--- a/gapic-generator/templates/default/snippets/standalone.erb
+++ b/gapic-generator/templates/default/snippets/standalone.erb
@@ -2,5 +2,5 @@
 <%= render partial: "shared/header" -%>
 
 # [START <%= snippet.region_tag %>]
-<%= render partial: "snippets/snippet/structure", locals: { snippet: snippet} -%>
+<%= render partial: "snippets/snippet/standalone", locals: { snippet: snippet} -%>
 # [END <%= snippet.region_tag %>]

--- a/shared/output/cloud/compute_small/.rubocop.yml
+++ b/shared/output/cloud/compute_small/.rubocop.yml
@@ -25,6 +25,9 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/AccessorMethodName:
+  Exclude:
+    - "snippets/**/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-compute-v1.rb"

--- a/shared/output/cloud/compute_small/snippets/Gemfile
+++ b/shared/output/cloud/compute_small/snippets/Gemfile
@@ -25,8 +25,8 @@ else
 end
 
 group :test do
-  gem "google-style", "~> 1.25.1"
-  gem "minitest", "~> 5.14"
+  gem "google-style", "~> 1.26.1"
+  gem "minitest", "~> 5.16"
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~> 1.5"
 end

--- a/shared/output/cloud/compute_small/snippets/addresses/aggregated_list.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/aggregated_list.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_Addresses_AggregatedList_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::Addresses::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Addresses::Client#aggregated_list
+#
+def aggregated_list
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::Addresses::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::AggregatedListAddressesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::AggregatedListAddressesRequest.new
 
-# Call the aggregated_list method.
-result = client.aggregated_list request
+  # Call the aggregated_list method.
+  result = client.aggregated_list request
 
-# The returned object is of type Google::Cloud::Compute::V1::AddressAggregatedList.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::AddressAggregatedList.
+  p result
+end
 # [END compute_v1_generated_Addresses_AggregatedList_sync]

--- a/shared/output/cloud/compute_small/snippets/addresses/delete.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/delete.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_Addresses_Delete_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::Addresses::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Addresses::Client#delete
+#
+def delete
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::Addresses::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::DeleteAddressRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::DeleteAddressRequest.new
 
-# Call the delete method.
-result = client.delete request
+  # Call the delete method.
+  result = client.delete request
 
-# The returned object is of type Google::Cloud::Compute::V1::Operation.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::Operation.
+  p result
+end
 # [END compute_v1_generated_Addresses_Delete_sync]

--- a/shared/output/cloud/compute_small/snippets/addresses/get.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/get.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_Addresses_Get_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::Addresses::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Addresses::Client#get
+#
+def get
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::Addresses::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::GetAddressRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::GetAddressRequest.new
 
-# Call the get method.
-result = client.get request
+  # Call the get method.
+  result = client.get request
 
-# The returned object is of type Google::Cloud::Compute::V1::Address.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::Address.
+  p result
+end
 # [END compute_v1_generated_Addresses_Get_sync]

--- a/shared/output/cloud/compute_small/snippets/addresses/insert.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/insert.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_Addresses_Insert_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::Addresses::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Addresses::Client#insert
+#
+def insert
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::Addresses::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::InsertAddressRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::InsertAddressRequest.new
 
-# Call the insert method.
-result = client.insert request
+  # Call the insert method.
+  result = client.insert request
 
-# The returned object is of type Google::Cloud::Compute::V1::Operation.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::Operation.
+  p result
+end
 # [END compute_v1_generated_Addresses_Insert_sync]

--- a/shared/output/cloud/compute_small/snippets/addresses/list.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/list.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_Addresses_List_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::Addresses::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Addresses::Client#list
+#
+def list
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::Addresses::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::ListAddressesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::ListAddressesRequest.new
 
-# Call the list method.
-result = client.list request
+  # Call the list method.
+  result = client.list request
 
-# The returned object is of type Google::Cloud::Compute::V1::AddressList.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::AddressList.
+  p result
+end
 # [END compute_v1_generated_Addresses_List_sync]

--- a/shared/output/cloud/compute_small/snippets/global_operations/delete.rb
+++ b/shared/output/cloud/compute_small/snippets/global_operations/delete.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_GlobalOperations_Delete_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::GlobalOperations::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::GlobalOperations::Client#delete
+#
+def delete
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::GlobalOperations::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::DeleteGlobalOperationRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::DeleteGlobalOperationRequest.new
 
-# Call the delete method.
-result = client.delete request
+  # Call the delete method.
+  result = client.delete request
 
-# The returned object is of type Google::Cloud::Compute::V1::DeleteGlobalOperationResponse.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::DeleteGlobalOperationResponse.
+  p result
+end
 # [END compute_v1_generated_GlobalOperations_Delete_sync]

--- a/shared/output/cloud/compute_small/snippets/global_operations/get.rb
+++ b/shared/output/cloud/compute_small/snippets/global_operations/get.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_GlobalOperations_Get_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::GlobalOperations::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::GlobalOperations::Client#get
+#
+def get
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::GlobalOperations::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::GetGlobalOperationRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::GetGlobalOperationRequest.new
 
-# Call the get method.
-result = client.get request
+  # Call the get method.
+  result = client.get request
 
-# The returned object is of type Google::Cloud::Compute::V1::Operation.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::Operation.
+  p result
+end
 # [END compute_v1_generated_GlobalOperations_Get_sync]

--- a/shared/output/cloud/compute_small/snippets/networks/list_peering_routes.rb
+++ b/shared/output/cloud/compute_small/snippets/networks/list_peering_routes.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_Networks_ListPeeringRoutes_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::Networks::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Networks::Client#list_peering_routes
+#
+def list_peering_routes
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::Networks::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::ListPeeringRoutesNetworksRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::ListPeeringRoutesNetworksRequest.new
 
-# Call the list_peering_routes method.
-result = client.list_peering_routes request
+  # Call the list_peering_routes method.
+  result = client.list_peering_routes request
 
-# The returned object is of type Google::Cloud::Compute::V1::ExchangedPeeringRoutesList.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::ExchangedPeeringRoutesList.
+  p result
+end
 # [END compute_v1_generated_Networks_ListPeeringRoutes_sync]

--- a/shared/output/cloud/compute_small/snippets/networks/remove_peering.rb
+++ b/shared/output/cloud/compute_small/snippets/networks/remove_peering.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_Networks_RemovePeering_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::Networks::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Networks::Client#remove_peering
+#
+def remove_peering
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::Networks::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::RemovePeeringNetworkRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::RemovePeeringNetworkRequest.new
 
-# Call the remove_peering method.
-result = client.remove_peering request
+  # Call the remove_peering method.
+  result = client.remove_peering request
 
-# The returned object is of type Google::Cloud::Compute::V1::Operation.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::Operation.
+  p result
+end
 # [END compute_v1_generated_Networks_RemovePeering_sync]

--- a/shared/output/cloud/compute_small/snippets/region_instance_group_managers/resize.rb
+++ b/shared/output/cloud/compute_small/snippets/region_instance_group_managers/resize.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_RegionInstanceGroupManagers_Resize_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Client#resize
+#
+def resize
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::ResizeRegionInstanceGroupManagerRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::ResizeRegionInstanceGroupManagerRequest.new
 
-# Call the resize method.
-result = client.resize request
+  # Call the resize method.
+  result = client.resize request
 
-# The returned object is of type Google::Cloud::Compute::V1::Operation.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::Operation.
+  p result
+end
 # [END compute_v1_generated_RegionInstanceGroupManagers_Resize_sync]

--- a/shared/output/cloud/compute_small/snippets/region_operations/delete.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/delete.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_RegionOperations_Delete_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::RegionOperations::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::RegionOperations::Client#delete
+#
+def delete
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::RegionOperations::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::DeleteRegionOperationRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::DeleteRegionOperationRequest.new
 
-# Call the delete method.
-result = client.delete request
+  # Call the delete method.
+  result = client.delete request
 
-# The returned object is of type Google::Cloud::Compute::V1::DeleteRegionOperationResponse.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::DeleteRegionOperationResponse.
+  p result
+end
 # [END compute_v1_generated_RegionOperations_Delete_sync]

--- a/shared/output/cloud/compute_small/snippets/region_operations/get.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/get.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_RegionOperations_Get_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::RegionOperations::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::RegionOperations::Client#get
+#
+def get
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::RegionOperations::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::GetRegionOperationRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::GetRegionOperationRequest.new
 
-# Call the get method.
-result = client.get request
+  # Call the get method.
+  result = client.get request
 
-# The returned object is of type Google::Cloud::Compute::V1::Operation.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::Operation.
+  p result
+end
 # [END compute_v1_generated_RegionOperations_Get_sync]

--- a/shared/output/cloud/compute_small/snippets/region_operations/list.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/list.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_RegionOperations_List_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::RegionOperations::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::RegionOperations::Client#list
+#
+def list
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::RegionOperations::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::ListRegionOperationsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::ListRegionOperationsRequest.new
 
-# Call the list method.
-result = client.list request
+  # Call the list method.
+  result = client.list request
 
-# The returned object is of type Google::Cloud::Compute::V1::OperationList.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::OperationList.
+  p result
+end
 # [END compute_v1_generated_RegionOperations_List_sync]

--- a/shared/output/cloud/compute_small/snippets/region_operations/wait.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/wait.rb
@@ -19,15 +19,21 @@
 # [START compute_v1_generated_RegionOperations_Wait_sync]
 require "google/cloud/compute/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Compute::V1::RegionOperations::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Compute::V1::RegionOperations::Client#wait
+#
+def wait
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Compute::V1::RegionOperations::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Compute::V1::WaitRegionOperationRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Compute::V1::WaitRegionOperationRequest.new
 
-# Call the wait method.
-result = client.wait request
+  # Call the wait method.
+  result = client.wait request
 
-# The returned object is of type Google::Cloud::Compute::V1::Operation.
-p result
+  # The returned object is of type Google::Cloud::Compute::V1::Operation.
+  p result
+end
 # [END compute_v1_generated_RegionOperations_Wait_sync]

--- a/shared/output/cloud/compute_small/snippets/snippet_metadata_google.cloud.compute.v1.json
+++ b/shared/output/cloud/compute_small/snippets/snippet_metadata_google.cloud.compute.v1.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -166,7 +166,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -206,7 +206,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -246,7 +246,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -286,7 +286,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -326,7 +326,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -366,7 +366,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -406,7 +406,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -446,7 +446,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -486,7 +486,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -526,7 +526,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -566,7 +566,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/grafeas_v1/.rubocop.yml
+++ b/shared/output/cloud/grafeas_v1/.rubocop.yml
@@ -25,6 +25,9 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/AccessorMethodName:
+  Exclude:
+    - "snippets/**/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/grafeas-v1.rb"

--- a/shared/output/cloud/grafeas_v1/snippets/Gemfile
+++ b/shared/output/cloud/grafeas_v1/snippets/Gemfile
@@ -25,8 +25,8 @@ else
 end
 
 group :test do
-  gem "google-style", "~> 1.25.1"
-  gem "minitest", "~> 5.14"
+  gem "google-style", "~> 1.26.1"
+  gem "minitest", "~> 5.16"
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~> 1.5"
 end

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/batch_create_notes.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/batch_create_notes.rb
@@ -19,15 +19,21 @@
 # [START grafeas_v1_generated_Grafeas_BatchCreateNotes_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#batch_create_notes
+#
+def batch_create_notes
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::BatchCreateNotesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::BatchCreateNotesRequest.new
 
-# Call the batch_create_notes method.
-result = client.batch_create_notes request
+  # Call the batch_create_notes method.
+  result = client.batch_create_notes request
 
-# The returned object is of type Grafeas::V1::BatchCreateNotesResponse.
-p result
+  # The returned object is of type Grafeas::V1::BatchCreateNotesResponse.
+  p result
+end
 # [END grafeas_v1_generated_Grafeas_BatchCreateNotes_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/batch_create_occurrences.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/batch_create_occurrences.rb
@@ -19,15 +19,21 @@
 # [START grafeas_v1_generated_Grafeas_BatchCreateOccurrences_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#batch_create_occurrences
+#
+def batch_create_occurrences
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::BatchCreateOccurrencesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::BatchCreateOccurrencesRequest.new
 
-# Call the batch_create_occurrences method.
-result = client.batch_create_occurrences request
+  # Call the batch_create_occurrences method.
+  result = client.batch_create_occurrences request
 
-# The returned object is of type Grafeas::V1::BatchCreateOccurrencesResponse.
-p result
+  # The returned object is of type Grafeas::V1::BatchCreateOccurrencesResponse.
+  p result
+end
 # [END grafeas_v1_generated_Grafeas_BatchCreateOccurrences_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/create_note.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/create_note.rb
@@ -19,15 +19,21 @@
 # [START grafeas_v1_generated_Grafeas_CreateNote_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#create_note
+#
+def create_note
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::CreateNoteRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::CreateNoteRequest.new
 
-# Call the create_note method.
-result = client.create_note request
+  # Call the create_note method.
+  result = client.create_note request
 
-# The returned object is of type Grafeas::V1::Note.
-p result
+  # The returned object is of type Grafeas::V1::Note.
+  p result
+end
 # [END grafeas_v1_generated_Grafeas_CreateNote_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/create_occurrence.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/create_occurrence.rb
@@ -19,15 +19,21 @@
 # [START grafeas_v1_generated_Grafeas_CreateOccurrence_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#create_occurrence
+#
+def create_occurrence
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::CreateOccurrenceRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::CreateOccurrenceRequest.new
 
-# Call the create_occurrence method.
-result = client.create_occurrence request
+  # Call the create_occurrence method.
+  result = client.create_occurrence request
 
-# The returned object is of type Grafeas::V1::Occurrence.
-p result
+  # The returned object is of type Grafeas::V1::Occurrence.
+  p result
+end
 # [END grafeas_v1_generated_Grafeas_CreateOccurrence_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/delete_note.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/delete_note.rb
@@ -19,15 +19,21 @@
 # [START grafeas_v1_generated_Grafeas_DeleteNote_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#delete_note
+#
+def delete_note
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::DeleteNoteRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::DeleteNoteRequest.new
 
-# Call the delete_note method.
-result = client.delete_note request
+  # Call the delete_note method.
+  result = client.delete_note request
 
-# The returned object is of type Google::Protobuf::Empty.
-p result
+  # The returned object is of type Google::Protobuf::Empty.
+  p result
+end
 # [END grafeas_v1_generated_Grafeas_DeleteNote_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/delete_occurrence.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/delete_occurrence.rb
@@ -19,15 +19,21 @@
 # [START grafeas_v1_generated_Grafeas_DeleteOccurrence_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#delete_occurrence
+#
+def delete_occurrence
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::DeleteOccurrenceRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::DeleteOccurrenceRequest.new
 
-# Call the delete_occurrence method.
-result = client.delete_occurrence request
+  # Call the delete_occurrence method.
+  result = client.delete_occurrence request
 
-# The returned object is of type Google::Protobuf::Empty.
-p result
+  # The returned object is of type Google::Protobuf::Empty.
+  p result
+end
 # [END grafeas_v1_generated_Grafeas_DeleteOccurrence_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/get_note.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/get_note.rb
@@ -19,15 +19,21 @@
 # [START grafeas_v1_generated_Grafeas_GetNote_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#get_note
+#
+def get_note
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::GetNoteRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::GetNoteRequest.new
 
-# Call the get_note method.
-result = client.get_note request
+  # Call the get_note method.
+  result = client.get_note request
 
-# The returned object is of type Grafeas::V1::Note.
-p result
+  # The returned object is of type Grafeas::V1::Note.
+  p result
+end
 # [END grafeas_v1_generated_Grafeas_GetNote_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/get_occurrence.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/get_occurrence.rb
@@ -19,15 +19,21 @@
 # [START grafeas_v1_generated_Grafeas_GetOccurrence_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#get_occurrence
+#
+def get_occurrence
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::GetOccurrenceRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::GetOccurrenceRequest.new
 
-# Call the get_occurrence method.
-result = client.get_occurrence request
+  # Call the get_occurrence method.
+  result = client.get_occurrence request
 
-# The returned object is of type Grafeas::V1::Occurrence.
-p result
+  # The returned object is of type Grafeas::V1::Occurrence.
+  p result
+end
 # [END grafeas_v1_generated_Grafeas_GetOccurrence_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/get_occurrence_note.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/get_occurrence_note.rb
@@ -19,15 +19,21 @@
 # [START grafeas_v1_generated_Grafeas_GetOccurrenceNote_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#get_occurrence_note
+#
+def get_occurrence_note
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::GetOccurrenceNoteRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::GetOccurrenceNoteRequest.new
 
-# Call the get_occurrence_note method.
-result = client.get_occurrence_note request
+  # Call the get_occurrence_note method.
+  result = client.get_occurrence_note request
 
-# The returned object is of type Grafeas::V1::Note.
-p result
+  # The returned object is of type Grafeas::V1::Note.
+  p result
+end
 # [END grafeas_v1_generated_Grafeas_GetOccurrenceNote_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/list_note_occurrences.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/list_note_occurrences.rb
@@ -19,21 +19,27 @@
 # [START grafeas_v1_generated_Grafeas_ListNoteOccurrences_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#list_note_occurrences
+#
+def list_note_occurrences
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::ListNoteOccurrencesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::ListNoteOccurrencesRequest.new
 
-# Call the list_note_occurrences method.
-result = client.list_note_occurrences request
+  # Call the list_note_occurrences method.
+  result = client.list_note_occurrences request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Grafeas::V1::Occurrence.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Grafeas::V1::Occurrence.
+    p response
+  end
 end
 # [END grafeas_v1_generated_Grafeas_ListNoteOccurrences_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/list_notes.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/list_notes.rb
@@ -19,21 +19,27 @@
 # [START grafeas_v1_generated_Grafeas_ListNotes_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#list_notes
+#
+def list_notes
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::ListNotesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::ListNotesRequest.new
 
-# Call the list_notes method.
-result = client.list_notes request
+  # Call the list_notes method.
+  result = client.list_notes request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Grafeas::V1::Note.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Grafeas::V1::Note.
+    p response
+  end
 end
 # [END grafeas_v1_generated_Grafeas_ListNotes_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/list_occurrences.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/list_occurrences.rb
@@ -19,21 +19,27 @@
 # [START grafeas_v1_generated_Grafeas_ListOccurrences_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#list_occurrences
+#
+def list_occurrences
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::ListOccurrencesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::ListOccurrencesRequest.new
 
-# Call the list_occurrences method.
-result = client.list_occurrences request
+  # Call the list_occurrences method.
+  result = client.list_occurrences request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Grafeas::V1::Occurrence.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Grafeas::V1::Occurrence.
+    p response
+  end
 end
 # [END grafeas_v1_generated_Grafeas_ListOccurrences_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/update_note.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/update_note.rb
@@ -19,15 +19,21 @@
 # [START grafeas_v1_generated_Grafeas_UpdateNote_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#update_note
+#
+def update_note
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::UpdateNoteRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::UpdateNoteRequest.new
 
-# Call the update_note method.
-result = client.update_note request
+  # Call the update_note method.
+  result = client.update_note request
 
-# The returned object is of type Grafeas::V1::Note.
-p result
+  # The returned object is of type Grafeas::V1::Note.
+  p result
+end
 # [END grafeas_v1_generated_Grafeas_UpdateNote_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/update_occurrence.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/update_occurrence.rb
@@ -19,15 +19,21 @@
 # [START grafeas_v1_generated_Grafeas_UpdateOccurrence_sync]
 require "grafeas/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Grafeas::V1::Grafeas::Client.new
+##
+# Example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#update_occurrence
+#
+def update_occurrence
+  # Create a client object. The client can be reused for multiple calls.
+  client = Grafeas::V1::Grafeas::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Grafeas::V1::UpdateOccurrenceRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Grafeas::V1::UpdateOccurrenceRequest.new
 
-# Call the update_occurrence method.
-result = client.update_occurrence request
+  # Call the update_occurrence method.
+  result = client.update_occurrence request
 
-# The returned object is of type Grafeas::V1::Occurrence.
-p result
+  # The returned object is of type Grafeas::V1::Occurrence.
+  p result
+end
 # [END grafeas_v1_generated_Grafeas_UpdateOccurrence_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/snippet_metadata_grafeas.v1.json
+++ b/shared/output/cloud/grafeas_v1/snippets/snippet_metadata_grafeas.v1.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 44,
           "type": "FULL"
         }
       ]
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -166,7 +166,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -206,7 +206,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -246,7 +246,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -286,7 +286,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -326,7 +326,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -366,7 +366,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 44,
           "type": "FULL"
         }
       ]
@@ -406,7 +406,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -446,7 +446,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -486,7 +486,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -526,7 +526,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -566,7 +566,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 44,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/language_v1/.rubocop.yml
+++ b/shared/output/cloud/language_v1/.rubocop.yml
@@ -25,6 +25,9 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/AccessorMethodName:
+  Exclude:
+    - "snippets/**/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-language-v1.rb"

--- a/shared/output/cloud/language_v1/snippets/Gemfile
+++ b/shared/output/cloud/language_v1/snippets/Gemfile
@@ -25,8 +25,8 @@ else
 end
 
 group :test do
-  gem "google-style", "~> 1.25.1"
-  gem "minitest", "~> 5.14"
+  gem "google-style", "~> 1.26.1"
+  gem "minitest", "~> 5.16"
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~> 1.5"
 end

--- a/shared/output/cloud/language_v1/snippets/language_service/analyze_entities.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/analyze_entities.rb
@@ -19,15 +19,21 @@
 # [START language_v1_generated_LanguageService_AnalyzeEntities_sync]
 require "google/cloud/language/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1::LanguageService::Client#analyze_entities
+#
+def analyze_entities
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new
 
-# Call the analyze_entities method.
-result = client.analyze_entities request
+  # Call the analyze_entities method.
+  result = client.analyze_entities request
 
-# The returned object is of type Google::Cloud::Language::V1::AnalyzeEntitiesResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1::AnalyzeEntitiesResponse.
+  p result
+end
 # [END language_v1_generated_LanguageService_AnalyzeEntities_sync]

--- a/shared/output/cloud/language_v1/snippets/language_service/analyze_entity_sentiment.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/analyze_entity_sentiment.rb
@@ -19,15 +19,21 @@
 # [START language_v1_generated_LanguageService_AnalyzeEntitySentiment_sync]
 require "google/cloud/language/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1::LanguageService::Client#analyze_entity_sentiment
+#
+def analyze_entity_sentiment
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new
 
-# Call the analyze_entity_sentiment method.
-result = client.analyze_entity_sentiment request
+  # Call the analyze_entity_sentiment method.
+  result = client.analyze_entity_sentiment request
 
-# The returned object is of type Google::Cloud::Language::V1::AnalyzeEntitySentimentResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1::AnalyzeEntitySentimentResponse.
+  p result
+end
 # [END language_v1_generated_LanguageService_AnalyzeEntitySentiment_sync]

--- a/shared/output/cloud/language_v1/snippets/language_service/analyze_sentiment.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/analyze_sentiment.rb
@@ -19,15 +19,21 @@
 # [START language_v1_generated_LanguageService_AnalyzeSentiment_sync]
 require "google/cloud/language/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1::LanguageService::Client#analyze_sentiment
+#
+def analyze_sentiment
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1::AnalyzeSentimentRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1::AnalyzeSentimentRequest.new
 
-# Call the analyze_sentiment method.
-result = client.analyze_sentiment request
+  # Call the analyze_sentiment method.
+  result = client.analyze_sentiment request
 
-# The returned object is of type Google::Cloud::Language::V1::AnalyzeSentimentResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1::AnalyzeSentimentResponse.
+  p result
+end
 # [END language_v1_generated_LanguageService_AnalyzeSentiment_sync]

--- a/shared/output/cloud/language_v1/snippets/language_service/analyze_syntax.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/analyze_syntax.rb
@@ -19,15 +19,21 @@
 # [START language_v1_generated_LanguageService_AnalyzeSyntax_sync]
 require "google/cloud/language/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1::LanguageService::Client#analyze_syntax
+#
+def analyze_syntax
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new
 
-# Call the analyze_syntax method.
-result = client.analyze_syntax request
+  # Call the analyze_syntax method.
+  result = client.analyze_syntax request
 
-# The returned object is of type Google::Cloud::Language::V1::AnalyzeSyntaxResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1::AnalyzeSyntaxResponse.
+  p result
+end
 # [END language_v1_generated_LanguageService_AnalyzeSyntax_sync]

--- a/shared/output/cloud/language_v1/snippets/language_service/annotate_text.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/annotate_text.rb
@@ -19,15 +19,21 @@
 # [START language_v1_generated_LanguageService_AnnotateText_sync]
 require "google/cloud/language/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1::LanguageService::Client#annotate_text
+#
+def annotate_text
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1::AnnotateTextRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1::AnnotateTextRequest.new
 
-# Call the annotate_text method.
-result = client.annotate_text request
+  # Call the annotate_text method.
+  result = client.annotate_text request
 
-# The returned object is of type Google::Cloud::Language::V1::AnnotateTextResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1::AnnotateTextResponse.
+  p result
+end
 # [END language_v1_generated_LanguageService_AnnotateText_sync]

--- a/shared/output/cloud/language_v1/snippets/language_service/classify_text.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/classify_text.rb
@@ -19,15 +19,21 @@
 # [START language_v1_generated_LanguageService_ClassifyText_sync]
 require "google/cloud/language/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1::LanguageService::Client#classify_text
+#
+def classify_text
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1::ClassifyTextRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1::ClassifyTextRequest.new
 
-# Call the classify_text method.
-result = client.classify_text request
+  # Call the classify_text method.
+  result = client.classify_text request
 
-# The returned object is of type Google::Cloud::Language::V1::ClassifyTextResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1::ClassifyTextResponse.
+  p result
+end
 # [END language_v1_generated_LanguageService_ClassifyText_sync]

--- a/shared/output/cloud/language_v1/snippets/snippet_metadata_google.cloud.language.v1.json
+++ b/shared/output/cloud/language_v1/snippets/snippet_metadata_google.cloud.language.v1.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -166,7 +166,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -206,7 +206,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -246,7 +246,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/language_v1beta1/.rubocop.yml
+++ b/shared/output/cloud/language_v1beta1/.rubocop.yml
@@ -25,6 +25,9 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/AccessorMethodName:
+  Exclude:
+    - "snippets/**/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-language-v1beta1.rb"

--- a/shared/output/cloud/language_v1beta1/snippets/Gemfile
+++ b/shared/output/cloud/language_v1beta1/snippets/Gemfile
@@ -25,8 +25,8 @@ else
 end
 
 group :test do
-  gem "google-style", "~> 1.25.1"
-  gem "minitest", "~> 5.14"
+  gem "google-style", "~> 1.26.1"
+  gem "minitest", "~> 5.16"
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~> 1.5"
 end

--- a/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_entities.rb
+++ b/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_entities.rb
@@ -19,15 +19,21 @@
 # [START language_v1beta1_generated_LanguageService_AnalyzeEntities_sync]
 require "google/cloud/language/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1beta1::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1beta1::LanguageService::Client#analyze_entities
+#
+def analyze_entities
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1beta1::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1beta1::AnalyzeEntitiesRequest.new
 
-# Call the analyze_entities method.
-result = client.analyze_entities request
+  # Call the analyze_entities method.
+  result = client.analyze_entities request
 
-# The returned object is of type Google::Cloud::Language::V1beta1::AnalyzeEntitiesResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1beta1::AnalyzeEntitiesResponse.
+  p result
+end
 # [END language_v1beta1_generated_LanguageService_AnalyzeEntities_sync]

--- a/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_sentiment.rb
+++ b/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_sentiment.rb
@@ -19,15 +19,21 @@
 # [START language_v1beta1_generated_LanguageService_AnalyzeSentiment_sync]
 require "google/cloud/language/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1beta1::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1beta1::LanguageService::Client#analyze_sentiment
+#
+def analyze_sentiment
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1beta1::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1beta1::AnalyzeSentimentRequest.new
 
-# Call the analyze_sentiment method.
-result = client.analyze_sentiment request
+  # Call the analyze_sentiment method.
+  result = client.analyze_sentiment request
 
-# The returned object is of type Google::Cloud::Language::V1beta1::AnalyzeSentimentResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1beta1::AnalyzeSentimentResponse.
+  p result
+end
 # [END language_v1beta1_generated_LanguageService_AnalyzeSentiment_sync]

--- a/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_syntax.rb
+++ b/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_syntax.rb
@@ -19,15 +19,21 @@
 # [START language_v1beta1_generated_LanguageService_AnalyzeSyntax_sync]
 require "google/cloud/language/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1beta1::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1beta1::LanguageService::Client#analyze_syntax
+#
+def analyze_syntax
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1beta1::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1beta1::AnalyzeSyntaxRequest.new
 
-# Call the analyze_syntax method.
-result = client.analyze_syntax request
+  # Call the analyze_syntax method.
+  result = client.analyze_syntax request
 
-# The returned object is of type Google::Cloud::Language::V1beta1::AnalyzeSyntaxResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1beta1::AnalyzeSyntaxResponse.
+  p result
+end
 # [END language_v1beta1_generated_LanguageService_AnalyzeSyntax_sync]

--- a/shared/output/cloud/language_v1beta1/snippets/language_service/annotate_text.rb
+++ b/shared/output/cloud/language_v1beta1/snippets/language_service/annotate_text.rb
@@ -19,15 +19,21 @@
 # [START language_v1beta1_generated_LanguageService_AnnotateText_sync]
 require "google/cloud/language/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1beta1::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1beta1::LanguageService::Client#annotate_text
+#
+def annotate_text
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1beta1::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1beta1::AnnotateTextRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1beta1::AnnotateTextRequest.new
 
-# Call the annotate_text method.
-result = client.annotate_text request
+  # Call the annotate_text method.
+  result = client.annotate_text request
 
-# The returned object is of type Google::Cloud::Language::V1beta1::AnnotateTextResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1beta1::AnnotateTextResponse.
+  p result
+end
 # [END language_v1beta1_generated_LanguageService_AnnotateText_sync]

--- a/shared/output/cloud/language_v1beta1/snippets/snippet_metadata_google.cloud.language.v1beta1.json
+++ b/shared/output/cloud/language_v1beta1/snippets/snippet_metadata_google.cloud.language.v1beta1.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -166,7 +166,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/language_v1beta2/.rubocop.yml
+++ b/shared/output/cloud/language_v1beta2/.rubocop.yml
@@ -25,6 +25,9 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/AccessorMethodName:
+  Exclude:
+    - "snippets/**/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-language-v1beta2.rb"

--- a/shared/output/cloud/language_v1beta2/snippets/Gemfile
+++ b/shared/output/cloud/language_v1beta2/snippets/Gemfile
@@ -25,8 +25,8 @@ else
 end
 
 group :test do
-  gem "google-style", "~> 1.25.1"
-  gem "minitest", "~> 5.14"
+  gem "google-style", "~> 1.26.1"
+  gem "minitest", "~> 5.16"
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~> 1.5"
 end

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_entities.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_entities.rb
@@ -19,15 +19,21 @@
 # [START language_v1beta2_generated_LanguageService_AnalyzeEntities_sync]
 require "google/cloud/language/v1beta2"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1beta2::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_entities
+#
+def analyze_entities
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1beta2::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1beta2::AnalyzeEntitiesRequest.new
 
-# Call the analyze_entities method.
-result = client.analyze_entities request
+  # Call the analyze_entities method.
+  result = client.analyze_entities request
 
-# The returned object is of type Google::Cloud::Language::V1beta2::AnalyzeEntitiesResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1beta2::AnalyzeEntitiesResponse.
+  p result
+end
 # [END language_v1beta2_generated_LanguageService_AnalyzeEntities_sync]

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_entity_sentiment.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_entity_sentiment.rb
@@ -19,15 +19,21 @@
 # [START language_v1beta2_generated_LanguageService_AnalyzeEntitySentiment_sync]
 require "google/cloud/language/v1beta2"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1beta2::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_entity_sentiment
+#
+def analyze_entity_sentiment
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1beta2::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentRequest.new
 
-# Call the analyze_entity_sentiment method.
-result = client.analyze_entity_sentiment request
+  # Call the analyze_entity_sentiment method.
+  result = client.analyze_entity_sentiment request
 
-# The returned object is of type Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1beta2::AnalyzeEntitySentimentResponse.
+  p result
+end
 # [END language_v1beta2_generated_LanguageService_AnalyzeEntitySentiment_sync]

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_sentiment.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_sentiment.rb
@@ -19,15 +19,21 @@
 # [START language_v1beta2_generated_LanguageService_AnalyzeSentiment_sync]
 require "google/cloud/language/v1beta2"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1beta2::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_sentiment
+#
+def analyze_sentiment
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1beta2::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1beta2::AnalyzeSentimentRequest.new
 
-# Call the analyze_sentiment method.
-result = client.analyze_sentiment request
+  # Call the analyze_sentiment method.
+  result = client.analyze_sentiment request
 
-# The returned object is of type Google::Cloud::Language::V1beta2::AnalyzeSentimentResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1beta2::AnalyzeSentimentResponse.
+  p result
+end
 # [END language_v1beta2_generated_LanguageService_AnalyzeSentiment_sync]

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_syntax.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_syntax.rb
@@ -19,15 +19,21 @@
 # [START language_v1beta2_generated_LanguageService_AnalyzeSyntax_sync]
 require "google/cloud/language/v1beta2"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1beta2::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_syntax
+#
+def analyze_syntax
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1beta2::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1beta2::AnalyzeSyntaxRequest.new
 
-# Call the analyze_syntax method.
-result = client.analyze_syntax request
+  # Call the analyze_syntax method.
+  result = client.analyze_syntax request
 
-# The returned object is of type Google::Cloud::Language::V1beta2::AnalyzeSyntaxResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1beta2::AnalyzeSyntaxResponse.
+  p result
+end
 # [END language_v1beta2_generated_LanguageService_AnalyzeSyntax_sync]

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/annotate_text.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/annotate_text.rb
@@ -19,15 +19,21 @@
 # [START language_v1beta2_generated_LanguageService_AnnotateText_sync]
 require "google/cloud/language/v1beta2"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1beta2::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1beta2::LanguageService::Client#annotate_text
+#
+def annotate_text
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1beta2::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1beta2::AnnotateTextRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1beta2::AnnotateTextRequest.new
 
-# Call the annotate_text method.
-result = client.annotate_text request
+  # Call the annotate_text method.
+  result = client.annotate_text request
 
-# The returned object is of type Google::Cloud::Language::V1beta2::AnnotateTextResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1beta2::AnnotateTextResponse.
+  p result
+end
 # [END language_v1beta2_generated_LanguageService_AnnotateText_sync]

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/classify_text.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/classify_text.rb
@@ -19,15 +19,21 @@
 # [START language_v1beta2_generated_LanguageService_ClassifyText_sync]
 require "google/cloud/language/v1beta2"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Language::V1beta2::LanguageService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Language::V1beta2::LanguageService::Client#classify_text
+#
+def classify_text
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Language::V1beta2::LanguageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Language::V1beta2::ClassifyTextRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Language::V1beta2::ClassifyTextRequest.new
 
-# Call the classify_text method.
-result = client.classify_text request
+  # Call the classify_text method.
+  result = client.classify_text request
 
-# The returned object is of type Google::Cloud::Language::V1beta2::ClassifyTextResponse.
-p result
+  # The returned object is of type Google::Cloud::Language::V1beta2::ClassifyTextResponse.
+  p result
+end
 # [END language_v1beta2_generated_LanguageService_ClassifyText_sync]

--- a/shared/output/cloud/language_v1beta2/snippets/snippet_metadata_google.cloud.language.v1beta2.json
+++ b/shared/output/cloud/language_v1beta2/snippets/snippet_metadata_google.cloud.language.v1beta2.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -166,7 +166,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -206,7 +206,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -246,7 +246,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/secretmanager_v1beta1/.rubocop.yml
+++ b/shared/output/cloud/secretmanager_v1beta1/.rubocop.yml
@@ -25,6 +25,9 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/AccessorMethodName:
+  Exclude:
+    - "snippets/**/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-secret_manager-v1beta1.rb"

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/Gemfile
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/Gemfile
@@ -25,8 +25,8 @@ else
 end
 
 group :test do
-  gem "google-style", "~> 1.25.1"
-  gem "minitest", "~> 5.14"
+  gem "google-style", "~> 1.26.1"
+  gem "minitest", "~> 5.16"
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~> 1.5"
 end

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/access_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/access_secret_version.rb
@@ -19,15 +19,21 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_AccessSecretVersion_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#access_secret_version
+#
+def access_secret_version
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::SecretManager::V1beta1::AccessSecretVersionRequest.new
 
-# Call the access_secret_version method.
-result = client.access_secret_version request
+  # Call the access_secret_version method.
+  result = client.access_secret_version request
 
-# The returned object is of type Google::Cloud::SecretManager::V1beta1::AccessSecretVersionResponse.
-p result
+  # The returned object is of type Google::Cloud::SecretManager::V1beta1::AccessSecretVersionResponse.
+  p result
+end
 # [END secretmanager_v1beta1_generated_SecretManagerService_AccessSecretVersion_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/add_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/add_secret_version.rb
@@ -19,15 +19,21 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_AddSecretVersion_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#add_secret_version
+#
+def add_secret_version
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::SecretManager::V1beta1::AddSecretVersionRequest.new
 
-# Call the add_secret_version method.
-result = client.add_secret_version request
+  # Call the add_secret_version method.
+  result = client.add_secret_version request
 
-# The returned object is of type Google::Cloud::SecretManager::V1beta1::SecretVersion.
-p result
+  # The returned object is of type Google::Cloud::SecretManager::V1beta1::SecretVersion.
+  p result
+end
 # [END secretmanager_v1beta1_generated_SecretManagerService_AddSecretVersion_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/create_secret.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/create_secret.rb
@@ -19,15 +19,21 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_CreateSecret_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#create_secret
+#
+def create_secret
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::SecretManager::V1beta1::CreateSecretRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::SecretManager::V1beta1::CreateSecretRequest.new
 
-# Call the create_secret method.
-result = client.create_secret request
+  # Call the create_secret method.
+  result = client.create_secret request
 
-# The returned object is of type Google::Cloud::SecretManager::V1beta1::Secret.
-p result
+  # The returned object is of type Google::Cloud::SecretManager::V1beta1::Secret.
+  p result
+end
 # [END secretmanager_v1beta1_generated_SecretManagerService_CreateSecret_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/delete_secret.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/delete_secret.rb
@@ -19,15 +19,21 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_DeleteSecret_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#delete_secret
+#
+def delete_secret
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::SecretManager::V1beta1::DeleteSecretRequest.new
 
-# Call the delete_secret method.
-result = client.delete_secret request
+  # Call the delete_secret method.
+  result = client.delete_secret request
 
-# The returned object is of type Google::Protobuf::Empty.
-p result
+  # The returned object is of type Google::Protobuf::Empty.
+  p result
+end
 # [END secretmanager_v1beta1_generated_SecretManagerService_DeleteSecret_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/destroy_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/destroy_secret_version.rb
@@ -19,15 +19,21 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_DestroySecretVersion_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#destroy_secret_version
+#
+def destroy_secret_version
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::SecretManager::V1beta1::DestroySecretVersionRequest.new
 
-# Call the destroy_secret_version method.
-result = client.destroy_secret_version request
+  # Call the destroy_secret_version method.
+  result = client.destroy_secret_version request
 
-# The returned object is of type Google::Cloud::SecretManager::V1beta1::SecretVersion.
-p result
+  # The returned object is of type Google::Cloud::SecretManager::V1beta1::SecretVersion.
+  p result
+end
 # [END secretmanager_v1beta1_generated_SecretManagerService_DestroySecretVersion_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/disable_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/disable_secret_version.rb
@@ -19,15 +19,21 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_DisableSecretVersion_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#disable_secret_version
+#
+def disable_secret_version
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::SecretManager::V1beta1::DisableSecretVersionRequest.new
 
-# Call the disable_secret_version method.
-result = client.disable_secret_version request
+  # Call the disable_secret_version method.
+  result = client.disable_secret_version request
 
-# The returned object is of type Google::Cloud::SecretManager::V1beta1::SecretVersion.
-p result
+  # The returned object is of type Google::Cloud::SecretManager::V1beta1::SecretVersion.
+  p result
+end
 # [END secretmanager_v1beta1_generated_SecretManagerService_DisableSecretVersion_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/enable_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/enable_secret_version.rb
@@ -19,15 +19,21 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_EnableSecretVersion_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#enable_secret_version
+#
+def enable_secret_version
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::SecretManager::V1beta1::EnableSecretVersionRequest.new
 
-# Call the enable_secret_version method.
-result = client.enable_secret_version request
+  # Call the enable_secret_version method.
+  result = client.enable_secret_version request
 
-# The returned object is of type Google::Cloud::SecretManager::V1beta1::SecretVersion.
-p result
+  # The returned object is of type Google::Cloud::SecretManager::V1beta1::SecretVersion.
+  p result
+end
 # [END secretmanager_v1beta1_generated_SecretManagerService_EnableSecretVersion_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_iam_policy.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_iam_policy.rb
@@ -19,15 +19,21 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_GetIamPolicy_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_iam_policy
+#
+def get_iam_policy
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Iam::V1::GetIamPolicyRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Iam::V1::GetIamPolicyRequest.new
 
-# Call the get_iam_policy method.
-result = client.get_iam_policy request
+  # Call the get_iam_policy method.
+  result = client.get_iam_policy request
 
-# The returned object is of type Google::Iam::V1::Policy.
-p result
+  # The returned object is of type Google::Iam::V1::Policy.
+  p result
+end
 # [END secretmanager_v1beta1_generated_SecretManagerService_GetIamPolicy_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_secret.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_secret.rb
@@ -19,15 +19,21 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_GetSecret_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_secret
+#
+def get_secret
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::SecretManager::V1beta1::GetSecretRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::SecretManager::V1beta1::GetSecretRequest.new
 
-# Call the get_secret method.
-result = client.get_secret request
+  # Call the get_secret method.
+  result = client.get_secret request
 
-# The returned object is of type Google::Cloud::SecretManager::V1beta1::Secret.
-p result
+  # The returned object is of type Google::Cloud::SecretManager::V1beta1::Secret.
+  p result
+end
 # [END secretmanager_v1beta1_generated_SecretManagerService_GetSecret_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_secret_version.rb
@@ -19,15 +19,21 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_GetSecretVersion_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_secret_version
+#
+def get_secret_version
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::SecretManager::V1beta1::GetSecretVersionRequest.new
 
-# Call the get_secret_version method.
-result = client.get_secret_version request
+  # Call the get_secret_version method.
+  result = client.get_secret_version request
 
-# The returned object is of type Google::Cloud::SecretManager::V1beta1::SecretVersion.
-p result
+  # The returned object is of type Google::Cloud::SecretManager::V1beta1::SecretVersion.
+  p result
+end
 # [END secretmanager_v1beta1_generated_SecretManagerService_GetSecretVersion_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secret_versions.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secret_versions.rb
@@ -19,21 +19,27 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_ListSecretVersions_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secret_versions
+#
+def list_secret_versions
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::SecretManager::V1beta1::ListSecretVersionsRequest.new
 
-# Call the list_secret_versions method.
-result = client.list_secret_versions request
+  # Call the list_secret_versions method.
+  result = client.list_secret_versions request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Google::Cloud::SecretManager::V1beta1::SecretVersion.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Google::Cloud::SecretManager::V1beta1::SecretVersion.
+    p response
+  end
 end
 # [END secretmanager_v1beta1_generated_SecretManagerService_ListSecretVersions_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secrets.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secrets.rb
@@ -19,21 +19,27 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_ListSecrets_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secrets
+#
+def list_secrets
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::SecretManager::V1beta1::ListSecretsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::SecretManager::V1beta1::ListSecretsRequest.new
 
-# Call the list_secrets method.
-result = client.list_secrets request
+  # Call the list_secrets method.
+  result = client.list_secrets request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Google::Cloud::SecretManager::V1beta1::Secret.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Google::Cloud::SecretManager::V1beta1::Secret.
+    p response
+  end
 end
 # [END secretmanager_v1beta1_generated_SecretManagerService_ListSecrets_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/set_iam_policy.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/set_iam_policy.rb
@@ -19,15 +19,21 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_SetIamPolicy_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#set_iam_policy
+#
+def set_iam_policy
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Iam::V1::SetIamPolicyRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Iam::V1::SetIamPolicyRequest.new
 
-# Call the set_iam_policy method.
-result = client.set_iam_policy request
+  # Call the set_iam_policy method.
+  result = client.set_iam_policy request
 
-# The returned object is of type Google::Iam::V1::Policy.
-p result
+  # The returned object is of type Google::Iam::V1::Policy.
+  p result
+end
 # [END secretmanager_v1beta1_generated_SecretManagerService_SetIamPolicy_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/test_iam_permissions.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/test_iam_permissions.rb
@@ -19,15 +19,21 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_TestIamPermissions_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#test_iam_permissions
+#
+def test_iam_permissions
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Iam::V1::TestIamPermissionsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Iam::V1::TestIamPermissionsRequest.new
 
-# Call the test_iam_permissions method.
-result = client.test_iam_permissions request
+  # Call the test_iam_permissions method.
+  result = client.test_iam_permissions request
 
-# The returned object is of type Google::Iam::V1::TestIamPermissionsResponse.
-p result
+  # The returned object is of type Google::Iam::V1::TestIamPermissionsResponse.
+  p result
+end
 # [END secretmanager_v1beta1_generated_SecretManagerService_TestIamPermissions_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/update_secret.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/update_secret.rb
@@ -19,15 +19,21 @@
 # [START secretmanager_v1beta1_generated_SecretManagerService_UpdateSecret_sync]
 require "google/cloud/secret_manager/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#update_secret
+#
+def update_secret
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::SecretManager::V1beta1::UpdateSecretRequest.new
 
-# Call the update_secret method.
-result = client.update_secret request
+  # Call the update_secret method.
+  result = client.update_secret request
 
-# The returned object is of type Google::Cloud::SecretManager::V1beta1::Secret.
-p result
+  # The returned object is of type Google::Cloud::SecretManager::V1beta1::Secret.
+  p result
+end
 # [END secretmanager_v1beta1_generated_SecretManagerService_UpdateSecret_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/snippet_metadata_google.cloud.secrets.v1beta1.json
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/snippet_metadata_google.cloud.secrets.v1beta1.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 44,
           "type": "FULL"
         }
       ]
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -166,7 +166,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -206,7 +206,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -246,7 +246,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -286,7 +286,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 44,
           "type": "FULL"
         }
       ]
@@ -326,7 +326,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -366,7 +366,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -406,7 +406,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -446,7 +446,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -486,7 +486,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -526,7 +526,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -566,7 +566,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -606,7 +606,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/speech_v1/.rubocop.yml
+++ b/shared/output/cloud/speech_v1/.rubocop.yml
@@ -25,6 +25,9 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/AccessorMethodName:
+  Exclude:
+    - "snippets/**/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-speech-v1.rb"

--- a/shared/output/cloud/speech_v1/snippets/Gemfile
+++ b/shared/output/cloud/speech_v1/snippets/Gemfile
@@ -25,8 +25,8 @@ else
 end
 
 group :test do
-  gem "google-style", "~> 1.25.1"
-  gem "minitest", "~> 5.14"
+  gem "google-style", "~> 1.26.1"
+  gem "minitest", "~> 5.16"
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~> 1.5"
 end

--- a/shared/output/cloud/speech_v1/snippets/snippet_metadata_google.cloud.speech.v1.json
+++ b/shared/output/cloud/speech_v1/snippets/snippet_metadata_google.cloud.speech.v1.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 39,
+          "end": 45,
           "type": "FULL"
         }
       ]
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 41,
+          "end": 47,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/speech_v1/snippets/speech/long_running_recognize.rb
+++ b/shared/output/cloud/speech_v1/snippets/speech/long_running_recognize.rb
@@ -19,22 +19,28 @@
 # [START speech_v1_generated_Speech_LongRunningRecognize_sync]
 require "google/cloud/speech/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Speech::V1::Speech::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Speech::V1::Speech::Client#long_running_recognize
+#
+def long_running_recognize
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Speech::V1::Speech::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Speech::V1::LongRunningRecognizeRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Speech::V1::LongRunningRecognizeRequest.new
 
-# Call the long_running_recognize method.
-result = client.long_running_recognize request
+  # Call the long_running_recognize method.
+  result = client.long_running_recognize request
 
-# The returned object is of type Gapic::Operation. You can use this
-# object to check the status of an operation, cancel it, or wait
-# for results. Here is how to block until completion:
-result.wait_until_done! timeout: 60
-if result.response?
-  p result.response
-else
-  puts "Error!"
+  # The returned object is of type Gapic::Operation. You can use this
+  # object to check the status of an operation, cancel it, or wait
+  # for results. Here is how to block until completion:
+  result.wait_until_done! timeout: 60
+  if result.response?
+    p result.response
+  else
+    puts "Error!"
+  end
 end
 # [END speech_v1_generated_Speech_LongRunningRecognize_sync]

--- a/shared/output/cloud/speech_v1/snippets/speech/recognize.rb
+++ b/shared/output/cloud/speech_v1/snippets/speech/recognize.rb
@@ -19,15 +19,21 @@
 # [START speech_v1_generated_Speech_Recognize_sync]
 require "google/cloud/speech/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Speech::V1::Speech::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Speech::V1::Speech::Client#recognize
+#
+def recognize
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Speech::V1::Speech::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Speech::V1::RecognizeRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Speech::V1::RecognizeRequest.new
 
-# Call the recognize method.
-result = client.recognize request
+  # Call the recognize method.
+  result = client.recognize request
 
-# The returned object is of type Google::Cloud::Speech::V1::RecognizeResponse.
-p result
+  # The returned object is of type Google::Cloud::Speech::V1::RecognizeResponse.
+  p result
+end
 # [END speech_v1_generated_Speech_Recognize_sync]

--- a/shared/output/cloud/speech_v1/snippets/speech/streaming_recognize.rb
+++ b/shared/output/cloud/speech_v1/snippets/speech/streaming_recognize.rb
@@ -19,24 +19,30 @@
 # [START speech_v1_generated_Speech_StreamingRecognize_sync]
 require "google/cloud/speech/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Speech::V1::Speech::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Speech::V1::Speech::Client#streaming_recognize
+#
+def streaming_recognize
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Speech::V1::Speech::Client.new
 
-# Create an input stream
-input = Gapic::StreamInput.new
+  # Create an input stream
+  input = Gapic::StreamInput.new
 
-# Call the streaming_recognize method to start streaming.
-output = client.streaming_recognize input
+  # Call the streaming_recognize method to start streaming.
+  output = client.streaming_recognize input
 
-# Send requests on the stream. For each request, pass in keyword
-# arguments to set fields. Be sure to close the stream when done.
-input << Google::Cloud::Speech::V1::StreamingRecognizeRequest.new
-input << Google::Cloud::Speech::V1::StreamingRecognizeRequest.new
-input.close
+  # Send requests on the stream. For each request, pass in keyword
+  # arguments to set fields. Be sure to close the stream when done.
+  input << Google::Cloud::Speech::V1::StreamingRecognizeRequest.new
+  input << Google::Cloud::Speech::V1::StreamingRecognizeRequest.new
+  input.close
 
-# Handle streamed responses. These may be interleaved with inputs.
-# Each response is of type ::Google::Cloud::Speech::V1::StreamingRecognizeResponse.
-output.each do |response|
-  p response
+  # Handle streamed responses. These may be interleaved with inputs.
+  # Each response is of type ::Google::Cloud::Speech::V1::StreamingRecognizeResponse.
+  output.each do |response|
+    p response
+  end
 end
 # [END speech_v1_generated_Speech_StreamingRecognize_sync]

--- a/shared/output/cloud/vision_v1/.rubocop.yml
+++ b/shared/output/cloud/vision_v1/.rubocop.yml
@@ -25,6 +25,9 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/AccessorMethodName:
+  Exclude:
+    - "snippets/**/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-vision-v1.rb"

--- a/shared/output/cloud/vision_v1/snippets/Gemfile
+++ b/shared/output/cloud/vision_v1/snippets/Gemfile
@@ -25,8 +25,8 @@ else
 end
 
 group :test do
-  gem "google-style", "~> 1.25.1"
-  gem "minitest", "~> 5.14"
+  gem "google-style", "~> 1.26.1"
+  gem "minitest", "~> 5.16"
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~> 1.5"
 end

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_files.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_files.rb
@@ -19,22 +19,28 @@
 # [START vision_v1_generated_ImageAnnotator_AsyncBatchAnnotateFiles_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_files
+#
+def async_batch_annotate_files
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new
 
-# Call the async_batch_annotate_files method.
-result = client.async_batch_annotate_files request
+  # Call the async_batch_annotate_files method.
+  result = client.async_batch_annotate_files request
 
-# The returned object is of type Gapic::Operation. You can use this
-# object to check the status of an operation, cancel it, or wait
-# for results. Here is how to block until completion:
-result.wait_until_done! timeout: 60
-if result.response?
-  p result.response
-else
-  puts "Error!"
+  # The returned object is of type Gapic::Operation. You can use this
+  # object to check the status of an operation, cancel it, or wait
+  # for results. Here is how to block until completion:
+  result.wait_until_done! timeout: 60
+  if result.response?
+    p result.response
+  else
+    puts "Error!"
+  end
 end
 # [END vision_v1_generated_ImageAnnotator_AsyncBatchAnnotateFiles_sync]

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_images.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_images.rb
@@ -19,22 +19,28 @@
 # [START vision_v1_generated_ImageAnnotator_AsyncBatchAnnotateImages_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_images
+#
+def async_batch_annotate_images
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new
 
-# Call the async_batch_annotate_images method.
-result = client.async_batch_annotate_images request
+  # Call the async_batch_annotate_images method.
+  result = client.async_batch_annotate_images request
 
-# The returned object is of type Gapic::Operation. You can use this
-# object to check the status of an operation, cancel it, or wait
-# for results. Here is how to block until completion:
-result.wait_until_done! timeout: 60
-if result.response?
-  p result.response
-else
-  puts "Error!"
+  # The returned object is of type Gapic::Operation. You can use this
+  # object to check the status of an operation, cancel it, or wait
+  # for results. Here is how to block until completion:
+  result.wait_until_done! timeout: 60
+  if result.response?
+    p result.response
+  else
+    puts "Error!"
+  end
 end
 # [END vision_v1_generated_ImageAnnotator_AsyncBatchAnnotateImages_sync]

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/batch_annotate_files.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/batch_annotate_files.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ImageAnnotator_BatchAnnotateFiles_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_files
+#
+def batch_annotate_files
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new
 
-# Call the batch_annotate_files method.
-result = client.batch_annotate_files request
+  # Call the batch_annotate_files method.
+  result = client.batch_annotate_files request
 
-# The returned object is of type Google::Cloud::Vision::V1::BatchAnnotateFilesResponse.
-p result
+  # The returned object is of type Google::Cloud::Vision::V1::BatchAnnotateFilesResponse.
+  p result
+end
 # [END vision_v1_generated_ImageAnnotator_BatchAnnotateFiles_sync]

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/batch_annotate_images.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/batch_annotate_images.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ImageAnnotator_BatchAnnotateImages_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_images
+#
+def batch_annotate_images
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ImageAnnotator::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new
 
-# Call the batch_annotate_images method.
-result = client.batch_annotate_images request
+  # Call the batch_annotate_images method.
+  result = client.batch_annotate_images request
 
-# The returned object is of type Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.
-p result
+  # The returned object is of type Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.
+  p result
+end
 # [END vision_v1_generated_ImageAnnotator_BatchAnnotateImages_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/add_product_to_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/add_product_to_product_set.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ProductSearch_AddProductToProductSet_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#add_product_to_product_set
+#
+def add_product_to_product_set
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::AddProductToProductSetRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::AddProductToProductSetRequest.new
 
-# Call the add_product_to_product_set method.
-result = client.add_product_to_product_set request
+  # Call the add_product_to_product_set method.
+  result = client.add_product_to_product_set request
 
-# The returned object is of type Google::Protobuf::Empty.
-p result
+  # The returned object is of type Google::Protobuf::Empty.
+  p result
+end
 # [END vision_v1_generated_ProductSearch_AddProductToProductSet_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/create_product.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/create_product.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ProductSearch_CreateProduct_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#create_product
+#
+def create_product
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::CreateProductRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::CreateProductRequest.new
 
-# Call the create_product method.
-result = client.create_product request
+  # Call the create_product method.
+  result = client.create_product request
 
-# The returned object is of type Google::Cloud::Vision::V1::Product.
-p result
+  # The returned object is of type Google::Cloud::Vision::V1::Product.
+  p result
+end
 # [END vision_v1_generated_ProductSearch_CreateProduct_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/create_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/create_product_set.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ProductSearch_CreateProductSet_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#create_product_set
+#
+def create_product_set
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::CreateProductSetRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::CreateProductSetRequest.new
 
-# Call the create_product_set method.
-result = client.create_product_set request
+  # Call the create_product_set method.
+  result = client.create_product_set request
 
-# The returned object is of type Google::Cloud::Vision::V1::ProductSet.
-p result
+  # The returned object is of type Google::Cloud::Vision::V1::ProductSet.
+  p result
+end
 # [END vision_v1_generated_ProductSearch_CreateProductSet_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/create_reference_image.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/create_reference_image.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ProductSearch_CreateReferenceImage_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#create_reference_image
+#
+def create_reference_image
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::CreateReferenceImageRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::CreateReferenceImageRequest.new
 
-# Call the create_reference_image method.
-result = client.create_reference_image request
+  # Call the create_reference_image method.
+  result = client.create_reference_image request
 
-# The returned object is of type Google::Cloud::Vision::V1::ReferenceImage.
-p result
+  # The returned object is of type Google::Cloud::Vision::V1::ReferenceImage.
+  p result
+end
 # [END vision_v1_generated_ProductSearch_CreateReferenceImage_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/delete_product.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/delete_product.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ProductSearch_DeleteProduct_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#delete_product
+#
+def delete_product
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::DeleteProductRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::DeleteProductRequest.new
 
-# Call the delete_product method.
-result = client.delete_product request
+  # Call the delete_product method.
+  result = client.delete_product request
 
-# The returned object is of type Google::Protobuf::Empty.
-p result
+  # The returned object is of type Google::Protobuf::Empty.
+  p result
+end
 # [END vision_v1_generated_ProductSearch_DeleteProduct_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/delete_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/delete_product_set.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ProductSearch_DeleteProductSet_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#delete_product_set
+#
+def delete_product_set
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::DeleteProductSetRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::DeleteProductSetRequest.new
 
-# Call the delete_product_set method.
-result = client.delete_product_set request
+  # Call the delete_product_set method.
+  result = client.delete_product_set request
 
-# The returned object is of type Google::Protobuf::Empty.
-p result
+  # The returned object is of type Google::Protobuf::Empty.
+  p result
+end
 # [END vision_v1_generated_ProductSearch_DeleteProductSet_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/delete_reference_image.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/delete_reference_image.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ProductSearch_DeleteReferenceImage_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#delete_reference_image
+#
+def delete_reference_image
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new
 
-# Call the delete_reference_image method.
-result = client.delete_reference_image request
+  # Call the delete_reference_image method.
+  result = client.delete_reference_image request
 
-# The returned object is of type Google::Protobuf::Empty.
-p result
+  # The returned object is of type Google::Protobuf::Empty.
+  p result
+end
 # [END vision_v1_generated_ProductSearch_DeleteReferenceImage_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/get_product.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/get_product.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ProductSearch_GetProduct_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#get_product
+#
+def get_product
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::GetProductRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::GetProductRequest.new
 
-# Call the get_product method.
-result = client.get_product request
+  # Call the get_product method.
+  result = client.get_product request
 
-# The returned object is of type Google::Cloud::Vision::V1::Product.
-p result
+  # The returned object is of type Google::Cloud::Vision::V1::Product.
+  p result
+end
 # [END vision_v1_generated_ProductSearch_GetProduct_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/get_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/get_product_set.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ProductSearch_GetProductSet_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#get_product_set
+#
+def get_product_set
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::GetProductSetRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::GetProductSetRequest.new
 
-# Call the get_product_set method.
-result = client.get_product_set request
+  # Call the get_product_set method.
+  result = client.get_product_set request
 
-# The returned object is of type Google::Cloud::Vision::V1::ProductSet.
-p result
+  # The returned object is of type Google::Cloud::Vision::V1::ProductSet.
+  p result
+end
 # [END vision_v1_generated_ProductSearch_GetProductSet_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/get_reference_image.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/get_reference_image.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ProductSearch_GetReferenceImage_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#get_reference_image
+#
+def get_reference_image
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::GetReferenceImageRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::GetReferenceImageRequest.new
 
-# Call the get_reference_image method.
-result = client.get_reference_image request
+  # Call the get_reference_image method.
+  result = client.get_reference_image request
 
-# The returned object is of type Google::Cloud::Vision::V1::ReferenceImage.
-p result
+  # The returned object is of type Google::Cloud::Vision::V1::ReferenceImage.
+  p result
+end
 # [END vision_v1_generated_ProductSearch_GetReferenceImage_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/import_product_sets.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/import_product_sets.rb
@@ -19,22 +19,28 @@
 # [START vision_v1_generated_ProductSearch_ImportProductSets_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#import_product_sets
+#
+def import_product_sets
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::ImportProductSetsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::ImportProductSetsRequest.new
 
-# Call the import_product_sets method.
-result = client.import_product_sets request
+  # Call the import_product_sets method.
+  result = client.import_product_sets request
 
-# The returned object is of type Gapic::Operation. You can use this
-# object to check the status of an operation, cancel it, or wait
-# for results. Here is how to block until completion:
-result.wait_until_done! timeout: 60
-if result.response?
-  p result.response
-else
-  puts "Error!"
+  # The returned object is of type Gapic::Operation. You can use this
+  # object to check the status of an operation, cancel it, or wait
+  # for results. Here is how to block until completion:
+  result.wait_until_done! timeout: 60
+  if result.response?
+    p result.response
+  else
+    puts "Error!"
+  end
 end
 # [END vision_v1_generated_ProductSearch_ImportProductSets_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_product_sets.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_product_sets.rb
@@ -19,21 +19,27 @@
 # [START vision_v1_generated_ProductSearch_ListProductSets_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#list_product_sets
+#
+def list_product_sets
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::ListProductSetsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::ListProductSetsRequest.new
 
-# Call the list_product_sets method.
-result = client.list_product_sets request
+  # Call the list_product_sets method.
+  result = client.list_product_sets request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Google::Cloud::Vision::V1::ProductSet.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Google::Cloud::Vision::V1::ProductSet.
+    p response
+  end
 end
 # [END vision_v1_generated_ProductSearch_ListProductSets_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_products.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_products.rb
@@ -19,21 +19,27 @@
 # [START vision_v1_generated_ProductSearch_ListProducts_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#list_products
+#
+def list_products
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::ListProductsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::ListProductsRequest.new
 
-# Call the list_products method.
-result = client.list_products request
+  # Call the list_products method.
+  result = client.list_products request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Google::Cloud::Vision::V1::Product.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Google::Cloud::Vision::V1::Product.
+    p response
+  end
 end
 # [END vision_v1_generated_ProductSearch_ListProducts_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_products_in_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_products_in_product_set.rb
@@ -19,21 +19,27 @@
 # [START vision_v1_generated_ProductSearch_ListProductsInProductSet_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#list_products_in_product_set
+#
+def list_products_in_product_set
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new
 
-# Call the list_products_in_product_set method.
-result = client.list_products_in_product_set request
+  # Call the list_products_in_product_set method.
+  result = client.list_products_in_product_set request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Google::Cloud::Vision::V1::Product.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Google::Cloud::Vision::V1::Product.
+    p response
+  end
 end
 # [END vision_v1_generated_ProductSearch_ListProductsInProductSet_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_reference_images.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_reference_images.rb
@@ -19,21 +19,27 @@
 # [START vision_v1_generated_ProductSearch_ListReferenceImages_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#list_reference_images
+#
+def list_reference_images
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::ListReferenceImagesRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::ListReferenceImagesRequest.new
 
-# Call the list_reference_images method.
-result = client.list_reference_images request
+  # Call the list_reference_images method.
+  result = client.list_reference_images request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Google::Cloud::Vision::V1::ReferenceImage.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Google::Cloud::Vision::V1::ReferenceImage.
+    p response
+  end
 end
 # [END vision_v1_generated_ProductSearch_ListReferenceImages_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/purge_products.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/purge_products.rb
@@ -19,22 +19,28 @@
 # [START vision_v1_generated_ProductSearch_PurgeProducts_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#purge_products
+#
+def purge_products
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::PurgeProductsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::PurgeProductsRequest.new
 
-# Call the purge_products method.
-result = client.purge_products request
+  # Call the purge_products method.
+  result = client.purge_products request
 
-# The returned object is of type Gapic::Operation. You can use this
-# object to check the status of an operation, cancel it, or wait
-# for results. Here is how to block until completion:
-result.wait_until_done! timeout: 60
-if result.response?
-  p result.response
-else
-  puts "Error!"
+  # The returned object is of type Gapic::Operation. You can use this
+  # object to check the status of an operation, cancel it, or wait
+  # for results. Here is how to block until completion:
+  result.wait_until_done! timeout: 60
+  if result.response?
+    p result.response
+  else
+    puts "Error!"
+  end
 end
 # [END vision_v1_generated_ProductSearch_PurgeProducts_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/remove_product_from_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/remove_product_from_product_set.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ProductSearch_RemoveProductFromProductSet_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#remove_product_from_product_set
+#
+def remove_product_from_product_set
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new
 
-# Call the remove_product_from_product_set method.
-result = client.remove_product_from_product_set request
+  # Call the remove_product_from_product_set method.
+  result = client.remove_product_from_product_set request
 
-# The returned object is of type Google::Protobuf::Empty.
-p result
+  # The returned object is of type Google::Protobuf::Empty.
+  p result
+end
 # [END vision_v1_generated_ProductSearch_RemoveProductFromProductSet_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/update_product.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/update_product.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ProductSearch_UpdateProduct_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#update_product
+#
+def update_product
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::UpdateProductRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::UpdateProductRequest.new
 
-# Call the update_product method.
-result = client.update_product request
+  # Call the update_product method.
+  result = client.update_product request
 
-# The returned object is of type Google::Cloud::Vision::V1::Product.
-p result
+  # The returned object is of type Google::Cloud::Vision::V1::Product.
+  p result
+end
 # [END vision_v1_generated_ProductSearch_UpdateProduct_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/update_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/update_product_set.rb
@@ -19,15 +19,21 @@
 # [START vision_v1_generated_ProductSearch_UpdateProductSet_sync]
 require "google/cloud/vision/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Cloud::Vision::V1::ProductSearch::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#update_product_set
+#
+def update_product_set
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Cloud::Vision::V1::ProductSearch::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Cloud::Vision::V1::UpdateProductSetRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Cloud::Vision::V1::UpdateProductSetRequest.new
 
-# Call the update_product_set method.
-result = client.update_product_set request
+  # Call the update_product_set method.
+  result = client.update_product_set request
 
-# The returned object is of type Google::Cloud::Vision::V1::ProductSet.
-p result
+  # The returned object is of type Google::Cloud::Vision::V1::ProductSet.
+  p result
+end
 # [END vision_v1_generated_ProductSearch_UpdateProductSet_sync]

--- a/shared/output/cloud/vision_v1/snippets/snippet_metadata_google.cloud.vision.v1.json
+++ b/shared/output/cloud/vision_v1/snippets/snippet_metadata_google.cloud.vision.v1.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 44,
           "type": "FULL"
         }
       ]
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -166,7 +166,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -206,7 +206,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -246,7 +246,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -286,7 +286,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 44,
           "type": "FULL"
         }
       ]
@@ -326,7 +326,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -366,7 +366,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -406,7 +406,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -446,7 +446,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -486,7 +486,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -526,7 +526,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 44,
           "type": "FULL"
         }
       ]
@@ -566,7 +566,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -606,7 +606,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -646,7 +646,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -686,7 +686,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 44,
           "type": "FULL"
         }
       ]
@@ -726,7 +726,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 39,
+          "end": 45,
           "type": "FULL"
         }
       ]
@@ -766,7 +766,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 39,
+          "end": 45,
           "type": "FULL"
         }
       ]
@@ -806,7 +806,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -846,7 +846,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 32,
+          "end": 38,
           "type": "FULL"
         }
       ]
@@ -886,7 +886,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 39,
+          "end": 45,
           "type": "FULL"
         }
       ]
@@ -926,7 +926,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 39,
+          "end": 45,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/garbage/.rubocop.yml
+++ b/shared/output/gapic/templates/garbage/.rubocop.yml
@@ -21,6 +21,9 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/AccessorMethodName:
+  Exclude:
+    - "snippets/**/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/google-garbage.rb"

--- a/shared/output/gapic/templates/garbage/snippets/Gemfile
+++ b/shared/output/gapic/templates/garbage/snippets/Gemfile
@@ -33,8 +33,8 @@ else
 end
 
 group :test do
-  gem "google-style", "~> 1.25.1"
-  gem "minitest", "~> 5.14"
+  gem "google-style", "~> 1.26.1"
+  gem "minitest", "~> 5.16"
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~> 1.5"
 end

--- a/shared/output/gapic/templates/garbage/snippets/deprecated_service/deprecated_get.rb
+++ b/shared/output/gapic/templates/garbage/snippets/deprecated_service/deprecated_get.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_DeprecatedService_DeprecatedGet_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::DeprecatedService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::DeprecatedService::Client#deprecated_get
+#
+def deprecated_get
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::DeprecatedService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::EmptyGarbage.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::EmptyGarbage.new
 
-# Call the deprecated_get method.
-result = client.deprecated_get request
+  # Call the deprecated_get method.
+  result = client.deprecated_get request
 
-# The returned object is of type So::Much::Trash::EmptyGarbage.
-p result
+  # The returned object is of type So::Much::Trash::EmptyGarbage.
+  p result
+end
 # [END garbage_v0_generated_DeprecatedService_DeprecatedGet_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/bidi_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/bidi_garbage.rb
@@ -27,24 +27,30 @@
 # [START garbage_v0_generated_GarbageService_BidiGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#bidi_garbage
+#
+def bidi_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create an input stream
-input = Gapic::StreamInput.new
+  # Create an input stream
+  input = Gapic::StreamInput.new
 
-# Call the bidi_garbage method to start streaming.
-output = client.bidi_garbage input
+  # Call the bidi_garbage method to start streaming.
+  output = client.bidi_garbage input
 
-# Send requests on the stream. For each request, pass in keyword
-# arguments to set fields. Be sure to close the stream when done.
-input << So::Much::Trash::ListGarbageRequest.new
-input << So::Much::Trash::ListGarbageRequest.new
-input.close
+  # Send requests on the stream. For each request, pass in keyword
+  # arguments to set fields. Be sure to close the stream when done.
+  input << So::Much::Trash::ListGarbageRequest.new
+  input << So::Much::Trash::ListGarbageRequest.new
+  input.close
 
-# Handle streamed responses. These may be interleaved with inputs.
-# Each response is of type ::So::Much::Trash::GarbageItem.
-output.each do |response|
-  p response
+  # Handle streamed responses. These may be interleaved with inputs.
+  # Each response is of type ::So::Much::Trash::GarbageItem.
+  output.each do |response|
+    p response
+  end
 end
 # [END garbage_v0_generated_GarbageService_BidiGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/bidi_typical_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/bidi_typical_garbage.rb
@@ -27,24 +27,30 @@
 # [START garbage_v0_generated_GarbageService_BidiTypicalGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#bidi_typical_garbage
+#
+def bidi_typical_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create an input stream
-input = Gapic::StreamInput.new
+  # Create an input stream
+  input = Gapic::StreamInput.new
 
-# Call the bidi_typical_garbage method to start streaming.
-output = client.bidi_typical_garbage input
+  # Call the bidi_typical_garbage method to start streaming.
+  output = client.bidi_typical_garbage input
 
-# Send requests on the stream. For each request, pass in keyword
-# arguments to set fields. Be sure to close the stream when done.
-input << So::Much::Trash::TypicalGarbage.new
-input << So::Much::Trash::TypicalGarbage.new
-input.close
+  # Send requests on the stream. For each request, pass in keyword
+  # arguments to set fields. Be sure to close the stream when done.
+  input << So::Much::Trash::TypicalGarbage.new
+  input << So::Much::Trash::TypicalGarbage.new
+  input.close
 
-# Handle streamed responses. These may be interleaved with inputs.
-# Each response is of type ::So::Much::Trash::TypicalGarbage.
-output.each do |response|
-  p response
+  # Handle streamed responses. These may be interleaved with inputs.
+  # Each response is of type ::So::Much::Trash::TypicalGarbage.
+  output.each do |response|
+    p response
+  end
 end
 # [END garbage_v0_generated_GarbageService_BidiTypicalGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/call_send.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/call_send.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_GarbageService_Send_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#call_send
+#
+def call_send
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::EmptyGarbage.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::EmptyGarbage.new
 
-# Call the call_send method.
-result = client.call_send request
+  # Call the call_send method.
+  result = client.call_send request
 
-# The returned object is of type So::Much::Trash::EmptyGarbage.
-p result
+  # The returned object is of type So::Much::Trash::EmptyGarbage.
+  p result
+end
 # [END garbage_v0_generated_GarbageService_Send_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/client_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/client_garbage.rb
@@ -27,19 +27,25 @@
 # [START garbage_v0_generated_GarbageService_ClientGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#client_garbage
+#
+def client_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a stream of requests, as an Enumerator.
-# For each request, pass in keyword arguments to set fields.
-request = [
-  So::Much::Trash::ListGarbageRequest.new,
-  So::Much::Trash::ListGarbageRequest.new
-].to_enum
+  # Create a stream of requests, as an Enumerator.
+  # For each request, pass in keyword arguments to set fields.
+  request = [
+    So::Much::Trash::ListGarbageRequest.new,
+    So::Much::Trash::ListGarbageRequest.new
+  ].to_enum
 
-# Call the client_garbage method.
-result = client.client_garbage request
+  # Call the client_garbage method.
+  result = client.client_garbage request
 
-# The returned object is of type So::Much::Trash::ListGarbageResponse.
-p result
+  # The returned object is of type So::Much::Trash::ListGarbageResponse.
+  p result
+end
 # [END garbage_v0_generated_GarbageService_ClientGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_complex_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_complex_garbage.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_GarbageService_GetComplexGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_complex_garbage
+#
+def get_complex_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::ComplexGarbage.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::ComplexGarbage.new
 
-# Call the get_complex_garbage method.
-result = client.get_complex_garbage request
+  # Call the get_complex_garbage method.
+  result = client.get_complex_garbage request
 
-# The returned object is of type So::Much::Trash::ComplexGarbage.
-p result
+  # The returned object is of type So::Much::Trash::ComplexGarbage.
+  p result
+end
 # [END garbage_v0_generated_GarbageService_GetComplexGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_empty_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_empty_garbage.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_GarbageService_GetEmptyGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_empty_garbage
+#
+def get_empty_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::EmptyGarbage.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::EmptyGarbage.new
 
-# Call the get_empty_garbage method.
-result = client.get_empty_garbage request
+  # Call the get_empty_garbage method.
+  result = client.get_empty_garbage request
 
-# The returned object is of type So::Much::Trash::EmptyGarbage.
-p result
+  # The returned object is of type So::Much::Trash::EmptyGarbage.
+  p result
+end
 # [END garbage_v0_generated_GarbageService_GetEmptyGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_garbage_node.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_garbage_node.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_GarbageService_GetGarbageNode_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_garbage_node
+#
+def get_garbage_node
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::GarbageNode.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::GarbageNode.new
 
-# Call the get_garbage_node method.
-result = client.get_garbage_node request
+  # Call the get_garbage_node method.
+  result = client.get_garbage_node request
 
-# The returned object is of type So::Much::Trash::GarbageNode.
-p result
+  # The returned object is of type So::Much::Trash::GarbageNode.
+  p result
+end
 # [END garbage_v0_generated_GarbageService_GetGarbageNode_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_nested_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_nested_garbage.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_GarbageService_GetNestedGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_nested_garbage
+#
+def get_nested_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::SpecificGarbage::NestedGarbage.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::SpecificGarbage::NestedGarbage.new
 
-# Call the get_nested_garbage method.
-result = client.get_nested_garbage request
+  # Call the get_nested_garbage method.
+  result = client.get_nested_garbage request
 
-# The returned object is of type So::Much::Trash::SpecificGarbage::NestedGarbage.
-p result
+  # The returned object is of type So::Much::Trash::SpecificGarbage::NestedGarbage.
+  p result
+end
 # [END garbage_v0_generated_GarbageService_GetNestedGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_paged_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_paged_garbage.rb
@@ -27,21 +27,27 @@
 # [START garbage_v0_generated_GarbageService_GetPagedGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_paged_garbage
+#
+def get_paged_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::PagedGarbageRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::PagedGarbageRequest.new
 
-# Call the get_paged_garbage method.
-result = client.get_paged_garbage request
+  # Call the get_paged_garbage method.
+  result = client.get_paged_garbage request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::So::Much::Trash::GarbageItem.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::So::Much::Trash::GarbageItem.
+    p response
+  end
 end
 # [END garbage_v0_generated_GarbageService_GetPagedGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_repeated_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_repeated_garbage.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_GarbageService_GetRepeatedGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_repeated_garbage
+#
+def get_repeated_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::RepeatedGarbage.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::RepeatedGarbage.new
 
-# Call the get_repeated_garbage method.
-result = client.get_repeated_garbage request
+  # Call the get_repeated_garbage method.
+  result = client.get_repeated_garbage request
 
-# The returned object is of type So::Much::Trash::RepeatedGarbage.
-p result
+  # The returned object is of type So::Much::Trash::RepeatedGarbage.
+  p result
+end
 # [END garbage_v0_generated_GarbageService_GetRepeatedGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_simple_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_simple_garbage.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_GarbageService_GetSimpleGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_simple_garbage
+#
+def get_simple_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::SimpleGarbage.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::SimpleGarbage.new
 
-# Call the get_simple_garbage method.
-result = client.get_simple_garbage request
+  # Call the get_simple_garbage method.
+  result = client.get_simple_garbage request
 
-# The returned object is of type So::Much::Trash::SimpleGarbage.
-p result
+  # The returned object is of type So::Much::Trash::SimpleGarbage.
+  p result
+end
 # [END garbage_v0_generated_GarbageService_GetSimpleGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_specific_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_specific_garbage.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_GarbageService_GetSpecificGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_specific_garbage
+#
+def get_specific_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::SpecificGarbage.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::SpecificGarbage.new
 
-# Call the get_specific_garbage method.
-result = client.get_specific_garbage request
+  # Call the get_specific_garbage method.
+  result = client.get_specific_garbage request
 
-# The returned object is of type So::Much::Trash::SpecificGarbage.
-p result
+  # The returned object is of type So::Much::Trash::SpecificGarbage.
+  p result
+end
 # [END garbage_v0_generated_GarbageService_GetSpecificGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_typical_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_typical_garbage.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_GarbageService_GetTypicalGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_typical_garbage
+#
+def get_typical_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::TypicalGarbage.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::TypicalGarbage.new
 
-# Call the get_typical_garbage method.
-result = client.get_typical_garbage request
+  # Call the get_typical_garbage method.
+  result = client.get_typical_garbage request
 
-# The returned object is of type So::Much::Trash::TypicalGarbage.
-p result
+  # The returned object is of type So::Much::Trash::TypicalGarbage.
+  p result
+end
 # [END garbage_v0_generated_GarbageService_GetTypicalGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_typical_garbage_by_request.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_typical_garbage_by_request.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_GarbageService_GetTypicalGarbageByRequest_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_typical_garbage_by_request
+#
+def get_typical_garbage_by_request
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::GetTypicalGarbageRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::GetTypicalGarbageRequest.new
 
-# Call the get_typical_garbage_by_request method.
-result = client.get_typical_garbage_by_request request
+  # Call the get_typical_garbage_by_request method.
+  result = client.get_typical_garbage_by_request request
 
-# The returned object is of type So::Much::Trash::TypicalGarbage.
-p result
+  # The returned object is of type So::Much::Trash::TypicalGarbage.
+  p result
+end
 # [END garbage_v0_generated_GarbageService_GetTypicalGarbageByRequest_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/long_running_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/long_running_garbage.rb
@@ -27,22 +27,28 @@
 # [START garbage_v0_generated_GarbageService_LongRunningGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#long_running_garbage
+#
+def long_running_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::LongRunningGarbageRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::LongRunningGarbageRequest.new
 
-# Call the long_running_garbage method.
-result = client.long_running_garbage request
+  # Call the long_running_garbage method.
+  result = client.long_running_garbage request
 
-# The returned object is of type Gapic::Operation. You can use this
-# object to check the status of an operation, cancel it, or wait
-# for results. Here is how to block until completion:
-result.wait_until_done! timeout: 60
-if result.response?
-  p result.response
-else
-  puts "Error!"
+  # The returned object is of type Gapic::Operation. You can use this
+  # object to check the status of an operation, cancel it, or wait
+  # for results. Here is how to block until completion:
+  result.wait_until_done! timeout: 60
+  if result.response?
+    p result.response
+  else
+    puts "Error!"
+  end
 end
 # [END garbage_v0_generated_GarbageService_LongRunningGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/server_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/server_garbage.rb
@@ -27,18 +27,24 @@
 # [START garbage_v0_generated_GarbageService_ServerGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::GarbageService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#server_garbage
+#
+def server_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::GarbageService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::ListGarbageRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::ListGarbageRequest.new
 
-# Call the server_garbage method.
-result = client.server_garbage request
+  # Call the server_garbage method.
+  result = client.server_garbage request
 
-# The returned object is a streamed enumerable yielding elements of
-# type ::So::Much::Trash::GarbageItem.
-result.each do |response|
-  p response
+  # The returned object is a streamed enumerable yielding elements of
+  # type ::So::Much::Trash::GarbageItem.
+  result.each do |response|
+    p response
+  end
 end
 # [END garbage_v0_generated_GarbageService_ServerGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/iam_policy/get_iam_policy.rb
+++ b/shared/output/gapic/templates/garbage/snippets/iam_policy/get_iam_policy.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_IAMPolicy_GetIamPolicy_sync]
 require "google/iam/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::IAMPolicy::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::IAMPolicy::Client#get_iam_policy
+#
+def get_iam_policy
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::IAMPolicy::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Iam::V1::GetIamPolicyRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Iam::V1::GetIamPolicyRequest.new
 
-# Call the get_iam_policy method.
-result = client.get_iam_policy request
+  # Call the get_iam_policy method.
+  result = client.get_iam_policy request
 
-# The returned object is of type Google::Iam::V1::Policy.
-p result
+  # The returned object is of type Google::Iam::V1::Policy.
+  p result
+end
 # [END garbage_v0_generated_IAMPolicy_GetIamPolicy_sync]

--- a/shared/output/gapic/templates/garbage/snippets/iam_policy/set_iam_policy.rb
+++ b/shared/output/gapic/templates/garbage/snippets/iam_policy/set_iam_policy.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_IAMPolicy_SetIamPolicy_sync]
 require "google/iam/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::IAMPolicy::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::IAMPolicy::Client#set_iam_policy
+#
+def set_iam_policy
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::IAMPolicy::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Iam::V1::SetIamPolicyRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Iam::V1::SetIamPolicyRequest.new
 
-# Call the set_iam_policy method.
-result = client.set_iam_policy request
+  # Call the set_iam_policy method.
+  result = client.set_iam_policy request
 
-# The returned object is of type Google::Iam::V1::Policy.
-p result
+  # The returned object is of type Google::Iam::V1::Policy.
+  p result
+end
 # [END garbage_v0_generated_IAMPolicy_SetIamPolicy_sync]

--- a/shared/output/gapic/templates/garbage/snippets/iam_policy/test_iam_permissions.rb
+++ b/shared/output/gapic/templates/garbage/snippets/iam_policy/test_iam_permissions.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_IAMPolicy_TestIamPermissions_sync]
 require "google/iam/v1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::IAMPolicy::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::IAMPolicy::Client#test_iam_permissions
+#
+def test_iam_permissions
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::IAMPolicy::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Iam::V1::TestIamPermissionsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Iam::V1::TestIamPermissionsRequest.new
 
-# Call the test_iam_permissions method.
-result = client.test_iam_permissions request
+  # Call the test_iam_permissions method.
+  result = client.test_iam_permissions request
 
-# The returned object is of type Google::Iam::V1::TestIamPermissionsResponse.
-p result
+  # The returned object is of type Google::Iam::V1::TestIamPermissionsResponse.
+  p result
+end
 # [END garbage_v0_generated_IAMPolicy_TestIamPermissions_sync]

--- a/shared/output/gapic/templates/garbage/snippets/really_renamed_service/get_empty_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/really_renamed_service/get_empty_garbage.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_ReallyRenamedService_GetEmptyGarbage_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::ReallyRenamedService::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::ReallyRenamedService::Client#get_empty_garbage
+#
+def get_empty_garbage
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::ReallyRenamedService::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::EmptyGarbage.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::EmptyGarbage.new
 
-# Call the get_empty_garbage method.
-result = client.get_empty_garbage request
+  # Call the get_empty_garbage method.
+  result = client.get_empty_garbage request
 
-# The returned object is of type So::Much::Trash::EmptyGarbage.
-p result
+  # The returned object is of type So::Much::Trash::EmptyGarbage.
+  p result
+end
 # [END garbage_v0_generated_ReallyRenamedService_GetEmptyGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/resource_names/complex_pattern_method.rb
+++ b/shared/output/gapic/templates/garbage/snippets/resource_names/complex_pattern_method.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_ResourceNames_ComplexPatternMethod_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::ResourceNames::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::ResourceNames::Client#complex_pattern_method
+#
+def complex_pattern_method
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::ResourceNames::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::ComplexPatternRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::ComplexPatternRequest.new
 
-# Call the complex_pattern_method method.
-result = client.complex_pattern_method request
+  # Call the complex_pattern_method method.
+  result = client.complex_pattern_method request
 
-# The returned object is of type So::Much::Trash::Response.
-p result
+  # The returned object is of type So::Much::Trash::Response.
+  p result
+end
 # [END garbage_v0_generated_ResourceNames_ComplexPatternMethod_sync]

--- a/shared/output/gapic/templates/garbage/snippets/resource_names/multiparent_method.rb
+++ b/shared/output/gapic/templates/garbage/snippets/resource_names/multiparent_method.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_ResourceNames_MultiparentMethod_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::ResourceNames::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::ResourceNames::Client#multiparent_method
+#
+def multiparent_method
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::ResourceNames::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::MultiparentRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::MultiparentRequest.new
 
-# Call the multiparent_method method.
-result = client.multiparent_method request
+  # Call the multiparent_method method.
+  result = client.multiparent_method request
 
-# The returned object is of type So::Much::Trash::Response.
-p result
+  # The returned object is of type So::Much::Trash::Response.
+  p result
+end
 # [END garbage_v0_generated_ResourceNames_MultiparentMethod_sync]

--- a/shared/output/gapic/templates/garbage/snippets/resource_names/no_arguments_multi_method.rb
+++ b/shared/output/gapic/templates/garbage/snippets/resource_names/no_arguments_multi_method.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_ResourceNames_NoArgumentsMultiMethod_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::ResourceNames::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::ResourceNames::Client#no_arguments_multi_method
+#
+def no_arguments_multi_method
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::ResourceNames::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::NoArgumentsMultiRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::NoArgumentsMultiRequest.new
 
-# Call the no_arguments_multi_method method.
-result = client.no_arguments_multi_method request
+  # Call the no_arguments_multi_method method.
+  result = client.no_arguments_multi_method request
 
-# The returned object is of type So::Much::Trash::Response.
-p result
+  # The returned object is of type So::Much::Trash::Response.
+  p result
+end
 # [END garbage_v0_generated_ResourceNames_NoArgumentsMultiMethod_sync]

--- a/shared/output/gapic/templates/garbage/snippets/resource_names/resource_name_pattern_method.rb
+++ b/shared/output/gapic/templates/garbage/snippets/resource_names/resource_name_pattern_method.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_ResourceNames_ResourceNamePatternMethod_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::ResourceNames::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::ResourceNames::Client#resource_name_pattern_method
+#
+def resource_name_pattern_method
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::ResourceNames::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::ResourceNamePatternRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::ResourceNamePatternRequest.new
 
-# Call the resource_name_pattern_method method.
-result = client.resource_name_pattern_method request
+  # Call the resource_name_pattern_method method.
+  result = client.resource_name_pattern_method request
 
-# The returned object is of type So::Much::Trash::Response.
-p result
+  # The returned object is of type So::Much::Trash::Response.
+  p result
+end
 # [END garbage_v0_generated_ResourceNames_ResourceNamePatternMethod_sync]

--- a/shared/output/gapic/templates/garbage/snippets/resource_names/simple_pattern_method.rb
+++ b/shared/output/gapic/templates/garbage/snippets/resource_names/simple_pattern_method.rb
@@ -27,15 +27,21 @@
 # [START garbage_v0_generated_ResourceNames_SimplePatternMethod_sync]
 require "so/much/trash"
 
-# Create a client object. The client can be reused for multiple calls.
-client = So::Much::Trash::ResourceNames::Client.new
+##
+# Example demonstrating basic usage of
+# So::Much::Trash::ResourceNames::Client#simple_pattern_method
+#
+def simple_pattern_method
+  # Create a client object. The client can be reused for multiple calls.
+  client = So::Much::Trash::ResourceNames::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = So::Much::Trash::SimplePatternRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = So::Much::Trash::SimplePatternRequest.new
 
-# Call the simple_pattern_method method.
-result = client.simple_pattern_method request
+  # Call the simple_pattern_method method.
+  result = client.simple_pattern_method request
 
-# The returned object is of type So::Much::Trash::Response.
-p result
+  # The returned object is of type So::Much::Trash::Response.
+  p result
+end
 # [END garbage_v0_generated_ResourceNames_SimplePatternMethod_sync]

--- a/shared/output/gapic/templates/garbage/snippets/snippet_metadata_endless.trash.forever.json
+++ b/shared/output/gapic/templates/garbage/snippets/snippet_metadata_endless.trash.forever.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -166,7 +166,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -206,7 +206,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -246,7 +246,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -286,7 +286,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -326,7 +326,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -366,7 +366,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -406,7 +406,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 52,
           "type": "FULL"
         }
       ]
@@ -446,7 +446,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 47,
+          "end": 53,
           "type": "FULL"
         }
       ]
@@ -486,7 +486,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 44,
+          "end": 50,
           "type": "FULL"
         }
       ]
@@ -526,7 +526,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 43,
+          "end": 49,
           "type": "FULL"
         }
       ]
@@ -566,7 +566,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 49,
+          "end": 55,
           "type": "FULL"
         }
       ]
@@ -606,7 +606,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 49,
+          "end": 55,
           "type": "FULL"
         }
       ]
@@ -646,7 +646,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -686,7 +686,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -726,7 +726,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -766,7 +766,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -806,7 +806,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -846,7 +846,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -886,7 +886,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -926,7 +926,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -966,7 +966,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -1006,7 +1006,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -1046,7 +1046,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/showcase/.rubocop.yml
+++ b/shared/output/gapic/templates/showcase/.rubocop.yml
@@ -21,6 +21,9 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/AccessorMethodName:
+  Exclude:
+    - "snippets/**/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/google-showcase.rb"

--- a/shared/output/gapic/templates/showcase/snippets/Gemfile
+++ b/shared/output/gapic/templates/showcase/snippets/Gemfile
@@ -33,8 +33,8 @@ else
 end
 
 group :test do
-  gem "google-style", "~> 1.25.1"
-  gem "minitest", "~> 5.14"
+  gem "google-style", "~> 1.26.1"
+  gem "minitest", "~> 5.16"
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~> 1.5"
 end

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Compliance_RepeatDataBody_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Compliance::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_body
+#
+def repeat_data_body
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Compliance::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::RepeatRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::RepeatRequest.new
 
-# Call the repeat_data_body method.
-result = client.repeat_data_body request
+  # Call the repeat_data_body method.
+  result = client.repeat_data_body request
 
-# The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+  p result
+end
 # [END showcase_v0_generated_Compliance_RepeatDataBody_sync]

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body_info.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body_info.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Compliance_RepeatDataBodyInfo_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Compliance::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_body_info
+#
+def repeat_data_body_info
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Compliance::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::RepeatRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::RepeatRequest.new
 
-# Call the repeat_data_body_info method.
-result = client.repeat_data_body_info request
+  # Call the repeat_data_body_info method.
+  result = client.repeat_data_body_info request
 
-# The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+  p result
+end
 # [END showcase_v0_generated_Compliance_RepeatDataBodyInfo_sync]

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body_patch.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body_patch.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Compliance_RepeatDataBodyPatch_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Compliance::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_body_patch
+#
+def repeat_data_body_patch
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Compliance::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::RepeatRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::RepeatRequest.new
 
-# Call the repeat_data_body_patch method.
-result = client.repeat_data_body_patch request
+  # Call the repeat_data_body_patch method.
+  result = client.repeat_data_body_patch request
 
-# The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+  p result
+end
 # [END showcase_v0_generated_Compliance_RepeatDataBodyPatch_sync]

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body_put.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body_put.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Compliance_RepeatDataBodyPut_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Compliance::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_body_put
+#
+def repeat_data_body_put
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Compliance::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::RepeatRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::RepeatRequest.new
 
-# Call the repeat_data_body_put method.
-result = client.repeat_data_body_put request
+  # Call the repeat_data_body_put method.
+  result = client.repeat_data_body_put request
 
-# The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+  p result
+end
 # [END showcase_v0_generated_Compliance_RepeatDataBodyPut_sync]

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_path_resource.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_path_resource.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Compliance_RepeatDataPathResource_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Compliance::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_path_resource
+#
+def repeat_data_path_resource
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Compliance::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::RepeatRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::RepeatRequest.new
 
-# Call the repeat_data_path_resource method.
-result = client.repeat_data_path_resource request
+  # Call the repeat_data_path_resource method.
+  result = client.repeat_data_path_resource request
 
-# The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+  p result
+end
 # [END showcase_v0_generated_Compliance_RepeatDataPathResource_sync]

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_path_trailing_resource.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_path_trailing_resource.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Compliance_RepeatDataPathTrailingResource_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Compliance::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_path_trailing_resource
+#
+def repeat_data_path_trailing_resource
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Compliance::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::RepeatRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::RepeatRequest.new
 
-# Call the repeat_data_path_trailing_resource method.
-result = client.repeat_data_path_trailing_resource request
+  # Call the repeat_data_path_trailing_resource method.
+  result = client.repeat_data_path_trailing_resource request
 
-# The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+  p result
+end
 # [END showcase_v0_generated_Compliance_RepeatDataPathTrailingResource_sync]

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_query.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_query.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Compliance_RepeatDataQuery_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Compliance::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_query
+#
+def repeat_data_query
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Compliance::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::RepeatRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::RepeatRequest.new
 
-# Call the repeat_data_query method.
-result = client.repeat_data_query request
+  # Call the repeat_data_query method.
+  result = client.repeat_data_query request
 
-# The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+  p result
+end
 # [END showcase_v0_generated_Compliance_RepeatDataQuery_sync]

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_simple_path.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_simple_path.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Compliance_RepeatDataSimplePath_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Compliance::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_simple_path
+#
+def repeat_data_simple_path
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Compliance::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::RepeatRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::RepeatRequest.new
 
-# Call the repeat_data_simple_path method.
-result = client.repeat_data_simple_path request
+  # Call the repeat_data_simple_path method.
+  result = client.repeat_data_simple_path request
 
-# The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+  p result
+end
 # [END showcase_v0_generated_Compliance_RepeatDataSimplePath_sync]

--- a/shared/output/gapic/templates/showcase/snippets/echo/block.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/block.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Echo_Block_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Echo::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#block
+#
+def block
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Echo::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::BlockRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::BlockRequest.new
 
-# Call the block method.
-result = client.block request
+  # Call the block method.
+  result = client.block request
 
-# The returned object is of type Google::Showcase::V1beta1::BlockResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::BlockResponse.
+  p result
+end
 # [END showcase_v0_generated_Echo_Block_sync]

--- a/shared/output/gapic/templates/showcase/snippets/echo/chat.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/chat.rb
@@ -27,24 +27,30 @@
 # [START showcase_v0_generated_Echo_Chat_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Echo::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#chat
+#
+def chat
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Echo::Client.new
 
-# Create an input stream
-input = Gapic::StreamInput.new
+  # Create an input stream
+  input = Gapic::StreamInput.new
 
-# Call the chat method to start streaming.
-output = client.chat input
+  # Call the chat method to start streaming.
+  output = client.chat input
 
-# Send requests on the stream. For each request, pass in keyword
-# arguments to set fields. Be sure to close the stream when done.
-input << Google::Showcase::V1beta1::EchoRequest.new
-input << Google::Showcase::V1beta1::EchoRequest.new
-input.close
+  # Send requests on the stream. For each request, pass in keyword
+  # arguments to set fields. Be sure to close the stream when done.
+  input << Google::Showcase::V1beta1::EchoRequest.new
+  input << Google::Showcase::V1beta1::EchoRequest.new
+  input.close
 
-# Handle streamed responses. These may be interleaved with inputs.
-# Each response is of type ::Google::Showcase::V1beta1::EchoResponse.
-output.each do |response|
-  p response
+  # Handle streamed responses. These may be interleaved with inputs.
+  # Each response is of type ::Google::Showcase::V1beta1::EchoResponse.
+  output.each do |response|
+    p response
+  end
 end
 # [END showcase_v0_generated_Echo_Chat_sync]

--- a/shared/output/gapic/templates/showcase/snippets/echo/collect.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/collect.rb
@@ -27,19 +27,25 @@
 # [START showcase_v0_generated_Echo_Collect_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Echo::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#collect
+#
+def collect
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Echo::Client.new
 
-# Create a stream of requests, as an Enumerator.
-# For each request, pass in keyword arguments to set fields.
-request = [
-  Google::Showcase::V1beta1::EchoRequest.new,
-  Google::Showcase::V1beta1::EchoRequest.new
-].to_enum
+  # Create a stream of requests, as an Enumerator.
+  # For each request, pass in keyword arguments to set fields.
+  request = [
+    Google::Showcase::V1beta1::EchoRequest.new,
+    Google::Showcase::V1beta1::EchoRequest.new
+  ].to_enum
 
-# Call the collect method.
-result = client.collect request
+  # Call the collect method.
+  result = client.collect request
 
-# The returned object is of type Google::Showcase::V1beta1::EchoResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::EchoResponse.
+  p result
+end
 # [END showcase_v0_generated_Echo_Collect_sync]

--- a/shared/output/gapic/templates/showcase/snippets/echo/echo.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/echo.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Echo_Echo_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Echo::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#echo
+#
+def echo
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Echo::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::EchoRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::EchoRequest.new
 
-# Call the echo method.
-result = client.echo request
+  # Call the echo method.
+  result = client.echo request
 
-# The returned object is of type Google::Showcase::V1beta1::EchoResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::EchoResponse.
+  p result
+end
 # [END showcase_v0_generated_Echo_Echo_sync]

--- a/shared/output/gapic/templates/showcase/snippets/echo/expand.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/expand.rb
@@ -27,18 +27,24 @@
 # [START showcase_v0_generated_Echo_Expand_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Echo::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#expand
+#
+def expand
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Echo::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::ExpandRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::ExpandRequest.new
 
-# Call the expand method.
-result = client.expand request
+  # Call the expand method.
+  result = client.expand request
 
-# The returned object is a streamed enumerable yielding elements of
-# type ::Google::Showcase::V1beta1::EchoResponse.
-result.each do |response|
-  p response
+  # The returned object is a streamed enumerable yielding elements of
+  # type ::Google::Showcase::V1beta1::EchoResponse.
+  result.each do |response|
+    p response
+  end
 end
 # [END showcase_v0_generated_Echo_Expand_sync]

--- a/shared/output/gapic/templates/showcase/snippets/echo/paged_expand.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/paged_expand.rb
@@ -27,21 +27,27 @@
 # [START showcase_v0_generated_Echo_PagedExpand_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Echo::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#paged_expand
+#
+def paged_expand
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Echo::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::PagedExpandRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::PagedExpandRequest.new
 
-# Call the paged_expand method.
-result = client.paged_expand request
+  # Call the paged_expand method.
+  result = client.paged_expand request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Google::Showcase::V1beta1::EchoResponse.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Google::Showcase::V1beta1::EchoResponse.
+    p response
+  end
 end
 # [END showcase_v0_generated_Echo_PagedExpand_sync]

--- a/shared/output/gapic/templates/showcase/snippets/echo/wait.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/wait.rb
@@ -27,22 +27,28 @@
 # [START showcase_v0_generated_Echo_Wait_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Echo::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#wait
+#
+def wait
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Echo::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::WaitRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::WaitRequest.new
 
-# Call the wait method.
-result = client.wait request
+  # Call the wait method.
+  result = client.wait request
 
-# The returned object is of type Gapic::Operation. You can use this
-# object to check the status of an operation, cancel it, or wait
-# for results. Here is how to block until completion:
-result.wait_until_done! timeout: 60
-if result.response?
-  p result.response
-else
-  puts "Error!"
+  # The returned object is of type Gapic::Operation. You can use this
+  # object to check the status of an operation, cancel it, or wait
+  # for results. Here is how to block until completion:
+  result.wait_until_done! timeout: 60
+  if result.response?
+    p result.response
+  else
+    puts "Error!"
+  end
 end
 # [END showcase_v0_generated_Echo_Wait_sync]

--- a/shared/output/gapic/templates/showcase/snippets/identity/create_user.rb
+++ b/shared/output/gapic/templates/showcase/snippets/identity/create_user.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Identity_CreateUser_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Identity::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Identity::Client#create_user
+#
+def create_user
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Identity::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::CreateUserRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::CreateUserRequest.new
 
-# Call the create_user method.
-result = client.create_user request
+  # Call the create_user method.
+  result = client.create_user request
 
-# The returned object is of type Google::Showcase::V1beta1::User.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::User.
+  p result
+end
 # [END showcase_v0_generated_Identity_CreateUser_sync]

--- a/shared/output/gapic/templates/showcase/snippets/identity/delete_user.rb
+++ b/shared/output/gapic/templates/showcase/snippets/identity/delete_user.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Identity_DeleteUser_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Identity::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Identity::Client#delete_user
+#
+def delete_user
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Identity::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::DeleteUserRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::DeleteUserRequest.new
 
-# Call the delete_user method.
-result = client.delete_user request
+  # Call the delete_user method.
+  result = client.delete_user request
 
-# The returned object is of type Google::Protobuf::Empty.
-p result
+  # The returned object is of type Google::Protobuf::Empty.
+  p result
+end
 # [END showcase_v0_generated_Identity_DeleteUser_sync]

--- a/shared/output/gapic/templates/showcase/snippets/identity/get_user.rb
+++ b/shared/output/gapic/templates/showcase/snippets/identity/get_user.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Identity_GetUser_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Identity::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Identity::Client#get_user
+#
+def get_user
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Identity::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::GetUserRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::GetUserRequest.new
 
-# Call the get_user method.
-result = client.get_user request
+  # Call the get_user method.
+  result = client.get_user request
 
-# The returned object is of type Google::Showcase::V1beta1::User.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::User.
+  p result
+end
 # [END showcase_v0_generated_Identity_GetUser_sync]

--- a/shared/output/gapic/templates/showcase/snippets/identity/list_users.rb
+++ b/shared/output/gapic/templates/showcase/snippets/identity/list_users.rb
@@ -27,21 +27,27 @@
 # [START showcase_v0_generated_Identity_ListUsers_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Identity::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Identity::Client#list_users
+#
+def list_users
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Identity::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::ListUsersRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::ListUsersRequest.new
 
-# Call the list_users method.
-result = client.list_users request
+  # Call the list_users method.
+  result = client.list_users request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Google::Showcase::V1beta1::User.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Google::Showcase::V1beta1::User.
+    p response
+  end
 end
 # [END showcase_v0_generated_Identity_ListUsers_sync]

--- a/shared/output/gapic/templates/showcase/snippets/identity/update_user.rb
+++ b/shared/output/gapic/templates/showcase/snippets/identity/update_user.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Identity_UpdateUser_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Identity::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Identity::Client#update_user
+#
+def update_user
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Identity::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::UpdateUserRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::UpdateUserRequest.new
 
-# Call the update_user method.
-result = client.update_user request
+  # Call the update_user method.
+  result = client.update_user request
 
-# The returned object is of type Google::Showcase::V1beta1::User.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::User.
+  p result
+end
 # [END showcase_v0_generated_Identity_UpdateUser_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/connect.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/connect.rb
@@ -27,24 +27,30 @@
 # [START showcase_v0_generated_Messaging_Connect_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#connect
+#
+def connect
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create an input stream
-input = Gapic::StreamInput.new
+  # Create an input stream
+  input = Gapic::StreamInput.new
 
-# Call the connect method to start streaming.
-output = client.connect input
+  # Call the connect method to start streaming.
+  output = client.connect input
 
-# Send requests on the stream. For each request, pass in keyword
-# arguments to set fields. Be sure to close the stream when done.
-input << Google::Showcase::V1beta1::ConnectRequest.new
-input << Google::Showcase::V1beta1::ConnectRequest.new
-input.close
+  # Send requests on the stream. For each request, pass in keyword
+  # arguments to set fields. Be sure to close the stream when done.
+  input << Google::Showcase::V1beta1::ConnectRequest.new
+  input << Google::Showcase::V1beta1::ConnectRequest.new
+  input.close
 
-# Handle streamed responses. These may be interleaved with inputs.
-# Each response is of type ::Google::Showcase::V1beta1::StreamBlurbsResponse.
-output.each do |response|
-  p response
+  # Handle streamed responses. These may be interleaved with inputs.
+  # Each response is of type ::Google::Showcase::V1beta1::StreamBlurbsResponse.
+  output.each do |response|
+    p response
+  end
 end
 # [END showcase_v0_generated_Messaging_Connect_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/create_blurb.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/create_blurb.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Messaging_CreateBlurb_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#create_blurb
+#
+def create_blurb
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::CreateBlurbRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::CreateBlurbRequest.new
 
-# Call the create_blurb method.
-result = client.create_blurb request
+  # Call the create_blurb method.
+  result = client.create_blurb request
 
-# The returned object is of type Google::Showcase::V1beta1::Blurb.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::Blurb.
+  p result
+end
 # [END showcase_v0_generated_Messaging_CreateBlurb_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/create_room.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/create_room.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Messaging_CreateRoom_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#create_room
+#
+def create_room
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::CreateRoomRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::CreateRoomRequest.new
 
-# Call the create_room method.
-result = client.create_room request
+  # Call the create_room method.
+  result = client.create_room request
 
-# The returned object is of type Google::Showcase::V1beta1::Room.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::Room.
+  p result
+end
 # [END showcase_v0_generated_Messaging_CreateRoom_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/delete_blurb.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/delete_blurb.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Messaging_DeleteBlurb_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#delete_blurb
+#
+def delete_blurb
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::DeleteBlurbRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::DeleteBlurbRequest.new
 
-# Call the delete_blurb method.
-result = client.delete_blurb request
+  # Call the delete_blurb method.
+  result = client.delete_blurb request
 
-# The returned object is of type Google::Protobuf::Empty.
-p result
+  # The returned object is of type Google::Protobuf::Empty.
+  p result
+end
 # [END showcase_v0_generated_Messaging_DeleteBlurb_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/delete_room.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/delete_room.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Messaging_DeleteRoom_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#delete_room
+#
+def delete_room
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::DeleteRoomRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::DeleteRoomRequest.new
 
-# Call the delete_room method.
-result = client.delete_room request
+  # Call the delete_room method.
+  result = client.delete_room request
 
-# The returned object is of type Google::Protobuf::Empty.
-p result
+  # The returned object is of type Google::Protobuf::Empty.
+  p result
+end
 # [END showcase_v0_generated_Messaging_DeleteRoom_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/get_blurb.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/get_blurb.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Messaging_GetBlurb_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#get_blurb
+#
+def get_blurb
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::GetBlurbRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::GetBlurbRequest.new
 
-# Call the get_blurb method.
-result = client.get_blurb request
+  # Call the get_blurb method.
+  result = client.get_blurb request
 
-# The returned object is of type Google::Showcase::V1beta1::Blurb.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::Blurb.
+  p result
+end
 # [END showcase_v0_generated_Messaging_GetBlurb_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/get_room.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/get_room.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Messaging_GetRoom_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#get_room
+#
+def get_room
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::GetRoomRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::GetRoomRequest.new
 
-# Call the get_room method.
-result = client.get_room request
+  # Call the get_room method.
+  result = client.get_room request
 
-# The returned object is of type Google::Showcase::V1beta1::Room.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::Room.
+  p result
+end
 # [END showcase_v0_generated_Messaging_GetRoom_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/list_blurbs.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/list_blurbs.rb
@@ -27,21 +27,27 @@
 # [START showcase_v0_generated_Messaging_ListBlurbs_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#list_blurbs
+#
+def list_blurbs
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::ListBlurbsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::ListBlurbsRequest.new
 
-# Call the list_blurbs method.
-result = client.list_blurbs request
+  # Call the list_blurbs method.
+  result = client.list_blurbs request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Google::Showcase::V1beta1::Blurb.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Google::Showcase::V1beta1::Blurb.
+    p response
+  end
 end
 # [END showcase_v0_generated_Messaging_ListBlurbs_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/list_rooms.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/list_rooms.rb
@@ -27,21 +27,27 @@
 # [START showcase_v0_generated_Messaging_ListRooms_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#list_rooms
+#
+def list_rooms
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::ListRoomsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::ListRoomsRequest.new
 
-# Call the list_rooms method.
-result = client.list_rooms request
+  # Call the list_rooms method.
+  result = client.list_rooms request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Google::Showcase::V1beta1::Room.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Google::Showcase::V1beta1::Room.
+    p response
+  end
 end
 # [END showcase_v0_generated_Messaging_ListRooms_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/search_blurbs.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/search_blurbs.rb
@@ -27,22 +27,28 @@
 # [START showcase_v0_generated_Messaging_SearchBlurbs_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#search_blurbs
+#
+def search_blurbs
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::SearchBlurbsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::SearchBlurbsRequest.new
 
-# Call the search_blurbs method.
-result = client.search_blurbs request
+  # Call the search_blurbs method.
+  result = client.search_blurbs request
 
-# The returned object is of type Gapic::Operation. You can use this
-# object to check the status of an operation, cancel it, or wait
-# for results. Here is how to block until completion:
-result.wait_until_done! timeout: 60
-if result.response?
-  p result.response
-else
-  puts "Error!"
+  # The returned object is of type Gapic::Operation. You can use this
+  # object to check the status of an operation, cancel it, or wait
+  # for results. Here is how to block until completion:
+  result.wait_until_done! timeout: 60
+  if result.response?
+    p result.response
+  else
+    puts "Error!"
+  end
 end
 # [END showcase_v0_generated_Messaging_SearchBlurbs_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/send_blurbs.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/send_blurbs.rb
@@ -27,19 +27,25 @@
 # [START showcase_v0_generated_Messaging_SendBlurbs_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#send_blurbs
+#
+def send_blurbs
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create a stream of requests, as an Enumerator.
-# For each request, pass in keyword arguments to set fields.
-request = [
-  Google::Showcase::V1beta1::CreateBlurbRequest.new,
-  Google::Showcase::V1beta1::CreateBlurbRequest.new
-].to_enum
+  # Create a stream of requests, as an Enumerator.
+  # For each request, pass in keyword arguments to set fields.
+  request = [
+    Google::Showcase::V1beta1::CreateBlurbRequest.new,
+    Google::Showcase::V1beta1::CreateBlurbRequest.new
+  ].to_enum
 
-# Call the send_blurbs method.
-result = client.send_blurbs request
+  # Call the send_blurbs method.
+  result = client.send_blurbs request
 
-# The returned object is of type Google::Showcase::V1beta1::SendBlurbsResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::SendBlurbsResponse.
+  p result
+end
 # [END showcase_v0_generated_Messaging_SendBlurbs_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/stream_blurbs.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/stream_blurbs.rb
@@ -27,18 +27,24 @@
 # [START showcase_v0_generated_Messaging_StreamBlurbs_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#stream_blurbs
+#
+def stream_blurbs
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::StreamBlurbsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::StreamBlurbsRequest.new
 
-# Call the stream_blurbs method.
-result = client.stream_blurbs request
+  # Call the stream_blurbs method.
+  result = client.stream_blurbs request
 
-# The returned object is a streamed enumerable yielding elements of
-# type ::Google::Showcase::V1beta1::StreamBlurbsResponse.
-result.each do |response|
-  p response
+  # The returned object is a streamed enumerable yielding elements of
+  # type ::Google::Showcase::V1beta1::StreamBlurbsResponse.
+  result.each do |response|
+    p response
+  end
 end
 # [END showcase_v0_generated_Messaging_StreamBlurbs_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/update_blurb.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/update_blurb.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Messaging_UpdateBlurb_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#update_blurb
+#
+def update_blurb
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::UpdateBlurbRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::UpdateBlurbRequest.new
 
-# Call the update_blurb method.
-result = client.update_blurb request
+  # Call the update_blurb method.
+  result = client.update_blurb request
 
-# The returned object is of type Google::Showcase::V1beta1::Blurb.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::Blurb.
+  p result
+end
 # [END showcase_v0_generated_Messaging_UpdateBlurb_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/update_room.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/update_room.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Messaging_UpdateRoom_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Messaging::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#update_room
+#
+def update_room
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Messaging::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::UpdateRoomRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::UpdateRoomRequest.new
 
-# Call the update_room method.
-result = client.update_room request
+  # Call the update_room method.
+  result = client.update_room request
 
-# The returned object is of type Google::Showcase::V1beta1::Room.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::Room.
+  p result
+end
 # [END showcase_v0_generated_Messaging_UpdateRoom_sync]

--- a/shared/output/gapic/templates/showcase/snippets/snippet_metadata_google.showcase.v1beta1.json
+++ b/shared/output/gapic/templates/showcase/snippets/snippet_metadata_google.showcase.v1beta1.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -166,7 +166,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -206,7 +206,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -246,7 +246,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -286,7 +286,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -326,7 +326,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -366,7 +366,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -406,7 +406,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 43,
+          "end": 49,
           "type": "FULL"
         }
       ]
@@ -446,7 +446,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 44,
+          "end": 50,
           "type": "FULL"
         }
       ]
@@ -486,7 +486,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 49,
+          "end": 55,
           "type": "FULL"
         }
       ]
@@ -526,7 +526,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 52,
           "type": "FULL"
         }
       ]
@@ -566,7 +566,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 47,
+          "end": 53,
           "type": "FULL"
         }
       ]
@@ -606,7 +606,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -646,7 +646,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -686,7 +686,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -726,7 +726,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -766,7 +766,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -806,7 +806,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 52,
           "type": "FULL"
         }
       ]
@@ -846,7 +846,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -886,7 +886,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -926,7 +926,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -966,7 +966,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -1006,7 +1006,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 52,
           "type": "FULL"
         }
       ]
@@ -1046,7 +1046,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -1086,7 +1086,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -1126,7 +1126,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -1166,7 +1166,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -1206,7 +1206,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 52,
           "type": "FULL"
         }
       ]
@@ -1246,7 +1246,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 47,
+          "end": 53,
           "type": "FULL"
         }
       ]
@@ -1286,7 +1286,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 43,
+          "end": 49,
           "type": "FULL"
         }
       ]
@@ -1326,7 +1326,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 44,
+          "end": 50,
           "type": "FULL"
         }
       ]
@@ -1366,7 +1366,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 49,
+          "end": 55,
           "type": "FULL"
         }
       ]
@@ -1406,7 +1406,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -1446,7 +1446,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -1486,7 +1486,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 52,
           "type": "FULL"
         }
       ]
@@ -1526,7 +1526,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -1566,7 +1566,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -1606,7 +1606,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 52,
           "type": "FULL"
         }
       ]
@@ -1646,7 +1646,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -1686,7 +1686,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/showcase/snippets/testing/create_session.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/create_session.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Testing_CreateSession_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Testing::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#create_session
+#
+def create_session
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Testing::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::CreateSessionRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::CreateSessionRequest.new
 
-# Call the create_session method.
-result = client.create_session request
+  # Call the create_session method.
+  result = client.create_session request
 
-# The returned object is of type Google::Showcase::V1beta1::Session.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::Session.
+  p result
+end
 # [END showcase_v0_generated_Testing_CreateSession_sync]

--- a/shared/output/gapic/templates/showcase/snippets/testing/delete_session.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/delete_session.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Testing_DeleteSession_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Testing::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#delete_session
+#
+def delete_session
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Testing::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::DeleteSessionRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::DeleteSessionRequest.new
 
-# Call the delete_session method.
-result = client.delete_session request
+  # Call the delete_session method.
+  result = client.delete_session request
 
-# The returned object is of type Google::Protobuf::Empty.
-p result
+  # The returned object is of type Google::Protobuf::Empty.
+  p result
+end
 # [END showcase_v0_generated_Testing_DeleteSession_sync]

--- a/shared/output/gapic/templates/showcase/snippets/testing/delete_test.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/delete_test.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Testing_DeleteTest_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Testing::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#delete_test
+#
+def delete_test
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Testing::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::DeleteTestRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::DeleteTestRequest.new
 
-# Call the delete_test method.
-result = client.delete_test request
+  # Call the delete_test method.
+  result = client.delete_test request
 
-# The returned object is of type Google::Protobuf::Empty.
-p result
+  # The returned object is of type Google::Protobuf::Empty.
+  p result
+end
 # [END showcase_v0_generated_Testing_DeleteTest_sync]

--- a/shared/output/gapic/templates/showcase/snippets/testing/get_session.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/get_session.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Testing_GetSession_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Testing::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#get_session
+#
+def get_session
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Testing::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::GetSessionRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::GetSessionRequest.new
 
-# Call the get_session method.
-result = client.get_session request
+  # Call the get_session method.
+  result = client.get_session request
 
-# The returned object is of type Google::Showcase::V1beta1::Session.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::Session.
+  p result
+end
 # [END showcase_v0_generated_Testing_GetSession_sync]

--- a/shared/output/gapic/templates/showcase/snippets/testing/list_sessions.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/list_sessions.rb
@@ -27,21 +27,27 @@
 # [START showcase_v0_generated_Testing_ListSessions_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Testing::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#list_sessions
+#
+def list_sessions
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Testing::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::ListSessionsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::ListSessionsRequest.new
 
-# Call the list_sessions method.
-result = client.list_sessions request
+  # Call the list_sessions method.
+  result = client.list_sessions request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Google::Showcase::V1beta1::Session.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Google::Showcase::V1beta1::Session.
+    p response
+  end
 end
 # [END showcase_v0_generated_Testing_ListSessions_sync]

--- a/shared/output/gapic/templates/showcase/snippets/testing/list_tests.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/list_tests.rb
@@ -27,21 +27,27 @@
 # [START showcase_v0_generated_Testing_ListTests_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Testing::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#list_tests
+#
+def list_tests
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Testing::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::ListTestsRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::ListTestsRequest.new
 
-# Call the list_tests method.
-result = client.list_tests request
+  # Call the list_tests method.
+  result = client.list_tests request
 
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type ::Google::Showcase::V1beta1::Test.
-  p response
+  # The returned object is of type Gapic::PagedEnumerable. You can
+  # iterate over all elements by calling #each, and the enumerable
+  # will lazily make API calls to fetch subsequent pages. Other
+  # methods are also available for managing paging directly.
+  result.each do |response|
+    # Each element is of type ::Google::Showcase::V1beta1::Test.
+    p response
+  end
 end
 # [END showcase_v0_generated_Testing_ListTests_sync]

--- a/shared/output/gapic/templates/showcase/snippets/testing/report_session.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/report_session.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Testing_ReportSession_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Testing::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#report_session
+#
+def report_session
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Testing::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::ReportSessionRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::ReportSessionRequest.new
 
-# Call the report_session method.
-result = client.report_session request
+  # Call the report_session method.
+  result = client.report_session request
 
-# The returned object is of type Google::Showcase::V1beta1::ReportSessionResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::ReportSessionResponse.
+  p result
+end
 # [END showcase_v0_generated_Testing_ReportSession_sync]

--- a/shared/output/gapic/templates/showcase/snippets/testing/verify_test.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/verify_test.rb
@@ -27,15 +27,21 @@
 # [START showcase_v0_generated_Testing_VerifyTest_sync]
 require "google/showcase/v1beta1"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Google::Showcase::V1beta1::Testing::Client.new
+##
+# Example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#verify_test
+#
+def verify_test
+  # Create a client object. The client can be reused for multiple calls.
+  client = Google::Showcase::V1beta1::Testing::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Google::Showcase::V1beta1::VerifyTestRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Google::Showcase::V1beta1::VerifyTestRequest.new
 
-# Call the verify_test method.
-result = client.verify_test request
+  # Call the verify_test method.
+  result = client.verify_test request
 
-# The returned object is of type Google::Showcase::V1beta1::VerifyTestResponse.
-p result
+  # The returned object is of type Google::Showcase::V1beta1::VerifyTestResponse.
+  p result
+end
 # [END showcase_v0_generated_Testing_VerifyTest_sync]

--- a/shared/output/gapic/templates/testing/.rubocop.yml
+++ b/shared/output/gapic/templates/testing/.rubocop.yml
@@ -21,6 +21,9 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Naming/AccessorMethodName:
+  Exclude:
+    - "snippets/**/*.rb"
 Naming/FileName:
   Exclude:
     - "lib/testing.rb"

--- a/shared/output/gapic/templates/testing/snippets/Gemfile
+++ b/shared/output/gapic/templates/testing/snippets/Gemfile
@@ -33,8 +33,8 @@ else
 end
 
 group :test do
-  gem "google-style", "~> 1.25.1"
-  gem "minitest", "~> 5.14"
+  gem "google-style", "~> 1.26.1"
+  gem "minitest", "~> 5.16"
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~> 1.5"
 end

--- a/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/aip_lro.rb
+++ b/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/aip_lro.rb
@@ -27,22 +27,28 @@
 # [START testing_v0_generated_AllSubclientsConsumer_AipLRO_sync]
 require "testing/nonstandard_lro_grpc"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#aip_lro
+#
+def aip_lro
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::NonstandardLroGrpc::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::NonstandardLroGrpc::Request.new
 
-# Call the aip_lro method.
-result = client.aip_lro request
+  # Call the aip_lro method.
+  result = client.aip_lro request
 
-# The returned object is of type Gapic::Operation. You can use this
-# object to check the status of an operation, cancel it, or wait
-# for results. Here is how to block until completion:
-result.wait_until_done! timeout: 60
-if result.response?
-  p result.response
-else
-  puts "Error!"
+  # The returned object is of type Gapic::Operation. You can use this
+  # object to check the status of an operation, cancel it, or wait
+  # for results. Here is how to block until completion:
+  result.wait_until_done! timeout: 60
+  if result.response?
+    p result.response
+  else
+    puts "Error!"
+  end
 end
 # [END testing_v0_generated_AllSubclientsConsumer_AipLRO_sync]

--- a/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/another_lro_rpc.rb
+++ b/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/another_lro_rpc.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_AllSubclientsConsumer_AnotherLroRpc_sync]
 require "testing/nonstandard_lro_grpc"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#another_lro_rpc
+#
+def another_lro_rpc
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::NonstandardLroGrpc::AnotherRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::NonstandardLroGrpc::AnotherRequest.new
 
-# Call the another_lro_rpc method.
-result = client.another_lro_rpc request
+  # Call the another_lro_rpc method.
+  result = client.another_lro_rpc request
 
-# The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
-p result
+  # The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
+  p result
+end
 # [END testing_v0_generated_AllSubclientsConsumer_AnotherLroRpc_sync]

--- a/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/no_lro.rb
+++ b/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/no_lro.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_AllSubclientsConsumer_NoLRO_sync]
 require "testing/nonstandard_lro_grpc"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#no_lro
+#
+def no_lro
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::NonstandardLroGrpc::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::NonstandardLroGrpc::Request.new
 
-# Call the no_lro method.
-result = client.no_lro request
+  # Call the no_lro method.
+  result = client.no_lro request
 
-# The returned object is of type Testing::NonstandardLroGrpc::Response.
-p result
+  # The returned object is of type Testing::NonstandardLroGrpc::Response.
+  p result
+end
 # [END testing_v0_generated_AllSubclientsConsumer_NoLRO_sync]

--- a/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/non_copy_another_lro_rpc.rb
+++ b/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/non_copy_another_lro_rpc.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_AllSubclientsConsumer_NonCopyAnotherLroRpc_sync]
 require "testing/nonstandard_lro_grpc"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#non_copy_another_lro_rpc
+#
+def non_copy_another_lro_rpc
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::NonstandardLroGrpc::NonCopyRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::NonstandardLroGrpc::NonCopyRequest.new
 
-# Call the non_copy_another_lro_rpc method.
-result = client.non_copy_another_lro_rpc request
+  # Call the non_copy_another_lro_rpc method.
+  result = client.non_copy_another_lro_rpc request
 
-# The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
-p result
+  # The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
+  p result
+end
 # [END testing_v0_generated_AllSubclientsConsumer_NonCopyAnotherLroRpc_sync]

--- a/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/plain_lro_rpc.rb
+++ b/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/plain_lro_rpc.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_AllSubclientsConsumer_PlainLroRpc_sync]
 require "testing/nonstandard_lro_grpc"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#plain_lro_rpc
+#
+def plain_lro_rpc
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::NonstandardLroGrpc::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::NonstandardLroGrpc::Request.new
 
-# Call the plain_lro_rpc method.
-result = client.plain_lro_rpc request
+  # Call the plain_lro_rpc method.
+  result = client.plain_lro_rpc request
 
-# The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
-p result
+  # The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
+  p result
+end
 # [END testing_v0_generated_AllSubclientsConsumer_PlainLroRpc_sync]

--- a/shared/output/gapic/templates/testing/snippets/another_lro_provider/get_another.rb
+++ b/shared/output/gapic/templates/testing/snippets/another_lro_provider/get_another.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_AnotherLroProvider_GetAnother_sync]
 require "testing/nonstandard_lro_grpc"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::NonstandardLroGrpc::AnotherLroProvider::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::AnotherLroProvider::Client#get_another
+#
+def get_another
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::NonstandardLroGrpc::AnotherLroProvider::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::NonstandardLroGrpc::LroAnotherGetRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::NonstandardLroGrpc::LroAnotherGetRequest.new
 
-# Call the get_another method.
-result = client.get_another request
+  # Call the get_another method.
+  result = client.get_another request
 
-# The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
-p result
+  # The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
+  p result
+end
 # [END testing_v0_generated_AnotherLroProvider_GetAnother_sync]

--- a/shared/output/gapic/templates/testing/snippets/plain_lro_consumer/plain_lro_rpc.rb
+++ b/shared/output/gapic/templates/testing/snippets/plain_lro_consumer/plain_lro_rpc.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_PlainLroConsumer_PlainLroRpc_sync]
 require "testing/nonstandard_lro_grpc"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::NonstandardLroGrpc::PlainLroConsumer::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::PlainLroConsumer::Client#plain_lro_rpc
+#
+def plain_lro_rpc
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::NonstandardLroGrpc::PlainLroConsumer::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::NonstandardLroGrpc::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::NonstandardLroGrpc::Request.new
 
-# Call the plain_lro_rpc method.
-result = client.plain_lro_rpc request
+  # Call the plain_lro_rpc method.
+  result = client.plain_lro_rpc request
 
-# The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
-p result
+  # The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
+  p result
+end
 # [END testing_v0_generated_PlainLroConsumer_PlainLroRpc_sync]

--- a/shared/output/gapic/templates/testing/snippets/plain_lro_provider/get.rb
+++ b/shared/output/gapic/templates/testing/snippets/plain_lro_provider/get.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_PlainLroProvider_Get_sync]
 require "testing/nonstandard_lro_grpc"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::NonstandardLroGrpc::PlainLroProvider::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::PlainLroProvider::Client#get
+#
+def get
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::NonstandardLroGrpc::PlainLroProvider::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::NonstandardLroGrpc::LroGetRequest.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::NonstandardLroGrpc::LroGetRequest.new
 
-# Call the get method.
-result = client.get request
+  # Call the get method.
+  result = client.get request
 
-# The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
-p result
+  # The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
+  p result
+end
 # [END testing_v0_generated_PlainLroProvider_Get_sync]

--- a/shared/output/gapic/templates/testing/snippets/service_explicit_headers/complex.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_explicit_headers/complex.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_ServiceExplicitHeaders_Complex_sync]
 require "testing/routing_headers"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#complex
+#
+def complex
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::RoutingHeaders::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::RoutingHeaders::Request.new
 
-# Call the complex method.
-result = client.complex request
+  # Call the complex method.
+  result = client.complex request
 
-# The returned object is of type Testing::RoutingHeaders::Response.
-p result
+  # The returned object is of type Testing::RoutingHeaders::Response.
+  p result
+end
 # [END testing_v0_generated_ServiceExplicitHeaders_Complex_sync]

--- a/shared/output/gapic/templates/testing/snippets/service_explicit_headers/plain_extract.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_explicit_headers/plain_extract.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_ServiceExplicitHeaders_PlainExtract_sync]
 require "testing/routing_headers"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#plain_extract
+#
+def plain_extract
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::RoutingHeaders::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::RoutingHeaders::Request.new
 
-# Call the plain_extract method.
-result = client.plain_extract request
+  # Call the plain_extract method.
+  result = client.plain_extract request
 
-# The returned object is of type Testing::RoutingHeaders::Response.
-p result
+  # The returned object is of type Testing::RoutingHeaders::Response.
+  p result
+end
 # [END testing_v0_generated_ServiceExplicitHeaders_PlainExtract_sync]

--- a/shared/output/gapic/templates/testing/snippets/service_explicit_headers/plain_full_field.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_explicit_headers/plain_full_field.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_ServiceExplicitHeaders_PlainFullField_sync]
 require "testing/routing_headers"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#plain_full_field
+#
+def plain_full_field
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::RoutingHeaders::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::RoutingHeaders::Request.new
 
-# Call the plain_full_field method.
-result = client.plain_full_field request
+  # Call the plain_full_field method.
+  result = client.plain_full_field request
 
-# The returned object is of type Testing::RoutingHeaders::Response.
-p result
+  # The returned object is of type Testing::RoutingHeaders::Response.
+  p result
+end
 # [END testing_v0_generated_ServiceExplicitHeaders_PlainFullField_sync]

--- a/shared/output/gapic/templates/testing/snippets/service_explicit_headers/plain_no_template.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_explicit_headers/plain_no_template.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_ServiceExplicitHeaders_PlainNoTemplate_sync]
 require "testing/routing_headers"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#plain_no_template
+#
+def plain_no_template
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::RoutingHeaders::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::RoutingHeaders::Request.new
 
-# Call the plain_no_template method.
-result = client.plain_no_template request
+  # Call the plain_no_template method.
+  result = client.plain_no_template request
 
-# The returned object is of type Testing::RoutingHeaders::Response.
-p result
+  # The returned object is of type Testing::RoutingHeaders::Response.
+  p result
+end
 # [END testing_v0_generated_ServiceExplicitHeaders_PlainNoTemplate_sync]

--- a/shared/output/gapic/templates/testing/snippets/service_explicit_headers/with_sub_message.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_explicit_headers/with_sub_message.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_ServiceExplicitHeaders_WithSubMessage_sync]
 require "testing/routing_headers"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#with_sub_message
+#
+def with_sub_message
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::RoutingHeaders::ServiceExplicitHeaders::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::RoutingHeaders::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::RoutingHeaders::Request.new
 
-# Call the with_sub_message method.
-result = client.with_sub_message request
+  # Call the with_sub_message method.
+  result = client.with_sub_message request
 
-# The returned object is of type Testing::RoutingHeaders::Response.
-p result
+  # The returned object is of type Testing::RoutingHeaders::Response.
+  p result
+end
 # [END testing_v0_generated_ServiceExplicitHeaders_WithSubMessage_sync]

--- a/shared/output/gapic/templates/testing/snippets/service_implicit_headers/plain.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_implicit_headers/plain.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_ServiceImplicitHeaders_Plain_sync]
 require "testing/routing_headers"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceImplicitHeaders::Client#plain
+#
+def plain
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::RoutingHeaders::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::RoutingHeaders::Request.new
 
-# Call the plain method.
-result = client.plain request
+  # Call the plain method.
+  result = client.plain request
 
-# The returned object is of type Testing::RoutingHeaders::Response.
-p result
+  # The returned object is of type Testing::RoutingHeaders::Response.
+  p result
+end
 # [END testing_v0_generated_ServiceImplicitHeaders_Plain_sync]

--- a/shared/output/gapic/templates/testing/snippets/service_implicit_headers/with_multiple_levels.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_implicit_headers/with_multiple_levels.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_ServiceImplicitHeaders_WithMultipleLevels_sync]
 require "testing/routing_headers"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceImplicitHeaders::Client#with_multiple_levels
+#
+def with_multiple_levels
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::RoutingHeaders::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::RoutingHeaders::Request.new
 
-# Call the with_multiple_levels method.
-result = client.with_multiple_levels request
+  # Call the with_multiple_levels method.
+  result = client.with_multiple_levels request
 
-# The returned object is of type Testing::RoutingHeaders::Response.
-p result
+  # The returned object is of type Testing::RoutingHeaders::Response.
+  p result
+end
 # [END testing_v0_generated_ServiceImplicitHeaders_WithMultipleLevels_sync]

--- a/shared/output/gapic/templates/testing/snippets/service_implicit_headers/with_sub_message.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_implicit_headers/with_sub_message.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_ServiceImplicitHeaders_WithSubMessage_sync]
 require "testing/routing_headers"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceImplicitHeaders::Client#with_sub_message
+#
+def with_sub_message
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::RoutingHeaders::ServiceImplicitHeaders::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::RoutingHeaders::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::RoutingHeaders::Request.new
 
-# Call the with_sub_message method.
-result = client.with_sub_message request
+  # Call the with_sub_message method.
+  result = client.with_sub_message request
 
-# The returned object is of type Testing::RoutingHeaders::Response.
-p result
+  # The returned object is of type Testing::RoutingHeaders::Response.
+  p result
+end
 # [END testing_v0_generated_ServiceImplicitHeaders_WithSubMessage_sync]

--- a/shared/output/gapic/templates/testing/snippets/service_no_headers/plain.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_no_headers/plain.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_ServiceNoHeaders_Plain_sync]
 require "testing/routing_headers"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::RoutingHeaders::ServiceNoHeaders::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceNoHeaders::Client#plain
+#
+def plain
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::RoutingHeaders::ServiceNoHeaders::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::RoutingHeaders::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::RoutingHeaders::Request.new
 
-# Call the plain method.
-result = client.plain request
+  # Call the plain method.
+  result = client.plain request
 
-# The returned object is of type Testing::RoutingHeaders::Response.
-p result
+  # The returned object is of type Testing::RoutingHeaders::Response.
+  p result
+end
 # [END testing_v0_generated_ServiceNoHeaders_Plain_sync]

--- a/shared/output/gapic/templates/testing/snippets/service_no_retry/no_retry_method.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_no_retry/no_retry_method.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_ServiceNoRetry_NoRetryMethod_sync]
 require "testing/grpc_service_config"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::GrpcServiceConfig::ServiceNoRetry::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::GrpcServiceConfig::ServiceNoRetry::Client#no_retry_method
+#
+def no_retry_method
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::GrpcServiceConfig::ServiceNoRetry::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::GrpcServiceConfig::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::GrpcServiceConfig::Request.new
 
-# Call the no_retry_method method.
-result = client.no_retry_method request
+  # Call the no_retry_method method.
+  result = client.no_retry_method request
 
-# The returned object is of type Testing::GrpcServiceConfig::Response.
-p result
+  # The returned object is of type Testing::GrpcServiceConfig::Response.
+  p result
+end
 # [END testing_v0_generated_ServiceNoRetry_NoRetryMethod_sync]

--- a/shared/output/gapic/templates/testing/snippets/service_with_loc/call_method.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_with_loc/call_method.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_ServiceWithLoc_Method_sync]
 require "testing/mixins"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::Mixins::ServiceWithLoc::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::Mixins::ServiceWithLoc::Client#call_method
+#
+def call_method
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::Mixins::ServiceWithLoc::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::Mixins::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::Mixins::Request.new
 
-# Call the call_method method.
-result = client.call_method request
+  # Call the call_method method.
+  result = client.call_method request
 
-# The returned object is of type Testing::Mixins::Response.
-p result
+  # The returned object is of type Testing::Mixins::Response.
+  p result
+end
 # [END testing_v0_generated_ServiceWithLoc_Method_sync]

--- a/shared/output/gapic/templates/testing/snippets/service_with_retries/method_level_retry_method.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_with_retries/method_level_retry_method.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_ServiceWithRetries_MethodLevelRetryMethod_sync]
 require "testing/grpc_service_config"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::GrpcServiceConfig::ServiceWithRetries::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::GrpcServiceConfig::ServiceWithRetries::Client#method_level_retry_method
+#
+def method_level_retry_method
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::GrpcServiceConfig::ServiceWithRetries::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::GrpcServiceConfig::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::GrpcServiceConfig::Request.new
 
-# Call the method_level_retry_method method.
-result = client.method_level_retry_method request
+  # Call the method_level_retry_method method.
+  result = client.method_level_retry_method request
 
-# The returned object is of type Testing::GrpcServiceConfig::Response.
-p result
+  # The returned object is of type Testing::GrpcServiceConfig::Response.
+  p result
+end
 # [END testing_v0_generated_ServiceWithRetries_MethodLevelRetryMethod_sync]

--- a/shared/output/gapic/templates/testing/snippets/service_with_retries/service_level_retry_method.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_with_retries/service_level_retry_method.rb
@@ -27,15 +27,21 @@
 # [START testing_v0_generated_ServiceWithRetries_ServiceLevelRetryMethod_sync]
 require "testing/grpc_service_config"
 
-# Create a client object. The client can be reused for multiple calls.
-client = Testing::GrpcServiceConfig::ServiceWithRetries::Client.new
+##
+# Example demonstrating basic usage of
+# Testing::GrpcServiceConfig::ServiceWithRetries::Client#service_level_retry_method
+#
+def service_level_retry_method
+  # Create a client object. The client can be reused for multiple calls.
+  client = Testing::GrpcServiceConfig::ServiceWithRetries::Client.new
 
-# Create a request. To set request fields, pass in keyword arguments.
-request = Testing::GrpcServiceConfig::Request.new
+  # Create a request. To set request fields, pass in keyword arguments.
+  request = Testing::GrpcServiceConfig::Request.new
 
-# Call the service_level_retry_method method.
-result = client.service_level_retry_method request
+  # Call the service_level_retry_method method.
+  result = client.service_level_retry_method request
 
-# The returned object is of type Testing::GrpcServiceConfig::Response.
-p result
+  # The returned object is of type Testing::GrpcServiceConfig::Response.
+  p result
+end
 # [END testing_v0_generated_ServiceWithRetries_ServiceLevelRetryMethod_sync]

--- a/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.grpcserviceconfig.json
+++ b/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.grpcserviceconfig.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.mixins.json
+++ b/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.mixins.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.nonstandardlrogrpc.json
+++ b/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.nonstandardlrogrpc.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -166,7 +166,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -206,7 +206,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -246,7 +246,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -286,7 +286,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 47,
+          "end": 53,
           "type": "FULL"
         }
       ]
@@ -326,7 +326,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.routingheaders.json
+++ b/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.routingheaders.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -166,7 +166,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -206,7 +206,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -246,7 +246,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -286,7 +286,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -326,7 +326,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]
@@ -366,7 +366,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 40,
+          "end": 46,
           "type": "FULL"
         }
       ]


### PR DESCRIPTION
This updates the standalone snippets (phase 1) to conform to the [samples style guide](https://googlecloudplatform.github.io/samples-style-guide/). In particular, standalone snippets should be in a method. This of course will be a requirement for phase 2, but we're updating it for phase 1 because we expect phase 1 to be a special case of phase 2. Snippets that appear inline in reference documentation (i.e. for cloud rad) are unaffected. Also updated the Gemfile in snippets directories with the latest minitest and google-style gems, for consistency with what we're doing in google-cloud-ruby.