### PR TITLE
feat: Implement core snippetgen phase2 presenters

### DIFF
--- a/gapic-generator/lib/gapic/presenters/snippet/client_call_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/snippet/client_call_presenter.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "active_support/inflector"
+require "google/cloud/tools/snippetgen/configlanguage/v1/snippet_config_language.pb"
+require "gapic/presenters/snippet/statement_presenter"
+
+module Gapic
+  module Presenters
+    class SnippetPresenter
+      ##
+      # Presentation information about client call invocation
+      #
+      class ClientCallPresenter
+        ##
+        # Create a client call presenter
+        #
+        # @param proto [Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::ClientCall]
+        #     The protobuf representation
+        # @param json [String]
+        #     The JSON representation
+        # @param method_name [String] The method name
+        # @param request_name [String] The request variable name
+        # @param response_name [String,nil] The response variable name, or nil for no response handling
+        # @param client_streaming [Boolean] True if the call is client streaming
+        # @param server_streaming [Boolean] True if the call is server streaming
+        # @param phase1 [Boolean] True if this is a phase 1 snippet without config
+        #
+        def initialize proto, json,
+                       method_name:, request_name:, response_name:, client_streaming:, server_streaming:, phase1:
+          @render_lines = pre_call_lines proto, json, method_name, client_streaming, server_streaming, phase1
+          main_line = "client.#{method_name} #{request_name}"
+          main_line = "#{response_name} = #{main_line}" if response_name
+          @render_lines << main_line
+          @render = @render_lines.join "\n"
+        end
+
+        ##
+        # The lines of rendered code
+        # @return [Array<String>]
+        #
+        attr_reader :render_lines
+
+        ##
+        # The rendered code as a single string, possibly with line breaks
+        # @return [String]
+        #
+        attr_reader :render
+
+        private
+
+        def pre_call_lines proto, json, method_name, client_streaming, server_streaming, phase1
+          lines = []
+          if json&.key? "preCall"
+            proto.pre_call.each_with_index do |statement_proto, index|
+              statement = StatementPresenter.new statement_proto, json["preCall"][index]
+              lines += statement.render_lines
+            end
+          elsif phase1
+            lines <<
+              if client_streaming || server_streaming
+                "# Call the #{method_name} method to start streaming."
+              else
+                "# Call the #{method_name} method."
+              end
+          end
+          lines
+        end
+      end
+    end
+  end
+end

--- a/gapic-generator/lib/gapic/presenters/snippet/client_initialization_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/snippet/client_initialization_presenter.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "active_support/inflector"
+require "google/cloud/tools/snippetgen/configlanguage/v1/snippet_config_language.pb"
+require "gapic/presenters/snippet/statement_presenter"
+
+module Gapic
+  module Presenters
+    class SnippetPresenter
+      ##
+      # Presentation information about client object initialization
+      #
+      class ClientInitializationPresenter
+        ##
+        # Create an client init presenter.
+        #
+        # @param proto [Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::ClientInitialization]
+        #     The protobuf representation
+        # @param json [String]
+        #     The JSON representation
+        # @param phase1 [Boolean] Whether to inject phase 1 content
+        # @param client_type [String] The fully qualified class name of the client
+        #
+        def initialize proto, json, phase1:, client_type:
+          @render_lines = []
+          if json&.key? "preClientInitialization"
+            proto.pre_client_initialization.each_with_index do |stmt_proto, index|
+              statement = StatementPresenter.new stmt_proto, json["preClientInitialization"][index]
+              @render_lines += statement.render_lines
+            end
+          elsif phase1
+            @render_lines << "# Create a client object. The client can be reused for multiple calls."
+          end
+          @render_lines += build_create_code proto, client_type
+          @render = @render_lines.join "\n"
+        end
+
+        ##
+        # The lines of rendered code
+        # @return [Array<String>]
+        #
+        attr_reader :render_lines
+
+        ##
+        # The rendered code as a single string, possibly with line breaks
+        # @return [String]
+        #
+        attr_reader :render
+
+        private
+
+        def build_create_code proto, client_type
+          create_code = "client = #{client_type}.new"
+          if proto&.custom_service_endpoint
+            endpoint = build_endpoint proto.custom_service_endpoint
+            [
+              "#{create_code} do |config|",
+              "  config.endpoint = #{endpoint.inspect}",
+              "end"
+            ]
+          else
+            [create_code]
+          end
+        end
+
+        def build_endpoint proto
+          init_module = Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::ClientInitialization
+          schema = proto.schema == init_module::ServiceEndpoint::ServiceEndpointSchema::HTTP ? "http://" : "https://"
+          region = proto.region.to_s.empty? ? "" : "#{proto.region}-"
+          port = proto.port.zero? ? "" : ":#{proto.port}"
+          [schema, region, proto.host, port].join
+        end
+      end
+    end
+  end
+end

--- a/gapic-generator/lib/gapic/presenters/snippet/expression_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/snippet/expression_presenter.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "active_support/inflector"
+require "google/cloud/tools/snippetgen/configlanguage/v1/snippet_config_language.pb"
+
+module Gapic
+  module Presenters
+    class SnippetPresenter
+      ##
+      # Presentation information about an expression
+      #
+      class ExpressionPresenter
+        ##
+        # Create an expression presenter.
+        #
+        # @param proto [Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Expression]
+        #     The protobuf representation of the expression
+        # @param json [String]
+        #     The JSON representation of the expression
+        #
+        def initialize proto, json
+          @render_lines =
+            if json&.key? "stringValue"
+              render_string proto
+            elsif json&.key? "numberValue"
+              render_number proto
+            elsif json&.key? "booleanValue"
+              render_boolean proto
+            elsif json&.key? "nullValue"
+              ["nil"]
+            elsif json&.key? "nameValue"
+              render_name proto
+            elsif json&.key? "complexValue"
+              render_complex proto, json
+            end
+          @render = @render_lines&.join " "
+        end
+
+        ##
+        # The lines of rendered code
+        # @return [Array<String>]
+        #
+        attr_reader :render_lines
+
+        ##
+        # The rendered code as a single string, possibly with line breaks
+        # @return [String]
+        #
+        attr_reader :render
+
+        ##
+        # Whether the expression could be interpreted.
+        # @return [Boolean]
+        #
+        def exist?
+          !render_lines.nil?
+        end
+
+        private
+
+        def render_string proto
+          [proto.string_value.inspect]
+        end
+
+        def render_number proto
+          value = proto.number_value
+          value = value.to_i if value == value.to_i
+          [value.inspect]
+        end
+
+        def render_boolean proto
+          [proto.boolean_value.inspect]
+        end
+
+        def render_name proto
+          proto = proto.name_value
+          line = ([proto.name] + Array(proto.path&.to_a)).join "."
+          [line]
+        end
+
+        def render_complex proto, json
+          proto = proto.complex_value.properties
+          json = json["complexValue"]["properties"]
+          lines = ["{"]
+          proto.each do |key, value_expr|
+            value_presenter = ExpressionPresenter.new value_expr, json[key]
+            value_lines = value_presenter.render_lines
+            next unless value_lines
+            lines[lines.size - 1] = "#{lines.last}," if lines.size > 1
+            value_lines[0] = "#{key}: #{value_lines.first}"
+            lines += value_lines.map { |line| "  #{line}" }
+          end
+          lines + ["}"]
+        end
+      end
+    end
+  end
+end

