### PR TITLE
chore: Fix requires in generated wrapper tests

### DIFF
--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/client_test.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/client_test.erb
@@ -4,7 +4,12 @@
 require "helper"
 require "<%= gem.namespace_require %>"
 require "gapic/common"
+<%- if gem.generate_grpc_clients? -%>
 require "gapic/grpc"
+<%- end -%>
+<%- if gem.generate_rest_clients? -%>
+require "gapic/rest"
+<%- end -%>
 
 class <%= gem.namespace %>::ClientConstructionMinitest < Minitest::Test
 <%- gem.services.each do |service| -%>

--- a/shared/output/cloud/compute_small_wrapper/test/google/cloud/compute/client_test.rb
+++ b/shared/output/cloud/compute_small_wrapper/test/google/cloud/compute/client_test.rb
@@ -19,7 +19,7 @@
 require "helper"
 require "google/cloud/compute"
 require "gapic/common"
-require "gapic/grpc"
+require "gapic/rest"
 
 class Google::Cloud::Compute::ClientConstructionMinitest < Minitest::Test
   def test_addresses_rest

--- a/shared/output/cloud/language_wrapper/test/google/cloud/language/client_test.rb
+++ b/shared/output/cloud/language_wrapper/test/google/cloud/language/client_test.rb
@@ -20,6 +20,7 @@ require "helper"
 require "google/cloud/language"
 require "gapic/common"
 require "gapic/grpc"
+require "gapic/rest"
 
 class Google::Cloud::Language::ClientConstructionMinitest < Minitest::Test
   def test_language_service_grpc


### PR DESCRIPTION
Using "chore" because this is a fix to a previous PR that hasn't yet been released, so we don't need an extra changelog entry.