### PR TITLE
fix: avoid creating rest default configuration for non-rest methods

### DIFF
--- a/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
@@ -47,7 +47,7 @@ module Gapic
 
       # The namespace of the service. (not the client)
       # Intentionally does not include "Rest", since
-      # we do not want Rest service's configuration to 
+      # we do not want Rest service's configuration to
       # default to GRPC configuration (right now).
       def namespace
         main_service.namespace

--- a/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
@@ -45,6 +45,14 @@ module Gapic
         main_service.name
       end
 
+      # The namespace of the service. (not the client)
+      # Intentionally does not include "Rest", since
+      # we do not want Rest service's configuration to 
+      # default to GRPC configuration (right now).
+      def namespace
+        main_service.namespace
+      end
+
       ##
       # Full Ruby name of this service
       #
@@ -312,6 +320,14 @@ module Gapic
       #
       def methods
         main_service.methods.select(&:can_generate_rest?)
+      end
+
+      def grpc_service_config
+        main_service.grpc_service_config
+      end
+
+      def grpc_service_config_presenter
+        main_service.grpc_service_config_presenter
       end
 
       ##

--- a/gapic-generator/templates/default/service/rest/client/_client.erb
+++ b/gapic-generator/templates/default/service/rest/client/_client.erb
@@ -49,7 +49,7 @@ class <%= service.rest.client_name %>
   # @return [<%= service.rest.client_name %>::Configuration]
   #
   def self.configure
-<%= indent render(partial: "service/client/self_configure", locals: { service: service }), 4 %>
+<%= indent render(partial: "service/client/self_configure", locals: { service: service.rest }), 4 %>
   end
 
   ##


### PR DESCRIPTION
fix: avoid creating rest default configuration for the methods that don't have rest bindings