--- a/gapic-generator/lib/gapic/presenters/snippet/request_initialization_presenters.rb
+++ b/gapic-generator/lib/gapic/presenters/snippet/request_initialization_presenters.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "active_support/inflector"
+require "google/cloud/tools/snippetgen/configlanguage/v1/snippet_config_language.pb"
+require "gapic/presenters/snippet/statement_presenter"
+
+module Gapic
+  module Presenters
+    class SnippetPresenter
+      ##
+      # Presentation information about simple request initialization
+      #
+      class SimpleRequestInitializationPresenter
+        ##
+        # Create a simple request init presenter.
+        #
+        # @param proto [Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::SimpleRequestInitialization]
+        #     The protobuf representation
+        # @param json [String]
+        #     The JSON representation
+        # @param request_type [String] The fully qualified request message class
+        # @param phase1 [Boolean] True if this is a phase 1 snippet without config
+        # @param default_request_name [String] Default name of request variable
+        #
+        def initialize proto, json, request_type:, phase1:, default_request_name: "request"
+          @request_name = phase1 ? default_request_name : proto.request_name
+          @render_precall_lines =
+            if proto
+              configured_lines proto, json, request_type
+            else
+              fallback_lines request_type
+            end
+          @render_precall = @render_precall_lines.join "\n"
+          @render_postcall_lines = []
+          @render_postcall = ""
+        end
+
+        ##
+        # The lines of rendered code for before the rpc call
+        # @return [Array<String>]
+        #
+        attr_reader :render_precall_lines
+
+        ##
+        # The pre-call rendered code as a single string, possibly with line breaks
+        # @return [String]
+        #
+        attr_reader :render_precall
+
+        ##
+        # The lines of rendered code for after the rpc call
+        # @return [Array<String>]
+        #
+        attr_reader :render_postcall_lines
+
+        ##
+        # The post-call rendered code as a single string, possibly with line breaks
+        # @return [String]
+        #
+        attr_reader :render_postcall
+
+        ##
+        # The name of the request variable set
+        # @return [String]
+        #
+        attr_reader :request_name
+
+        private
+
+        def fallback_lines request_type
+          [
+            "# Create a request. To set request fields, pass in keyword arguments.",
+            "#{@request_name} = #{request_type}.new"
+          ]
+        end
+
+        def configured_lines proto, json, request_type
+          pre_lines = []
+          if json.key? "preRequestInitialization"
+            proto.pre_request_initialization&.each_with_index do |statement_proto, index|
+              statement = StatementPresenter.new statement_proto, json["preRequestInitialization"][index]
+              pre_lines += statement.render_lines
+            end
+          end
+          expr = ExpressionPresenter.new proto.request_value, json["requestValue"]
+          if expr.exist?
+            request_lines = expr.render_lines
+            request_lines[0] = "#{@request_name} = #{request_lines.first}"
+          else
+            request_lines = fallback_lines request_type
+          end
+          pre_lines + request_lines
+        end
+      end
+
+      ##
+      # Presentation information about client-streaming request initialization
+      #
+      class StreamingRequestInitializationPresenter
+        ##
+        # Create a streaming request init presenter.
+        #
+        # @param proto [Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::StreamingRequestInitialization]
+        #     The protobuf representation
+        # @param json [String]
+        #     The JSON representation
+        # @param request_name [String] The request variable name
+        # @param request_type [String] The fully qualified request message class
+        # @param phase1 [Boolean] True if this is a phase 1 snippet without config
+        #
+        def initialize _proto, _json, request_name:, request_type:, phase1:
+          @request_name = request_name
+          @render_precall_lines = []
+          @render_precall_lines << "# Create an input stream." if phase1
+          @render_precall_lines << "#{request_name} = Gapic::StreamInput.new"
+          @render_precall = @render_precall_lines.join "\n"
+
+          # TODO
+          @render_postcall_lines = fallback_lines request_name, request_type
+          @render_postcall = @render_postcall_lines.join "\n"
+        end
+
+        ##
+        # The lines of rendered code for before the rpc call
+        # @return [Array<String>]
+        #
+        attr_reader :render_precall_lines
+
+        ##
+        # The pre-call rendered code as a single string, possibly with line breaks
+        # @return [String]
+        #
+        attr_reader :render_precall
+
+        ##
+        # The lines of rendered code for after the rpc call
+        # @return [Array<String>]
+        #
+        attr_reader :render_postcall_lines
+
+        ##
+        # The post-call rendered code as a single string, possibly with line breaks
+        # @return [String]
+        #
+        attr_reader :render_postcall
+
+        ##
+        # The name of the request variable set
+        # @return [String]
+        #
+        attr_reader :request_name
+
+        private
+
+        def fallback_lines request_name, request_type
+          [
+            "# Send requests on the stream. For each request object, set fields by",
+            "# passing keyword arguments. Be sure to close the stream when done.",
+            "#{request_name} << #{request_type}.new",
+            "#{request_name} << #{request_type}.new",
+            "#{request_name}.close"
+          ]
+        end
+      end
+    end
+  end
+end

