### PR TITLE
fix: fail when rest transport specified but no HTTP bindings

### DIFF
--- a/gapic-generator/lib/gapic/generators/default_generator.rb
+++ b/gapic-generator/lib/gapic/generators/default_generator.rb
@@ -48,6 +48,10 @@ module Gapic
 
         gem = gem_presenter || Gapic::Presenters.gem_presenter(@api)
 
+        if @api.generate_rest_clients? && gem.packages.find(&:generate_rest_clients?).nil?
+          raise "Rest transport specified but no services have HTTP bindings"
+        end
+
         gem.packages.each do |package|
           package_snippets = PackageSnippets.new snippet_dir: "snippets",
                                                  proto_package: package.name,


### PR DESCRIPTION
fixes [887](https://github.com/googleapis/gapic-generator-ruby/issues/887)