### PR TITLE
fix: deadlock fix

### DIFF
--- a/gapic-common/lib/gapic/rest/threaded_enumerator.rb
+++ b/gapic-common/lib/gapic/rest/threaded_enumerator.rb
@@ -44,6 +44,7 @@ module Gapic
 
         Thread.new do
           yield @in_q, @out_q
+          @out_q.enq nil
         rescue StandardError => e
           @out_q.push e
         end


### PR DESCRIPTION
Fixes a bug in the threaded enumerator where out_q indefinitely waits for nil (terminating) value.