--- a/gapic-generator/lib/gapic/presenters/snippet/response_handling_presenters.rb
+++ b/gapic-generator/lib/gapic/presenters/snippet/response_handling_presenters.rb
@@ -1,0 +1,334 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "active_support/inflector"
+require "google/cloud/tools/snippetgen/configlanguage/v1/snippet_config_language.pb"
+require "gapic/presenters/snippet/statement_presenter"
+
+module Gapic
+  module Presenters
+    class SnippetPresenter
+      ##
+      # Some common private methods for response handling presenters
+      #
+      module ResponseHandlingPresenterCommon
+        private
+
+        def compute_response_name proto, phase1
+          return "result" if phase1
+          return nil if proto&.response_name.to_s.empty?
+          proto.response_name
+        end
+      end
+
+      ##
+      # Presentation information about simple response handling
+      #
+      class SimpleResponseHandlingPresenter
+        include ResponseHandlingPresenterCommon
+
+        ##
+        # Create a simple response handling presenter
+        #
+        # @param proto [Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::SimpleResponseHandling]
+        #     The protobuf representation
+        # @param json [String]
+        #     The JSON representation
+        # @param response_type [String] The fully qualified response message class
+        # @param phase1 [Boolean] True if this is a phase 1 snippet without config
+        #
+        def initialize proto, _json, response_type:, phase1:
+          @response_name = compute_response_name proto, phase1
+          @render_lines =
+            if @response_name && phase1
+              [
+                "# The returned object is of type #{response_type}.",
+                "p #{@response_name}"
+              ]
+            else
+              []
+            end
+          @render = @render_lines.join "\n"
+        end
+
+        ##
+        # The lines of rendered code
+        # @return [Array<String>]
+        #
+        attr_reader :render_lines
+
+        ##
+        # The rendered code as a single string, possibly with line breaks
+        # @return [String]
+        #
+        attr_reader :render
+
+        ##
+        # The name of the response variable, or nil for no response handling
+        # @return [String,nil]
+        #
+        attr_reader :response_name
+      end
+
+      ##
+      # Presentation information about LRO response handling
+      #
+      class LroResponseHandlingPresenter
+        include ResponseHandlingPresenterCommon
+
+        ##
+        # Create an LRO response handling presenter
+        #
+        # @param proto [Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::LroResponseHandling]
+        #     The protobuf representation
+        # @param json [String]
+        #     The JSON representation
+        # @param phase1 [Boolean] True if this is a phase 1 snippet without config
+        #
+        def initialize proto, _json, phase1:
+          @response_name = compute_response_name proto, phase1
+          @render_lines = []
+          if @response_name
+            if phase1
+              @render_lines << "# The returned object is of type Gapic::Operation. You can use it to"
+              @render_lines << "# check the status of an operation, cancel it, or wait for results."
+            end
+            polling_type_class =
+              Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::LroResponseHandling::PollingType
+            case proto&.polling_type
+            when polling_type_class::NONE
+              # Do nothing
+            when polling_type_class::ONCE
+              @render_lines += check_once_lines phase1
+            else
+              @render_lines += wait_response_lines phase1
+            end
+          end
+          @render = @render_lines.join "\n"
+        end
+
+        ##
+        # The lines of rendered code
+        # @return [Array<String>]
+        #
+        attr_reader :render_lines
+
+        ##
+        # The rendered code as a single string, possibly with line breaks
+        # @return [String]
+        #
+        attr_reader :render
+
+        ##
+        # The name of the response variable, or nil for no response handling
+        # @return [String,nil]
+        #
+        attr_reader :response_name
+
+        private
+
+        def check_once_lines phase1
+          lines = []
+          lines << "# Here is how to check once for a response." if phase1
+          lines + [
+            "if #{@response_name}.response?",
+            "  p #{@response_name}.response",
+            "else",
+            '  puts "Response not yet arrived."',
+            "end"
+          ]
+        end
+
+        def wait_response_lines phase1
+          lines = []
+          lines << "# Here is how to wait for a response." if phase1
+          lines + [
+            "#{@response_name}.wait_until_done! timeout: 60",
+            "if #{@response_name}.response?",
+            "  p #{@response_name}.response",
+            "else",
+            '  puts "No response received."',
+            "end"
+          ]
+        end
+      end
+
+      ##
+      # Presentation information about server-streaming response handling
+      #
+      class StreamingResponseHandlingPresenter
+        ##
+        # Create a server-streaming response handling presenter
+        #
+        # @param proto [Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::StreamingResponseHandling]
+        #     The protobuf representation
+        # @param json [String]
+        #     The JSON representation
+        # @param response_name [String] The name of the stream variable
+        # @param base_response_type [String] The fully qualified message class
+        #     for individual responses
+        # @param phase1 [Boolean] True if this is a phase 1 snippet without config
+        #
+        def initialize proto, json, response_name:, base_response_type:, phase1:
+          @response_name = response_name
+          @render_lines = []
+          if response_name
+            if phase1 && base_response_type
+              @render_lines << "# The returned object is a streamed enumerable yielding elements of type"
+              @render_lines << "# #{base_response_type}"
+            end
+            @render_lines += per_stream_response_lines proto, json, response_name, phase1
+          end
+          @render = @render_lines.join "\n"
+        end
+
+        ##
+        # The lines of rendered code
+        # @return [Array<String>]
+        #
+        attr_reader :render_lines
+
+        ##
+        # The rendered code as a single string, possibly with line breaks
+        # @return [String]
+        #
+        attr_reader :render
+
+        ##
+        # The name of the response variable, or nil for no response handling
+        # @return [String,nil]
+        #
+        attr_reader :response_name
+
+        private
+
+        def per_stream_response_lines proto, json, response_name, phase1
+          lines = []
+          item_name = phase1 ? "current_response" : proto.current_response_name
+          lines << "#{response_name}.each do |#{item_name}|"
+          if json&.key? "perStreamResponseStatements"
+            proto.per_stream_response_statements&.each_with_index do |statement_proto, index|
+              statement = StatementPresenter.new statement_proto, json["perStreamResponseStatements"][index]
+              lines += statement.render_lines.map { |line| "  #{line}" }
+            end
+          else
+            lines << "  p #{item_name}"
+          end
+          lines << "end"
+          lines
+        end
+      end
+
+      ##
+      # Presentation information about paginated response handling
+      #
+      class PaginatedResponseHandlingPresenter
+        include ResponseHandlingPresenterCommon
+
+        ##
+        # Create a paginated response handling presenter
+        #
+        # @param proto [Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::PaginatedResponseHandling]
+        #     The protobuf representation
+        # @param json [String]
+        #     The JSON representation
+        # @param paged_response_type [String] The fully qualified message class
+        #     for individual responses
+        # @param phase1 [Boolean] True if this is a phase 1 snippet without config
+        #
+        def initialize proto, json, paged_response_type:, phase1:
+          @response_name = compute_response_name proto, phase1
+          @render_lines = []
+          if @response_name
+            if phase1
+              @render_lines << "# The returned object is of type Gapic::PagedEnumerable. You can iterate"
+              @render_lines << "# over elements, and API calls will be issued to fetch pages as needed."
+            end
+            @render_lines +=
+              if proto&.by_page
+                by_page_lines proto, json, @response_name, paged_response_type, phase1
+              elsif proto&.next_page_token
+                next_page_token_lines proto, json
+              else
+                by_item_lines proto, json, @response_name, paged_response_type, phase1
+              end
+          end
+          @render = @render_lines.join "\n"
+        end
+
+        ##
+        # The lines of rendered code
+        # @return [Array<String>]
+        #
+        attr_reader :render_lines
+
+        ##
+        # The rendered code as a single string, possibly with line breaks
+        # @return [String]
+        #
+        attr_reader :render
+
+        ##
+        # The name of the response variable, or nil for no response handling
+        # @return [String,nil]
+        #
+        attr_reader :response_name
+
+        private
+
+        def by_item_lines proto, json, collection_name, paged_response_type, phase1
+          lines = []
+          proto = proto&.by_item
+          json = json&.fetch "byItem", nil
+          item_name = phase1 ? "item" : proto.item_name
+          lines << "#{collection_name}.each do |#{item_name}|"
+          if json&.key? "perItemStatements"
+            proto.per_item_statements&.each_with_index do |item_proto, index|
+              statement = StatementPresenter.new item_proto, json["perItemStatements"][index]
+              lines += statement.render_lines.map { |line| "  #{line}" }
+            end
+          else
+            lines << "  # Each element is of type #{paged_response_type}." if phase1
+            lines << "  p #{item_name}"
+          end
+          lines << "end"
+          lines
+        end
+
+        def by_page_lines proto, json, response_name, paged_response_type, phase1
+          lines = []
+          proto = proto.by_page
+          json = json["byPage"]
+          page_name = phase1 ? "page" : proto.page_name
+          lines << "#{response_name}.each_page do |#{page_name}|"
+          if json&.key? "perPageStatements"
+            proto.per_page_statements&.each_with_index do |page_proto, index|
+              statement = StatementPresenter.new page_proto, json["perPageStatements"][index]
+              lines += statement.render_lines.map { |line| "  #{line}" }
+            end
+          end
+          iteration_lines = by_item_lines proto, json, page_name, paged_response_type, phase1
+          lines + iteration_lines.map { |line| "  #{line}" } + ["end"]
+        end
+
+        def next_page_token_lines _proto, _json
+          # TODO
+          []
+        end
+      end
+    end
+  end
+end

