### PR TITLE
fix: Don't generate bindings_override.rb unless REST transport is active

### DIFF
--- a/gapic-generator/lib/gapic/generators/default_generator.rb
+++ b/gapic-generator/lib/gapic/generators/default_generator.rb
@@ -56,7 +56,7 @@ module Gapic
           # Package level files
           files << g("package.erb", "lib/#{package.package_file_path}", package: package)
           files << g("package_rest.erb", "lib/#{package.package_rest_file_path}", package: package) if package.generate_rest_clients?
-          files << g("binding_override.erb", "lib/#{package.mixin_binding_overrides_file_path}", package: package) if package.mixin_binding_overrides?
+          files << g("binding_override.erb", "lib/#{package.mixin_binding_overrides_file_path}", package: package) if package.mixin_binding_overrides? && package.generate_rest_clients?
 
           package.services.each do |service|
             should_generate_grpc = service.generate_grpc_clients?


### PR DESCRIPTION
The code (currently) applies only to REST, and it's required from rest.rb so it's dead code if that's not present.