### PR TITLE
fix: Fixed uninitialized constant when checking retry policy for a REST call

### DIFF
--- a/gapic-common/lib/gapic/call_options/retry_policy.rb
+++ b/gapic-common/lib/gapic/call_options/retry_policy.rb
@@ -106,7 +106,7 @@ module Gapic
       private
 
       def retry? error
-        (error.is_a?(::GRPC::BadStatus) && retry_codes.include?(error.code)) ||
+        (defined?(::GRPC) && error.is_a?(::GRPC::BadStatus) && retry_codes.include?(error.code)) ||
           (error.respond_to?(:response_status) &&
             retry_codes.include?(ErrorCodes.grpc_error_for(error.response_status)))
       end


### PR DESCRIPTION
This happens because GRPC does not actually get loaded unless you're coming from the GRPC stub classes. For a REST call, we need to check whether the GRPC namespace exists before attempting to test against its contents.