--- a/gapic-generator/lib/gapic/presenters/snippet/statement_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/snippet/statement_presenter.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "active_support/inflector"
+require "google/cloud/tools/snippetgen/configlanguage/v1/snippet_config_language.pb"
+require "gapic/presenters/snippet/expression_presenter"
+
+module Gapic
+  module Presenters
+    class SnippetPresenter
+      ##
+      # Presentation information about a statement
+      #
+      class StatementPresenter
+        ##
+        # Create a statement presenter.
+        #
+        # @param proto [Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Statement]
+        #     The protobuf representation of the statement
+        # @param json [String]
+        #     The JSON representation of the statement
+        #
+        def initialize proto, json
+          @render_lines =
+            if json&.key? "declaration"
+              declaration_lines proto.declaration, json["declaration"]
+            elsif json&.key? "standardOutput"
+              output_lines proto.standard_output, json["standardOutput"]
+            elsif json&.key? "return"
+              return_lines proto.return, json["return"]
+            elsif json&.key? "conditional"
+              conditional_lines proto.conditional, json["conditional"]
+            elsif json&.key? "iteration"
+              iteration_lines proto.iteration, json["iteration"]
+            else
+              ["# Unknown statement omitted here."]
+            end
+          @render = @render_lines.join "\n"
+        end
+
+        ##
+        # The lines of rendered code
+        # @return [Array<String>]
+        #
+        attr_reader :render_lines
+
+        ##
+        # The rendered code as a single string, possibly with line breaks
+        # @return [String]
+        #
+        attr_reader :render
+
+        private
+
+        def declaration_lines proto, json
+          expr = ExpressionPresenter.new proto.value, json["value"]
+          return ["# Unknown declaration statement omitted here."] unless expr.exist?
+          lines = expr.render_lines
+          lines[0] = "#{proto.name} = #{lines.first}"
+          if proto.description && !proto.description.empty?
+            lines.unshift "# #{proto.description}"
+          end
+          lines
+        end
+
+        def output_lines proto, json
+          expr = ExpressionPresenter.new proto.value, json["value"]
+          return ["# Unknown output statement omitted here."] unless expr.exist?
+          lines = expr.render_lines
+          if lines.size == 1
+            ["puts(#{lines.first})"]
+          else
+            ["puts("] + lines.map { |line| "  #{line}" } + [")"]
+          end
+        end
+
+        def return_lines proto, json
+          expr = ExpressionPresenter.new proto.result, json["result"]
+          return ["# Unknown return statement omitted here."] unless expr.exist?
+          lines = expr.render_lines
+          lines[0] = "return #{lines.first}"
+          lines
+        end
+
+        def conditional_lines proto, json
+          expr = ExpressionPresenter.new proto.condition, json["condition"]
+          return ["# Unknown conditional statement omitted here."] unless expr.exist?
+
+          if json.key? "onTrue"
+            conditional_lines_inner "if", expr, proto.on_true, json["onTrue"], proto.on_false, json["onFalse"]
+          elsif json.key? "onFalse"
+            conditional_lines_inner "unless", expr, proto.on_false, json["onFalse"], nil, nil
+          else
+            ["# Do nothing"]
+          end
+        end
+
+        def conditional_lines_inner keyword, expr, if_protos, if_json, else_protos, else_json
+          lines = ["#{keyword} #{expr.render}"]
+          if_protos.each_with_index do |statement_proto, index|
+            statement = StatementPresenter.new statement_proto, if_json[index]
+            lines += statement.render_lines.map { |line| "  #{line}" }
+          end
+          if else_json
+            lines << "else"
+            else_protos.each_with_index do |statement_proto, index|
+              statement = StatementPresenter.new statement_proto, else_json[index]
+              lines += statement.render_lines.map { |line| "  #{line}" }
+            end
+          end
+          lines << "end"
+          lines
+        end
+
+        def iteration_lines _proto, _json
+          # TODO
+          ["# Unknown iteration statement omitted here."]
+        end
+      end
+    end
+  end
+end

--- a/gapic-generator/lib/gapic/presenters/snippet/type_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/snippet/type_presenter.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "active_support/inflector"
+require "google/cloud/tools/snippetgen/configlanguage/v1/snippet_config_language.pb"
+
+module Gapic
+  module Presenters
+    class SnippetPresenter
+      ##
+      # Presentation information about a type
+      #
+      class TypePresenter
+        ##
+        # Create a type presenter.
+        #
+        # @param proto [Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Type]
+        #     The protobuf representation of the type
+        # @param json [String]
+        #     The JSON representation of the type
+        #
+        def initialize proto, json
+          @render =
+            if json&.key? "scalarType"
+              SCALAR_TYPE_MAPPING[proto.scalar_type] || "Object"
+            elsif json&.key? "bytesType"
+              "String"
+            elsif json&.key? "messageType"
+              proto_to_ruby proto.message_type.message_full_name
+            elsif json&.key? "enumType"
+              proto_to_ruby proto.enum_type.enum_full_name
+            elsif json&.key? "repeatedType"
+              repeated_render proto, json
+            elsif json&.key? "mapType"
+              map_render proto, json
+            else
+              "Object"
+            end
+        end
+
+        ##
+        # The rendered type string.
+        # @return [String]
+        #
+        attr_reader :render
+
+        private
+
+        def proto_to_ruby name
+          name.split(".").map { |str| ActiveSupport::Inflector.upcase_first str }.join "::"
+        end
+
+        def repeated_render proto, json
+          inner_type = TypePresenter.new proto.repeated_type.element_type, json["repeatedType"]["elementType"]
+          "Array<#{inner_type.render}>"
+        end
+
+        def map_render proto, json
+          proto = proto.map_type
+          json = json["mapType"]
+          key_type = TypePresenter.new proto.key_type, json["keyType"]
+          value_type = TypePresenter.new proto.value_type, json["valueType"]
+          "Hash{#{key_type.render}=>#{value_type.render}}"
+        end
+
+        scalar_type = Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Type::ScalarType
+        SCALAR_TYPE_MAPPING = {
+          scalar_type::TYPE_DOUBLE => "Float",
+          scalar_type::TYPE_FLOAT => "Float",
+          scalar_type::TYPE_INT64 => "Integer",
+          scalar_type::TYPE_UINT64 => "Integer",
+          scalar_type::TYPE_INT32 => "Integer",
+          scalar_type::TYPE_FIXED64 => "Integer",
+          scalar_type::TYPE_FIXED32 => "Integer",
+          scalar_type::TYPE_BOOL => "boolean",
+          scalar_type::TYPE_STRING => "String",
+          scalar_type::TYPE_UINT32 => "Integer",
+          scalar_type::TYPE_SFIXED32 => "Integer",
+          scalar_type::TYPE_SFIXED64 => "Integer",
+          scalar_type::TYPE_SINT32 => "Integer",
+          scalar_type::TYPE_SINT64 => "Integer"
+        }.freeze
+      end
+    end
+  end
+end

