### PR TITLE
feat: add support for different types of credentials to REST

### DIFF
--- a/gapic-common/lib/gapic/rest/faraday_middleware.rb
+++ b/gapic-common/lib/gapic/rest/faraday_middleware.rb
@@ -18,22 +18,43 @@ module Gapic
     # Registers the middleware with Faraday
     module FaradayMiddleware
       ##
+      # @private
       # Request middleware that constructs the Authorization HTTP header
       # using ::Google::Auth::Credentials
       #
       class GoogleAuthorization < Faraday::Middleware
         ##
+        # @private
         # @param app [#call]
-        # @param credentials [::Google::Auth::Credentials]
+        # @param credentials [Google::Auth::Credentials, Signet::OAuth2::Client, Symbol, Proc]
+        #   Provides the means for authenticating requests made by
+        #   the client. This parameter can be many types:
+        #   * A `Google::Auth::Credentials` uses a the properties of its represented keyfile for authenticating requests
+        #     made by this client.
+        #   * A `Signet::OAuth2::Client` object used to apply the OAuth credentials.
+        #   * A `Proc` will be used as an updater_proc for the auth token.
+        #   * A `Symbol` is treated as a signal that authentication is not required.
+        #
         def initialize app, credentials
-          @credentials = credentials
+          @updater_proc = case credentials
+                          when Symbol
+                            credentials
+                          else
+                            updater_proc = credentials.updater_proc if credentials.respond_to? :updater_proc
+                            updater_proc ||= credentials if credentials.is_a? Proc
+                            raise ArgumentError, "invalid credentials (#{credentials.class})" if updater_proc.nil?
+                            updater_proc
+                          end
           super app
         end
 
+        # @private
         # @param env [Faraday::Env]
         def call env
-          auth_hash = @credentials.client.apply({})
-          env.request_headers["Authorization"] = auth_hash[:authorization]
+          unless @updater_proc.is_a? Symbol
+            auth_hash = @updater_proc.call({})
+            env.request_headers["Authorization"] = auth_hash[:authorization]
+          end
 
           @app.call env
         end


### PR DESCRIPTION
also take Faraday middleware `@private`.

fixes: https://github.com/googleapis/gapic-generator-ruby/issues/840