--- a/gapic-generator/test/gapic/presenters/snippet/client_call_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/snippet/client_call_presenter_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require_relative "snippet_test_helper"
+require "gapic/presenters/snippet/client_call_presenter"
+
+class ClientCallPresenterTest < PresenterTest
+  include SnippetTestHelper
+
+  METHOD_NAME = "do_something_big"
+  REQUEST_NAME = "request"
+  RESPONSE_NAME = "response"
+
+  def build_client_call_presenter json, phase1: false, streaming: false, response_name: RESPONSE_NAME
+    klass = Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::ClientCall
+    proto = build_proto_fragment klass, json if json
+    Gapic::Presenters::SnippetPresenter::ClientCallPresenter.new \
+      proto, json,
+      method_name: METHOD_NAME, request_name: REQUEST_NAME, response_name: response_name,
+      client_streaming: streaming, server_streaming: streaming, phase1: phase1
+  end
+
+  def test_phase1_non_streaming
+    presenter = build_client_call_presenter nil, phase1: true
+    expected = [
+      "# Call the do_something_big method.",
+      "#{RESPONSE_NAME} = client.#{METHOD_NAME} #{REQUEST_NAME}"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_phase1_streaming
+    presenter = build_client_call_presenter nil, phase1: true, streaming: true
+    expected = [
+      "# Call the do_something_big method to start streaming.",
+      "#{RESPONSE_NAME} = client.#{METHOD_NAME} #{REQUEST_NAME}"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_with_response
+    json = {
+      "preCall" => [
+        "standardOutput" => {
+          "value" => {
+            "stringValue" => "Making the call!"
+          }
+        }
+      ]
+    }
+    presenter = build_client_call_presenter json
+    expected = [
+      'puts("Making the call!")',
+      "#{RESPONSE_NAME} = client.#{METHOD_NAME} #{REQUEST_NAME}"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_with_no_response
+    json = {
+      "preCall" => [
+        "standardOutput" => {
+          "value" => {
+            "stringValue" => "Making the call!"
+          }
+        }
+      ]
+    }
+    presenter = build_client_call_presenter json, response_name: nil
+    expected = [
+      'puts("Making the call!")',
+      "client.#{METHOD_NAME} #{REQUEST_NAME}"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+end

--- a/gapic-generator/test/gapic/presenters/snippet/client_initialization_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/snippet/client_initialization_presenter_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require_relative "snippet_test_helper"
+require "gapic/presenters/snippet/client_initialization_presenter"
+
+class ClientInitializationPresenterTest < PresenterTest
+  include SnippetTestHelper
+
+  CLIENT_TYPE = "Google::Cloud::MyAPI::V1::MyService::Client"
+
+  def build_client_init_presenter json, phase1: false
+    klass = Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::ClientInitialization
+    proto = build_proto_fragment klass, json if json
+    Gapic::Presenters::SnippetPresenter::ClientInitializationPresenter.new \
+      proto, json, phase1: phase1, client_type: CLIENT_TYPE
+  end
+
+  def test_message_omitted_phase2
+    presenter = build_client_init_presenter nil
+    expected = ["client = #{CLIENT_TYPE}.new"]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_message_omitted_phase1
+    presenter = build_client_init_presenter nil, phase1: true
+    expected = [
+      "# Create a client object. The client can be reused for multiple calls.",
+      "client = #{CLIENT_TYPE}.new"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_with_endpoint
+    json = {
+      "customServiceEndpoint" => {
+        "schema" => "HTTPS",
+        "region" => "apac",
+        "host" => "myapi.googleapis.com",
+        "port" => 8088
+      }
+    }
+    presenter = build_client_init_presenter json
+    expected = [
+      "client = #{CLIENT_TYPE}.new do |config|",
+      '  config.endpoint = "https://apac-myapi.googleapis.com:8088"',
+      "end"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_with_pre_statements
+    json = {
+      "preClientInitialization" => [
+        "standardOutput" => {
+          "value" => {
+            "stringValue" => "Hello!"
+          }
+        }
+      ]
+    }
+    presenter = build_client_init_presenter json
+    expected = [
+      'puts("Hello!")',
+      "client = #{CLIENT_TYPE}.new"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+end

--- a/gapic-generator/test/gapic/presenters/snippet/expression_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/snippet/expression_presenter_test.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require_relative "snippet_test_helper"
+require "gapic/presenters/snippet/expression_presenter"
+
+class ExpressionPresenterTest < PresenterTest
+  include SnippetTestHelper
+
+  def build_expression_presenter json
+    proto = build_proto_fragment Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Expression, json
+    Gapic::Presenters::SnippetPresenter::ExpressionPresenter.new proto, json
+  end
+
+  def test_no_json
+    presenter = build_expression_presenter nil
+    refute presenter.exist?
+  end
+
+  def test_null
+    json = {"nullValue" => "NULL_VALUE"}
+    presenter = build_expression_presenter json
+    assert_equal ["nil"], presenter.render_lines
+  end
+
+  def test_name
+    json = {"nameValue" => {"name" => "foo"}}
+    presenter = build_expression_presenter json
+    assert_equal ["foo"], presenter.render_lines
+  end
+
+  def test_name_with_path
+    json = {"nameValue" => {"name" => "foo", "path" => ["bar", "baz"]}}
+    presenter = build_expression_presenter json
+    assert_equal ["foo.bar.baz"], presenter.render_lines
+  end
+
+  def test_number
+    json = {"numberValue" => 1.2}
+    presenter = build_expression_presenter json
+    assert_equal ["1.2"], presenter.render_lines
+  end
+
+  def test_number_integer
+    json = {"numberValue" => 2}
+    presenter = build_expression_presenter json
+    assert_equal ["2"], presenter.render_lines
+  end
+
+  def test_string
+    json = {"stringValue" => 'Hello, "Ruby"'}
+    presenter = build_expression_presenter json
+    assert_equal ['"Hello, \\"Ruby\\""'], presenter.render_lines
+  end
+
+  def test_boolean
+    json = {"booleanValue" => true}
+    presenter = build_expression_presenter json
+    assert_equal ["true"], presenter.render_lines
+  end
+
+  def test_complex
+    json = {
+      "complexValue" => {
+        "properties" => {
+          "id" => {
+            "nameValue" => {
+              "name" => "my_id"
+            }
+          },
+          "name" => {
+            "stringValue" => "Jane Doe"
+          },
+          "age" => {
+            "numberValue" => 21
+          }
+        }
+      }
+    }
+    presenter = build_expression_presenter json
+    expected = [
+      "{",
+      "  id: my_id,",
+      '  name: "Jane Doe",',
+      "  age: 21",
+      "}"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_complex_nested
+    json = {
+      "complexValue" => {
+        "properties" => {
+          "id" => {
+            "nameValue" => {
+              "name" => "my_id"
+            }
+          },
+          "stats" => {
+            "complexValue" => {
+              "properties" => {
+                "eyes" => {
+                  "stringValue" => "brown",
+                },
+                "hair" => {
+                  "stringValue" => "black",
+                }
+              }
+            }
+          },
+          "name" => {
+            "stringValue" => "Jane Doe"
+          }
+        }
+      }
+    }
+    presenter = build_expression_presenter json
+    expected = [
+      "{",
+      "  id: my_id,",
+      "  stats: {",
+      '    eyes: "brown",',
+      '    hair: "black"',
+      "  },",
+      '  name: "Jane Doe"',
+      "}"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+end

--- a/gapic-generator/test/gapic/presenters/snippet/request_initialization_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/snippet/request_initialization_presenter_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require_relative "snippet_test_helper"
+require "gapic/presenters/snippet/request_initialization_presenters"
+
+class RequestInitializationPresenterTest < PresenterTest
+  include SnippetTestHelper
+
+  REQUEST_TYPE = "Google::Cloud::MyAPI::V1::MyRequest"
+  STANDARD_REQUEST_NAME = "request"
+
+  def build_simple_presenter json, phase1: false
+    klass = Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::SimpleRequestInitialization
+    proto = build_proto_fragment klass, json if json
+    Gapic::Presenters::SnippetPresenter::SimpleRequestInitializationPresenter.new \
+      proto, json, request_type: REQUEST_TYPE, phase1: phase1
+  end
+
+  def build_streaming_presenter json, phase1: false
+    klass = Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::StreamingRequestInitialization
+    proto = build_proto_fragment klass, json if json
+    Gapic::Presenters::SnippetPresenter::StreamingRequestInitializationPresenter.new \
+      proto, json, request_name: STANDARD_REQUEST_NAME, request_type: REQUEST_TYPE, phase1: phase1
+  end
+
+  def test_simple_phase1
+    presenter = build_simple_presenter nil, phase1: true
+    expected = [
+      "# Create a request. To set request fields, pass in keyword arguments.",
+      "request = #{REQUEST_TYPE}.new"
+    ]
+    assert_equal expected, presenter.render_precall_lines
+    assert_empty presenter.render_postcall_lines
+    assert_equal "request", presenter.request_name
+  end
+
+  def test_simple_value
+    json = {
+      "requestValue" => {
+        "complexValue" => {
+          "properties" => {
+            "name" => {
+              "stringValue" => "Jane Doe"
+            },
+            "age" => {
+              "numberValue" => 21
+            }
+          }
+        }
+      },
+      "requestName" => "the_request"
+    }
+    presenter = build_simple_presenter json
+    expected = [
+      "the_request = {",
+      '  name: "Jane Doe",',
+      "  age: 21",
+      "}"
+    ]
+    assert_equal expected, presenter.render_precall_lines
+    assert_empty presenter.render_postcall_lines
+    assert_equal "the_request", presenter.request_name
+  end
+
+  def test_simple_value_with_pre_lines
+    json = {
+      "preRequestInitialization" => [
+        {
+          "declaration" => {
+            "name" => "age",
+            "value" => {
+              "numberValue" => 21
+            }
+          }
+        }
+      ],
+      "requestValue" => {
+        "complexValue" => {
+          "properties" => {
+            "name" => {
+              "stringValue" => "Jane Doe"
+            },
+            "age" => {
+              "nameValue" => {
+                "name" => "age"
+              }
+            }
+          }
+        }
+      },
+      "requestName" => "the_request"
+    }
+    presenter = build_simple_presenter json
+    expected = [
+      "age = 21",
+      "the_request = {",
+      '  name: "Jane Doe",',
+      "  age: age",
+      "}"
+    ]
+    assert_equal expected, presenter.render_precall_lines
+    assert_empty presenter.render_postcall_lines
+    assert_equal "the_request", presenter.request_name
+  end
+
+  def test_streaming_phase1
+    presenter = build_streaming_presenter nil, phase1: true
+    expected_precall = [
+      "# Create an input stream.",
+      "request = Gapic::StreamInput.new"
+    ]
+    expected_postcall = [
+      "# Send requests on the stream. For each request object, set fields by",
+      "# passing keyword arguments. Be sure to close the stream when done.",
+      "request << #{REQUEST_TYPE}.new",
+      "request << #{REQUEST_TYPE}.new",
+      "request.close"
+    ]
+    assert_equal expected_precall, presenter.render_precall_lines
+    assert_equal expected_postcall, presenter.render_postcall_lines
+    assert_equal "request", presenter.request_name
+  end
+end

--- a/gapic-generator/test/gapic/presenters/snippet/response_handling_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/snippet/response_handling_presenter_test.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require_relative "snippet_test_helper"
+require "gapic/presenters/snippet/response_handling_presenters"
+
+class ResponseHandlingPresenterTest < PresenterTest
+  include SnippetTestHelper
+
+  RESPONSE_TYPE = "Google::Cloud::MyAPI::V1::MyResponse"
+  STANDARD_RESPONSE_NAME = "result"
+
+  def build_simple_presenter json, phase1: false
+    klass = Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::SimpleResponseHandling
+    proto = build_proto_fragment klass, json if json
+    Gapic::Presenters::SnippetPresenter::SimpleResponseHandlingPresenter.new \
+      proto, json, response_type: RESPONSE_TYPE, phase1: phase1
+  end
+
+  def build_lro_presenter json, phase1: false
+    klass = Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::LroResponseHandling
+    proto = build_proto_fragment klass, json if json
+    Gapic::Presenters::SnippetPresenter::LroResponseHandlingPresenter.new proto, json, phase1: phase1
+  end
+
+  def build_streaming_presenter json, phase1: false, response_name: STANDARD_RESPONSE_NAME
+    klass = Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::StreamingResponseHandling
+    proto = build_proto_fragment klass, json if json
+    Gapic::Presenters::SnippetPresenter::StreamingResponseHandlingPresenter.new \
+      proto, json, response_name: response_name, base_response_type: RESPONSE_TYPE, phase1: phase1
+  end
+
+  def build_paginated_presenter json, phase1: false
+    klass = Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Snippet::PaginatedResponseHandling
+    proto = build_proto_fragment klass, json if json
+    Gapic::Presenters::SnippetPresenter::PaginatedResponseHandlingPresenter.new \
+      proto, json, paged_response_type: RESPONSE_TYPE, phase1: phase1
+  end
+
+  def test_simple_phase1
+    presenter = build_simple_presenter nil, phase1: true
+    expected = [
+      "# The returned object is of type #{RESPONSE_TYPE}.",
+      "p #{STANDARD_RESPONSE_NAME}"
+    ]
+    assert_equal expected, presenter.render_lines
+    assert_equal "result", presenter.response_name
+  end
+
+  def test_simple_with_no_handling
+    json = {}
+    presenter = build_simple_presenter json
+    assert_empty presenter.render_lines
+    assert_nil presenter.response_name
+  end
+
+  def test_simple_with_default_handling
+    json = {"responseName" => "response"}
+    presenter = build_simple_presenter json
+    assert_empty presenter.render_lines
+    assert_equal "response", presenter.response_name
+  end
+
+  def test_lro_phase1
+    presenter = build_lro_presenter nil, phase1: true
+    expected = [
+      "# The returned object is of type Gapic::Operation. You can use it to",
+      "# check the status of an operation, cancel it, or wait for results.",
+      "# Here is how to wait for a response.",
+      "result.wait_until_done! timeout: 60",
+      "if result.response?",
+      "  p result.response",
+      "else",
+      '  puts "No response received."',
+      "end"
+    ]
+    assert_equal expected, presenter.render_lines
+    assert_equal "result", presenter.response_name
+  end
+
+  def test_lro_once
+    json = {
+      "responseName" => "lro",
+      "pollingType" => "ONCE"
+    }
+    presenter = build_lro_presenter json
+    expected = [
+      "if lro.response?",
+      "  p lro.response",
+      "else",
+      '  puts "Response not yet arrived."',
+      "end"
+    ]
+    assert_equal expected, presenter.render_lines
+    assert_equal "lro", presenter.response_name
+  end
+
+  def test_lro_until_completion
+    json = {
+      "responseName" => "lro",
+    }
+    presenter = build_lro_presenter json
+    expected = [
+      "lro.wait_until_done! timeout: 60",
+      "if lro.response?",
+      "  p lro.response",
+      "else",
+      '  puts "No response received."',
+      "end"
+    ]
+    assert_equal expected, presenter.render_lines
+    assert_equal "lro", presenter.response_name
+  end
+
+  def test_lro_no_poll
+    json = {
+      "responseName" => "lro",
+      "pollingType" => "NONE"
+    }
+    presenter = build_lro_presenter json
+    assert_empty presenter.render_lines
+    assert_equal "lro", presenter.response_name
+  end
+
+  def test_streaming_phase1
+    presenter = build_streaming_presenter nil, phase1: true
+    expected = [
+      "# The returned object is a streamed enumerable yielding elements of type",
+      "# #{RESPONSE_TYPE}",
+      "result.each do |current_response|",
+      "  p current_response",
+      "end"
+    ]
+    assert_equal expected, presenter.render_lines
+    assert_equal "result", presenter.response_name
+  end
+
+  def test_streaming_with_statements
+    json = {
+      "currentResponseName" => "item",
+      "perStreamResponseStatements" => [
+        {
+          "standardOutput" => {
+            "value" => {
+              "nameValue" => {
+                "name" => "item",
+                "path" => ["address"]
+              }
+            }
+          }
+        }
+      ]
+    }
+    presenter = build_streaming_presenter json, response_name: "server_stream"
+    expected = [
+      "server_stream.each do |item|",
+      "  puts(item.address)",
+      "end"
+    ]
+    assert_equal expected, presenter.render_lines
+    assert_equal "server_stream", presenter.response_name
+  end
+
+  def test_paginated_phase1
+    presenter = build_paginated_presenter nil, phase1: true
+    expected = [
+      "# The returned object is of type Gapic::PagedEnumerable. You can iterate",
+      "# over elements, and API calls will be issued to fetch pages as needed.",
+      "result.each do |item|",
+      "  # Each element is of type #{RESPONSE_TYPE}.",
+      "  p item",
+      "end"
+    ]
+    assert_equal expected, presenter.render_lines
+    assert_equal "result", presenter.response_name
+  end
+
+  def test_paginated_by_item
+    json = {
+      "responseName" => "elements",
+      "byItem" => {
+        "itemName" => "elem",
+        "perItemStatements" => [
+          "standardOutput" => {
+            "value" => {
+              "nameValue" => {
+                "name" => "elem",
+                "path" => ["address"]
+              }
+            }
+          }
+        ]
+      }
+    }
+    presenter = build_paginated_presenter json
+    expected = [
+      "elements.each do |elem|",
+      "  puts(elem.address)",
+      "end"
+    ]
+    assert_equal expected, presenter.render_lines
+    assert_equal "elements", presenter.response_name
+  end
+
+  def test_paginated_by_page
+    json = {
+      "responseName" => "pages",
+      "byPage" => {
+        "pageName" => "page",
+        "perPageStatements" => [
+          "standardOutput" => {
+            "value" => {
+              "stringValue" => "Got new page."
+            }
+          }
+        ],
+        "byItem" => {
+          "itemName" => "elem",
+          "perItemStatements" => [
+            "standardOutput" => {
+              "value" => {
+                "nameValue" => {
+                  "name" => "elem",
+                  "path" => ["address"]
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+    presenter = build_paginated_presenter json
+    expected = [
+      "pages.each_page do |page|",
+      '  puts("Got new page.")',
+      "  page.each do |elem|",
+      "    puts(elem.address)",
+      "  end",
+      "end"
+    ]
+    assert_equal expected, presenter.render_lines
+    assert_equal "pages", presenter.response_name
+  end
+end

--- a/gapic-generator/test/gapic/presenters/snippet/snippet_test_helper.rb
+++ b/gapic-generator/test/gapic/presenters/snippet/snippet_test_helper.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "active_support/inflector"
+
+module SnippetTestHelper
+  def build_proto_fragment klass, json
+    return nil if json.nil?
+    klass.new underscore_keys json
+  end
+
+  def underscore_keys input
+    case input
+    when Hash
+      input.to_h { |key, value| [ActiveSupport::Inflector.underscore(key), underscore_keys(value)] }
+    when Array
+      input.map { |elem| underscore_keys elem }
+    else
+      input
+    end
+  end
+end

--- a/gapic-generator/test/gapic/presenters/snippet/statement_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/snippet/statement_presenter_test.rb
@@ -1,0 +1,301 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require_relative "snippet_test_helper"
+require "gapic/presenters/snippet/statement_presenter"
+
+class StatementPresenterTest < PresenterTest
+  include SnippetTestHelper
+
+  def build_statement_presenter json
+    proto = build_proto_fragment Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Statement, json
+    Gapic::Presenters::SnippetPresenter::StatementPresenter.new proto, json
+  end
+
+  def test_no_json
+    presenter = build_statement_presenter nil
+    expected = [
+      "# Unknown statement omitted here."
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_declaration_simple
+    json = {
+      "declaration" => {
+        "name" => "greeting",
+        "value" => {
+          "stringValue" => "Hello, world!"
+        }
+      }
+    }
+    presenter = build_statement_presenter json
+    expected = [
+      'greeting = "Hello, world!"'
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_declaration_complex
+    json = {
+      "declaration" => {
+        "name" => "message",
+        "value" => {
+          "complexValue" => {
+            "properties" => {
+              "name" => {
+                "stringValue" => "Jane Doe"
+              },
+              "age" => {
+                "numberValue" => 21
+              }
+            }
+          }
+        },
+        "description" => "Initialize the value"
+      }
+    }
+    presenter = build_statement_presenter json
+    expected = [
+      "# Initialize the value",
+      "message = {",
+      '  name: "Jane Doe",',
+      "  age: 21",
+      "}"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_stdout_variable
+    json = {
+      "standardOutput" => {
+        "value" => {
+          "nameValue" => {
+            "name" => "message",
+            "path" => ["foo", "bar"]
+          }
+        }
+      }
+    }
+    presenter = build_statement_presenter json
+    expected = [
+      "puts(message.foo.bar)"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_stdout_complex
+    json = {
+      "standardOutput" => {
+        "value" => {
+          "complexValue" => {
+            "properties" => {
+              "name" => {
+                "stringValue" => "Jane Doe"
+              },
+              "age" => {
+                "numberValue" => 21
+              }
+            }
+          }
+        }
+      }
+    }
+    presenter = build_statement_presenter json
+    expected = [
+      "puts(",
+      "  {",
+      '    name: "Jane Doe",',
+      "    age: 21",
+      "  }",
+      ")"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_return_nil
+    json = {
+      "return" => {
+        "result" => {
+          "nullValue" => "NULL_VALUE"
+        }
+      }
+    }
+    presenter = build_statement_presenter json
+    expected = [
+      "return nil"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_return_complex
+    json = {
+      "return" => {
+        "result" => {
+          "complexValue" => {
+            "properties" => {
+              "name" => {
+                "stringValue" => "Jane Doe"
+              },
+              "age" => {
+                "numberValue" => 21
+              }
+            }
+          }
+        }
+      }
+    }
+    presenter = build_statement_presenter json
+    expected = [
+      "return {",
+      '  name: "Jane Doe",',
+      "  age: 21",
+      "}"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_conditional_true_only
+    json = {
+      "conditional" => {
+        "condition" => {
+          "nameValue" => {
+            "name" => "object",
+            "path" => ["is_active"]
+          }
+        },
+        "onTrue" => [
+          {
+            "standardOutput" => {
+              "value" => {
+                "stringValue" => "Active!"
+              }
+            }
+          },
+          {
+            "return" => {
+              "result" => {
+                "booleanValue" => true
+              }
+            }
+          }
+        ]
+      }
+    }
+    presenter = build_statement_presenter json
+    expected = [
+      "if object.is_active",
+      '  puts("Active!")',
+      "  return true",
+      "end"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_conditional_false_only
+    json = {
+      "conditional" => {
+        "condition" => {
+          "nameValue" => {
+            "name" => "object",
+            "path" => ["is_active"]
+          }
+        },
+        "onFalse" => [
+          {
+            "standardOutput" => {
+              "value" => {
+                "stringValue" => "Dormant!"
+              }
+            }
+          },
+          {
+            "return" => {
+              "result" => {
+                "booleanValue" => false
+              }
+            }
+          }
+        ]
+      }
+    }
+    presenter = build_statement_presenter json
+    expected = [
+      "unless object.is_active",
+      '  puts("Dormant!")',
+      "  return false",
+      "end"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+
+  def test_conditional_both_branches
+    json = {
+      "conditional" => {
+        "condition" => {
+          "nameValue" => {
+            "name" => "object",
+            "path" => ["is_active"]
+          }
+        },
+        "onTrue" => [
+          {
+            "standardOutput" => {
+              "value" => {
+                "stringValue" => "Active!"
+              }
+            }
+          },
+          {
+            "return" => {
+              "result" => {
+                "booleanValue" => true
+              }
+            }
+          }
+        ],
+        "onFalse" => [
+          {
+            "standardOutput" => {
+              "value" => {
+                "stringValue" => "Dormant!"
+              }
+            }
+          },
+          {
+            "return" => {
+              "result" => {
+                "booleanValue" => false
+              }
+            }
+          }
+        ]
+      }
+    }
+    presenter = build_statement_presenter json
+    expected = [
+      "if object.is_active",
+      '  puts("Active!")',
+      "  return true",
+      "else",
+      '  puts("Dormant!")',
+      "  return false",
+      "end"
+    ]
+    assert_equal expected, presenter.render_lines
+  end
+end

--- a/gapic-generator/test/gapic/presenters/snippet/type_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/snippet/type_presenter_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require_relative "snippet_test_helper"
+require "gapic/presenters/snippet/type_presenter"
+
+class TypePresenterTest < PresenterTest
+  include SnippetTestHelper
+
+  def build_type_presenter json
+    proto = build_proto_fragment Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Type, json
+    Gapic::Presenters::SnippetPresenter::TypePresenter.new proto, json
+  end
+
+  def test_no_json
+    presenter = build_type_presenter nil
+    assert_equal "Object", presenter.render
+  end
+
+  def test_scalar_float
+    json = {"scalarType" => "TYPE_FLOAT"}
+    presenter = build_type_presenter json
+    assert_equal "Float", presenter.render
+  end
+
+  def test_scalar_integer
+    json = {"scalarType" => "TYPE_UINT64"}
+    presenter = build_type_presenter json
+    assert_equal "Integer", presenter.render
+  end
+
+  def test_scalar_string
+    json = {"scalarType" => "TYPE_STRING"}
+    presenter = build_type_presenter json
+    assert_equal "String", presenter.render
+  end
+
+  def test_bytes
+    json = {"bytesType" => {"languageEquivalent" => "BASE64"}}
+    presenter = build_type_presenter json
+    assert_equal "String", presenter.render
+  end
+
+  def test_message_string
+    json = {"messageType" => {"messageFullName" => "google.cloud.snippetgen.data.RubyCode"}}
+    presenter = build_type_presenter json
+    assert_equal "Google::Cloud::Snippetgen::Data::RubyCode", presenter.render
+  end
+
+  def test_enum_string
+    json = {"enumType" => {"enumFullName" => "google.cloud.snippetgen.data.LanguageName"}}
+    presenter = build_type_presenter json
+    assert_equal "Google::Cloud::Snippetgen::Data::LanguageName", presenter.render
+  end
+
+  def test_repeated_scalar
+    json = {
+      "repeatedType" => {
+        "elementType" => {
+          "scalarType" => "TYPE_STRING"
+        },
+        "languageEquivalent" => "ARRAY"
+      }
+    }
+    presenter = build_type_presenter json
+    assert_equal "Array<String>", presenter.render
+  end
+
+  def test_repeated_message
+    json = {
+      "repeatedType" => {
+        "elementType" => {
+          "messageType" => {
+            "messageFullName" => "google.cloud.snippetgen.data.RubyCode"
+          }
+        },
+        "languageEquivalent" => "LIST"
+      }
+    }
+    presenter = build_type_presenter json
+    assert_equal "Array<Google::Cloud::Snippetgen::Data::RubyCode>", presenter.render
+  end
+
+  def test_map
+    json = {
+      "mapType" => {
+        "keyType" => {
+          "scalarType" => "TYPE_STRING"
+        },
+        "valueType" => {
+          "messageType" => {
+            "messageFullName" => "google.cloud.snippetgen.data.RubyCode"
+          }
+        },
+        "languageEquivalent" => "DICTIONARY"
+      }
+    }
+    presenter = build_type_presenter json
+    assert_equal "Hash{String=>Google::Cloud::Snippetgen::Data::RubyCode}", presenter.render
+  end
+end


### PR DESCRIPTION
This is the "core" of the Ruby snippetgen phase2 implementation, a series of classes that interpret snippetgen configuration and generate snippets of code.

Each class takes as input a proto object, and the corresponding JSON source, and generally provides a `render` and/or `render_lines` method to get the code rendering. The JSON is needed, unfortunately, because the Ruby generator currently uses a third-party proto implementation that doesn't fully understand oneof, and we need the original JSON to fully disambiguate which choice is made.

In this PR, these classes are unit tested, but the main pipeline does not use them yet.

Note: until #890 is merged, the first 4 commits are part of #890 and should be ignored.

The remaining commits implement the following, in order. Each commit is self-contained with its tests; it is probably easiest to look at each commit in isolation.
1. A presenter for types. This is only used in the documentation generated in snippets, as Ruby doesn't have static types otherwise. All types are supported with a few corner-case caveats.
2. A presenter for expressions. Currently, literals, null, NameValue, and ComplexValue are supported, but the other types are not yet.
3. A presenter for statements. Most statement types are currently supported, except for Iteration.
4. A presenter for ClientInitialization. This should be code complete.
5. Presenters for SimpleRequestInitialization and StreamingRequestInitialization. Simple is complete, but streaming is a stub because Iteration is not yet implemented.
6. Presenters for response handling. These are mostly complete, except for Paginated.NextPageToken, and Lro.PollingCall.
7. A presenter for ClientCall. This is code complete.

One final note, these are still implemented in our presentation layer, pending a refactor to separate model logic from presentation logic that is scheduled for next year. However, I've been able to decouple them almost completely from the other presenters, so a later move to the model layer should be fairly straightforward.