### PR TITLE
feat: Reimplement snippetgen phase 1 using phase 2

### DIFF
--- a/gapic-generator/lib/gapic/package_snippets.rb
+++ b/gapic-generator/lib/gapic/package_snippets.rb
@@ -90,8 +90,8 @@ module Gapic
     def build_snippet_object snippet_presenter, method_presenter, service_presenter, snippet_lines
       SnippetIndex::Snippet.new(
         region_tag: snippet_presenter.region_tag,
-        title: "Snippet for #{method_presenter.name} in #{service_presenter.module_name}",
-        description: "Basic snippet for #{method_presenter.name} in #{service_presenter.module_name}",
+        title: snippet_presenter.snippet_name,
+        description: snippet_presenter.description,
         file: snippet_presenter.snippet_file_path,
         language: "RUBY",
         client_method: build_client_method_object(method_presenter, service_presenter),

--- a/gapic-generator/lib/gapic/presenters/snippet/parameter_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/snippet/parameter_presenter.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "active_support/inflector"
+require "google/cloud/tools/snippetgen/configlanguage/v1/snippet_config_language.pb"
+require "gapic/presenters/snippet/expression_presenter"
+require "gapic/presenters/snippet/type_presenter"
+
+module Gapic
+  module Presenters
+    class SnippetPresenter
+      ##
+      # Presentation information about a snippet method parameter
+      #
+      class ParameterPresenter
+        ##
+        # Create an expression presenter.
+        #
+        # @param proto [Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Statement::Declaration]
+        #     The protobuf representation of the parameter
+        # @param json [String]
+        #     The JSON representation of the parameter
+        #
+        def initialize proto, json
+          @name = proto.name
+          @description = proto.description
+          @description = nil if @description&.empty?
+          @type = TypePresenter.new proto&.type, json&.fetch("type", nil)
+          @example = ExpressionPresenter.new proto&.value, json&.fetch("value", nil)
+        end
+
+        ##
+        # The name of this parameter
+        # @return [String]
+        #
+        attr_reader :name
+
+        ##
+        # A description of this parameter, or nil if none.
+        # @return [String,nil]
+        #
+        attr_reader :description
+
+        ##
+        # The type of this parameter, as a presenter.
+        # @return [Gapic::Presenters::SnippetPresenter::TypePresenter]
+        #
+        attr_reader :type
+
+        ##
+        # The default/example value for this parameter, as a presenter.
+        # @return [Gapic::Presenters::SnippetPresenter::ExpressionPresenter]
+        #
+        attr_reader :example
+      end
+    end
+  end
+end

--- a/gapic-generator/lib/gapic/presenters/snippet_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/snippet_presenter.rb
@@ -15,6 +15,14 @@
 # limitations under the License.
 
 require "active_support/inflector"
+require "google/cloud/tools/snippetgen/configlanguage/v1/snippet_config_language.pb"
+require "gapic/presenters/snippet/client_call_presenter"
+require "gapic/presenters/snippet/client_initialization_presenter"
+require "gapic/presenters/snippet/expression_presenter"
+require "gapic/presenters/snippet/request_initialization_presenters"
+require "gapic/presenters/snippet/response_handling_presenters"
+require "gapic/presenters/snippet/statement_presenter"
+require "gapic/presenters/snippet/type_presenter"
 
 module Gapic
   module Presenters
@@ -22,17 +30,25 @@ module Gapic
     # A presenter for snippets.
     #
     class SnippetPresenter
-      def initialize method_presenter, api
+      def initialize method_presenter, api, config = nil
         @method_presenter = method_presenter
         @api = api
+        @config = config
+        analyze_config
+      end
+
+      attr_reader :config
+
+      def config?
+        !config.nil?
       end
 
       def client_streaming?
         @method_presenter.client_streaming?
       end
 
-      def bidi_streaming?
-        @method_presenter.client_streaming? && @method_presenter.server_streaming?
+      def server_streaming?
+        @method_presenter.server_streaming?
       end
 
       def response_kind
@@ -48,7 +64,7 @@ module Gapic
       end
 
       def snippet_file_path
-        "#{@method_presenter.service.service_require.split('/').last}/#{@method_presenter.name}.rb"
+        "#{@method_presenter.service.service_require.split('/').last}/#{snippet_method_name}.rb"
       end
 
       def require_path
@@ -82,6 +98,25 @@ module Gapic
         @method_presenter.name
       end
 
+      def snippet_method_name
+        config? ? "#{method_name}_#{snake_config_id}" : method_name
+      end
+
+      def snippet_name
+        @config&.metadata&.snippet_name
+      end
+
+      def description
+        @config&.metadata&.snippet_description ||
+          "Example demonstrating basic usage of #{client_type}##{method_name}"
+      end
+
+      attr_reader :client_initialization
+      attr_reader :request_initialization
+      attr_reader :client_call
+      attr_reader :response_handling
+      attr_reader :final_statements
+
       def region_tag
         gem_presenter = @method_presenter.service.gem
         api_id = gem_presenter.api_shortname || gem_presenter.api_id&.split(".")&.first
@@ -97,7 +132,122 @@ module Gapic
         api_id = api_id.downcase.gsub(/[^a-z0-9]/, "")
         service_name = @method_presenter.service.module_name
         method_name = @method_presenter.method.name
-        "#{api_id}_#{api_version}_generated_#{service_name}_#{method_name}_sync"
+        type = config? ? "config" : "generated"
+        config_id = config? ? "#{@config.metadata.config_id}_" : ""
+        "#{api_id}_#{api_version}_#{type}_#{service_name}_#{method_name}_#{config_id}sync"
+      end
+
+      private
+
+      def analyze_config
+        snippet_proto, snippet_json = snippet_proto_info
+        call_proto, call_json = call_proto_info snippet_proto, snippet_json
+        @client_initialization = build_client_initialization_presenter snippet_proto, snippet_json
+        @request_initialization = build_request_initialization_presenter call_proto, call_json
+        @response_handling = build_response_handling_presenter call_proto, call_json
+        @client_call = build_client_call_presenter call_proto, call_json,
+                                                   @request_initialization.request_name,
+                                                   @response_handling.response_name
+        @final_statements = build_final_statements snippet_proto, snippet_json
+      end
+
+      def snippet_proto_info
+        [@config&.snippet, @config&.json_representation&.fetch("snippet", nil)]
+      end
+
+      def call_proto_info snippet_proto, snippet_json
+        if snippet_proto&.standard
+          [snippet_proto.standard, snippet_json["standard"]]
+        elsif snippet_proto&.paginated
+          [snippet_proto.paginated, snippet_json["paginated"]]
+        elsif snippet_proto&.lro
+          [snippet_proto.lro, snippet_json["lro"]]
+        elsif snippet_proto&.server_streaming
+          [snippet_proto.server_streaming, snippet_json["serverStreaming"]]
+        elsif snippet_proto&.client_streaming
+          [snippet_proto.client_streaming, snippet_json["clientStreaming"]]
+        elsif snippet_proto&.bidi_streaming
+          [snippet_proto.bidi_streaming, snippet_json["bidiStreaming"]]
+        else
+          [nil, nil]
+        end
+      end
+
+      def build_client_initialization_presenter snippet_proto, snippet_json
+        ClientInitializationPresenter.new snippet_proto&.service_client_initialization,
+                                          snippet_json&.fetch("serviceClientInitialization", nil),
+                                          phase1: !config?, client_type: client_type
+      end
+
+      def build_request_initialization_presenter call_proto, call_json
+        phase1 = !config?
+        request_init_proto = call_proto&.request_initialization
+        request_init_json = call_json&.fetch "requestInitialization", nil
+        if client_streaming?
+          request_name = phase1 ? "input" : call_proto.client_stream_name
+          StreamingRequestInitializationPresenter.new request_init_proto, request_init_json,
+                                                      request_name: request_name, request_type: request_type,
+                                                      phase1: phase1
+        else
+          SimpleRequestInitializationPresenter.new request_init_proto, request_init_json,
+                                                   request_type: request_type, phase1: phase1
+        end
+      end
+
+      def build_response_handling_presenter call_proto, call_json
+        phase1 = !config?
+        case response_kind
+        when :paged
+          PaginatedResponseHandlingPresenter.new call_proto&.paginated_handling,
+                                                 call_json&.fetch("paginatedHandling", nil),
+                                                 paged_response_type: paged_response_type, phase1: phase1
+        when :lro
+          LroResponseHandlingPresenter.new call_proto&.lro_handling,
+                                           call_json&.fetch("lroHandling", nil),
+                                           phase1: phase1
+        when :streaming
+          response_name = phase1 ? "output" : call_proto&.server_stream_name
+          response_name = nil if response_name == ""
+          StreamingResponseHandlingPresenter.new call_proto&.response_handling,
+                                                 call_json&.fetch("responseHandling", nil),
+                                                 response_name: response_name, base_response_type: base_response_type,
+                                                 phase1: phase1
+        else
+          SimpleResponseHandlingPresenter.new call_proto&.response_handling,
+                                              call_json&.fetch("responseHandling", nil),
+                                              response_type: return_type, phase1: phase1
+        end
+      end
+
+      def build_client_call_presenter call_proto, call_json, request_name, response_name
+        phase1 = !config?
+        if response_kind == :paged
+          ClientCallPresenter.new call_proto&.paginated_call, call_json&.fetch("paginatedCall", nil),
+                                  method_name: method_name, request_name: request_name, response_name: response_name,
+                                  client_streaming: client_streaming?, server_streaming: server_streaming?,
+                                  phase1: phase1
+        elsif client_streaming? || server_streaming?
+          ClientCallPresenter.new call_proto&.initialization_call, call_json&.fetch("initializationCall", nil),
+                                  method_name: method_name, request_name: request_name, response_name: response_name,
+                                  client_streaming: client_streaming?, server_streaming: server_streaming?,
+                                  phase1: phase1
+        else
+          ClientCallPresenter.new call_proto&.call, call_json&.fetch("call", nil),
+                                  method_name: method_name, request_name: request_name, response_name: response_name,
+                                  client_streaming: false, server_streaming: false, phase1: phase1
+        end
+      end
+
+      def build_final_statements snippet_proto, snippet_json
+        return [] unless snippet_proto&.final_statements
+        snippet_proto.final_statements.each_with_index.map do |statement_proto, index|
+          statement_json = snippet_json["finalStatements"][index]
+          StatementPresenter.new statement_proto, statement_json
+        end
+      end
+
+      def snake_config_id
+        ActiveSupport::Inflector.underscore @config.metadata.config_id
       end
     end
   end

--- a/gapic-generator/templates/default/helpers/default_helper.rb
+++ b/gapic-generator/templates/default/helpers/default_helper.rb
@@ -34,6 +34,25 @@ module DefaultHelper
     ret.split("\n").map(&:rstrip).join("\n")
   end
 
+  def wrap input, max_width
+    lines = []
+    input.split("\n").each do |line|
+      cur_width = 0
+      cur_words = []
+      line.split.each do |word|
+        if cur_width.positive? && cur_width + word.length > max_width
+          lines << cur_words.join(" ")
+          cur_width = 0
+          cur_words = []
+        end
+        cur_words << word
+        cur_width += word.length + 1
+      end
+      lines << cur_words.join(" ") if cur_width.positive?
+    end
+    lines.join "\n"
+  end
+
   def indent_tail input, spacing
     return input if input.lines.count < 2
 

--- a/gapic-generator/templates/default/snippets/snippet/_body.erb
+++ b/gapic-generator/templates/default/snippets/snippet/_body.erb
@@ -1,69 +1,24 @@
 <%- assert_locals snippet -%>
-# Create a client object. The client can be reused for multiple calls.
-client = <%= snippet.client_type %>.new
+<%- unless snippet.client_initialization.render.empty? -%>
+<%= snippet.client_initialization.render %>
 
-<%- if snippet.bidi_streaming? -%>
-# Create an input stream
-input = Gapic::StreamInput.new
-
-# Call the <%= snippet.method_name %> method to start streaming.
-output = client.<%= snippet.method_name %> input
-
-# Send requests on the stream. For each request, pass in keyword
-# arguments to set fields. Be sure to close the stream when done.
-input << <%= snippet.request_type %>.new
-input << <%= snippet.request_type %>.new
-input.close
-
-# Handle streamed responses. These may be interleaved with inputs.
-# Each response is of type <%= snippet.base_response_type %>.
-output.each do |response|
-  p response
-end
-<%- else -%>
-<%- if snippet.client_streaming? -%>
-# Create a stream of requests, as an Enumerator.
-# For each request, pass in keyword arguments to set fields.
-request = [
-  <%= snippet.request_type %>.new,
-  <%= snippet.request_type %>.new
-].to_enum
-<%- else -%>
-# Create a request. To set request fields, pass in keyword arguments.
-request = <%= snippet.request_type %>.new
 <%- end -%>
+<%- unless snippet.request_initialization.render_precall.empty? -%>
+<%= snippet.request_initialization.render_precall %>
 
-# Call the <%= snippet.method_name %> method.
-result = client.<%= snippet.method_name %> request
+<%- end -%>
+<%= snippet.client_call.render %>
+<%- unless snippet.request_initialization.render_postcall.empty? -%>
 
-<%- case snippet.response_kind -%>
-<%- when :lro -%>
-# The returned object is of type Gapic::Operation. You can use this
-# object to check the status of an operation, cancel it, or wait
-# for results. Here is how to block until completion:
-result.wait_until_done! timeout: 60
-if result.response?
-  p result.response
-else
-  puts "Error!"
-end
-<%- when :paged -%>
-# The returned object is of type Gapic::PagedEnumerable. You can
-# iterate over all elements by calling #each, and the enumerable
-# will lazily make API calls to fetch subsequent pages. Other
-# methods are also available for managing paging directly.
-result.each do |response|
-  # Each element is of type <%= snippet.paged_response_type %>.
-  p response
-end
-<%- when :streaming -%>
-# The returned object is a streamed enumerable yielding elements of
-# type <%= snippet.base_response_type %>.
-result.each do |response|
-  p response
-end
-<%- else -%>
-# The returned object is of type <%= snippet.return_type %>.
-p result
+<%= snippet.request_initialization.render_postcall %>
+<%- end -%>
+<%- unless snippet.response_handling.render.empty? -%>
+
+<%= snippet.response_handling.render %>
+<%- end -%>
+<%- unless snippet.final_statements.empty? -%>
+
+<%- snippet.final_statements.each do |statement| -%>
+<%= statement.render %>
 <%- end -%>
 <%- end -%>

--- a/gapic-generator/templates/default/snippets/snippet/_inline.erb
+++ b/gapic-generator/templates/default/snippets/snippet/_inline.erb
@@ -1,4 +1,11 @@
 <%- assert_locals snippet -%>
 require "<%= snippet.require_path %>"
+<%- snippet.snippet_method_parameters.each do |param| -%>
+
+<%- if param.description -%>
+<%= indent wrap(param.description, 78), "# " %>
+<%- end -%>
+# <%= param.name %> = <%= param.example.exist? ? param.example.render : "..." %>
+<%- end -%>
 
 <%= render partial: "snippets/snippet/body", locals: { snippet: snippet} -%>

--- a/gapic-generator/templates/default/snippets/snippet/_standalone.erb
+++ b/gapic-generator/templates/default/snippets/snippet/_standalone.erb
@@ -2,9 +2,22 @@
 require "<%= snippet.require_path %>"
 
 ##
-# Example demonstrating basic usage of
-# <%= snippet.client_type %>#<%= snippet.method_name %>
+# <%= snippet.snippet_name %>
 #
-def <%= snippet.method_name %>
+<%= indent wrap(snippet.description, 78), "# " %>
+<%- unless snippet.snippet_method_parameters.empty? -%>
+#
+<%- end -%>
+<%- snippet.snippet_method_parameters.each do |param| -%>
+# @param <%= param.name %> [<%= param.type.render %>]
+<%- if param.description -%>
+<%= indent wrap(param.description, 74), "#     " %>
+<%- end -%>
+<%- if param.example.exist? -%>
+#     (Example: `<%= param.example.render %>`)
+<%- end -%>
+<%- end -%>
+#
+def <%= snippet.snippet_method_name %><%= snippet.snippet_method_parameters_render %>
 <%= indent render(partial: "snippets/snippet/body", locals: { snippet: snippet }), "  " %>
 end

--- a/gapic-generator/test/gapic/helpers/default_helper_test.rb
+++ b/gapic-generator/test/gapic/helpers/default_helper_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require_relative "../../../templates/default/helpers/default_helper"
+
+class DefaultHelperTest < Minitest::Test
+  class HelperClass
+    include DefaultHelper
+  end
+
+  def helper_object
+    HelperClass.new
+  end
+
+  def test_wrap_empty_string
+    result = helper_object.wrap "", 80
+    assert_equal "", result
+  end
+
+  def test_wrap_one_line_string
+    result = helper_object.wrap "hello world", 80
+    assert_equal "hello world", result
+  end
+
+  def test_wrap_two_line_string
+    result = helper_object.wrap "hello world ruby rules", 11
+    assert_equal "hello world\nruby rules", result
+  end
+
+  def test_wrap_line_threshold
+    result = helper_object.wrap "hello world ruby rules", 10
+    assert_equal "hello\nworld ruby\nrules", result
+  end
+
+  def test_wrap_long_lines
+    result = helper_object.wrap "hi ya rubyyyyyyy rules", 8
+    assert_equal "hi ya\nrubyyyyyyy\nrules", result
+  end
+
+  def test_wrap_with_line_breaks
+    result = helper_object.wrap "hello world\nruby rules", 10
+    assert_equal "hello\nworld\nruby rules", result
+  end
+end

--- a/gapic-generator/test/gapic/package_snippets_test.rb
+++ b/gapic-generator/test/gapic/package_snippets_test.rb
@@ -21,7 +21,7 @@ require "google/protobuf/compiler/plugin.pb"
 describe Gapic::PackageSnippets do
   FakeServicePresenter = Struct.new :client_name, :client_name_full, :grpc_full_name, :module_name, :name
   FakeMethodPresenter = Struct.new :grpc_full_name, :grpc_name, :name, :request_type, :return_type, :service
-  FakeSnippetPresenter = Struct.new :region_tag, :service, :snippet_file_path
+  FakeSnippetPresenter = Struct.new :description, :region_tag, :service, :snippet_file_path, :snippet_name
 
   let(:proto_package) { "google.snippetstest.v1" }
   let(:gem_name) { "google-snippets_test-v1" }
@@ -41,6 +41,10 @@ describe Gapic::PackageSnippets do
   let(:region_tag2) { "snippettest_v1_generated_SnippetService_SetFoo_sync" }
   let(:snippet_file_path1) { "snippet_service/get_foo.rb" }
   let(:snippet_file_path2) { "snippet_service/set_foo.rb" }
+  let(:description1) { "get_foo description" }
+  let(:description2) { "set_foo description" }
+  let(:snippet_name1) { "get_foo name" }
+  let(:snippet_name2) { "set_foo name" }
   let(:snippet_file_fullpath1) { "snippets/#{snippet_file_path1}" }
   let(:snippet_file_fullpath2) { "snippets/#{snippet_file_path2}" }
   let(:service_client_name) { "Client" }
@@ -56,10 +60,10 @@ describe Gapic::PackageSnippets do
     FakeMethodPresenter.new method_protoname_full2, method_protoname2, method_name2, request_type2, return_type, service_presenter
   end
   let(:snippet_presenter1) do
-    FakeSnippetPresenter.new region_tag1, service_presenter, snippet_file_path1
+    FakeSnippetPresenter.new description1, region_tag1, service_presenter, snippet_file_path1, snippet_name1
   end
   let(:snippet_presenter2) do
-    FakeSnippetPresenter.new region_tag2, service_presenter, snippet_file_path2
+    FakeSnippetPresenter.new description2, region_tag2, service_presenter, snippet_file_path2, snippet_name2
   end
   let(:snippet_content1) do
     <<~CONTENT
@@ -127,8 +131,8 @@ describe Gapic::PackageSnippets do
       "snippets" => [
         {
           "region_tag" => region_tag1,
-          "title" => "Snippet for #{method_name1} in #{service_module_name}",
-          "description" => "Basic snippet for #{method_name1} in #{service_module_name}",
+          "title" => snippet_name1,
+          "description" => description1,
           "file" => snippet_file_path1,
           "language" => "RUBY",
           "client_method" => {
@@ -167,8 +171,8 @@ describe Gapic::PackageSnippets do
         },
         {
           "region_tag" => region_tag2,
-          "title" => "Snippet for #{method_name2} in #{service_module_name}",
-          "description" => "Basic snippet for #{method_name2} in #{service_module_name}",
+          "title" => snippet_name2,
+          "description" => description2,
           "file" => snippet_file_path2,
           "language" => "RUBY",
           "client_method" => {

--- a/gapic-generator/test/gapic/presenters/snippet/parameter_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/snippet/parameter_presenter_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require_relative "snippet_test_helper"
+require "gapic/presenters/snippet/parameter_presenter"
+
+class ParameterPresenterTest < PresenterTest
+  include SnippetTestHelper
+
+  def build_parameter_presenter json
+    proto = build_proto_fragment Google::Cloud::Tools::Snippetgen::Configlanguage::V1::Statement::Declaration, json
+    Gapic::Presenters::SnippetPresenter::ParameterPresenter.new proto, json
+  end
+
+  def test_trivial
+    json = {"name" => "parent"}
+    presenter = build_parameter_presenter json
+    assert_equal "parent", presenter.name
+    assert_nil presenter.description
+    assert_equal "Object", presenter.type.render
+    refute presenter.example.exist?
+  end
+
+  def test_full
+    json = {
+      "name" => "parent",
+      "type" => {
+        "scalarType" => "TYPE_STRING"
+      },
+      "description" => "Name of the parent resource",
+      "value" => {
+        "stringValue" => "/projects/hello"
+      }
+    }
+    presenter = build_parameter_presenter json
+    assert_equal "parent", presenter.name
+    assert_equal "Name of the parent resource", presenter.description
+    assert_equal "String", presenter.type.render
+    assert_equal '"/projects/hello"', presenter.example.render
+  end
+end

--- a/shared/output/cloud/compute_small/snippets/addresses/aggregated_list.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/aggregated_list.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Addresses::Client#aggregated_list
+# Snippet for the aggregated_list call in the Addresses service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Addresses::Client#aggregated_list. It may require
+# modification in order to execute successfully.
 #
 def aggregated_list
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/addresses/delete.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/delete.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Addresses::Client#delete
+# Snippet for the delete call in the Addresses service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Addresses::Client#delete. It may require
+# modification in order to execute successfully.
 #
 def delete
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/addresses/get.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/get.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Addresses::Client#get
+# Snippet for the get call in the Addresses service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Addresses::Client#get. It may require modification
+# in order to execute successfully.
 #
 def get
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/addresses/insert.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/insert.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Addresses::Client#insert
+# Snippet for the insert call in the Addresses service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Addresses::Client#insert. It may require
+# modification in order to execute successfully.
 #
 def insert
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/addresses/list.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/list.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Addresses::Client#list
+# Snippet for the list call in the Addresses service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Addresses::Client#list. It may require
+# modification in order to execute successfully.
 #
 def list
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/global_operations/delete.rb
+++ b/shared/output/cloud/compute_small/snippets/global_operations/delete.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::GlobalOperations::Client#delete
+# Snippet for the delete call in the GlobalOperations service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::GlobalOperations::Client#delete. It may require
+# modification in order to execute successfully.
 #
 def delete
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/global_operations/get.rb
+++ b/shared/output/cloud/compute_small/snippets/global_operations/get.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::GlobalOperations::Client#get
+# Snippet for the get call in the GlobalOperations service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::GlobalOperations::Client#get. It may require
+# modification in order to execute successfully.
 #
 def get
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/networks/list_peering_routes.rb
+++ b/shared/output/cloud/compute_small/snippets/networks/list_peering_routes.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Networks::Client#list_peering_routes
+# Snippet for the list_peering_routes call in the Networks service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Networks::Client#list_peering_routes. It may
+# require modification in order to execute successfully.
 #
 def list_peering_routes
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/networks/remove_peering.rb
+++ b/shared/output/cloud/compute_small/snippets/networks/remove_peering.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Networks::Client#remove_peering
+# Snippet for the remove_peering call in the Networks service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::Networks::Client#remove_peering. It may require
+# modification in order to execute successfully.
 #
 def remove_peering
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/region_instance_group_managers/resize.rb
+++ b/shared/output/cloud/compute_small/snippets/region_instance_group_managers/resize.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Client#resize
+# Snippet for the resize call in the RegionInstanceGroupManagers service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Client#resize. It may
+# require modification in order to execute successfully.
 #
 def resize
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/region_operations/delete.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/delete.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::RegionOperations::Client#delete
+# Snippet for the delete call in the RegionOperations service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::RegionOperations::Client#delete. It may require
+# modification in order to execute successfully.
 #
 def delete
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/region_operations/get.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/get.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::RegionOperations::Client#get
+# Snippet for the get call in the RegionOperations service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::RegionOperations::Client#get. It may require
+# modification in order to execute successfully.
 #
 def get
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/region_operations/list.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/list.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::RegionOperations::Client#list
+# Snippet for the list call in the RegionOperations service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::RegionOperations::Client#list. It may require
+# modification in order to execute successfully.
 #
 def list
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/region_operations/wait.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/wait.rb
@@ -20,8 +20,11 @@
 require "google/cloud/compute/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Compute::V1::RegionOperations::Client#wait
+# Snippet for the wait call in the RegionOperations service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Compute::V1::RegionOperations::Client#wait. It may require
+# modification in order to execute successfully.
 #
 def wait
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/compute_small/snippets/snippet_metadata_google.cloud.compute.v1.json
+++ b/shared/output/cloud/compute_small/snippets/snippet_metadata_google.cloud.compute.v1.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "compute_v1_generated_Addresses_AggregatedList_sync",
-      "title": "Snippet for aggregated_list in Addresses",
-      "description": "Basic snippet for aggregated_list in Addresses",
+      "title": "Snippet for the aggregated_list call in the Addresses service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Client#aggregated_list. It may require modification in order to execute successfully.",
       "file": "addresses/aggregated_list.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "compute_v1_generated_Addresses_Delete_sync",
-      "title": "Snippet for delete in Addresses",
-      "description": "Basic snippet for delete in Addresses",
+      "title": "Snippet for the delete call in the Addresses service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Client#delete. It may require modification in order to execute successfully.",
       "file": "addresses/delete.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,15 +86,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "compute_v1_generated_Addresses_Get_sync",
-      "title": "Snippet for get in Addresses",
-      "description": "Basic snippet for get in Addresses",
+      "title": "Snippet for the get call in the Addresses service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Client#get. It may require modification in order to execute successfully.",
       "file": "addresses/get.rb",
       "language": "RUBY",
       "client_method": {
@@ -126,15 +126,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "compute_v1_generated_Addresses_Insert_sync",
-      "title": "Snippet for insert in Addresses",
-      "description": "Basic snippet for insert in Addresses",
+      "title": "Snippet for the insert call in the Addresses service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Client#insert. It may require modification in order to execute successfully.",
       "file": "addresses/insert.rb",
       "language": "RUBY",
       "client_method": {
@@ -166,15 +166,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "compute_v1_generated_Addresses_List_sync",
-      "title": "Snippet for list in Addresses",
-      "description": "Basic snippet for list in Addresses",
+      "title": "Snippet for the list call in the Addresses service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Client#list. It may require modification in order to execute successfully.",
       "file": "addresses/list.rb",
       "language": "RUBY",
       "client_method": {
@@ -206,15 +206,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "compute_v1_generated_RegionOperations_Delete_sync",
-      "title": "Snippet for delete in RegionOperations",
-      "description": "Basic snippet for delete in RegionOperations",
+      "title": "Snippet for the delete call in the RegionOperations service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionOperations::Client#delete. It may require modification in order to execute successfully.",
       "file": "region_operations/delete.rb",
       "language": "RUBY",
       "client_method": {
@@ -246,15 +246,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "compute_v1_generated_RegionOperations_Get_sync",
-      "title": "Snippet for get in RegionOperations",
-      "description": "Basic snippet for get in RegionOperations",
+      "title": "Snippet for the get call in the RegionOperations service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionOperations::Client#get. It may require modification in order to execute successfully.",
       "file": "region_operations/get.rb",
       "language": "RUBY",
       "client_method": {
@@ -286,15 +286,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "compute_v1_generated_RegionOperations_List_sync",
-      "title": "Snippet for list in RegionOperations",
-      "description": "Basic snippet for list in RegionOperations",
+      "title": "Snippet for the list call in the RegionOperations service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionOperations::Client#list. It may require modification in order to execute successfully.",
       "file": "region_operations/list.rb",
       "language": "RUBY",
       "client_method": {
@@ -326,15 +326,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "compute_v1_generated_RegionOperations_Wait_sync",
-      "title": "Snippet for wait in RegionOperations",
-      "description": "Basic snippet for wait in RegionOperations",
+      "title": "Snippet for the wait call in the RegionOperations service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionOperations::Client#wait. It may require modification in order to execute successfully.",
       "file": "region_operations/wait.rb",
       "language": "RUBY",
       "client_method": {
@@ -366,15 +366,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "compute_v1_generated_RegionInstanceGroupManagers_Resize_sync",
-      "title": "Snippet for resize in RegionInstanceGroupManagers",
-      "description": "Basic snippet for resize in RegionInstanceGroupManagers",
+      "title": "Snippet for the resize call in the RegionInstanceGroupManagers service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Client#resize. It may require modification in order to execute successfully.",
       "file": "region_instance_group_managers/resize.rb",
       "language": "RUBY",
       "client_method": {
@@ -406,15 +406,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "compute_v1_generated_Networks_ListPeeringRoutes_sync",
-      "title": "Snippet for list_peering_routes in Networks",
-      "description": "Basic snippet for list_peering_routes in Networks",
+      "title": "Snippet for the list_peering_routes call in the Networks service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Networks::Client#list_peering_routes. It may require modification in order to execute successfully.",
       "file": "networks/list_peering_routes.rb",
       "language": "RUBY",
       "client_method": {
@@ -446,15 +446,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "compute_v1_generated_Networks_RemovePeering_sync",
-      "title": "Snippet for remove_peering in Networks",
-      "description": "Basic snippet for remove_peering in Networks",
+      "title": "Snippet for the remove_peering call in the Networks service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Networks::Client#remove_peering. It may require modification in order to execute successfully.",
       "file": "networks/remove_peering.rb",
       "language": "RUBY",
       "client_method": {
@@ -486,15 +486,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "compute_v1_generated_GlobalOperations_Delete_sync",
-      "title": "Snippet for delete in GlobalOperations",
-      "description": "Basic snippet for delete in GlobalOperations",
+      "title": "Snippet for the delete call in the GlobalOperations service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::GlobalOperations::Client#delete. It may require modification in order to execute successfully.",
       "file": "global_operations/delete.rb",
       "language": "RUBY",
       "client_method": {
@@ -526,15 +526,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "compute_v1_generated_GlobalOperations_Get_sync",
-      "title": "Snippet for get in GlobalOperations",
-      "description": "Basic snippet for get in GlobalOperations",
+      "title": "Snippet for the get call in the GlobalOperations service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::GlobalOperations::Client#get. It may require modification in order to execute successfully.",
       "file": "global_operations/get.rb",
       "language": "RUBY",
       "client_method": {
@@ -566,7 +566,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/grafeas_v1/lib/grafeas/v1/grafeas/client.rb
+++ b/shared/output/cloud/grafeas_v1/lib/grafeas/v1/grafeas/client.rb
@@ -281,13 +281,11 @@ module Grafeas
         #   # Call the list_occurrences method.
         #   result = client.list_occurrences request
         #
-        #   # The returned object is of type Gapic::PagedEnumerable. You can
-        #   # iterate over all elements by calling #each, and the enumerable
-        #   # will lazily make API calls to fetch subsequent pages. Other
-        #   # methods are also available for managing paging directly.
-        #   result.each do |response|
+        #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+        #   # over elements, and API calls will be issued to fetch pages as needed.
+        #   result.each do |item|
         #     # Each element is of type ::Grafeas::V1::Occurrence.
-        #     p response
+        #     p item
         #   end
         #
         def list_occurrences request, options = nil
@@ -908,13 +906,11 @@ module Grafeas
         #   # Call the list_notes method.
         #   result = client.list_notes request
         #
-        #   # The returned object is of type Gapic::PagedEnumerable. You can
-        #   # iterate over all elements by calling #each, and the enumerable
-        #   # will lazily make API calls to fetch subsequent pages. Other
-        #   # methods are also available for managing paging directly.
-        #   result.each do |response|
+        #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+        #   # over elements, and API calls will be issued to fetch pages as needed.
+        #   result.each do |item|
         #     # Each element is of type ::Grafeas::V1::Note.
-        #     p response
+        #     p item
         #   end
         #
         def list_notes request, options = nil
@@ -1363,13 +1359,11 @@ module Grafeas
         #   # Call the list_note_occurrences method.
         #   result = client.list_note_occurrences request
         #
-        #   # The returned object is of type Gapic::PagedEnumerable. You can
-        #   # iterate over all elements by calling #each, and the enumerable
-        #   # will lazily make API calls to fetch subsequent pages. Other
-        #   # methods are also available for managing paging directly.
-        #   result.each do |response|
+        #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+        #   # over elements, and API calls will be issued to fetch pages as needed.
+        #   result.each do |item|
         #     # Each element is of type ::Grafeas::V1::Occurrence.
-        #     p response
+        #     p item
         #   end
         #
         def list_note_occurrences request, options = nil

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/batch_create_notes.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/batch_create_notes.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#batch_create_notes
+# Snippet for the batch_create_notes call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#batch_create_notes. It may require modification
+# in order to execute successfully.
 #
 def batch_create_notes
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/batch_create_occurrences.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/batch_create_occurrences.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#batch_create_occurrences
+# Snippet for the batch_create_occurrences call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#batch_create_occurrences. It may require
+# modification in order to execute successfully.
 #
 def batch_create_occurrences
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/create_note.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/create_note.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#create_note
+# Snippet for the create_note call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#create_note. It may require modification in order
+# to execute successfully.
 #
 def create_note
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/create_occurrence.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/create_occurrence.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#create_occurrence
+# Snippet for the create_occurrence call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#create_occurrence. It may require modification in
+# order to execute successfully.
 #
 def create_occurrence
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/delete_note.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/delete_note.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#delete_note
+# Snippet for the delete_note call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#delete_note. It may require modification in order
+# to execute successfully.
 #
 def delete_note
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/delete_occurrence.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/delete_occurrence.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#delete_occurrence
+# Snippet for the delete_occurrence call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#delete_occurrence. It may require modification in
+# order to execute successfully.
 #
 def delete_occurrence
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/get_note.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/get_note.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#get_note
+# Snippet for the get_note call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#get_note. It may require modification in order to
+# execute successfully.
 #
 def get_note
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/get_occurrence.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/get_occurrence.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#get_occurrence
+# Snippet for the get_occurrence call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#get_occurrence. It may require modification in
+# order to execute successfully.
 #
 def get_occurrence
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/get_occurrence_note.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/get_occurrence_note.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#get_occurrence_note
+# Snippet for the get_occurrence_note call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#get_occurrence_note. It may require modification
+# in order to execute successfully.
 #
 def get_occurrence_note
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/list_note_occurrences.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/list_note_occurrences.rb
@@ -33,13 +33,11 @@ def list_note_occurrences
   # Call the list_note_occurrences method.
   result = client.list_note_occurrences request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Grafeas::V1::Occurrence.
-    p response
+    p item
   end
 end
 # [END grafeas_v1_generated_Grafeas_ListNoteOccurrences_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/list_note_occurrences.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/list_note_occurrences.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#list_note_occurrences
+# Snippet for the list_note_occurrences call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#list_note_occurrences. It may require
+# modification in order to execute successfully.
 #
 def list_note_occurrences
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/list_notes.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/list_notes.rb
@@ -33,13 +33,11 @@ def list_notes
   # Call the list_notes method.
   result = client.list_notes request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Grafeas::V1::Note.
-    p response
+    p item
   end
 end
 # [END grafeas_v1_generated_Grafeas_ListNotes_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/list_notes.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/list_notes.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#list_notes
+# Snippet for the list_notes call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#list_notes. It may require modification in order
+# to execute successfully.
 #
 def list_notes
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/list_occurrences.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/list_occurrences.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#list_occurrences
+# Snippet for the list_occurrences call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#list_occurrences. It may require modification in
+# order to execute successfully.
 #
 def list_occurrences
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/list_occurrences.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/list_occurrences.rb
@@ -33,13 +33,11 @@ def list_occurrences
   # Call the list_occurrences method.
   result = client.list_occurrences request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Grafeas::V1::Occurrence.
-    p response
+    p item
   end
 end
 # [END grafeas_v1_generated_Grafeas_ListOccurrences_sync]

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/update_note.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/update_note.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#update_note
+# Snippet for the update_note call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#update_note. It may require modification in order
+# to execute successfully.
 #
 def update_note
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/grafeas/update_occurrence.rb
+++ b/shared/output/cloud/grafeas_v1/snippets/grafeas/update_occurrence.rb
@@ -20,8 +20,11 @@
 require "grafeas/v1"
 
 ##
-# Example demonstrating basic usage of
-# Grafeas::V1::Grafeas::Client#update_occurrence
+# Snippet for the update_occurrence call in the Grafeas service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Grafeas::V1::Grafeas::Client#update_occurrence. It may require modification in
+# order to execute successfully.
 #
 def update_occurrence
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/grafeas_v1/snippets/snippet_metadata_grafeas.v1.json
+++ b/shared/output/cloud/grafeas_v1/snippets/snippet_metadata_grafeas.v1.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "grafeas_v1_generated_Grafeas_GetOccurrence_sync",
-      "title": "Snippet for get_occurrence in Grafeas",
-      "description": "Basic snippet for get_occurrence in Grafeas",
+      "title": "Snippet for the get_occurrence call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#get_occurrence. It may require modification in order to execute successfully.",
       "file": "grafeas/get_occurrence.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "grafeas_v1_generated_Grafeas_ListOccurrences_sync",
-      "title": "Snippet for list_occurrences in Grafeas",
-      "description": "Basic snippet for list_occurrences in Grafeas",
+      "title": "Snippet for the list_occurrences call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#list_occurrences. It may require modification in order to execute successfully.",
       "file": "grafeas/list_occurrences.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,15 +86,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 42,
+          "end": 45,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "grafeas_v1_generated_Grafeas_DeleteOccurrence_sync",
-      "title": "Snippet for delete_occurrence in Grafeas",
-      "description": "Basic snippet for delete_occurrence in Grafeas",
+      "title": "Snippet for the delete_occurrence call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#delete_occurrence. It may require modification in order to execute successfully.",
       "file": "grafeas/delete_occurrence.rb",
       "language": "RUBY",
       "client_method": {
@@ -126,15 +126,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "grafeas_v1_generated_Grafeas_CreateOccurrence_sync",
-      "title": "Snippet for create_occurrence in Grafeas",
-      "description": "Basic snippet for create_occurrence in Grafeas",
+      "title": "Snippet for the create_occurrence call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#create_occurrence. It may require modification in order to execute successfully.",
       "file": "grafeas/create_occurrence.rb",
       "language": "RUBY",
       "client_method": {
@@ -166,15 +166,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "grafeas_v1_generated_Grafeas_BatchCreateOccurrences_sync",
-      "title": "Snippet for batch_create_occurrences in Grafeas",
-      "description": "Basic snippet for batch_create_occurrences in Grafeas",
+      "title": "Snippet for the batch_create_occurrences call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#batch_create_occurrences. It may require modification in order to execute successfully.",
       "file": "grafeas/batch_create_occurrences.rb",
       "language": "RUBY",
       "client_method": {
@@ -206,15 +206,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "grafeas_v1_generated_Grafeas_UpdateOccurrence_sync",
-      "title": "Snippet for update_occurrence in Grafeas",
-      "description": "Basic snippet for update_occurrence in Grafeas",
+      "title": "Snippet for the update_occurrence call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#update_occurrence. It may require modification in order to execute successfully.",
       "file": "grafeas/update_occurrence.rb",
       "language": "RUBY",
       "client_method": {
@@ -246,15 +246,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "grafeas_v1_generated_Grafeas_GetOccurrenceNote_sync",
-      "title": "Snippet for get_occurrence_note in Grafeas",
-      "description": "Basic snippet for get_occurrence_note in Grafeas",
+      "title": "Snippet for the get_occurrence_note call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#get_occurrence_note. It may require modification in order to execute successfully.",
       "file": "grafeas/get_occurrence_note.rb",
       "language": "RUBY",
       "client_method": {
@@ -286,15 +286,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "grafeas_v1_generated_Grafeas_GetNote_sync",
-      "title": "Snippet for get_note in Grafeas",
-      "description": "Basic snippet for get_note in Grafeas",
+      "title": "Snippet for the get_note call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#get_note. It may require modification in order to execute successfully.",
       "file": "grafeas/get_note.rb",
       "language": "RUBY",
       "client_method": {
@@ -326,15 +326,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "grafeas_v1_generated_Grafeas_ListNotes_sync",
-      "title": "Snippet for list_notes in Grafeas",
-      "description": "Basic snippet for list_notes in Grafeas",
+      "title": "Snippet for the list_notes call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#list_notes. It may require modification in order to execute successfully.",
       "file": "grafeas/list_notes.rb",
       "language": "RUBY",
       "client_method": {
@@ -366,15 +366,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 42,
+          "end": 45,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "grafeas_v1_generated_Grafeas_DeleteNote_sync",
-      "title": "Snippet for delete_note in Grafeas",
-      "description": "Basic snippet for delete_note in Grafeas",
+      "title": "Snippet for the delete_note call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#delete_note. It may require modification in order to execute successfully.",
       "file": "grafeas/delete_note.rb",
       "language": "RUBY",
       "client_method": {
@@ -406,15 +406,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "grafeas_v1_generated_Grafeas_CreateNote_sync",
-      "title": "Snippet for create_note in Grafeas",
-      "description": "Basic snippet for create_note in Grafeas",
+      "title": "Snippet for the create_note call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#create_note. It may require modification in order to execute successfully.",
       "file": "grafeas/create_note.rb",
       "language": "RUBY",
       "client_method": {
@@ -446,15 +446,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "grafeas_v1_generated_Grafeas_BatchCreateNotes_sync",
-      "title": "Snippet for batch_create_notes in Grafeas",
-      "description": "Basic snippet for batch_create_notes in Grafeas",
+      "title": "Snippet for the batch_create_notes call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#batch_create_notes. It may require modification in order to execute successfully.",
       "file": "grafeas/batch_create_notes.rb",
       "language": "RUBY",
       "client_method": {
@@ -486,15 +486,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "grafeas_v1_generated_Grafeas_UpdateNote_sync",
-      "title": "Snippet for update_note in Grafeas",
-      "description": "Basic snippet for update_note in Grafeas",
+      "title": "Snippet for the update_note call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#update_note. It may require modification in order to execute successfully.",
       "file": "grafeas/update_note.rb",
       "language": "RUBY",
       "client_method": {
@@ -526,15 +526,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "grafeas_v1_generated_Grafeas_ListNoteOccurrences_sync",
-      "title": "Snippet for list_note_occurrences in Grafeas",
-      "description": "Basic snippet for list_note_occurrences in Grafeas",
+      "title": "Snippet for the list_note_occurrences call in the Grafeas service",
+      "description": "This is an auto-generated example demonstrating basic usage of Grafeas::V1::Grafeas::Client#list_note_occurrences. It may require modification in order to execute successfully.",
       "file": "grafeas/list_note_occurrences.rb",
       "language": "RUBY",
       "client_method": {
@@ -566,7 +566,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 42,
+          "end": 45,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/grafeas_v1/snippets/snippet_metadata_grafeas.v1.json
+++ b/shared/output/cloud/grafeas_v1/snippets/snippet_metadata_grafeas.v1.json
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 44,
+          "end": 42,
           "type": "FULL"
         }
       ]
@@ -366,7 +366,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 44,
+          "end": 42,
           "type": "FULL"
         }
       ]
@@ -566,7 +566,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 44,
+          "end": 42,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/language_v1/snippets/language_service/analyze_entities.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/analyze_entities.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1::LanguageService::Client#analyze_entities
+# Snippet for the analyze_entities call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1::LanguageService::Client#analyze_entities. It may
+# require modification in order to execute successfully.
 #
 def analyze_entities
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1/snippets/language_service/analyze_entity_sentiment.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/analyze_entity_sentiment.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1::LanguageService::Client#analyze_entity_sentiment
+# Snippet for the analyze_entity_sentiment call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1::LanguageService::Client#analyze_entity_sentiment.
+# It may require modification in order to execute successfully.
 #
 def analyze_entity_sentiment
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1/snippets/language_service/analyze_sentiment.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/analyze_sentiment.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1::LanguageService::Client#analyze_sentiment
+# Snippet for the analyze_sentiment call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1::LanguageService::Client#analyze_sentiment. It may
+# require modification in order to execute successfully.
 #
 def analyze_sentiment
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1/snippets/language_service/analyze_syntax.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/analyze_syntax.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1::LanguageService::Client#analyze_syntax
+# Snippet for the analyze_syntax call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1::LanguageService::Client#analyze_syntax. It may
+# require modification in order to execute successfully.
 #
 def analyze_syntax
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1/snippets/language_service/annotate_text.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/annotate_text.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1::LanguageService::Client#annotate_text
+# Snippet for the annotate_text call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1::LanguageService::Client#annotate_text. It may
+# require modification in order to execute successfully.
 #
 def annotate_text
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1/snippets/language_service/classify_text.rb
+++ b/shared/output/cloud/language_v1/snippets/language_service/classify_text.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1::LanguageService::Client#classify_text
+# Snippet for the classify_text call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1::LanguageService::Client#classify_text. It may
+# require modification in order to execute successfully.
 #
 def classify_text
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1/snippets/snippet_metadata_google.cloud.language.v1.json
+++ b/shared/output/cloud/language_v1/snippets/snippet_metadata_google.cloud.language.v1.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "language_v1_generated_LanguageService_AnalyzeSentiment_sync",
-      "title": "Snippet for analyze_sentiment in LanguageService",
-      "description": "Basic snippet for analyze_sentiment in LanguageService",
+      "title": "Snippet for the analyze_sentiment call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1::LanguageService::Client#analyze_sentiment. It may require modification in order to execute successfully.",
       "file": "language_service/analyze_sentiment.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "language_v1_generated_LanguageService_AnalyzeEntities_sync",
-      "title": "Snippet for analyze_entities in LanguageService",
-      "description": "Basic snippet for analyze_entities in LanguageService",
+      "title": "Snippet for the analyze_entities call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1::LanguageService::Client#analyze_entities. It may require modification in order to execute successfully.",
       "file": "language_service/analyze_entities.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,15 +86,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "language_v1_generated_LanguageService_AnalyzeEntitySentiment_sync",
-      "title": "Snippet for analyze_entity_sentiment in LanguageService",
-      "description": "Basic snippet for analyze_entity_sentiment in LanguageService",
+      "title": "Snippet for the analyze_entity_sentiment call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1::LanguageService::Client#analyze_entity_sentiment. It may require modification in order to execute successfully.",
       "file": "language_service/analyze_entity_sentiment.rb",
       "language": "RUBY",
       "client_method": {
@@ -126,15 +126,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "language_v1_generated_LanguageService_AnalyzeSyntax_sync",
-      "title": "Snippet for analyze_syntax in LanguageService",
-      "description": "Basic snippet for analyze_syntax in LanguageService",
+      "title": "Snippet for the analyze_syntax call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1::LanguageService::Client#analyze_syntax. It may require modification in order to execute successfully.",
       "file": "language_service/analyze_syntax.rb",
       "language": "RUBY",
       "client_method": {
@@ -166,15 +166,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "language_v1_generated_LanguageService_ClassifyText_sync",
-      "title": "Snippet for classify_text in LanguageService",
-      "description": "Basic snippet for classify_text in LanguageService",
+      "title": "Snippet for the classify_text call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1::LanguageService::Client#classify_text. It may require modification in order to execute successfully.",
       "file": "language_service/classify_text.rb",
       "language": "RUBY",
       "client_method": {
@@ -206,15 +206,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "language_v1_generated_LanguageService_AnnotateText_sync",
-      "title": "Snippet for annotate_text in LanguageService",
-      "description": "Basic snippet for annotate_text in LanguageService",
+      "title": "Snippet for the annotate_text call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1::LanguageService::Client#annotate_text. It may require modification in order to execute successfully.",
       "file": "language_service/annotate_text.rb",
       "language": "RUBY",
       "client_method": {
@@ -246,7 +246,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_entities.rb
+++ b/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_entities.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1beta1::LanguageService::Client#analyze_entities
+# Snippet for the analyze_entities call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1beta1::LanguageService::Client#analyze_entities. It
+# may require modification in order to execute successfully.
 #
 def analyze_entities
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_sentiment.rb
+++ b/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_sentiment.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1beta1::LanguageService::Client#analyze_sentiment
+# Snippet for the analyze_sentiment call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1beta1::LanguageService::Client#analyze_sentiment.
+# It may require modification in order to execute successfully.
 #
 def analyze_sentiment
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_syntax.rb
+++ b/shared/output/cloud/language_v1beta1/snippets/language_service/analyze_syntax.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1beta1::LanguageService::Client#analyze_syntax
+# Snippet for the analyze_syntax call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1beta1::LanguageService::Client#analyze_syntax. It
+# may require modification in order to execute successfully.
 #
 def analyze_syntax
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1beta1/snippets/language_service/annotate_text.rb
+++ b/shared/output/cloud/language_v1beta1/snippets/language_service/annotate_text.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1beta1::LanguageService::Client#annotate_text
+# Snippet for the annotate_text call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1beta1::LanguageService::Client#annotate_text. It
+# may require modification in order to execute successfully.
 #
 def annotate_text
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1beta1/snippets/snippet_metadata_google.cloud.language.v1beta1.json
+++ b/shared/output/cloud/language_v1beta1/snippets/snippet_metadata_google.cloud.language.v1beta1.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "language_v1beta1_generated_LanguageService_AnalyzeSentiment_sync",
-      "title": "Snippet for analyze_sentiment in LanguageService",
-      "description": "Basic snippet for analyze_sentiment in LanguageService",
+      "title": "Snippet for the analyze_sentiment call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1beta1::LanguageService::Client#analyze_sentiment. It may require modification in order to execute successfully.",
       "file": "language_service/analyze_sentiment.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "language_v1beta1_generated_LanguageService_AnalyzeEntities_sync",
-      "title": "Snippet for analyze_entities in LanguageService",
-      "description": "Basic snippet for analyze_entities in LanguageService",
+      "title": "Snippet for the analyze_entities call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1beta1::LanguageService::Client#analyze_entities. It may require modification in order to execute successfully.",
       "file": "language_service/analyze_entities.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,15 +86,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "language_v1beta1_generated_LanguageService_AnalyzeSyntax_sync",
-      "title": "Snippet for analyze_syntax in LanguageService",
-      "description": "Basic snippet for analyze_syntax in LanguageService",
+      "title": "Snippet for the analyze_syntax call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1beta1::LanguageService::Client#analyze_syntax. It may require modification in order to execute successfully.",
       "file": "language_service/analyze_syntax.rb",
       "language": "RUBY",
       "client_method": {
@@ -126,15 +126,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "language_v1beta1_generated_LanguageService_AnnotateText_sync",
-      "title": "Snippet for annotate_text in LanguageService",
-      "description": "Basic snippet for annotate_text in LanguageService",
+      "title": "Snippet for the annotate_text call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1beta1::LanguageService::Client#annotate_text. It may require modification in order to execute successfully.",
       "file": "language_service/annotate_text.rb",
       "language": "RUBY",
       "client_method": {
@@ -166,7 +166,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_entities.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_entities.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1beta2"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_entities
+# Snippet for the analyze_entities call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_entities. It
+# may require modification in order to execute successfully.
 #
 def analyze_entities
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_entity_sentiment.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_entity_sentiment.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1beta2"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_entity_sentiment
+# Snippet for the analyze_entity_sentiment call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_entity_sentiment.
+# It may require modification in order to execute successfully.
 #
 def analyze_entity_sentiment
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_sentiment.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_sentiment.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1beta2"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_sentiment
+# Snippet for the analyze_sentiment call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_sentiment.
+# It may require modification in order to execute successfully.
 #
 def analyze_sentiment
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_syntax.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/analyze_syntax.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1beta2"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_syntax
+# Snippet for the analyze_syntax call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_syntax. It
+# may require modification in order to execute successfully.
 #
 def analyze_syntax
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/annotate_text.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/annotate_text.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1beta2"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1beta2::LanguageService::Client#annotate_text
+# Snippet for the annotate_text call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1beta2::LanguageService::Client#annotate_text. It
+# may require modification in order to execute successfully.
 #
 def annotate_text
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1beta2/snippets/language_service/classify_text.rb
+++ b/shared/output/cloud/language_v1beta2/snippets/language_service/classify_text.rb
@@ -20,8 +20,11 @@
 require "google/cloud/language/v1beta2"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Language::V1beta2::LanguageService::Client#classify_text
+# Snippet for the classify_text call in the LanguageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Language::V1beta2::LanguageService::Client#classify_text. It
+# may require modification in order to execute successfully.
 #
 def classify_text
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/language_v1beta2/snippets/snippet_metadata_google.cloud.language.v1beta2.json
+++ b/shared/output/cloud/language_v1beta2/snippets/snippet_metadata_google.cloud.language.v1beta2.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "language_v1beta2_generated_LanguageService_AnalyzeSentiment_sync",
-      "title": "Snippet for analyze_sentiment in LanguageService",
-      "description": "Basic snippet for analyze_sentiment in LanguageService",
+      "title": "Snippet for the analyze_sentiment call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_sentiment. It may require modification in order to execute successfully.",
       "file": "language_service/analyze_sentiment.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "language_v1beta2_generated_LanguageService_AnalyzeEntities_sync",
-      "title": "Snippet for analyze_entities in LanguageService",
-      "description": "Basic snippet for analyze_entities in LanguageService",
+      "title": "Snippet for the analyze_entities call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_entities. It may require modification in order to execute successfully.",
       "file": "language_service/analyze_entities.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,15 +86,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "language_v1beta2_generated_LanguageService_AnalyzeEntitySentiment_sync",
-      "title": "Snippet for analyze_entity_sentiment in LanguageService",
-      "description": "Basic snippet for analyze_entity_sentiment in LanguageService",
+      "title": "Snippet for the analyze_entity_sentiment call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_entity_sentiment. It may require modification in order to execute successfully.",
       "file": "language_service/analyze_entity_sentiment.rb",
       "language": "RUBY",
       "client_method": {
@@ -126,15 +126,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "language_v1beta2_generated_LanguageService_AnalyzeSyntax_sync",
-      "title": "Snippet for analyze_syntax in LanguageService",
-      "description": "Basic snippet for analyze_syntax in LanguageService",
+      "title": "Snippet for the analyze_syntax call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1beta2::LanguageService::Client#analyze_syntax. It may require modification in order to execute successfully.",
       "file": "language_service/analyze_syntax.rb",
       "language": "RUBY",
       "client_method": {
@@ -166,15 +166,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "language_v1beta2_generated_LanguageService_ClassifyText_sync",
-      "title": "Snippet for classify_text in LanguageService",
-      "description": "Basic snippet for classify_text in LanguageService",
+      "title": "Snippet for the classify_text call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1beta2::LanguageService::Client#classify_text. It may require modification in order to execute successfully.",
       "file": "language_service/classify_text.rb",
       "language": "RUBY",
       "client_method": {
@@ -206,15 +206,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "language_v1beta2_generated_LanguageService_AnnotateText_sync",
-      "title": "Snippet for annotate_text in LanguageService",
-      "description": "Basic snippet for annotate_text in LanguageService",
+      "title": "Snippet for the annotate_text call in the LanguageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Language::V1beta2::LanguageService::Client#annotate_text. It may require modification in order to execute successfully.",
       "file": "language_service/annotate_text.rb",
       "language": "RUBY",
       "client_method": {
@@ -246,7 +246,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/location/lib/google/cloud/location/locations/client.rb
+++ b/shared/output/cloud/location/lib/google/cloud/location/locations/client.rb
@@ -190,13 +190,11 @@ module Google
           #   # Call the list_locations method.
           #   result = client.list_locations request
           #
-          #   # The returned object is of type Gapic::PagedEnumerable. You can
-          #   # iterate over all elements by calling #each, and the enumerable
-          #   # will lazily make API calls to fetch subsequent pages. Other
-          #   # methods are also available for managing paging directly.
-          #   result.each do |response|
+          #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+          #   # over elements, and API calls will be issued to fetch pages as needed.
+          #   result.each do |item|
           #     # Each element is of type ::Google::Cloud::Location::Location.
-          #     p response
+          #     p item
           #   end
           #
           def list_locations request, options = nil

--- a/shared/output/cloud/location/snippets/locations/get_location.rb
+++ b/shared/output/cloud/location/snippets/locations/get_location.rb
@@ -20,8 +20,11 @@
 require "google/cloud/location"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Location::Locations::Client#get_location
+# Snippet for the get_location call in the Locations service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Location::Locations::Client#get_location. It may require
+# modification in order to execute successfully.
 #
 def get_location
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/location/snippets/locations/list_locations.rb
+++ b/shared/output/cloud/location/snippets/locations/list_locations.rb
@@ -33,13 +33,11 @@ def list_locations
   # Call the list_locations method.
   result = client.list_locations request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Cloud::Location::Location.
-    p response
+    p item
   end
 end
 # [END location_v0_generated_Locations_ListLocations_sync]

--- a/shared/output/cloud/location/snippets/locations/list_locations.rb
+++ b/shared/output/cloud/location/snippets/locations/list_locations.rb
@@ -20,8 +20,11 @@
 require "google/cloud/location"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Location::Locations::Client#list_locations
+# Snippet for the list_locations call in the Locations service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Location::Locations::Client#list_locations. It may require
+# modification in order to execute successfully.
 #
 def list_locations
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/location/snippets/snippet_metadata_google.cloud.location.json
+++ b/shared/output/cloud/location/snippets/snippet_metadata_google.cloud.location.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "location_v0_generated_Locations_ListLocations_sync",
-      "title": "Snippet for list_locations in Locations",
-      "description": "Basic snippet for list_locations in Locations",
+      "title": "Snippet for the list_locations call in the Locations service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Location::Locations::Client#list_locations. It may require modification in order to execute successfully.",
       "file": "locations/list_locations.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 42,
+          "end": 45,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "location_v0_generated_Locations_GetLocation_sync",
-      "title": "Snippet for get_location in Locations",
-      "description": "Basic snippet for get_location in Locations",
+      "title": "Snippet for the get_location call in the Locations service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Location::Locations::Client#get_location. It may require modification in order to execute successfully.",
       "file": "locations/get_location.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/location/snippets/snippet_metadata_google.cloud.location.json
+++ b/shared/output/cloud/location/snippets/snippet_metadata_google.cloud.location.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 44,
+          "end": 42,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -199,13 +199,11 @@ module Google
             #   # Call the list_secrets method.
             #   result = client.list_secrets request
             #
-            #   # The returned object is of type Gapic::PagedEnumerable. You can
-            #   # iterate over all elements by calling #each, and the enumerable
-            #   # will lazily make API calls to fetch subsequent pages. Other
-            #   # methods are also available for managing paging directly.
-            #   result.each do |response|
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
             #     # Each element is of type ::Google::Cloud::SecretManager::V1beta1::Secret.
-            #     p response
+            #     p item
             #   end
             #
             def list_secrets request, options = nil
@@ -742,13 +740,11 @@ module Google
             #   # Call the list_secret_versions method.
             #   result = client.list_secret_versions request
             #
-            #   # The returned object is of type Gapic::PagedEnumerable. You can
-            #   # iterate over all elements by calling #each, and the enumerable
-            #   # will lazily make API calls to fetch subsequent pages. Other
-            #   # methods are also available for managing paging directly.
-            #   result.each do |response|
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
             #     # Each element is of type ::Google::Cloud::SecretManager::V1beta1::SecretVersion.
-            #     p response
+            #     p item
             #   end
             #
             def list_secret_versions request, options = nil

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/access_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/access_secret_version.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#access_secret_version
+# Snippet for the access_secret_version call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#access_secret_version.
+# It may require modification in order to execute successfully.
 #
 def access_secret_version
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/add_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/add_secret_version.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#add_secret_version
+# Snippet for the add_secret_version call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#add_secret_version.
+# It may require modification in order to execute successfully.
 #
 def add_secret_version
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/create_secret.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/create_secret.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#create_secret
+# Snippet for the create_secret call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#create_secret.
+# It may require modification in order to execute successfully.
 #
 def create_secret
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/delete_secret.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/delete_secret.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#delete_secret
+# Snippet for the delete_secret call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#delete_secret.
+# It may require modification in order to execute successfully.
 #
 def delete_secret
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/destroy_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/destroy_secret_version.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#destroy_secret_version
+# Snippet for the destroy_secret_version call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#destroy_secret_version.
+# It may require modification in order to execute successfully.
 #
 def destroy_secret_version
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/disable_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/disable_secret_version.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#disable_secret_version
+# Snippet for the disable_secret_version call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#disable_secret_version.
+# It may require modification in order to execute successfully.
 #
 def disable_secret_version
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/enable_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/enable_secret_version.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#enable_secret_version
+# Snippet for the enable_secret_version call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#enable_secret_version.
+# It may require modification in order to execute successfully.
 #
 def enable_secret_version
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_iam_policy.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_iam_policy.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_iam_policy
+# Snippet for the get_iam_policy call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_iam_policy.
+# It may require modification in order to execute successfully.
 #
 def get_iam_policy
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_secret.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_secret.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_secret
+# Snippet for the get_secret call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_secret.
+# It may require modification in order to execute successfully.
 #
 def get_secret
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_secret_version.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/get_secret_version.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_secret_version
+# Snippet for the get_secret_version call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_secret_version.
+# It may require modification in order to execute successfully.
 #
 def get_secret_version
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secret_versions.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secret_versions.rb
@@ -33,13 +33,11 @@ def list_secret_versions
   # Call the list_secret_versions method.
   result = client.list_secret_versions request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Cloud::SecretManager::V1beta1::SecretVersion.
-    p response
+    p item
   end
 end
 # [END secretmanager_v1beta1_generated_SecretManagerService_ListSecretVersions_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secret_versions.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secret_versions.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secret_versions
+# Snippet for the list_secret_versions call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secret_versions.
+# It may require modification in order to execute successfully.
 #
 def list_secret_versions
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secrets.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secrets.rb
@@ -33,13 +33,11 @@ def list_secrets
   # Call the list_secrets method.
   result = client.list_secrets request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Cloud::SecretManager::V1beta1::Secret.
-    p response
+    p item
   end
 end
 # [END secretmanager_v1beta1_generated_SecretManagerService_ListSecrets_sync]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secrets.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/list_secrets.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secrets
+# Snippet for the list_secrets call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secrets.
+# It may require modification in order to execute successfully.
 #
 def list_secrets
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/set_iam_policy.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/set_iam_policy.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#set_iam_policy
+# Snippet for the set_iam_policy call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#set_iam_policy.
+# It may require modification in order to execute successfully.
 #
 def set_iam_policy
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/test_iam_permissions.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/test_iam_permissions.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#test_iam_permissions
+# Snippet for the test_iam_permissions call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#test_iam_permissions.
+# It may require modification in order to execute successfully.
 #
 def test_iam_permissions
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/update_secret.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/secret_manager_service/update_secret.rb
@@ -20,8 +20,11 @@
 require "google/cloud/secret_manager/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#update_secret
+# Snippet for the update_secret call in the SecretManagerService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#update_secret.
+# It may require modification in order to execute successfully.
 #
 def update_secret
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/snippet_metadata_google.cloud.secrets.v1beta1.json
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/snippet_metadata_google.cloud.secrets.v1beta1.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_ListSecrets_sync",
-      "title": "Snippet for list_secrets in SecretManagerService",
-      "description": "Basic snippet for list_secrets in SecretManagerService",
+      "title": "Snippet for the list_secrets call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secrets. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/list_secrets.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 42,
+          "end": 45,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_CreateSecret_sync",
-      "title": "Snippet for create_secret in SecretManagerService",
-      "description": "Basic snippet for create_secret in SecretManagerService",
+      "title": "Snippet for the create_secret call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#create_secret. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/create_secret.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,15 +86,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_AddSecretVersion_sync",
-      "title": "Snippet for add_secret_version in SecretManagerService",
-      "description": "Basic snippet for add_secret_version in SecretManagerService",
+      "title": "Snippet for the add_secret_version call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#add_secret_version. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/add_secret_version.rb",
       "language": "RUBY",
       "client_method": {
@@ -126,15 +126,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_GetSecret_sync",
-      "title": "Snippet for get_secret in SecretManagerService",
-      "description": "Basic snippet for get_secret in SecretManagerService",
+      "title": "Snippet for the get_secret call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_secret. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/get_secret.rb",
       "language": "RUBY",
       "client_method": {
@@ -166,15 +166,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_UpdateSecret_sync",
-      "title": "Snippet for update_secret in SecretManagerService",
-      "description": "Basic snippet for update_secret in SecretManagerService",
+      "title": "Snippet for the update_secret call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#update_secret. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/update_secret.rb",
       "language": "RUBY",
       "client_method": {
@@ -206,15 +206,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_DeleteSecret_sync",
-      "title": "Snippet for delete_secret in SecretManagerService",
-      "description": "Basic snippet for delete_secret in SecretManagerService",
+      "title": "Snippet for the delete_secret call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#delete_secret. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/delete_secret.rb",
       "language": "RUBY",
       "client_method": {
@@ -246,15 +246,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_ListSecretVersions_sync",
-      "title": "Snippet for list_secret_versions in SecretManagerService",
-      "description": "Basic snippet for list_secret_versions in SecretManagerService",
+      "title": "Snippet for the list_secret_versions call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#list_secret_versions. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/list_secret_versions.rb",
       "language": "RUBY",
       "client_method": {
@@ -286,15 +286,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 42,
+          "end": 45,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_GetSecretVersion_sync",
-      "title": "Snippet for get_secret_version in SecretManagerService",
-      "description": "Basic snippet for get_secret_version in SecretManagerService",
+      "title": "Snippet for the get_secret_version call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_secret_version. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/get_secret_version.rb",
       "language": "RUBY",
       "client_method": {
@@ -326,15 +326,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_AccessSecretVersion_sync",
-      "title": "Snippet for access_secret_version in SecretManagerService",
-      "description": "Basic snippet for access_secret_version in SecretManagerService",
+      "title": "Snippet for the access_secret_version call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#access_secret_version. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/access_secret_version.rb",
       "language": "RUBY",
       "client_method": {
@@ -366,15 +366,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_DisableSecretVersion_sync",
-      "title": "Snippet for disable_secret_version in SecretManagerService",
-      "description": "Basic snippet for disable_secret_version in SecretManagerService",
+      "title": "Snippet for the disable_secret_version call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#disable_secret_version. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/disable_secret_version.rb",
       "language": "RUBY",
       "client_method": {
@@ -406,15 +406,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_EnableSecretVersion_sync",
-      "title": "Snippet for enable_secret_version in SecretManagerService",
-      "description": "Basic snippet for enable_secret_version in SecretManagerService",
+      "title": "Snippet for the enable_secret_version call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#enable_secret_version. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/enable_secret_version.rb",
       "language": "RUBY",
       "client_method": {
@@ -446,15 +446,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_DestroySecretVersion_sync",
-      "title": "Snippet for destroy_secret_version in SecretManagerService",
-      "description": "Basic snippet for destroy_secret_version in SecretManagerService",
+      "title": "Snippet for the destroy_secret_version call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#destroy_secret_version. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/destroy_secret_version.rb",
       "language": "RUBY",
       "client_method": {
@@ -486,15 +486,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_SetIamPolicy_sync",
-      "title": "Snippet for set_iam_policy in SecretManagerService",
-      "description": "Basic snippet for set_iam_policy in SecretManagerService",
+      "title": "Snippet for the set_iam_policy call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#set_iam_policy. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/set_iam_policy.rb",
       "language": "RUBY",
       "client_method": {
@@ -526,15 +526,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_GetIamPolicy_sync",
-      "title": "Snippet for get_iam_policy in SecretManagerService",
-      "description": "Basic snippet for get_iam_policy in SecretManagerService",
+      "title": "Snippet for the get_iam_policy call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#get_iam_policy. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/get_iam_policy.rb",
       "language": "RUBY",
       "client_method": {
@@ -566,15 +566,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "secretmanager_v1beta1_generated_SecretManagerService_TestIamPermissions_sync",
-      "title": "Snippet for test_iam_permissions in SecretManagerService",
-      "description": "Basic snippet for test_iam_permissions in SecretManagerService",
+      "title": "Snippet for the test_iam_permissions call in the SecretManagerService service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client#test_iam_permissions. It may require modification in order to execute successfully.",
       "file": "secret_manager_service/test_iam_permissions.rb",
       "language": "RUBY",
       "client_method": {
@@ -606,7 +606,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/secretmanager_v1beta1/snippets/snippet_metadata_google.cloud.secrets.v1beta1.json
+++ b/shared/output/cloud/secretmanager_v1beta1/snippets/snippet_metadata_google.cloud.secrets.v1beta1.json
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 44,
+          "end": 42,
           "type": "FULL"
         }
       ]
@@ -286,7 +286,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 44,
+          "end": 42,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -494,14 +494,14 @@ module Google
             #   # Call the long_running_recognize method.
             #   result = client.long_running_recognize request
             #
-            #   # The returned object is of type Gapic::Operation. You can use this
-            #   # object to check the status of an operation, cancel it, or wait
-            #   # for results. Here is how to block until completion:
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
             #   result.wait_until_done! timeout: 60
             #   if result.response?
             #     p result.response
             #   else
-            #     puts "Error!"
+            #     puts "No response received."
             #   end
             #
             # @example Transcribe a long audio file using asynchronous speech recognition
@@ -661,22 +661,22 @@ module Google
             #   # Create a client object. The client can be reused for multiple calls.
             #   client = Google::Cloud::Speech::V1::Speech::Client.new
             #
-            #   # Create an input stream
+            #   # Create an input stream.
             #   input = Gapic::StreamInput.new
             #
             #   # Call the streaming_recognize method to start streaming.
             #   output = client.streaming_recognize input
             #
-            #   # Send requests on the stream. For each request, pass in keyword
-            #   # arguments to set fields. Be sure to close the stream when done.
+            #   # Send requests on the stream. For each request object, set fields by
+            #   # passing keyword arguments. Be sure to close the stream when done.
             #   input << Google::Cloud::Speech::V1::StreamingRecognizeRequest.new
             #   input << Google::Cloud::Speech::V1::StreamingRecognizeRequest.new
             #   input.close
             #
-            #   # Handle streamed responses. These may be interleaved with inputs.
-            #   # Each response is of type ::Google::Cloud::Speech::V1::StreamingRecognizeResponse.
-            #   output.each do |response|
-            #     p response
+            #   # The returned object is a streamed enumerable yielding elements of type
+            #   # ::Google::Cloud::Speech::V1::StreamingRecognizeResponse
+            #   output.each do |current_response|
+            #     p current_response
             #   end
             #
             def streaming_recognize request, options = nil

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -158,13 +158,11 @@ module Google
             #   # Call the list_operations method.
             #   result = client.list_operations request
             #
-            #   # The returned object is of type Gapic::PagedEnumerable. You can
-            #   # iterate over all elements by calling #each, and the enumerable
-            #   # will lazily make API calls to fetch subsequent pages. Other
-            #   # methods are also available for managing paging directly.
-            #   result.each do |response|
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
             #     # Each element is of type ::Google::Longrunning::Operation.
-            #     p response
+            #     p item
             #   end
             #
             def list_operations request, options = nil
@@ -253,14 +251,14 @@ module Google
             #   # Call the get_operation method.
             #   result = client.get_operation request
             #
-            #   # The returned object is of type Gapic::Operation. You can use this
-            #   # object to check the status of an operation, cancel it, or wait
-            #   # for results. Here is how to block until completion:
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
             #   result.wait_until_done! timeout: 60
             #   if result.response?
             #     p result.response
             #   else
-            #     puts "Error!"
+            #     puts "No response received."
             #   end
             #
             def get_operation request, options = nil
@@ -540,14 +538,14 @@ module Google
             #   # Call the wait_operation method.
             #   result = client.wait_operation request
             #
-            #   # The returned object is of type Gapic::Operation. You can use this
-            #   # object to check the status of an operation, cancel it, or wait
-            #   # for results. Here is how to block until completion:
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
             #   result.wait_until_done! timeout: 60
             #   if result.response?
             #     p result.response
             #   else
-            #     puts "Error!"
+            #     puts "No response received."
             #   end
             #
             def wait_operation request, options = nil

--- a/shared/output/cloud/speech_v1/snippets/snippet_metadata_google.cloud.speech.v1.json
+++ b/shared/output/cloud/speech_v1/snippets/snippet_metadata_google.cloud.speech.v1.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "speech_v1_generated_Speech_Recognize_sync",
-      "title": "Snippet for recognize in Speech",
-      "description": "Basic snippet for recognize in Speech",
+      "title": "Snippet for the recognize call in the Speech service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Speech::V1::Speech::Client#recognize. It may require modification in order to execute successfully.",
       "file": "speech/recognize.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "speech_v1_generated_Speech_LongRunningRecognize_sync",
-      "title": "Snippet for long_running_recognize in Speech",
-      "description": "Basic snippet for long_running_recognize in Speech",
+      "title": "Snippet for the long_running_recognize call in the Speech service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Speech::V1::Speech::Client#long_running_recognize. It may require modification in order to execute successfully.",
       "file": "speech/long_running_recognize.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,15 +86,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 45,
+          "end": 48,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "speech_v1_generated_Speech_StreamingRecognize_sync",
-      "title": "Snippet for streaming_recognize in Speech",
-      "description": "Basic snippet for streaming_recognize in Speech",
+      "title": "Snippet for the streaming_recognize call in the Speech service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Speech::V1::Speech::Client#streaming_recognize. It may require modification in order to execute successfully.",
       "file": "speech/streaming_recognize.rb",
       "language": "RUBY",
       "client_method": {
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 47,
+          "end": 50,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/speech_v1/snippets/speech/long_running_recognize.rb
+++ b/shared/output/cloud/speech_v1/snippets/speech/long_running_recognize.rb
@@ -20,8 +20,11 @@
 require "google/cloud/speech/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Speech::V1::Speech::Client#long_running_recognize
+# Snippet for the long_running_recognize call in the Speech service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Speech::V1::Speech::Client#long_running_recognize. It may
+# require modification in order to execute successfully.
 #
 def long_running_recognize
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/speech_v1/snippets/speech/long_running_recognize.rb
+++ b/shared/output/cloud/speech_v1/snippets/speech/long_running_recognize.rb
@@ -33,14 +33,14 @@ def long_running_recognize
   # Call the long_running_recognize method.
   result = client.long_running_recognize request
 
-  # The returned object is of type Gapic::Operation. You can use this
-  # object to check the status of an operation, cancel it, or wait
-  # for results. Here is how to block until completion:
+  # The returned object is of type Gapic::Operation. You can use it to
+  # check the status of an operation, cancel it, or wait for results.
+  # Here is how to wait for a response.
   result.wait_until_done! timeout: 60
   if result.response?
     p result.response
   else
-    puts "Error!"
+    puts "No response received."
   end
 end
 # [END speech_v1_generated_Speech_LongRunningRecognize_sync]

--- a/shared/output/cloud/speech_v1/snippets/speech/recognize.rb
+++ b/shared/output/cloud/speech_v1/snippets/speech/recognize.rb
@@ -20,8 +20,11 @@
 require "google/cloud/speech/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Speech::V1::Speech::Client#recognize
+# Snippet for the recognize call in the Speech service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Speech::V1::Speech::Client#recognize. It may require
+# modification in order to execute successfully.
 #
 def recognize
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/speech_v1/snippets/speech/streaming_recognize.rb
+++ b/shared/output/cloud/speech_v1/snippets/speech/streaming_recognize.rb
@@ -27,22 +27,22 @@ def streaming_recognize
   # Create a client object. The client can be reused for multiple calls.
   client = Google::Cloud::Speech::V1::Speech::Client.new
 
-  # Create an input stream
+  # Create an input stream.
   input = Gapic::StreamInput.new
 
   # Call the streaming_recognize method to start streaming.
   output = client.streaming_recognize input
 
-  # Send requests on the stream. For each request, pass in keyword
-  # arguments to set fields. Be sure to close the stream when done.
+  # Send requests on the stream. For each request object, set fields by
+  # passing keyword arguments. Be sure to close the stream when done.
   input << Google::Cloud::Speech::V1::StreamingRecognizeRequest.new
   input << Google::Cloud::Speech::V1::StreamingRecognizeRequest.new
   input.close
 
-  # Handle streamed responses. These may be interleaved with inputs.
-  # Each response is of type ::Google::Cloud::Speech::V1::StreamingRecognizeResponse.
-  output.each do |response|
-    p response
+  # The returned object is a streamed enumerable yielding elements of type
+  # ::Google::Cloud::Speech::V1::StreamingRecognizeResponse
+  output.each do |current_response|
+    p current_response
   end
 end
 # [END speech_v1_generated_Speech_StreamingRecognize_sync]

--- a/shared/output/cloud/speech_v1/snippets/speech/streaming_recognize.rb
+++ b/shared/output/cloud/speech_v1/snippets/speech/streaming_recognize.rb
@@ -20,8 +20,11 @@
 require "google/cloud/speech/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Speech::V1::Speech::Client#streaming_recognize
+# Snippet for the streaming_recognize call in the Speech service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Speech::V1::Speech::Client#streaming_recognize. It may require
+# modification in order to execute successfully.
 #
 def streaming_recognize
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -424,14 +424,14 @@ module Google
             #   # Call the async_batch_annotate_images method.
             #   result = client.async_batch_annotate_images request
             #
-            #   # The returned object is of type Gapic::Operation. You can use this
-            #   # object to check the status of an operation, cancel it, or wait
-            #   # for results. Here is how to block until completion:
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
             #   result.wait_until_done! timeout: 60
             #   if result.response?
             #     p result.response
             #   else
-            #     puts "Error!"
+            #     puts "No response received."
             #   end
             #
             def async_batch_annotate_images request, options = nil
@@ -527,14 +527,14 @@ module Google
             #   # Call the async_batch_annotate_files method.
             #   result = client.async_batch_annotate_files request
             #
-            #   # The returned object is of type Gapic::Operation. You can use this
-            #   # object to check the status of an operation, cancel it, or wait
-            #   # for results. Here is how to block until completion:
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
             #   result.wait_until_done! timeout: 60
             #   if result.response?
             #     p result.response
             #   else
-            #     puts "Error!"
+            #     puts "No response received."
             #   end
             #
             def async_batch_annotate_files request, options = nil

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -158,13 +158,11 @@ module Google
             #   # Call the list_operations method.
             #   result = client.list_operations request
             #
-            #   # The returned object is of type Gapic::PagedEnumerable. You can
-            #   # iterate over all elements by calling #each, and the enumerable
-            #   # will lazily make API calls to fetch subsequent pages. Other
-            #   # methods are also available for managing paging directly.
-            #   result.each do |response|
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
             #     # Each element is of type ::Google::Longrunning::Operation.
-            #     p response
+            #     p item
             #   end
             #
             def list_operations request, options = nil
@@ -253,14 +251,14 @@ module Google
             #   # Call the get_operation method.
             #   result = client.get_operation request
             #
-            #   # The returned object is of type Gapic::Operation. You can use this
-            #   # object to check the status of an operation, cancel it, or wait
-            #   # for results. Here is how to block until completion:
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
             #   result.wait_until_done! timeout: 60
             #   if result.response?
             #     p result.response
             #   else
-            #     puts "Error!"
+            #     puts "No response received."
             #   end
             #
             def get_operation request, options = nil
@@ -540,14 +538,14 @@ module Google
             #   # Call the wait_operation method.
             #   result = client.wait_operation request
             #
-            #   # The returned object is of type Gapic::Operation. You can use this
-            #   # object to check the status of an operation, cancel it, or wait
-            #   # for results. Here is how to block until completion:
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
             #   result.wait_until_done! timeout: 60
             #   if result.response?
             #     p result.response
             #   else
-            #     puts "Error!"
+            #     puts "No response received."
             #   end
             #
             def wait_operation request, options = nil

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -335,13 +335,11 @@ module Google
             #   # Call the list_product_sets method.
             #   result = client.list_product_sets request
             #
-            #   # The returned object is of type Gapic::PagedEnumerable. You can
-            #   # iterate over all elements by calling #each, and the enumerable
-            #   # will lazily make API calls to fetch subsequent pages. Other
-            #   # methods are also available for managing paging directly.
-            #   result.each do |response|
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
             #     # Each element is of type ::Google::Cloud::Vision::V1::ProductSet.
-            #     p response
+            #     p item
             #   end
             #
             def list_product_sets request, options = nil
@@ -820,13 +818,11 @@ module Google
             #   # Call the list_products method.
             #   result = client.list_products request
             #
-            #   # The returned object is of type Gapic::PagedEnumerable. You can
-            #   # iterate over all elements by calling #each, and the enumerable
-            #   # will lazily make API calls to fetch subsequent pages. Other
-            #   # methods are also available for managing paging directly.
-            #   result.each do |response|
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
             #     # Each element is of type ::Google::Cloud::Vision::V1::Product.
-            #     p response
+            #     p item
             #   end
             #
             def list_products request, options = nil
@@ -1426,13 +1422,11 @@ module Google
             #   # Call the list_reference_images method.
             #   result = client.list_reference_images request
             #
-            #   # The returned object is of type Gapic::PagedEnumerable. You can
-            #   # iterate over all elements by calling #each, and the enumerable
-            #   # will lazily make API calls to fetch subsequent pages. Other
-            #   # methods are also available for managing paging directly.
-            #   result.each do |response|
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
             #     # Each element is of type ::Google::Cloud::Vision::V1::ReferenceImage.
-            #     p response
+            #     p item
             #   end
             #
             def list_reference_images request, options = nil
@@ -1816,13 +1810,11 @@ module Google
             #   # Call the list_products_in_product_set method.
             #   result = client.list_products_in_product_set request
             #
-            #   # The returned object is of type Gapic::PagedEnumerable. You can
-            #   # iterate over all elements by calling #each, and the enumerable
-            #   # will lazily make API calls to fetch subsequent pages. Other
-            #   # methods are also available for managing paging directly.
-            #   result.each do |response|
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
             #     # Each element is of type ::Google::Cloud::Vision::V1::Product.
-            #     p response
+            #     p item
             #   end
             #
             def list_products_in_product_set request, options = nil
@@ -1922,14 +1914,14 @@ module Google
             #   # Call the import_product_sets method.
             #   result = client.import_product_sets request
             #
-            #   # The returned object is of type Gapic::Operation. You can use this
-            #   # object to check the status of an operation, cancel it, or wait
-            #   # for results. Here is how to block until completion:
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
             #   result.wait_until_done! timeout: 60
             #   if result.response?
             #     p result.response
             #   else
-            #     puts "Error!"
+            #     puts "No response received."
             #   end
             #
             def import_product_sets request, options = nil
@@ -2048,14 +2040,14 @@ module Google
             #   # Call the purge_products method.
             #   result = client.purge_products request
             #
-            #   # The returned object is of type Gapic::Operation. You can use this
-            #   # object to check the status of an operation, cancel it, or wait
-            #   # for results. Here is how to block until completion:
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
             #   result.wait_until_done! timeout: 60
             #   if result.response?
             #     p result.response
             #   else
-            #     puts "Error!"
+            #     puts "No response received."
             #   end
             #
             def purge_products request, options = nil

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -158,13 +158,11 @@ module Google
             #   # Call the list_operations method.
             #   result = client.list_operations request
             #
-            #   # The returned object is of type Gapic::PagedEnumerable. You can
-            #   # iterate over all elements by calling #each, and the enumerable
-            #   # will lazily make API calls to fetch subsequent pages. Other
-            #   # methods are also available for managing paging directly.
-            #   result.each do |response|
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
             #     # Each element is of type ::Google::Longrunning::Operation.
-            #     p response
+            #     p item
             #   end
             #
             def list_operations request, options = nil
@@ -253,14 +251,14 @@ module Google
             #   # Call the get_operation method.
             #   result = client.get_operation request
             #
-            #   # The returned object is of type Gapic::Operation. You can use this
-            #   # object to check the status of an operation, cancel it, or wait
-            #   # for results. Here is how to block until completion:
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
             #   result.wait_until_done! timeout: 60
             #   if result.response?
             #     p result.response
             #   else
-            #     puts "Error!"
+            #     puts "No response received."
             #   end
             #
             def get_operation request, options = nil
@@ -540,14 +538,14 @@ module Google
             #   # Call the wait_operation method.
             #   result = client.wait_operation request
             #
-            #   # The returned object is of type Gapic::Operation. You can use this
-            #   # object to check the status of an operation, cancel it, or wait
-            #   # for results. Here is how to block until completion:
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
             #   result.wait_until_done! timeout: 60
             #   if result.response?
             #     p result.response
             #   else
-            #     puts "Error!"
+            #     puts "No response received."
             #   end
             #
             def wait_operation request, options = nil

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_files.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_files.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_files
+# Snippet for the async_batch_annotate_files call in the ImageAnnotator service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_files.
+# It may require modification in order to execute successfully.
 #
 def async_batch_annotate_files
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_files.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_files.rb
@@ -33,14 +33,14 @@ def async_batch_annotate_files
   # Call the async_batch_annotate_files method.
   result = client.async_batch_annotate_files request
 
-  # The returned object is of type Gapic::Operation. You can use this
-  # object to check the status of an operation, cancel it, or wait
-  # for results. Here is how to block until completion:
+  # The returned object is of type Gapic::Operation. You can use it to
+  # check the status of an operation, cancel it, or wait for results.
+  # Here is how to wait for a response.
   result.wait_until_done! timeout: 60
   if result.response?
     p result.response
   else
-    puts "Error!"
+    puts "No response received."
   end
 end
 # [END vision_v1_generated_ImageAnnotator_AsyncBatchAnnotateFiles_sync]

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_images.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_images.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_images
+# Snippet for the async_batch_annotate_images call in the ImageAnnotator service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_images.
+# It may require modification in order to execute successfully.
 #
 def async_batch_annotate_images
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_images.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/async_batch_annotate_images.rb
@@ -33,14 +33,14 @@ def async_batch_annotate_images
   # Call the async_batch_annotate_images method.
   result = client.async_batch_annotate_images request
 
-  # The returned object is of type Gapic::Operation. You can use this
-  # object to check the status of an operation, cancel it, or wait
-  # for results. Here is how to block until completion:
+  # The returned object is of type Gapic::Operation. You can use it to
+  # check the status of an operation, cancel it, or wait for results.
+  # Here is how to wait for a response.
   result.wait_until_done! timeout: 60
   if result.response?
     p result.response
   else
-    puts "Error!"
+    puts "No response received."
   end
 end
 # [END vision_v1_generated_ImageAnnotator_AsyncBatchAnnotateImages_sync]

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/batch_annotate_files.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/batch_annotate_files.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_files
+# Snippet for the batch_annotate_files call in the ImageAnnotator service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_files. It may
+# require modification in order to execute successfully.
 #
 def batch_annotate_files
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/image_annotator/batch_annotate_images.rb
+++ b/shared/output/cloud/vision_v1/snippets/image_annotator/batch_annotate_images.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_images
+# Snippet for the batch_annotate_images call in the ImageAnnotator service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_images. It
+# may require modification in order to execute successfully.
 #
 def batch_annotate_images
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/add_product_to_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/add_product_to_product_set.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#add_product_to_product_set
+# Snippet for the add_product_to_product_set call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#add_product_to_product_set.
+# It may require modification in order to execute successfully.
 #
 def add_product_to_product_set
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/create_product.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/create_product.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#create_product
+# Snippet for the create_product call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#create_product. It may
+# require modification in order to execute successfully.
 #
 def create_product
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/create_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/create_product_set.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#create_product_set
+# Snippet for the create_product_set call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#create_product_set. It may
+# require modification in order to execute successfully.
 #
 def create_product_set
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/create_reference_image.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/create_reference_image.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#create_reference_image
+# Snippet for the create_reference_image call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#create_reference_image. It
+# may require modification in order to execute successfully.
 #
 def create_reference_image
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/delete_product.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/delete_product.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#delete_product
+# Snippet for the delete_product call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#delete_product. It may
+# require modification in order to execute successfully.
 #
 def delete_product
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/delete_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/delete_product_set.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#delete_product_set
+# Snippet for the delete_product_set call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#delete_product_set. It may
+# require modification in order to execute successfully.
 #
 def delete_product_set
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/delete_reference_image.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/delete_reference_image.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#delete_reference_image
+# Snippet for the delete_reference_image call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#delete_reference_image. It
+# may require modification in order to execute successfully.
 #
 def delete_reference_image
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/get_product.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/get_product.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#get_product
+# Snippet for the get_product call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#get_product. It may require
+# modification in order to execute successfully.
 #
 def get_product
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/get_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/get_product_set.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#get_product_set
+# Snippet for the get_product_set call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#get_product_set. It may
+# require modification in order to execute successfully.
 #
 def get_product_set
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/get_reference_image.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/get_reference_image.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#get_reference_image
+# Snippet for the get_reference_image call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#get_reference_image. It may
+# require modification in order to execute successfully.
 #
 def get_reference_image
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/import_product_sets.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/import_product_sets.rb
@@ -33,14 +33,14 @@ def import_product_sets
   # Call the import_product_sets method.
   result = client.import_product_sets request
 
-  # The returned object is of type Gapic::Operation. You can use this
-  # object to check the status of an operation, cancel it, or wait
-  # for results. Here is how to block until completion:
+  # The returned object is of type Gapic::Operation. You can use it to
+  # check the status of an operation, cancel it, or wait for results.
+  # Here is how to wait for a response.
   result.wait_until_done! timeout: 60
   if result.response?
     p result.response
   else
-    puts "Error!"
+    puts "No response received."
   end
 end
 # [END vision_v1_generated_ProductSearch_ImportProductSets_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/import_product_sets.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/import_product_sets.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#import_product_sets
+# Snippet for the import_product_sets call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#import_product_sets. It may
+# require modification in order to execute successfully.
 #
 def import_product_sets
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_product_sets.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_product_sets.rb
@@ -33,13 +33,11 @@ def list_product_sets
   # Call the list_product_sets method.
   result = client.list_product_sets request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Cloud::Vision::V1::ProductSet.
-    p response
+    p item
   end
 end
 # [END vision_v1_generated_ProductSearch_ListProductSets_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_product_sets.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_product_sets.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#list_product_sets
+# Snippet for the list_product_sets call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#list_product_sets. It may
+# require modification in order to execute successfully.
 #
 def list_product_sets
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_products.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_products.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#list_products
+# Snippet for the list_products call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#list_products. It may require
+# modification in order to execute successfully.
 #
 def list_products
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_products.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_products.rb
@@ -33,13 +33,11 @@ def list_products
   # Call the list_products method.
   result = client.list_products request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Cloud::Vision::V1::Product.
-    p response
+    p item
   end
 end
 # [END vision_v1_generated_ProductSearch_ListProducts_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_products_in_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_products_in_product_set.rb
@@ -33,13 +33,11 @@ def list_products_in_product_set
   # Call the list_products_in_product_set method.
   result = client.list_products_in_product_set request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Cloud::Vision::V1::Product.
-    p response
+    p item
   end
 end
 # [END vision_v1_generated_ProductSearch_ListProductsInProductSet_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_products_in_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_products_in_product_set.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#list_products_in_product_set
+# Snippet for the list_products_in_product_set call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#list_products_in_product_set.
+# It may require modification in order to execute successfully.
 #
 def list_products_in_product_set
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_reference_images.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_reference_images.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#list_reference_images
+# Snippet for the list_reference_images call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#list_reference_images. It may
+# require modification in order to execute successfully.
 #
 def list_reference_images
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/list_reference_images.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/list_reference_images.rb
@@ -33,13 +33,11 @@ def list_reference_images
   # Call the list_reference_images method.
   result = client.list_reference_images request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Cloud::Vision::V1::ReferenceImage.
-    p response
+    p item
   end
 end
 # [END vision_v1_generated_ProductSearch_ListReferenceImages_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/purge_products.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/purge_products.rb
@@ -33,14 +33,14 @@ def purge_products
   # Call the purge_products method.
   result = client.purge_products request
 
-  # The returned object is of type Gapic::Operation. You can use this
-  # object to check the status of an operation, cancel it, or wait
-  # for results. Here is how to block until completion:
+  # The returned object is of type Gapic::Operation. You can use it to
+  # check the status of an operation, cancel it, or wait for results.
+  # Here is how to wait for a response.
   result.wait_until_done! timeout: 60
   if result.response?
     p result.response
   else
-    puts "Error!"
+    puts "No response received."
   end
 end
 # [END vision_v1_generated_ProductSearch_PurgeProducts_sync]

--- a/shared/output/cloud/vision_v1/snippets/product_search/purge_products.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/purge_products.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#purge_products
+# Snippet for the purge_products call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#purge_products. It may
+# require modification in order to execute successfully.
 #
 def purge_products
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/remove_product_from_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/remove_product_from_product_set.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#remove_product_from_product_set
+# Snippet for the remove_product_from_product_set call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#remove_product_from_product_set.
+# It may require modification in order to execute successfully.
 #
 def remove_product_from_product_set
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/update_product.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/update_product.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#update_product
+# Snippet for the update_product call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#update_product. It may
+# require modification in order to execute successfully.
 #
 def update_product
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/product_search/update_product_set.rb
+++ b/shared/output/cloud/vision_v1/snippets/product_search/update_product_set.rb
@@ -20,8 +20,11 @@
 require "google/cloud/vision/v1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Cloud::Vision::V1::ProductSearch::Client#update_product_set
+# Snippet for the update_product_set call in the ProductSearch service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Cloud::Vision::V1::ProductSearch::Client#update_product_set. It may
+# require modification in order to execute successfully.
 #
 def update_product_set
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/cloud/vision_v1/snippets/snippet_metadata_google.cloud.vision.v1.json
+++ b/shared/output/cloud/vision_v1/snippets/snippet_metadata_google.cloud.vision.v1.json
@@ -86,7 +86,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 44,
+          "end": 42,
           "type": "FULL"
         }
       ]
@@ -286,7 +286,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 44,
+          "end": 42,
           "type": "FULL"
         }
       ]
@@ -526,7 +526,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 44,
+          "end": 42,
           "type": "FULL"
         }
       ]
@@ -686,7 +686,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 44,
+          "end": 42,
           "type": "FULL"
         }
       ]

--- a/shared/output/cloud/vision_v1/snippets/snippet_metadata_google.cloud.vision.v1.json
+++ b/shared/output/cloud/vision_v1/snippets/snippet_metadata_google.cloud.vision.v1.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "vision_v1_generated_ProductSearch_CreateProductSet_sync",
-      "title": "Snippet for create_product_set in ProductSearch",
-      "description": "Basic snippet for create_product_set in ProductSearch",
+      "title": "Snippet for the create_product_set call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#create_product_set. It may require modification in order to execute successfully.",
       "file": "product_search/create_product_set.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_ListProductSets_sync",
-      "title": "Snippet for list_product_sets in ProductSearch",
-      "description": "Basic snippet for list_product_sets in ProductSearch",
+      "title": "Snippet for the list_product_sets call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#list_product_sets. It may require modification in order to execute successfully.",
       "file": "product_search/list_product_sets.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,15 +86,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 42,
+          "end": 45,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_GetProductSet_sync",
-      "title": "Snippet for get_product_set in ProductSearch",
-      "description": "Basic snippet for get_product_set in ProductSearch",
+      "title": "Snippet for the get_product_set call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#get_product_set. It may require modification in order to execute successfully.",
       "file": "product_search/get_product_set.rb",
       "language": "RUBY",
       "client_method": {
@@ -126,15 +126,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_UpdateProductSet_sync",
-      "title": "Snippet for update_product_set in ProductSearch",
-      "description": "Basic snippet for update_product_set in ProductSearch",
+      "title": "Snippet for the update_product_set call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#update_product_set. It may require modification in order to execute successfully.",
       "file": "product_search/update_product_set.rb",
       "language": "RUBY",
       "client_method": {
@@ -166,15 +166,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_DeleteProductSet_sync",
-      "title": "Snippet for delete_product_set in ProductSearch",
-      "description": "Basic snippet for delete_product_set in ProductSearch",
+      "title": "Snippet for the delete_product_set call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#delete_product_set. It may require modification in order to execute successfully.",
       "file": "product_search/delete_product_set.rb",
       "language": "RUBY",
       "client_method": {
@@ -206,15 +206,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_CreateProduct_sync",
-      "title": "Snippet for create_product in ProductSearch",
-      "description": "Basic snippet for create_product in ProductSearch",
+      "title": "Snippet for the create_product call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#create_product. It may require modification in order to execute successfully.",
       "file": "product_search/create_product.rb",
       "language": "RUBY",
       "client_method": {
@@ -246,15 +246,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_ListProducts_sync",
-      "title": "Snippet for list_products in ProductSearch",
-      "description": "Basic snippet for list_products in ProductSearch",
+      "title": "Snippet for the list_products call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#list_products. It may require modification in order to execute successfully.",
       "file": "product_search/list_products.rb",
       "language": "RUBY",
       "client_method": {
@@ -286,15 +286,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 42,
+          "end": 45,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_GetProduct_sync",
-      "title": "Snippet for get_product in ProductSearch",
-      "description": "Basic snippet for get_product in ProductSearch",
+      "title": "Snippet for the get_product call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#get_product. It may require modification in order to execute successfully.",
       "file": "product_search/get_product.rb",
       "language": "RUBY",
       "client_method": {
@@ -326,15 +326,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_UpdateProduct_sync",
-      "title": "Snippet for update_product in ProductSearch",
-      "description": "Basic snippet for update_product in ProductSearch",
+      "title": "Snippet for the update_product call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#update_product. It may require modification in order to execute successfully.",
       "file": "product_search/update_product.rb",
       "language": "RUBY",
       "client_method": {
@@ -366,15 +366,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_DeleteProduct_sync",
-      "title": "Snippet for delete_product in ProductSearch",
-      "description": "Basic snippet for delete_product in ProductSearch",
+      "title": "Snippet for the delete_product call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#delete_product. It may require modification in order to execute successfully.",
       "file": "product_search/delete_product.rb",
       "language": "RUBY",
       "client_method": {
@@ -406,15 +406,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_CreateReferenceImage_sync",
-      "title": "Snippet for create_reference_image in ProductSearch",
-      "description": "Basic snippet for create_reference_image in ProductSearch",
+      "title": "Snippet for the create_reference_image call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#create_reference_image. It may require modification in order to execute successfully.",
       "file": "product_search/create_reference_image.rb",
       "language": "RUBY",
       "client_method": {
@@ -446,15 +446,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_DeleteReferenceImage_sync",
-      "title": "Snippet for delete_reference_image in ProductSearch",
-      "description": "Basic snippet for delete_reference_image in ProductSearch",
+      "title": "Snippet for the delete_reference_image call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#delete_reference_image. It may require modification in order to execute successfully.",
       "file": "product_search/delete_reference_image.rb",
       "language": "RUBY",
       "client_method": {
@@ -486,15 +486,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_ListReferenceImages_sync",
-      "title": "Snippet for list_reference_images in ProductSearch",
-      "description": "Basic snippet for list_reference_images in ProductSearch",
+      "title": "Snippet for the list_reference_images call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#list_reference_images. It may require modification in order to execute successfully.",
       "file": "product_search/list_reference_images.rb",
       "language": "RUBY",
       "client_method": {
@@ -526,15 +526,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 42,
+          "end": 45,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_GetReferenceImage_sync",
-      "title": "Snippet for get_reference_image in ProductSearch",
-      "description": "Basic snippet for get_reference_image in ProductSearch",
+      "title": "Snippet for the get_reference_image call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#get_reference_image. It may require modification in order to execute successfully.",
       "file": "product_search/get_reference_image.rb",
       "language": "RUBY",
       "client_method": {
@@ -566,15 +566,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_AddProductToProductSet_sync",
-      "title": "Snippet for add_product_to_product_set in ProductSearch",
-      "description": "Basic snippet for add_product_to_product_set in ProductSearch",
+      "title": "Snippet for the add_product_to_product_set call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#add_product_to_product_set. It may require modification in order to execute successfully.",
       "file": "product_search/add_product_to_product_set.rb",
       "language": "RUBY",
       "client_method": {
@@ -606,15 +606,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_RemoveProductFromProductSet_sync",
-      "title": "Snippet for remove_product_from_product_set in ProductSearch",
-      "description": "Basic snippet for remove_product_from_product_set in ProductSearch",
+      "title": "Snippet for the remove_product_from_product_set call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#remove_product_from_product_set. It may require modification in order to execute successfully.",
       "file": "product_search/remove_product_from_product_set.rb",
       "language": "RUBY",
       "client_method": {
@@ -646,15 +646,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_ListProductsInProductSet_sync",
-      "title": "Snippet for list_products_in_product_set in ProductSearch",
-      "description": "Basic snippet for list_products_in_product_set in ProductSearch",
+      "title": "Snippet for the list_products_in_product_set call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#list_products_in_product_set. It may require modification in order to execute successfully.",
       "file": "product_search/list_products_in_product_set.rb",
       "language": "RUBY",
       "client_method": {
@@ -686,15 +686,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 42,
+          "end": 45,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_ImportProductSets_sync",
-      "title": "Snippet for import_product_sets in ProductSearch",
-      "description": "Basic snippet for import_product_sets in ProductSearch",
+      "title": "Snippet for the import_product_sets call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#import_product_sets. It may require modification in order to execute successfully.",
       "file": "product_search/import_product_sets.rb",
       "language": "RUBY",
       "client_method": {
@@ -726,15 +726,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 45,
+          "end": 48,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ProductSearch_PurgeProducts_sync",
-      "title": "Snippet for purge_products in ProductSearch",
-      "description": "Basic snippet for purge_products in ProductSearch",
+      "title": "Snippet for the purge_products call in the ProductSearch service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ProductSearch::Client#purge_products. It may require modification in order to execute successfully.",
       "file": "product_search/purge_products.rb",
       "language": "RUBY",
       "client_method": {
@@ -766,15 +766,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 45,
+          "end": 48,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ImageAnnotator_BatchAnnotateImages_sync",
-      "title": "Snippet for batch_annotate_images in ImageAnnotator",
-      "description": "Basic snippet for batch_annotate_images in ImageAnnotator",
+      "title": "Snippet for the batch_annotate_images call in the ImageAnnotator service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_images. It may require modification in order to execute successfully.",
       "file": "image_annotator/batch_annotate_images.rb",
       "language": "RUBY",
       "client_method": {
@@ -806,15 +806,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ImageAnnotator_BatchAnnotateFiles_sync",
-      "title": "Snippet for batch_annotate_files in ImageAnnotator",
-      "description": "Basic snippet for batch_annotate_files in ImageAnnotator",
+      "title": "Snippet for the batch_annotate_files call in the ImageAnnotator service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ImageAnnotator::Client#batch_annotate_files. It may require modification in order to execute successfully.",
       "file": "image_annotator/batch_annotate_files.rb",
       "language": "RUBY",
       "client_method": {
@@ -846,15 +846,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 38,
+          "end": 41,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ImageAnnotator_AsyncBatchAnnotateImages_sync",
-      "title": "Snippet for async_batch_annotate_images in ImageAnnotator",
-      "description": "Basic snippet for async_batch_annotate_images in ImageAnnotator",
+      "title": "Snippet for the async_batch_annotate_images call in the ImageAnnotator service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_images. It may require modification in order to execute successfully.",
       "file": "image_annotator/async_batch_annotate_images.rb",
       "language": "RUBY",
       "client_method": {
@@ -886,15 +886,15 @@
       "segments": [
         {
           "start": 20,
-          "end": 45,
+          "end": 48,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "vision_v1_generated_ImageAnnotator_AsyncBatchAnnotateFiles_sync",
-      "title": "Snippet for async_batch_annotate_files in ImageAnnotator",
-      "description": "Basic snippet for async_batch_annotate_files in ImageAnnotator",
+      "title": "Snippet for the async_batch_annotate_files call in the ImageAnnotator service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Vision::V1::ImageAnnotator::Client#async_batch_annotate_files. It may require modification in order to execute successfully.",
       "file": "image_annotator/async_batch_annotate_files.rb",
       "language": "RUBY",
       "client_method": {
@@ -926,7 +926,7 @@
       "segments": [
         {
           "start": 20,
-          "end": 45,
+          "end": 48,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -1114,13 +1114,11 @@ module So
           #   # Call the get_paged_garbage method.
           #   result = client.get_paged_garbage request
           #
-          #   # The returned object is of type Gapic::PagedEnumerable. You can
-          #   # iterate over all elements by calling #each, and the enumerable
-          #   # will lazily make API calls to fetch subsequent pages. Other
-          #   # methods are also available for managing paging directly.
-          #   result.each do |response|
+          #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+          #   # over elements, and API calls will be issued to fetch pages as needed.
+          #   result.each do |item|
           #     # Each element is of type ::So::Much::Trash::GarbageItem.
-          #     p response
+          #     p item
           #   end
           #
           # @example Getting garbage
@@ -1215,14 +1213,14 @@ module So
           #   # Call the long_running_garbage method.
           #   result = client.long_running_garbage request
           #
-          #   # The returned object is of type Gapic::Operation. You can use this
-          #   # object to check the status of an operation, cancel it, or wait
-          #   # for results. Here is how to block until completion:
+          #   # The returned object is of type Gapic::Operation. You can use it to
+          #   # check the status of an operation, cancel it, or wait for results.
+          #   # Here is how to wait for a response.
           #   result.wait_until_done! timeout: 60
           #   if result.response?
           #     p result.response
           #   else
-          #     puts "Error!"
+          #     puts "No response received."
           #   end
           #
           def long_running_garbage request, options = nil
@@ -1279,15 +1277,17 @@ module So
           #   # Create a client object. The client can be reused for multiple calls.
           #   client = So::Much::Trash::GarbageService::Client.new
           #
-          #   # Create a stream of requests, as an Enumerator.
-          #   # For each request, pass in keyword arguments to set fields.
-          #   request = [
-          #     So::Much::Trash::ListGarbageRequest.new,
-          #     So::Much::Trash::ListGarbageRequest.new
-          #   ].to_enum
+          #   # Create an input stream.
+          #   input = Gapic::StreamInput.new
           #
-          #   # Call the client_garbage method.
-          #   result = client.client_garbage request
+          #   # Call the client_garbage method to start streaming.
+          #   result = client.client_garbage input
+          #
+          #   # Send requests on the stream. For each request object, set fields by
+          #   # passing keyword arguments. Be sure to close the stream when done.
+          #   input << So::Much::Trash::ListGarbageRequest.new
+          #   input << So::Much::Trash::ListGarbageRequest.new
+          #   input.close
           #
           #   # The returned object is of type So::Much::Trash::ListGarbageResponse.
           #   p result
@@ -1366,13 +1366,13 @@ module So
           #   # Create a request. To set request fields, pass in keyword arguments.
           #   request = So::Much::Trash::ListGarbageRequest.new
           #
-          #   # Call the server_garbage method.
-          #   result = client.server_garbage request
+          #   # Call the server_garbage method to start streaming.
+          #   output = client.server_garbage request
           #
-          #   # The returned object is a streamed enumerable yielding elements of
-          #   # type ::So::Much::Trash::GarbageItem.
-          #   result.each do |response|
-          #     p response
+          #   # The returned object is a streamed enumerable yielding elements of type
+          #   # ::So::Much::Trash::GarbageItem
+          #   output.each do |current_response|
+          #     p current_response
           #   end
           #
           # @example Getting garbage
@@ -1445,22 +1445,22 @@ module So
           #   # Create a client object. The client can be reused for multiple calls.
           #   client = So::Much::Trash::GarbageService::Client.new
           #
-          #   # Create an input stream
+          #   # Create an input stream.
           #   input = Gapic::StreamInput.new
           #
           #   # Call the bidi_garbage method to start streaming.
           #   output = client.bidi_garbage input
           #
-          #   # Send requests on the stream. For each request, pass in keyword
-          #   # arguments to set fields. Be sure to close the stream when done.
+          #   # Send requests on the stream. For each request object, set fields by
+          #   # passing keyword arguments. Be sure to close the stream when done.
           #   input << So::Much::Trash::ListGarbageRequest.new
           #   input << So::Much::Trash::ListGarbageRequest.new
           #   input.close
           #
-          #   # Handle streamed responses. These may be interleaved with inputs.
-          #   # Each response is of type ::So::Much::Trash::GarbageItem.
-          #   output.each do |response|
-          #     p response
+          #   # The returned object is a streamed enumerable yielding elements of type
+          #   # ::So::Much::Trash::GarbageItem
+          #   output.each do |current_response|
+          #     p current_response
           #   end
           #
           def bidi_garbage request, options = nil
@@ -1521,22 +1521,22 @@ module So
           #   # Create a client object. The client can be reused for multiple calls.
           #   client = So::Much::Trash::GarbageService::Client.new
           #
-          #   # Create an input stream
+          #   # Create an input stream.
           #   input = Gapic::StreamInput.new
           #
           #   # Call the bidi_typical_garbage method to start streaming.
           #   output = client.bidi_typical_garbage input
           #
-          #   # Send requests on the stream. For each request, pass in keyword
-          #   # arguments to set fields. Be sure to close the stream when done.
+          #   # Send requests on the stream. For each request object, set fields by
+          #   # passing keyword arguments. Be sure to close the stream when done.
           #   input << So::Much::Trash::TypicalGarbage.new
           #   input << So::Much::Trash::TypicalGarbage.new
           #   input.close
           #
-          #   # Handle streamed responses. These may be interleaved with inputs.
-          #   # Each response is of type ::So::Much::Trash::TypicalGarbage.
-          #   output.each do |response|
-          #     p response
+          #   # The returned object is a streamed enumerable yielding elements of type
+          #   # ::So::Much::Trash::TypicalGarbage
+          #   output.each do |current_response|
+          #     p current_response
           #   end
           #
           def bidi_typical_garbage request, options = nil

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -165,13 +165,11 @@ module So
           #   # Call the list_operations method.
           #   result = client.list_operations request
           #
-          #   # The returned object is of type Gapic::PagedEnumerable. You can
-          #   # iterate over all elements by calling #each, and the enumerable
-          #   # will lazily make API calls to fetch subsequent pages. Other
-          #   # methods are also available for managing paging directly.
-          #   result.each do |response|
+          #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+          #   # over elements, and API calls will be issued to fetch pages as needed.
+          #   result.each do |item|
           #     # Each element is of type ::Google::Longrunning::Operation.
-          #     p response
+          #     p item
           #   end
           #
           def list_operations request, options = nil
@@ -259,14 +257,14 @@ module So
           #   # Call the get_operation method.
           #   result = client.get_operation request
           #
-          #   # The returned object is of type Gapic::Operation. You can use this
-          #   # object to check the status of an operation, cancel it, or wait
-          #   # for results. Here is how to block until completion:
+          #   # The returned object is of type Gapic::Operation. You can use it to
+          #   # check the status of an operation, cancel it, or wait for results.
+          #   # Here is how to wait for a response.
           #   result.wait_until_done! timeout: 60
           #   if result.response?
           #     p result.response
           #   else
-          #     puts "Error!"
+          #     puts "No response received."
           #   end
           #
           def get_operation request, options = nil
@@ -540,14 +538,14 @@ module So
           #   # Call the wait_operation method.
           #   result = client.wait_operation request
           #
-          #   # The returned object is of type Gapic::Operation. You can use this
-          #   # object to check the status of an operation, cancel it, or wait
-          #   # for results. Here is how to block until completion:
+          #   # The returned object is of type Gapic::Operation. You can use it to
+          #   # check the status of an operation, cancel it, or wait for results.
+          #   # Here is how to wait for a response.
           #   result.wait_until_done! timeout: 60
           #   if result.response?
           #     p result.response
           #   else
-          #     puts "Error!"
+          #     puts "No response received."
           #   end
           #
           def wait_operation request, options = nil

--- a/shared/output/gapic/templates/garbage/snippets/deprecated_service/deprecated_get.rb
+++ b/shared/output/gapic/templates/garbage/snippets/deprecated_service/deprecated_get.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::DeprecatedService::Client#deprecated_get
+# Snippet for the deprecated_get call in the DeprecatedService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::DeprecatedService::Client#deprecated_get. It may require
+# modification in order to execute successfully.
 #
 def deprecated_get
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/bidi_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/bidi_garbage.rb
@@ -35,22 +35,22 @@ def bidi_garbage
   # Create a client object. The client can be reused for multiple calls.
   client = So::Much::Trash::GarbageService::Client.new
 
-  # Create an input stream
+  # Create an input stream.
   input = Gapic::StreamInput.new
 
   # Call the bidi_garbage method to start streaming.
   output = client.bidi_garbage input
 
-  # Send requests on the stream. For each request, pass in keyword
-  # arguments to set fields. Be sure to close the stream when done.
+  # Send requests on the stream. For each request object, set fields by
+  # passing keyword arguments. Be sure to close the stream when done.
   input << So::Much::Trash::ListGarbageRequest.new
   input << So::Much::Trash::ListGarbageRequest.new
   input.close
 
-  # Handle streamed responses. These may be interleaved with inputs.
-  # Each response is of type ::So::Much::Trash::GarbageItem.
-  output.each do |response|
-    p response
+  # The returned object is a streamed enumerable yielding elements of type
+  # ::So::Much::Trash::GarbageItem
+  output.each do |current_response|
+    p current_response
   end
 end
 # [END garbage_v0_generated_GarbageService_BidiGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/bidi_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/bidi_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#bidi_garbage
+# Snippet for the bidi_garbage call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#bidi_garbage. It may require
+# modification in order to execute successfully.
 #
 def bidi_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/bidi_typical_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/bidi_typical_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#bidi_typical_garbage
+# Snippet for the bidi_typical_garbage call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#bidi_typical_garbage. It may require
+# modification in order to execute successfully.
 #
 def bidi_typical_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/bidi_typical_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/bidi_typical_garbage.rb
@@ -35,22 +35,22 @@ def bidi_typical_garbage
   # Create a client object. The client can be reused for multiple calls.
   client = So::Much::Trash::GarbageService::Client.new
 
-  # Create an input stream
+  # Create an input stream.
   input = Gapic::StreamInput.new
 
   # Call the bidi_typical_garbage method to start streaming.
   output = client.bidi_typical_garbage input
 
-  # Send requests on the stream. For each request, pass in keyword
-  # arguments to set fields. Be sure to close the stream when done.
+  # Send requests on the stream. For each request object, set fields by
+  # passing keyword arguments. Be sure to close the stream when done.
   input << So::Much::Trash::TypicalGarbage.new
   input << So::Much::Trash::TypicalGarbage.new
   input.close
 
-  # Handle streamed responses. These may be interleaved with inputs.
-  # Each response is of type ::So::Much::Trash::TypicalGarbage.
-  output.each do |response|
-    p response
+  # The returned object is a streamed enumerable yielding elements of type
+  # ::So::Much::Trash::TypicalGarbage
+  output.each do |current_response|
+    p current_response
   end
 end
 # [END garbage_v0_generated_GarbageService_BidiTypicalGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/call_send.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/call_send.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#call_send
+# Snippet for the call_send call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#call_send. It may require modification
+# in order to execute successfully.
 #
 def call_send
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/client_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/client_garbage.rb
@@ -35,15 +35,17 @@ def client_garbage
   # Create a client object. The client can be reused for multiple calls.
   client = So::Much::Trash::GarbageService::Client.new
 
-  # Create a stream of requests, as an Enumerator.
-  # For each request, pass in keyword arguments to set fields.
-  request = [
-    So::Much::Trash::ListGarbageRequest.new,
-    So::Much::Trash::ListGarbageRequest.new
-  ].to_enum
+  # Create an input stream.
+  input = Gapic::StreamInput.new
 
-  # Call the client_garbage method.
-  result = client.client_garbage request
+  # Call the client_garbage method to start streaming.
+  result = client.client_garbage input
+
+  # Send requests on the stream. For each request object, set fields by
+  # passing keyword arguments. Be sure to close the stream when done.
+  input << So::Much::Trash::ListGarbageRequest.new
+  input << So::Much::Trash::ListGarbageRequest.new
+  input.close
 
   # The returned object is of type So::Much::Trash::ListGarbageResponse.
   p result

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/client_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/client_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#client_garbage
+# Snippet for the client_garbage call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#client_garbage. It may require
+# modification in order to execute successfully.
 #
 def client_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_complex_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_complex_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#get_complex_garbage
+# Snippet for the get_complex_garbage call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_complex_garbage. It may require
+# modification in order to execute successfully.
 #
 def get_complex_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_empty_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_empty_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#get_empty_garbage
+# Snippet for the get_empty_garbage call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_empty_garbage. It may require
+# modification in order to execute successfully.
 #
 def get_empty_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_garbage_node.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_garbage_node.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#get_garbage_node
+# Snippet for the get_garbage_node call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_garbage_node. It may require
+# modification in order to execute successfully.
 #
 def get_garbage_node
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_nested_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_nested_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#get_nested_garbage
+# Snippet for the get_nested_garbage call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_nested_garbage. It may require
+# modification in order to execute successfully.
 #
 def get_nested_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_paged_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_paged_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#get_paged_garbage
+# Snippet for the get_paged_garbage call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_paged_garbage. It may require
+# modification in order to execute successfully.
 #
 def get_paged_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_paged_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_paged_garbage.rb
@@ -41,13 +41,11 @@ def get_paged_garbage
   # Call the get_paged_garbage method.
   result = client.get_paged_garbage request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::So::Much::Trash::GarbageItem.
-    p response
+    p item
   end
 end
 # [END garbage_v0_generated_GarbageService_GetPagedGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_repeated_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_repeated_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#get_repeated_garbage
+# Snippet for the get_repeated_garbage call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_repeated_garbage. It may require
+# modification in order to execute successfully.
 #
 def get_repeated_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_simple_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_simple_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#get_simple_garbage
+# Snippet for the get_simple_garbage call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_simple_garbage. It may require
+# modification in order to execute successfully.
 #
 def get_simple_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_specific_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_specific_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#get_specific_garbage
+# Snippet for the get_specific_garbage call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_specific_garbage. It may require
+# modification in order to execute successfully.
 #
 def get_specific_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_typical_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_typical_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#get_typical_garbage
+# Snippet for the get_typical_garbage call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_typical_garbage. It may require
+# modification in order to execute successfully.
 #
 def get_typical_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/get_typical_garbage_by_request.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/get_typical_garbage_by_request.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#get_typical_garbage_by_request
+# Snippet for the get_typical_garbage_by_request call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#get_typical_garbage_by_request. It may
+# require modification in order to execute successfully.
 #
 def get_typical_garbage_by_request
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/long_running_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/long_running_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#long_running_garbage
+# Snippet for the long_running_garbage call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#long_running_garbage. It may require
+# modification in order to execute successfully.
 #
 def long_running_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/long_running_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/long_running_garbage.rb
@@ -41,14 +41,14 @@ def long_running_garbage
   # Call the long_running_garbage method.
   result = client.long_running_garbage request
 
-  # The returned object is of type Gapic::Operation. You can use this
-  # object to check the status of an operation, cancel it, or wait
-  # for results. Here is how to block until completion:
+  # The returned object is of type Gapic::Operation. You can use it to
+  # check the status of an operation, cancel it, or wait for results.
+  # Here is how to wait for a response.
   result.wait_until_done! timeout: 60
   if result.response?
     p result.response
   else
-    puts "Error!"
+    puts "No response received."
   end
 end
 # [END garbage_v0_generated_GarbageService_LongRunningGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/server_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/server_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::GarbageService::Client#server_garbage
+# Snippet for the server_garbage call in the GarbageService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::GarbageService::Client#server_garbage. It may require
+# modification in order to execute successfully.
 #
 def server_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/garbage_service/server_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/garbage_service/server_garbage.rb
@@ -38,13 +38,13 @@ def server_garbage
   # Create a request. To set request fields, pass in keyword arguments.
   request = So::Much::Trash::ListGarbageRequest.new
 
-  # Call the server_garbage method.
-  result = client.server_garbage request
+  # Call the server_garbage method to start streaming.
+  output = client.server_garbage request
 
-  # The returned object is a streamed enumerable yielding elements of
-  # type ::So::Much::Trash::GarbageItem.
-  result.each do |response|
-    p response
+  # The returned object is a streamed enumerable yielding elements of type
+  # ::So::Much::Trash::GarbageItem
+  output.each do |current_response|
+    p current_response
   end
 end
 # [END garbage_v0_generated_GarbageService_ServerGarbage_sync]

--- a/shared/output/gapic/templates/garbage/snippets/iam_policy/get_iam_policy.rb
+++ b/shared/output/gapic/templates/garbage/snippets/iam_policy/get_iam_policy.rb
@@ -28,8 +28,11 @@
 require "google/iam/v1"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::IAMPolicy::Client#get_iam_policy
+# Snippet for the get_iam_policy call in the IAMPolicy service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::IAMPolicy::Client#get_iam_policy. It may require modification
+# in order to execute successfully.
 #
 def get_iam_policy
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/iam_policy/set_iam_policy.rb
+++ b/shared/output/gapic/templates/garbage/snippets/iam_policy/set_iam_policy.rb
@@ -28,8 +28,11 @@
 require "google/iam/v1"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::IAMPolicy::Client#set_iam_policy
+# Snippet for the set_iam_policy call in the IAMPolicy service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::IAMPolicy::Client#set_iam_policy. It may require modification
+# in order to execute successfully.
 #
 def set_iam_policy
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/iam_policy/test_iam_permissions.rb
+++ b/shared/output/gapic/templates/garbage/snippets/iam_policy/test_iam_permissions.rb
@@ -28,8 +28,11 @@
 require "google/iam/v1"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::IAMPolicy::Client#test_iam_permissions
+# Snippet for the test_iam_permissions call in the IAMPolicy service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::IAMPolicy::Client#test_iam_permissions. It may require
+# modification in order to execute successfully.
 #
 def test_iam_permissions
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/really_renamed_service/get_empty_garbage.rb
+++ b/shared/output/gapic/templates/garbage/snippets/really_renamed_service/get_empty_garbage.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::ReallyRenamedService::Client#get_empty_garbage
+# Snippet for the get_empty_garbage call in the ReallyRenamedService service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::ReallyRenamedService::Client#get_empty_garbage. It may
+# require modification in order to execute successfully.
 #
 def get_empty_garbage
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/resource_names/complex_pattern_method.rb
+++ b/shared/output/gapic/templates/garbage/snippets/resource_names/complex_pattern_method.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::ResourceNames::Client#complex_pattern_method
+# Snippet for the complex_pattern_method call in the ResourceNames service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::ResourceNames::Client#complex_pattern_method. It may require
+# modification in order to execute successfully.
 #
 def complex_pattern_method
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/resource_names/multiparent_method.rb
+++ b/shared/output/gapic/templates/garbage/snippets/resource_names/multiparent_method.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::ResourceNames::Client#multiparent_method
+# Snippet for the multiparent_method call in the ResourceNames service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::ResourceNames::Client#multiparent_method. It may require
+# modification in order to execute successfully.
 #
 def multiparent_method
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/resource_names/no_arguments_multi_method.rb
+++ b/shared/output/gapic/templates/garbage/snippets/resource_names/no_arguments_multi_method.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::ResourceNames::Client#no_arguments_multi_method
+# Snippet for the no_arguments_multi_method call in the ResourceNames service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::ResourceNames::Client#no_arguments_multi_method. It may
+# require modification in order to execute successfully.
 #
 def no_arguments_multi_method
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/resource_names/resource_name_pattern_method.rb
+++ b/shared/output/gapic/templates/garbage/snippets/resource_names/resource_name_pattern_method.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::ResourceNames::Client#resource_name_pattern_method
+# Snippet for the resource_name_pattern_method call in the ResourceNames service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::ResourceNames::Client#resource_name_pattern_method. It may
+# require modification in order to execute successfully.
 #
 def resource_name_pattern_method
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/resource_names/simple_pattern_method.rb
+++ b/shared/output/gapic/templates/garbage/snippets/resource_names/simple_pattern_method.rb
@@ -28,8 +28,11 @@
 require "so/much/trash"
 
 ##
-# Example demonstrating basic usage of
-# So::Much::Trash::ResourceNames::Client#simple_pattern_method
+# Snippet for the simple_pattern_method call in the ResourceNames service
+#
+# This is an auto-generated example demonstrating basic usage of
+# So::Much::Trash::ResourceNames::Client#simple_pattern_method. It may require
+# modification in order to execute successfully.
 #
 def simple_pattern_method
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/garbage/snippets/snippet_metadata_endless.trash.forever.json
+++ b/shared/output/gapic/templates/garbage/snippets/snippet_metadata_endless.trash.forever.json
@@ -406,7 +406,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 52,
+          "end": 50,
           "type": "FULL"
         }
       ]
@@ -486,7 +486,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 50,
+          "end": 52,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/garbage/snippets/snippet_metadata_endless.trash.forever.json
+++ b/shared/output/gapic/templates/garbage/snippets/snippet_metadata_endless.trash.forever.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "garbage_v0_generated_GarbageService_GetEmptyGarbage_sync",
-      "title": "Snippet for get_empty_garbage in GarbageService",
-      "description": "Basic snippet for get_empty_garbage in GarbageService",
+      "title": "Snippet for the get_empty_garbage call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#get_empty_garbage. It may require modification in order to execute successfully.",
       "file": "garbage_service/get_empty_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_GetSimpleGarbage_sync",
-      "title": "Snippet for get_simple_garbage in GarbageService",
-      "description": "Basic snippet for get_simple_garbage in GarbageService",
+      "title": "Snippet for the get_simple_garbage call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#get_simple_garbage. It may require modification in order to execute successfully.",
       "file": "garbage_service/get_simple_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,15 +86,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_GetSpecificGarbage_sync",
-      "title": "Snippet for get_specific_garbage in GarbageService",
-      "description": "Basic snippet for get_specific_garbage in GarbageService",
+      "title": "Snippet for the get_specific_garbage call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#get_specific_garbage. It may require modification in order to execute successfully.",
       "file": "garbage_service/get_specific_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -126,15 +126,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_GetNestedGarbage_sync",
-      "title": "Snippet for get_nested_garbage in GarbageService",
-      "description": "Basic snippet for get_nested_garbage in GarbageService",
+      "title": "Snippet for the get_nested_garbage call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#get_nested_garbage. It may require modification in order to execute successfully.",
       "file": "garbage_service/get_nested_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -166,15 +166,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_GetRepeatedGarbage_sync",
-      "title": "Snippet for get_repeated_garbage in GarbageService",
-      "description": "Basic snippet for get_repeated_garbage in GarbageService",
+      "title": "Snippet for the get_repeated_garbage call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#get_repeated_garbage. It may require modification in order to execute successfully.",
       "file": "garbage_service/get_repeated_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -206,15 +206,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_GetTypicalGarbage_sync",
-      "title": "Snippet for get_typical_garbage in GarbageService",
-      "description": "Basic snippet for get_typical_garbage in GarbageService",
+      "title": "Snippet for the get_typical_garbage call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#get_typical_garbage. It may require modification in order to execute successfully.",
       "file": "garbage_service/get_typical_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -246,15 +246,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_GetTypicalGarbageByRequest_sync",
-      "title": "Snippet for get_typical_garbage_by_request in GarbageService",
-      "description": "Basic snippet for get_typical_garbage_by_request in GarbageService",
+      "title": "Snippet for the get_typical_garbage_by_request call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#get_typical_garbage_by_request. It may require modification in order to execute successfully.",
       "file": "garbage_service/get_typical_garbage_by_request.rb",
       "language": "RUBY",
       "client_method": {
@@ -286,15 +286,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_GetComplexGarbage_sync",
-      "title": "Snippet for get_complex_garbage in GarbageService",
-      "description": "Basic snippet for get_complex_garbage in GarbageService",
+      "title": "Snippet for the get_complex_garbage call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#get_complex_garbage. It may require modification in order to execute successfully.",
       "file": "garbage_service/get_complex_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -326,15 +326,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_GetGarbageNode_sync",
-      "title": "Snippet for get_garbage_node in GarbageService",
-      "description": "Basic snippet for get_garbage_node in GarbageService",
+      "title": "Snippet for the get_garbage_node call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#get_garbage_node. It may require modification in order to execute successfully.",
       "file": "garbage_service/get_garbage_node.rb",
       "language": "RUBY",
       "client_method": {
@@ -366,15 +366,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_GetPagedGarbage_sync",
-      "title": "Snippet for get_paged_garbage in GarbageService",
-      "description": "Basic snippet for get_paged_garbage in GarbageService",
+      "title": "Snippet for the get_paged_garbage call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#get_paged_garbage. It may require modification in order to execute successfully.",
       "file": "garbage_service/get_paged_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -406,15 +406,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 50,
+          "end": 53,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_LongRunningGarbage_sync",
-      "title": "Snippet for long_running_garbage in GarbageService",
-      "description": "Basic snippet for long_running_garbage in GarbageService",
+      "title": "Snippet for the long_running_garbage call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#long_running_garbage. It may require modification in order to execute successfully.",
       "file": "garbage_service/long_running_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -446,15 +446,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 53,
+          "end": 56,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_ClientGarbage_sync",
-      "title": "Snippet for client_garbage in GarbageService",
-      "description": "Basic snippet for client_garbage in GarbageService",
+      "title": "Snippet for the client_garbage call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#client_garbage. It may require modification in order to execute successfully.",
       "file": "garbage_service/client_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -486,15 +486,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 52,
+          "end": 55,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_ServerGarbage_sync",
-      "title": "Snippet for server_garbage in GarbageService",
-      "description": "Basic snippet for server_garbage in GarbageService",
+      "title": "Snippet for the server_garbage call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#server_garbage. It may require modification in order to execute successfully.",
       "file": "garbage_service/server_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -526,15 +526,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 49,
+          "end": 52,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_BidiGarbage_sync",
-      "title": "Snippet for bidi_garbage in GarbageService",
-      "description": "Basic snippet for bidi_garbage in GarbageService",
+      "title": "Snippet for the bidi_garbage call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#bidi_garbage. It may require modification in order to execute successfully.",
       "file": "garbage_service/bidi_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -566,15 +566,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 55,
+          "end": 58,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_BidiTypicalGarbage_sync",
-      "title": "Snippet for bidi_typical_garbage in GarbageService",
-      "description": "Basic snippet for bidi_typical_garbage in GarbageService",
+      "title": "Snippet for the bidi_typical_garbage call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#bidi_typical_garbage. It may require modification in order to execute successfully.",
       "file": "garbage_service/bidi_typical_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -606,15 +606,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 55,
+          "end": 58,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_GarbageService_Send_sync",
-      "title": "Snippet for call_send in GarbageService",
-      "description": "Basic snippet for call_send in GarbageService",
+      "title": "Snippet for the call_send call in the GarbageService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::GarbageService::Client#call_send. It may require modification in order to execute successfully.",
       "file": "garbage_service/call_send.rb",
       "language": "RUBY",
       "client_method": {
@@ -646,15 +646,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_ReallyRenamedService_GetEmptyGarbage_sync",
-      "title": "Snippet for get_empty_garbage in ReallyRenamedService",
-      "description": "Basic snippet for get_empty_garbage in ReallyRenamedService",
+      "title": "Snippet for the get_empty_garbage call in the ReallyRenamedService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::ReallyRenamedService::Client#get_empty_garbage. It may require modification in order to execute successfully.",
       "file": "really_renamed_service/get_empty_garbage.rb",
       "language": "RUBY",
       "client_method": {
@@ -686,15 +686,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_DeprecatedService_DeprecatedGet_sync",
-      "title": "Snippet for deprecated_get in DeprecatedService",
-      "description": "Basic snippet for deprecated_get in DeprecatedService",
+      "title": "Snippet for the deprecated_get call in the DeprecatedService service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::DeprecatedService::Client#deprecated_get. It may require modification in order to execute successfully.",
       "file": "deprecated_service/deprecated_get.rb",
       "language": "RUBY",
       "client_method": {
@@ -726,15 +726,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_ResourceNames_SimplePatternMethod_sync",
-      "title": "Snippet for simple_pattern_method in ResourceNames",
-      "description": "Basic snippet for simple_pattern_method in ResourceNames",
+      "title": "Snippet for the simple_pattern_method call in the ResourceNames service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::ResourceNames::Client#simple_pattern_method. It may require modification in order to execute successfully.",
       "file": "resource_names/simple_pattern_method.rb",
       "language": "RUBY",
       "client_method": {
@@ -766,15 +766,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_ResourceNames_ComplexPatternMethod_sync",
-      "title": "Snippet for complex_pattern_method in ResourceNames",
-      "description": "Basic snippet for complex_pattern_method in ResourceNames",
+      "title": "Snippet for the complex_pattern_method call in the ResourceNames service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::ResourceNames::Client#complex_pattern_method. It may require modification in order to execute successfully.",
       "file": "resource_names/complex_pattern_method.rb",
       "language": "RUBY",
       "client_method": {
@@ -806,15 +806,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_ResourceNames_ResourceNamePatternMethod_sync",
-      "title": "Snippet for resource_name_pattern_method in ResourceNames",
-      "description": "Basic snippet for resource_name_pattern_method in ResourceNames",
+      "title": "Snippet for the resource_name_pattern_method call in the ResourceNames service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::ResourceNames::Client#resource_name_pattern_method. It may require modification in order to execute successfully.",
       "file": "resource_names/resource_name_pattern_method.rb",
       "language": "RUBY",
       "client_method": {
@@ -846,15 +846,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_ResourceNames_MultiparentMethod_sync",
-      "title": "Snippet for multiparent_method in ResourceNames",
-      "description": "Basic snippet for multiparent_method in ResourceNames",
+      "title": "Snippet for the multiparent_method call in the ResourceNames service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::ResourceNames::Client#multiparent_method. It may require modification in order to execute successfully.",
       "file": "resource_names/multiparent_method.rb",
       "language": "RUBY",
       "client_method": {
@@ -886,15 +886,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_ResourceNames_NoArgumentsMultiMethod_sync",
-      "title": "Snippet for no_arguments_multi_method in ResourceNames",
-      "description": "Basic snippet for no_arguments_multi_method in ResourceNames",
+      "title": "Snippet for the no_arguments_multi_method call in the ResourceNames service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::ResourceNames::Client#no_arguments_multi_method. It may require modification in order to execute successfully.",
       "file": "resource_names/no_arguments_multi_method.rb",
       "language": "RUBY",
       "client_method": {
@@ -926,15 +926,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_IAMPolicy_SetIamPolicy_sync",
-      "title": "Snippet for set_iam_policy in IAMPolicy",
-      "description": "Basic snippet for set_iam_policy in IAMPolicy",
+      "title": "Snippet for the set_iam_policy call in the IAMPolicy service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::IAMPolicy::Client#set_iam_policy. It may require modification in order to execute successfully.",
       "file": "iam_policy/set_iam_policy.rb",
       "language": "RUBY",
       "client_method": {
@@ -966,15 +966,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_IAMPolicy_GetIamPolicy_sync",
-      "title": "Snippet for get_iam_policy in IAMPolicy",
-      "description": "Basic snippet for get_iam_policy in IAMPolicy",
+      "title": "Snippet for the get_iam_policy call in the IAMPolicy service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::IAMPolicy::Client#get_iam_policy. It may require modification in order to execute successfully.",
       "file": "iam_policy/get_iam_policy.rb",
       "language": "RUBY",
       "client_method": {
@@ -1006,15 +1006,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "garbage_v0_generated_IAMPolicy_TestIamPermissions_sync",
-      "title": "Snippet for test_iam_permissions in IAMPolicy",
-      "description": "Basic snippet for test_iam_permissions in IAMPolicy",
+      "title": "Snippet for the test_iam_permissions call in the IAMPolicy service",
+      "description": "This is an auto-generated example demonstrating basic usage of So::Much::Trash::IAMPolicy::Client#test_iam_permissions. It may require modification in order to execute successfully.",
       "file": "iam_policy/test_iam_permissions.rb",
       "language": "RUBY",
       "client_method": {
@@ -1046,7 +1046,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -324,13 +324,13 @@ module Google
           #   # Create a request. To set request fields, pass in keyword arguments.
           #   request = Google::Showcase::V1beta1::ExpandRequest.new
           #
-          #   # Call the expand method.
-          #   result = client.expand request
+          #   # Call the expand method to start streaming.
+          #   output = client.expand request
           #
-          #   # The returned object is a streamed enumerable yielding elements of
-          #   # type ::Google::Showcase::V1beta1::EchoResponse.
-          #   result.each do |response|
-          #     p response
+          #   # The returned object is a streamed enumerable yielding elements of type
+          #   # ::Google::Showcase::V1beta1::EchoResponse
+          #   output.each do |current_response|
+          #     p current_response
           #   end
           #
           def expand request, options = nil
@@ -388,15 +388,17 @@ module Google
           #   # Create a client object. The client can be reused for multiple calls.
           #   client = Google::Showcase::V1beta1::Echo::Client.new
           #
-          #   # Create a stream of requests, as an Enumerator.
-          #   # For each request, pass in keyword arguments to set fields.
-          #   request = [
-          #     Google::Showcase::V1beta1::EchoRequest.new,
-          #     Google::Showcase::V1beta1::EchoRequest.new
-          #   ].to_enum
+          #   # Create an input stream.
+          #   input = Gapic::StreamInput.new
           #
-          #   # Call the collect method.
-          #   result = client.collect request
+          #   # Call the collect method to start streaming.
+          #   result = client.collect input
+          #
+          #   # Send requests on the stream. For each request object, set fields by
+          #   # passing keyword arguments. Be sure to close the stream when done.
+          #   input << Google::Showcase::V1beta1::EchoRequest.new
+          #   input << Google::Showcase::V1beta1::EchoRequest.new
+          #   input.close
           #
           #   # The returned object is of type Google::Showcase::V1beta1::EchoResponse.
           #   p result
@@ -461,22 +463,22 @@ module Google
           #   # Create a client object. The client can be reused for multiple calls.
           #   client = Google::Showcase::V1beta1::Echo::Client.new
           #
-          #   # Create an input stream
+          #   # Create an input stream.
           #   input = Gapic::StreamInput.new
           #
           #   # Call the chat method to start streaming.
           #   output = client.chat input
           #
-          #   # Send requests on the stream. For each request, pass in keyword
-          #   # arguments to set fields. Be sure to close the stream when done.
+          #   # Send requests on the stream. For each request object, set fields by
+          #   # passing keyword arguments. Be sure to close the stream when done.
           #   input << Google::Showcase::V1beta1::EchoRequest.new
           #   input << Google::Showcase::V1beta1::EchoRequest.new
           #   input.close
           #
-          #   # Handle streamed responses. These may be interleaved with inputs.
-          #   # Each response is of type ::Google::Showcase::V1beta1::EchoResponse.
-          #   output.each do |response|
-          #     p response
+          #   # The returned object is a streamed enumerable yielding elements of type
+          #   # ::Google::Showcase::V1beta1::EchoResponse
+          #   output.each do |current_response|
+          #     p current_response
           #   end
           #
           def chat request, options = nil
@@ -561,13 +563,11 @@ module Google
           #   # Call the paged_expand method.
           #   result = client.paged_expand request
           #
-          #   # The returned object is of type Gapic::PagedEnumerable. You can
-          #   # iterate over all elements by calling #each, and the enumerable
-          #   # will lazily make API calls to fetch subsequent pages. Other
-          #   # methods are also available for managing paging directly.
-          #   result.each do |response|
+          #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+          #   # over elements, and API calls will be issued to fetch pages as needed.
+          #   result.each do |item|
           #     # Each element is of type ::Google::Showcase::V1beta1::EchoResponse.
-          #     p response
+          #     p item
           #   end
           #
           def paged_expand request, options = nil
@@ -825,14 +825,14 @@ module Google
           #   # Call the wait method.
           #   result = client.wait request
           #
-          #   # The returned object is of type Gapic::Operation. You can use this
-          #   # object to check the status of an operation, cancel it, or wait
-          #   # for results. Here is how to block until completion:
+          #   # The returned object is of type Gapic::Operation. You can use it to
+          #   # check the status of an operation, cancel it, or wait for results.
+          #   # Here is how to wait for a response.
           #   result.wait_until_done! timeout: 60
           #   if result.response?
           #     p result.response
           #   else
-          #     puts "Error!"
+          #     puts "No response received."
           #   end
           #
           def wait request, options = nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -734,13 +734,11 @@ module Google
           #   # Call the paged_expand_legacy_mapped method.
           #   result = client.paged_expand_legacy_mapped request
           #
-          #   # The returned object is of type Gapic::PagedEnumerable. You can
-          #   # iterate over all elements by calling #each, and the enumerable
-          #   # will lazily make API calls to fetch subsequent pages. Other
-          #   # methods are also available for managing paging directly.
-          #   result.each do |response|
+          #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+          #   # over elements, and API calls will be issued to fetch pages as needed.
+          #   result.each do |item|
           #     # Each element is of type ::Google::Showcase::V1beta1::PagedExpandLegacyMappedResponse::AlphabetizedEntry.
-          #     p response
+          #     p item
           #   end
           #
           def paged_expand_legacy_mapped request, options = nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -165,13 +165,11 @@ module Google
           #   # Call the list_operations method.
           #   result = client.list_operations request
           #
-          #   # The returned object is of type Gapic::PagedEnumerable. You can
-          #   # iterate over all elements by calling #each, and the enumerable
-          #   # will lazily make API calls to fetch subsequent pages. Other
-          #   # methods are also available for managing paging directly.
-          #   result.each do |response|
+          #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+          #   # over elements, and API calls will be issued to fetch pages as needed.
+          #   result.each do |item|
           #     # Each element is of type ::Google::Longrunning::Operation.
-          #     p response
+          #     p item
           #   end
           #
           def list_operations request, options = nil
@@ -251,14 +249,14 @@ module Google
           #   # Call the get_operation method.
           #   result = client.get_operation request
           #
-          #   # The returned object is of type Gapic::Operation. You can use this
-          #   # object to check the status of an operation, cancel it, or wait
-          #   # for results. Here is how to block until completion:
+          #   # The returned object is of type Gapic::Operation. You can use it to
+          #   # check the status of an operation, cancel it, or wait for results.
+          #   # Here is how to wait for a response.
           #   result.wait_until_done! timeout: 60
           #   if result.response?
           #     p result.response
           #   else
-          #     puts "Error!"
+          #     puts "No response received."
           #   end
           #
           def get_operation request, options = nil
@@ -532,14 +530,14 @@ module Google
           #   # Call the wait_operation method.
           #   result = client.wait_operation request
           #
-          #   # The returned object is of type Gapic::Operation. You can use this
-          #   # object to check the status of an operation, cancel it, or wait
-          #   # for results. Here is how to block until completion:
+          #   # The returned object is of type Gapic::Operation. You can use it to
+          #   # check the status of an operation, cancel it, or wait for results.
+          #   # Here is how to wait for a response.
           #   result.wait_until_done! timeout: 60
           #   if result.response?
           #     p result.response
           #   else
-          #     puts "Error!"
+          #     puts "No response received."
           #   end
           #
           def wait_operation request, options = nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -516,13 +516,11 @@ module Google
           #   # Call the list_users method.
           #   result = client.list_users request
           #
-          #   # The returned object is of type Gapic::PagedEnumerable. You can
-          #   # iterate over all elements by calling #each, and the enumerable
-          #   # will lazily make API calls to fetch subsequent pages. Other
-          #   # methods are also available for managing paging directly.
-          #   result.each do |response|
+          #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+          #   # over elements, and API calls will be issued to fetch pages as needed.
+          #   result.each do |item|
           #     # Each element is of type ::Google::Showcase::V1beta1::User.
-          #     p response
+          #     p item
           #   end
           #
           def list_users request, options = nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -532,13 +532,11 @@ module Google
           #   # Call the list_rooms method.
           #   result = client.list_rooms request
           #
-          #   # The returned object is of type Gapic::PagedEnumerable. You can
-          #   # iterate over all elements by calling #each, and the enumerable
-          #   # will lazily make API calls to fetch subsequent pages. Other
-          #   # methods are also available for managing paging directly.
-          #   result.each do |response|
+          #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+          #   # over elements, and API calls will be issued to fetch pages as needed.
+          #   result.each do |item|
           #     # Each element is of type ::Google::Showcase::V1beta1::Room.
-          #     p response
+          #     p item
           #   end
           #
           def list_rooms request, options = nil
@@ -964,13 +962,11 @@ module Google
           #   # Call the list_blurbs method.
           #   result = client.list_blurbs request
           #
-          #   # The returned object is of type Gapic::PagedEnumerable. You can
-          #   # iterate over all elements by calling #each, and the enumerable
-          #   # will lazily make API calls to fetch subsequent pages. Other
-          #   # methods are also available for managing paging directly.
-          #   result.each do |response|
+          #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+          #   # over elements, and API calls will be issued to fetch pages as needed.
+          #   result.each do |item|
           #     # Each element is of type ::Google::Showcase::V1beta1::Blurb.
-          #     p response
+          #     p item
           #   end
           #
           def list_blurbs request, options = nil
@@ -1070,14 +1066,14 @@ module Google
           #   # Call the search_blurbs method.
           #   result = client.search_blurbs request
           #
-          #   # The returned object is of type Gapic::Operation. You can use this
-          #   # object to check the status of an operation, cancel it, or wait
-          #   # for results. Here is how to block until completion:
+          #   # The returned object is of type Gapic::Operation. You can use it to
+          #   # check the status of an operation, cancel it, or wait for results.
+          #   # Here is how to wait for a response.
           #   result.wait_until_done! timeout: 60
           #   if result.response?
           #     p result.response
           #   else
-          #     puts "Error!"
+          #     puts "No response received."
           #   end
           #
           def search_blurbs request, options = nil
@@ -1161,13 +1157,13 @@ module Google
           #   # Create a request. To set request fields, pass in keyword arguments.
           #   request = Google::Showcase::V1beta1::StreamBlurbsRequest.new
           #
-          #   # Call the stream_blurbs method.
-          #   result = client.stream_blurbs request
+          #   # Call the stream_blurbs method to start streaming.
+          #   output = client.stream_blurbs request
           #
-          #   # The returned object is a streamed enumerable yielding elements of
-          #   # type ::Google::Showcase::V1beta1::StreamBlurbsResponse.
-          #   result.each do |response|
-          #     p response
+          #   # The returned object is a streamed enumerable yielding elements of type
+          #   # ::Google::Showcase::V1beta1::StreamBlurbsResponse
+          #   output.each do |current_response|
+          #     p current_response
           #   end
           #
           def stream_blurbs request, options = nil
@@ -1232,15 +1228,17 @@ module Google
           #   # Create a client object. The client can be reused for multiple calls.
           #   client = Google::Showcase::V1beta1::Messaging::Client.new
           #
-          #   # Create a stream of requests, as an Enumerator.
-          #   # For each request, pass in keyword arguments to set fields.
-          #   request = [
-          #     Google::Showcase::V1beta1::CreateBlurbRequest.new,
-          #     Google::Showcase::V1beta1::CreateBlurbRequest.new
-          #   ].to_enum
+          #   # Create an input stream.
+          #   input = Gapic::StreamInput.new
           #
-          #   # Call the send_blurbs method.
-          #   result = client.send_blurbs request
+          #   # Call the send_blurbs method to start streaming.
+          #   result = client.send_blurbs input
+          #
+          #   # Send requests on the stream. For each request object, set fields by
+          #   # passing keyword arguments. Be sure to close the stream when done.
+          #   input << Google::Showcase::V1beta1::CreateBlurbRequest.new
+          #   input << Google::Showcase::V1beta1::CreateBlurbRequest.new
+          #   input.close
           #
           #   # The returned object is of type Google::Showcase::V1beta1::SendBlurbsResponse.
           #   p result
@@ -1306,22 +1304,22 @@ module Google
           #   # Create a client object. The client can be reused for multiple calls.
           #   client = Google::Showcase::V1beta1::Messaging::Client.new
           #
-          #   # Create an input stream
+          #   # Create an input stream.
           #   input = Gapic::StreamInput.new
           #
           #   # Call the connect method to start streaming.
           #   output = client.connect input
           #
-          #   # Send requests on the stream. For each request, pass in keyword
-          #   # arguments to set fields. Be sure to close the stream when done.
+          #   # Send requests on the stream. For each request object, set fields by
+          #   # passing keyword arguments. Be sure to close the stream when done.
           #   input << Google::Showcase::V1beta1::ConnectRequest.new
           #   input << Google::Showcase::V1beta1::ConnectRequest.new
           #   input.close
           #
-          #   # Handle streamed responses. These may be interleaved with inputs.
-          #   # Each response is of type ::Google::Showcase::V1beta1::StreamBlurbsResponse.
-          #   output.each do |response|
-          #     p response
+          #   # The returned object is a streamed enumerable yielding elements of type
+          #   # ::Google::Showcase::V1beta1::StreamBlurbsResponse
+          #   output.each do |current_response|
+          #     p current_response
           #   end
           #
           def connect request, options = nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -165,13 +165,11 @@ module Google
           #   # Call the list_operations method.
           #   result = client.list_operations request
           #
-          #   # The returned object is of type Gapic::PagedEnumerable. You can
-          #   # iterate over all elements by calling #each, and the enumerable
-          #   # will lazily make API calls to fetch subsequent pages. Other
-          #   # methods are also available for managing paging directly.
-          #   result.each do |response|
+          #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+          #   # over elements, and API calls will be issued to fetch pages as needed.
+          #   result.each do |item|
           #     # Each element is of type ::Google::Longrunning::Operation.
-          #     p response
+          #     p item
           #   end
           #
           def list_operations request, options = nil
@@ -251,14 +249,14 @@ module Google
           #   # Call the get_operation method.
           #   result = client.get_operation request
           #
-          #   # The returned object is of type Gapic::Operation. You can use this
-          #   # object to check the status of an operation, cancel it, or wait
-          #   # for results. Here is how to block until completion:
+          #   # The returned object is of type Gapic::Operation. You can use it to
+          #   # check the status of an operation, cancel it, or wait for results.
+          #   # Here is how to wait for a response.
           #   result.wait_until_done! timeout: 60
           #   if result.response?
           #     p result.response
           #   else
-          #     puts "Error!"
+          #     puts "No response received."
           #   end
           #
           def get_operation request, options = nil
@@ -532,14 +530,14 @@ module Google
           #   # Call the wait_operation method.
           #   result = client.wait_operation request
           #
-          #   # The returned object is of type Gapic::Operation. You can use this
-          #   # object to check the status of an operation, cancel it, or wait
-          #   # for results. Here is how to block until completion:
+          #   # The returned object is of type Gapic::Operation. You can use it to
+          #   # check the status of an operation, cancel it, or wait for results.
+          #   # Here is how to wait for a response.
           #   result.wait_until_done! timeout: 60
           #   if result.response?
           #     p result.response
           #   else
-          #     puts "Error!"
+          #     puts "No response received."
           #   end
           #
           def wait_operation request, options = nil

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -347,13 +347,11 @@ module Google
           #   # Call the list_sessions method.
           #   result = client.list_sessions request
           #
-          #   # The returned object is of type Gapic::PagedEnumerable. You can
-          #   # iterate over all elements by calling #each, and the enumerable
-          #   # will lazily make API calls to fetch subsequent pages. Other
-          #   # methods are also available for managing paging directly.
-          #   result.each do |response|
+          #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+          #   # over elements, and API calls will be issued to fetch pages as needed.
+          #   result.each do |item|
           #     # Each element is of type ::Google::Showcase::V1beta1::Session.
-          #     p response
+          #     p item
           #   end
           #
           def list_sessions request, options = nil
@@ -602,13 +600,11 @@ module Google
           #   # Call the list_tests method.
           #   result = client.list_tests request
           #
-          #   # The returned object is of type Gapic::PagedEnumerable. You can
-          #   # iterate over all elements by calling #each, and the enumerable
-          #   # will lazily make API calls to fetch subsequent pages. Other
-          #   # methods are also available for managing paging directly.
-          #   result.each do |response|
+          #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+          #   # over elements, and API calls will be issued to fetch pages as needed.
+          #   result.each do |item|
           #     # Each element is of type ::Google::Showcase::V1beta1::Test.
-          #     p response
+          #     p item
           #   end
           #
           def list_tests request, options = nil

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Compliance::Client#repeat_data_body
+# Snippet for the repeat_data_body call in the Compliance service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_body. It may require
+# modification in order to execute successfully.
 #
 def repeat_data_body
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body_info.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body_info.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Compliance::Client#repeat_data_body_info
+# Snippet for the repeat_data_body_info call in the Compliance service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_body_info. It may
+# require modification in order to execute successfully.
 #
 def repeat_data_body_info
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body_patch.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body_patch.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Compliance::Client#repeat_data_body_patch
+# Snippet for the repeat_data_body_patch call in the Compliance service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_body_patch. It may
+# require modification in order to execute successfully.
 #
 def repeat_data_body_patch
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body_put.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_body_put.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Compliance::Client#repeat_data_body_put
+# Snippet for the repeat_data_body_put call in the Compliance service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_body_put. It may
+# require modification in order to execute successfully.
 #
 def repeat_data_body_put
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_path_resource.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_path_resource.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Compliance::Client#repeat_data_path_resource
+# Snippet for the repeat_data_path_resource call in the Compliance service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_path_resource. It
+# may require modification in order to execute successfully.
 #
 def repeat_data_path_resource
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_path_trailing_resource.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_path_trailing_resource.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Compliance::Client#repeat_data_path_trailing_resource
+# Snippet for the repeat_data_path_trailing_resource call in the Compliance service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_path_trailing_resource.
+# It may require modification in order to execute successfully.
 #
 def repeat_data_path_trailing_resource
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_query.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_query.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Compliance::Client#repeat_data_query
+# Snippet for the repeat_data_query call in the Compliance service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_query. It may
+# require modification in order to execute successfully.
 #
 def repeat_data_query
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_simple_path.rb
+++ b/shared/output/gapic/templates/showcase/snippets/compliance/repeat_data_simple_path.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Compliance::Client#repeat_data_simple_path
+# Snippet for the repeat_data_simple_path call in the Compliance service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Compliance::Client#repeat_data_simple_path. It may
+# require modification in order to execute successfully.
 #
 def repeat_data_simple_path
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/echo/block.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/block.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Echo::Client#block
+# Snippet for the block call in the Echo service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#block. It may require modification in
+# order to execute successfully.
 #
 def block
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/echo/chat.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/chat.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Echo::Client#chat
+# Snippet for the chat call in the Echo service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#chat. It may require modification in
+# order to execute successfully.
 #
 def chat
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/echo/chat.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/chat.rb
@@ -35,22 +35,22 @@ def chat
   # Create a client object. The client can be reused for multiple calls.
   client = Google::Showcase::V1beta1::Echo::Client.new
 
-  # Create an input stream
+  # Create an input stream.
   input = Gapic::StreamInput.new
 
   # Call the chat method to start streaming.
   output = client.chat input
 
-  # Send requests on the stream. For each request, pass in keyword
-  # arguments to set fields. Be sure to close the stream when done.
+  # Send requests on the stream. For each request object, set fields by
+  # passing keyword arguments. Be sure to close the stream when done.
   input << Google::Showcase::V1beta1::EchoRequest.new
   input << Google::Showcase::V1beta1::EchoRequest.new
   input.close
 
-  # Handle streamed responses. These may be interleaved with inputs.
-  # Each response is of type ::Google::Showcase::V1beta1::EchoResponse.
-  output.each do |response|
-    p response
+  # The returned object is a streamed enumerable yielding elements of type
+  # ::Google::Showcase::V1beta1::EchoResponse
+  output.each do |current_response|
+    p current_response
   end
 end
 # [END showcase_v0_generated_Echo_Chat_sync]

--- a/shared/output/gapic/templates/showcase/snippets/echo/collect.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/collect.rb
@@ -35,15 +35,17 @@ def collect
   # Create a client object. The client can be reused for multiple calls.
   client = Google::Showcase::V1beta1::Echo::Client.new
 
-  # Create a stream of requests, as an Enumerator.
-  # For each request, pass in keyword arguments to set fields.
-  request = [
-    Google::Showcase::V1beta1::EchoRequest.new,
-    Google::Showcase::V1beta1::EchoRequest.new
-  ].to_enum
+  # Create an input stream.
+  input = Gapic::StreamInput.new
 
-  # Call the collect method.
-  result = client.collect request
+  # Call the collect method to start streaming.
+  result = client.collect input
+
+  # Send requests on the stream. For each request object, set fields by
+  # passing keyword arguments. Be sure to close the stream when done.
+  input << Google::Showcase::V1beta1::EchoRequest.new
+  input << Google::Showcase::V1beta1::EchoRequest.new
+  input.close
 
   # The returned object is of type Google::Showcase::V1beta1::EchoResponse.
   p result

--- a/shared/output/gapic/templates/showcase/snippets/echo/collect.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/collect.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Echo::Client#collect
+# Snippet for the collect call in the Echo service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#collect. It may require modification
+# in order to execute successfully.
 #
 def collect
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/echo/echo.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/echo.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Echo::Client#echo
+# Snippet for the echo call in the Echo service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#echo. It may require modification in
+# order to execute successfully.
 #
 def echo
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/echo/expand.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/expand.rb
@@ -38,13 +38,13 @@ def expand
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Showcase::V1beta1::ExpandRequest.new
 
-  # Call the expand method.
-  result = client.expand request
+  # Call the expand method to start streaming.
+  output = client.expand request
 
-  # The returned object is a streamed enumerable yielding elements of
-  # type ::Google::Showcase::V1beta1::EchoResponse.
-  result.each do |response|
-    p response
+  # The returned object is a streamed enumerable yielding elements of type
+  # ::Google::Showcase::V1beta1::EchoResponse
+  output.each do |current_response|
+    p current_response
   end
 end
 # [END showcase_v0_generated_Echo_Expand_sync]

--- a/shared/output/gapic/templates/showcase/snippets/echo/expand.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/expand.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Echo::Client#expand
+# Snippet for the expand call in the Echo service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#expand. It may require modification in
+# order to execute successfully.
 #
 def expand
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/echo/paged_expand.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/paged_expand.rb
@@ -41,13 +41,11 @@ def paged_expand
   # Call the paged_expand method.
   result = client.paged_expand request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Showcase::V1beta1::EchoResponse.
-    p response
+    p item
   end
 end
 # [END showcase_v0_generated_Echo_PagedExpand_sync]

--- a/shared/output/gapic/templates/showcase/snippets/echo/paged_expand.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/paged_expand.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Echo::Client#paged_expand
+# Snippet for the paged_expand call in the Echo service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#paged_expand. It may require
+# modification in order to execute successfully.
 #
 def paged_expand
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/echo/paged_expand_legacy.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/paged_expand_legacy.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Echo::Client#paged_expand_legacy
+# Snippet for the paged_expand_legacy call in the Echo service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#paged_expand_legacy. It may require
+# modification in order to execute successfully.
 #
 def paged_expand_legacy
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/echo/paged_expand_legacy_mapped.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/paged_expand_legacy_mapped.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Echo::Client#paged_expand_legacy_mapped
+# Snippet for the paged_expand_legacy_mapped call in the Echo service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#paged_expand_legacy_mapped. It may
+# require modification in order to execute successfully.
 #
 def paged_expand_legacy_mapped
   # Create a client object. The client can be reused for multiple calls.
@@ -41,13 +44,11 @@ def paged_expand_legacy_mapped
   # Call the paged_expand_legacy_mapped method.
   result = client.paged_expand_legacy_mapped request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Showcase::V1beta1::PagedExpandLegacyMappedResponse::AlphabetizedEntry.
-    p response
+    p item
   end
 end
 # [END showcase_v0_generated_Echo_PagedExpandLegacyMapped_sync]

--- a/shared/output/gapic/templates/showcase/snippets/echo/wait.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/wait.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Echo::Client#wait
+# Snippet for the wait call in the Echo service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Echo::Client#wait. It may require modification in
+# order to execute successfully.
 #
 def wait
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/echo/wait.rb
+++ b/shared/output/gapic/templates/showcase/snippets/echo/wait.rb
@@ -41,14 +41,14 @@ def wait
   # Call the wait method.
   result = client.wait request
 
-  # The returned object is of type Gapic::Operation. You can use this
-  # object to check the status of an operation, cancel it, or wait
-  # for results. Here is how to block until completion:
+  # The returned object is of type Gapic::Operation. You can use it to
+  # check the status of an operation, cancel it, or wait for results.
+  # Here is how to wait for a response.
   result.wait_until_done! timeout: 60
   if result.response?
     p result.response
   else
-    puts "Error!"
+    puts "No response received."
   end
 end
 # [END showcase_v0_generated_Echo_Wait_sync]

--- a/shared/output/gapic/templates/showcase/snippets/identity/create_user.rb
+++ b/shared/output/gapic/templates/showcase/snippets/identity/create_user.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Identity::Client#create_user
+# Snippet for the create_user call in the Identity service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Identity::Client#create_user. It may require
+# modification in order to execute successfully.
 #
 def create_user
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/identity/delete_user.rb
+++ b/shared/output/gapic/templates/showcase/snippets/identity/delete_user.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Identity::Client#delete_user
+# Snippet for the delete_user call in the Identity service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Identity::Client#delete_user. It may require
+# modification in order to execute successfully.
 #
 def delete_user
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/identity/get_user.rb
+++ b/shared/output/gapic/templates/showcase/snippets/identity/get_user.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Identity::Client#get_user
+# Snippet for the get_user call in the Identity service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Identity::Client#get_user. It may require
+# modification in order to execute successfully.
 #
 def get_user
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/identity/list_users.rb
+++ b/shared/output/gapic/templates/showcase/snippets/identity/list_users.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Identity::Client#list_users
+# Snippet for the list_users call in the Identity service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Identity::Client#list_users. It may require
+# modification in order to execute successfully.
 #
 def list_users
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/identity/list_users.rb
+++ b/shared/output/gapic/templates/showcase/snippets/identity/list_users.rb
@@ -41,13 +41,11 @@ def list_users
   # Call the list_users method.
   result = client.list_users request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Showcase::V1beta1::User.
-    p response
+    p item
   end
 end
 # [END showcase_v0_generated_Identity_ListUsers_sync]

--- a/shared/output/gapic/templates/showcase/snippets/identity/update_user.rb
+++ b/shared/output/gapic/templates/showcase/snippets/identity/update_user.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Identity::Client#update_user
+# Snippet for the update_user call in the Identity service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Identity::Client#update_user. It may require
+# modification in order to execute successfully.
 #
 def update_user
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/connect.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/connect.rb
@@ -35,22 +35,22 @@ def connect
   # Create a client object. The client can be reused for multiple calls.
   client = Google::Showcase::V1beta1::Messaging::Client.new
 
-  # Create an input stream
+  # Create an input stream.
   input = Gapic::StreamInput.new
 
   # Call the connect method to start streaming.
   output = client.connect input
 
-  # Send requests on the stream. For each request, pass in keyword
-  # arguments to set fields. Be sure to close the stream when done.
+  # Send requests on the stream. For each request object, set fields by
+  # passing keyword arguments. Be sure to close the stream when done.
   input << Google::Showcase::V1beta1::ConnectRequest.new
   input << Google::Showcase::V1beta1::ConnectRequest.new
   input.close
 
-  # Handle streamed responses. These may be interleaved with inputs.
-  # Each response is of type ::Google::Showcase::V1beta1::StreamBlurbsResponse.
-  output.each do |response|
-    p response
+  # The returned object is a streamed enumerable yielding elements of type
+  # ::Google::Showcase::V1beta1::StreamBlurbsResponse
+  output.each do |current_response|
+    p current_response
   end
 end
 # [END showcase_v0_generated_Messaging_Connect_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/connect.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/connect.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#connect
+# Snippet for the connect call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#connect. It may require
+# modification in order to execute successfully.
 #
 def connect
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/create_blurb.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/create_blurb.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#create_blurb
+# Snippet for the create_blurb call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#create_blurb. It may require
+# modification in order to execute successfully.
 #
 def create_blurb
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/create_room.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/create_room.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#create_room
+# Snippet for the create_room call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#create_room. It may require
+# modification in order to execute successfully.
 #
 def create_room
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/delete_blurb.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/delete_blurb.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#delete_blurb
+# Snippet for the delete_blurb call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#delete_blurb. It may require
+# modification in order to execute successfully.
 #
 def delete_blurb
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/delete_room.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/delete_room.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#delete_room
+# Snippet for the delete_room call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#delete_room. It may require
+# modification in order to execute successfully.
 #
 def delete_room
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/get_blurb.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/get_blurb.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#get_blurb
+# Snippet for the get_blurb call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#get_blurb. It may require
+# modification in order to execute successfully.
 #
 def get_blurb
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/get_room.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/get_room.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#get_room
+# Snippet for the get_room call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#get_room. It may require
+# modification in order to execute successfully.
 #
 def get_room
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/list_blurbs.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/list_blurbs.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#list_blurbs
+# Snippet for the list_blurbs call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#list_blurbs. It may require
+# modification in order to execute successfully.
 #
 def list_blurbs
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/list_blurbs.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/list_blurbs.rb
@@ -41,13 +41,11 @@ def list_blurbs
   # Call the list_blurbs method.
   result = client.list_blurbs request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Showcase::V1beta1::Blurb.
-    p response
+    p item
   end
 end
 # [END showcase_v0_generated_Messaging_ListBlurbs_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/list_rooms.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/list_rooms.rb
@@ -41,13 +41,11 @@ def list_rooms
   # Call the list_rooms method.
   result = client.list_rooms request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Showcase::V1beta1::Room.
-    p response
+    p item
   end
 end
 # [END showcase_v0_generated_Messaging_ListRooms_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/list_rooms.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/list_rooms.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#list_rooms
+# Snippet for the list_rooms call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#list_rooms. It may require
+# modification in order to execute successfully.
 #
 def list_rooms
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/search_blurbs.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/search_blurbs.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#search_blurbs
+# Snippet for the search_blurbs call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#search_blurbs. It may require
+# modification in order to execute successfully.
 #
 def search_blurbs
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/search_blurbs.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/search_blurbs.rb
@@ -41,14 +41,14 @@ def search_blurbs
   # Call the search_blurbs method.
   result = client.search_blurbs request
 
-  # The returned object is of type Gapic::Operation. You can use this
-  # object to check the status of an operation, cancel it, or wait
-  # for results. Here is how to block until completion:
+  # The returned object is of type Gapic::Operation. You can use it to
+  # check the status of an operation, cancel it, or wait for results.
+  # Here is how to wait for a response.
   result.wait_until_done! timeout: 60
   if result.response?
     p result.response
   else
-    puts "Error!"
+    puts "No response received."
   end
 end
 # [END showcase_v0_generated_Messaging_SearchBlurbs_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/send_blurbs.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/send_blurbs.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#send_blurbs
+# Snippet for the send_blurbs call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#send_blurbs. It may require
+# modification in order to execute successfully.
 #
 def send_blurbs
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/send_blurbs.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/send_blurbs.rb
@@ -35,15 +35,17 @@ def send_blurbs
   # Create a client object. The client can be reused for multiple calls.
   client = Google::Showcase::V1beta1::Messaging::Client.new
 
-  # Create a stream of requests, as an Enumerator.
-  # For each request, pass in keyword arguments to set fields.
-  request = [
-    Google::Showcase::V1beta1::CreateBlurbRequest.new,
-    Google::Showcase::V1beta1::CreateBlurbRequest.new
-  ].to_enum
+  # Create an input stream.
+  input = Gapic::StreamInput.new
 
-  # Call the send_blurbs method.
-  result = client.send_blurbs request
+  # Call the send_blurbs method to start streaming.
+  result = client.send_blurbs input
+
+  # Send requests on the stream. For each request object, set fields by
+  # passing keyword arguments. Be sure to close the stream when done.
+  input << Google::Showcase::V1beta1::CreateBlurbRequest.new
+  input << Google::Showcase::V1beta1::CreateBlurbRequest.new
+  input.close
 
   # The returned object is of type Google::Showcase::V1beta1::SendBlurbsResponse.
   p result

--- a/shared/output/gapic/templates/showcase/snippets/messaging/stream_blurbs.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/stream_blurbs.rb
@@ -38,13 +38,13 @@ def stream_blurbs
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Showcase::V1beta1::StreamBlurbsRequest.new
 
-  # Call the stream_blurbs method.
-  result = client.stream_blurbs request
+  # Call the stream_blurbs method to start streaming.
+  output = client.stream_blurbs request
 
-  # The returned object is a streamed enumerable yielding elements of
-  # type ::Google::Showcase::V1beta1::StreamBlurbsResponse.
-  result.each do |response|
-    p response
+  # The returned object is a streamed enumerable yielding elements of type
+  # ::Google::Showcase::V1beta1::StreamBlurbsResponse
+  output.each do |current_response|
+    p current_response
   end
 end
 # [END showcase_v0_generated_Messaging_StreamBlurbs_sync]

--- a/shared/output/gapic/templates/showcase/snippets/messaging/stream_blurbs.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/stream_blurbs.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#stream_blurbs
+# Snippet for the stream_blurbs call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#stream_blurbs. It may require
+# modification in order to execute successfully.
 #
 def stream_blurbs
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/update_blurb.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/update_blurb.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#update_blurb
+# Snippet for the update_blurb call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#update_blurb. It may require
+# modification in order to execute successfully.
 #
 def update_blurb
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/messaging/update_room.rb
+++ b/shared/output/gapic/templates/showcase/snippets/messaging/update_room.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Messaging::Client#update_room
+# Snippet for the update_room call in the Messaging service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Messaging::Client#update_room. It may require
+# modification in order to execute successfully.
 #
 def update_room
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/snippet_metadata_google.showcase.v1beta1.json
+++ b/shared/output/gapic/templates/showcase/snippets/snippet_metadata_google.showcase.v1beta1.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "showcase_v0_generated_Compliance_RepeatDataBody_sync",
-      "title": "Snippet for repeat_data_body in Compliance",
-      "description": "Basic snippet for repeat_data_body in Compliance",
+      "title": "Snippet for the repeat_data_body call in the Compliance service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Compliance::Client#repeat_data_body. It may require modification in order to execute successfully.",
       "file": "compliance/repeat_data_body.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Compliance_RepeatDataBodyInfo_sync",
-      "title": "Snippet for repeat_data_body_info in Compliance",
-      "description": "Basic snippet for repeat_data_body_info in Compliance",
+      "title": "Snippet for the repeat_data_body_info call in the Compliance service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Compliance::Client#repeat_data_body_info. It may require modification in order to execute successfully.",
       "file": "compliance/repeat_data_body_info.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,15 +86,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Compliance_RepeatDataQuery_sync",
-      "title": "Snippet for repeat_data_query in Compliance",
-      "description": "Basic snippet for repeat_data_query in Compliance",
+      "title": "Snippet for the repeat_data_query call in the Compliance service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Compliance::Client#repeat_data_query. It may require modification in order to execute successfully.",
       "file": "compliance/repeat_data_query.rb",
       "language": "RUBY",
       "client_method": {
@@ -126,15 +126,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Compliance_RepeatDataSimplePath_sync",
-      "title": "Snippet for repeat_data_simple_path in Compliance",
-      "description": "Basic snippet for repeat_data_simple_path in Compliance",
+      "title": "Snippet for the repeat_data_simple_path call in the Compliance service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Compliance::Client#repeat_data_simple_path. It may require modification in order to execute successfully.",
       "file": "compliance/repeat_data_simple_path.rb",
       "language": "RUBY",
       "client_method": {
@@ -166,15 +166,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Compliance_RepeatDataPathResource_sync",
-      "title": "Snippet for repeat_data_path_resource in Compliance",
-      "description": "Basic snippet for repeat_data_path_resource in Compliance",
+      "title": "Snippet for the repeat_data_path_resource call in the Compliance service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Compliance::Client#repeat_data_path_resource. It may require modification in order to execute successfully.",
       "file": "compliance/repeat_data_path_resource.rb",
       "language": "RUBY",
       "client_method": {
@@ -206,15 +206,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Compliance_RepeatDataPathTrailingResource_sync",
-      "title": "Snippet for repeat_data_path_trailing_resource in Compliance",
-      "description": "Basic snippet for repeat_data_path_trailing_resource in Compliance",
+      "title": "Snippet for the repeat_data_path_trailing_resource call in the Compliance service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Compliance::Client#repeat_data_path_trailing_resource. It may require modification in order to execute successfully.",
       "file": "compliance/repeat_data_path_trailing_resource.rb",
       "language": "RUBY",
       "client_method": {
@@ -246,15 +246,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Compliance_RepeatDataBodyPut_sync",
-      "title": "Snippet for repeat_data_body_put in Compliance",
-      "description": "Basic snippet for repeat_data_body_put in Compliance",
+      "title": "Snippet for the repeat_data_body_put call in the Compliance service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Compliance::Client#repeat_data_body_put. It may require modification in order to execute successfully.",
       "file": "compliance/repeat_data_body_put.rb",
       "language": "RUBY",
       "client_method": {
@@ -286,15 +286,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Compliance_RepeatDataBodyPatch_sync",
-      "title": "Snippet for repeat_data_body_patch in Compliance",
-      "description": "Basic snippet for repeat_data_body_patch in Compliance",
+      "title": "Snippet for the repeat_data_body_patch call in the Compliance service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Compliance::Client#repeat_data_body_patch. It may require modification in order to execute successfully.",
       "file": "compliance/repeat_data_body_patch.rb",
       "language": "RUBY",
       "client_method": {
@@ -326,15 +326,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Echo_Echo_sync",
-      "title": "Snippet for echo in Echo",
-      "description": "Basic snippet for echo in Echo",
+      "title": "Snippet for the echo call in the Echo service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Echo::Client#echo. It may require modification in order to execute successfully.",
       "file": "echo/echo.rb",
       "language": "RUBY",
       "client_method": {
@@ -366,15 +366,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Echo_Expand_sync",
-      "title": "Snippet for expand in Echo",
-      "description": "Basic snippet for expand in Echo",
+      "title": "Snippet for the expand call in the Echo service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Echo::Client#expand. It may require modification in order to execute successfully.",
       "file": "echo/expand.rb",
       "language": "RUBY",
       "client_method": {
@@ -406,15 +406,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 49,
+          "end": 52,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Echo_Collect_sync",
-      "title": "Snippet for collect in Echo",
-      "description": "Basic snippet for collect in Echo",
+      "title": "Snippet for the collect call in the Echo service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Echo::Client#collect. It may require modification in order to execute successfully.",
       "file": "echo/collect.rb",
       "language": "RUBY",
       "client_method": {
@@ -446,15 +446,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 52,
+          "end": 55,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Echo_Chat_sync",
-      "title": "Snippet for chat in Echo",
-      "description": "Basic snippet for chat in Echo",
+      "title": "Snippet for the chat call in the Echo service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Echo::Client#chat. It may require modification in order to execute successfully.",
       "file": "echo/chat.rb",
       "language": "RUBY",
       "client_method": {
@@ -486,15 +486,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 55,
+          "end": 58,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Echo_PagedExpand_sync",
-      "title": "Snippet for paged_expand in Echo",
-      "description": "Basic snippet for paged_expand in Echo",
+      "title": "Snippet for the paged_expand call in the Echo service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Echo::Client#paged_expand. It may require modification in order to execute successfully.",
       "file": "echo/paged_expand.rb",
       "language": "RUBY",
       "client_method": {
@@ -526,15 +526,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 50,
+          "end": 53,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Echo_PagedExpandLegacy_sync",
-      "title": "Snippet for paged_expand_legacy in Echo",
-      "description": "Basic snippet for paged_expand_legacy in Echo",
+      "title": "Snippet for the paged_expand_legacy call in the Echo service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Echo::Client#paged_expand_legacy. It may require modification in order to execute successfully.",
       "file": "echo/paged_expand_legacy.rb",
       "language": "RUBY",
       "client_method": {
@@ -566,15 +566,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Echo_PagedExpandLegacyMapped_sync",
-      "title": "Snippet for paged_expand_legacy_mapped in Echo",
-      "description": "Basic snippet for paged_expand_legacy_mapped in Echo",
+      "title": "Snippet for the paged_expand_legacy_mapped call in the Echo service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Echo::Client#paged_expand_legacy_mapped. It may require modification in order to execute successfully.",
       "file": "echo/paged_expand_legacy_mapped.rb",
       "language": "RUBY",
       "client_method": {
@@ -606,15 +606,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 52,
+          "end": 53,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Echo_Wait_sync",
-      "title": "Snippet for wait in Echo",
-      "description": "Basic snippet for wait in Echo",
+      "title": "Snippet for the wait call in the Echo service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Echo::Client#wait. It may require modification in order to execute successfully.",
       "file": "echo/wait.rb",
       "language": "RUBY",
       "client_method": {
@@ -646,15 +646,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 53,
+          "end": 56,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Echo_Block_sync",
-      "title": "Snippet for block in Echo",
-      "description": "Basic snippet for block in Echo",
+      "title": "Snippet for the block call in the Echo service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Echo::Client#block. It may require modification in order to execute successfully.",
       "file": "echo/block.rb",
       "language": "RUBY",
       "client_method": {
@@ -686,15 +686,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Identity_CreateUser_sync",
-      "title": "Snippet for create_user in Identity",
-      "description": "Basic snippet for create_user in Identity",
+      "title": "Snippet for the create_user call in the Identity service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Identity::Client#create_user. It may require modification in order to execute successfully.",
       "file": "identity/create_user.rb",
       "language": "RUBY",
       "client_method": {
@@ -726,15 +726,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Identity_GetUser_sync",
-      "title": "Snippet for get_user in Identity",
-      "description": "Basic snippet for get_user in Identity",
+      "title": "Snippet for the get_user call in the Identity service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Identity::Client#get_user. It may require modification in order to execute successfully.",
       "file": "identity/get_user.rb",
       "language": "RUBY",
       "client_method": {
@@ -766,15 +766,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Identity_UpdateUser_sync",
-      "title": "Snippet for update_user in Identity",
-      "description": "Basic snippet for update_user in Identity",
+      "title": "Snippet for the update_user call in the Identity service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Identity::Client#update_user. It may require modification in order to execute successfully.",
       "file": "identity/update_user.rb",
       "language": "RUBY",
       "client_method": {
@@ -806,15 +806,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Identity_DeleteUser_sync",
-      "title": "Snippet for delete_user in Identity",
-      "description": "Basic snippet for delete_user in Identity",
+      "title": "Snippet for the delete_user call in the Identity service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Identity::Client#delete_user. It may require modification in order to execute successfully.",
       "file": "identity/delete_user.rb",
       "language": "RUBY",
       "client_method": {
@@ -846,15 +846,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Identity_ListUsers_sync",
-      "title": "Snippet for list_users in Identity",
-      "description": "Basic snippet for list_users in Identity",
+      "title": "Snippet for the list_users call in the Identity service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Identity::Client#list_users. It may require modification in order to execute successfully.",
       "file": "identity/list_users.rb",
       "language": "RUBY",
       "client_method": {
@@ -886,15 +886,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 50,
+          "end": 53,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_CreateRoom_sync",
-      "title": "Snippet for create_room in Messaging",
-      "description": "Basic snippet for create_room in Messaging",
+      "title": "Snippet for the create_room call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#create_room. It may require modification in order to execute successfully.",
       "file": "messaging/create_room.rb",
       "language": "RUBY",
       "client_method": {
@@ -926,15 +926,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_GetRoom_sync",
-      "title": "Snippet for get_room in Messaging",
-      "description": "Basic snippet for get_room in Messaging",
+      "title": "Snippet for the get_room call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#get_room. It may require modification in order to execute successfully.",
       "file": "messaging/get_room.rb",
       "language": "RUBY",
       "client_method": {
@@ -966,15 +966,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_UpdateRoom_sync",
-      "title": "Snippet for update_room in Messaging",
-      "description": "Basic snippet for update_room in Messaging",
+      "title": "Snippet for the update_room call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#update_room. It may require modification in order to execute successfully.",
       "file": "messaging/update_room.rb",
       "language": "RUBY",
       "client_method": {
@@ -1006,15 +1006,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_DeleteRoom_sync",
-      "title": "Snippet for delete_room in Messaging",
-      "description": "Basic snippet for delete_room in Messaging",
+      "title": "Snippet for the delete_room call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#delete_room. It may require modification in order to execute successfully.",
       "file": "messaging/delete_room.rb",
       "language": "RUBY",
       "client_method": {
@@ -1046,15 +1046,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_ListRooms_sync",
-      "title": "Snippet for list_rooms in Messaging",
-      "description": "Basic snippet for list_rooms in Messaging",
+      "title": "Snippet for the list_rooms call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#list_rooms. It may require modification in order to execute successfully.",
       "file": "messaging/list_rooms.rb",
       "language": "RUBY",
       "client_method": {
@@ -1086,15 +1086,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 50,
+          "end": 53,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_CreateBlurb_sync",
-      "title": "Snippet for create_blurb in Messaging",
-      "description": "Basic snippet for create_blurb in Messaging",
+      "title": "Snippet for the create_blurb call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#create_blurb. It may require modification in order to execute successfully.",
       "file": "messaging/create_blurb.rb",
       "language": "RUBY",
       "client_method": {
@@ -1126,15 +1126,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_GetBlurb_sync",
-      "title": "Snippet for get_blurb in Messaging",
-      "description": "Basic snippet for get_blurb in Messaging",
+      "title": "Snippet for the get_blurb call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#get_blurb. It may require modification in order to execute successfully.",
       "file": "messaging/get_blurb.rb",
       "language": "RUBY",
       "client_method": {
@@ -1166,15 +1166,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_UpdateBlurb_sync",
-      "title": "Snippet for update_blurb in Messaging",
-      "description": "Basic snippet for update_blurb in Messaging",
+      "title": "Snippet for the update_blurb call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#update_blurb. It may require modification in order to execute successfully.",
       "file": "messaging/update_blurb.rb",
       "language": "RUBY",
       "client_method": {
@@ -1206,15 +1206,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_DeleteBlurb_sync",
-      "title": "Snippet for delete_blurb in Messaging",
-      "description": "Basic snippet for delete_blurb in Messaging",
+      "title": "Snippet for the delete_blurb call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#delete_blurb. It may require modification in order to execute successfully.",
       "file": "messaging/delete_blurb.rb",
       "language": "RUBY",
       "client_method": {
@@ -1246,15 +1246,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_ListBlurbs_sync",
-      "title": "Snippet for list_blurbs in Messaging",
-      "description": "Basic snippet for list_blurbs in Messaging",
+      "title": "Snippet for the list_blurbs call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#list_blurbs. It may require modification in order to execute successfully.",
       "file": "messaging/list_blurbs.rb",
       "language": "RUBY",
       "client_method": {
@@ -1286,15 +1286,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 50,
+          "end": 53,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_SearchBlurbs_sync",
-      "title": "Snippet for search_blurbs in Messaging",
-      "description": "Basic snippet for search_blurbs in Messaging",
+      "title": "Snippet for the search_blurbs call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#search_blurbs. It may require modification in order to execute successfully.",
       "file": "messaging/search_blurbs.rb",
       "language": "RUBY",
       "client_method": {
@@ -1326,15 +1326,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 53,
+          "end": 56,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_StreamBlurbs_sync",
-      "title": "Snippet for stream_blurbs in Messaging",
-      "description": "Basic snippet for stream_blurbs in Messaging",
+      "title": "Snippet for the stream_blurbs call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#stream_blurbs. It may require modification in order to execute successfully.",
       "file": "messaging/stream_blurbs.rb",
       "language": "RUBY",
       "client_method": {
@@ -1366,15 +1366,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 49,
+          "end": 52,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_SendBlurbs_sync",
-      "title": "Snippet for send_blurbs in Messaging",
-      "description": "Basic snippet for send_blurbs in Messaging",
+      "title": "Snippet for the send_blurbs call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#send_blurbs. It may require modification in order to execute successfully.",
       "file": "messaging/send_blurbs.rb",
       "language": "RUBY",
       "client_method": {
@@ -1406,15 +1406,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 52,
+          "end": 55,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Messaging_Connect_sync",
-      "title": "Snippet for connect in Messaging",
-      "description": "Basic snippet for connect in Messaging",
+      "title": "Snippet for the connect call in the Messaging service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Messaging::Client#connect. It may require modification in order to execute successfully.",
       "file": "messaging/connect.rb",
       "language": "RUBY",
       "client_method": {
@@ -1446,15 +1446,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 55,
+          "end": 58,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Testing_CreateSession_sync",
-      "title": "Snippet for create_session in Testing",
-      "description": "Basic snippet for create_session in Testing",
+      "title": "Snippet for the create_session call in the Testing service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Testing::Client#create_session. It may require modification in order to execute successfully.",
       "file": "testing/create_session.rb",
       "language": "RUBY",
       "client_method": {
@@ -1486,15 +1486,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Testing_GetSession_sync",
-      "title": "Snippet for get_session in Testing",
-      "description": "Basic snippet for get_session in Testing",
+      "title": "Snippet for the get_session call in the Testing service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Testing::Client#get_session. It may require modification in order to execute successfully.",
       "file": "testing/get_session.rb",
       "language": "RUBY",
       "client_method": {
@@ -1526,15 +1526,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Testing_ListSessions_sync",
-      "title": "Snippet for list_sessions in Testing",
-      "description": "Basic snippet for list_sessions in Testing",
+      "title": "Snippet for the list_sessions call in the Testing service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Testing::Client#list_sessions. It may require modification in order to execute successfully.",
       "file": "testing/list_sessions.rb",
       "language": "RUBY",
       "client_method": {
@@ -1566,15 +1566,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 50,
+          "end": 53,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Testing_DeleteSession_sync",
-      "title": "Snippet for delete_session in Testing",
-      "description": "Basic snippet for delete_session in Testing",
+      "title": "Snippet for the delete_session call in the Testing service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Testing::Client#delete_session. It may require modification in order to execute successfully.",
       "file": "testing/delete_session.rb",
       "language": "RUBY",
       "client_method": {
@@ -1606,15 +1606,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Testing_ReportSession_sync",
-      "title": "Snippet for report_session in Testing",
-      "description": "Basic snippet for report_session in Testing",
+      "title": "Snippet for the report_session call in the Testing service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Testing::Client#report_session. It may require modification in order to execute successfully.",
       "file": "testing/report_session.rb",
       "language": "RUBY",
       "client_method": {
@@ -1646,15 +1646,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Testing_ListTests_sync",
-      "title": "Snippet for list_tests in Testing",
-      "description": "Basic snippet for list_tests in Testing",
+      "title": "Snippet for the list_tests call in the Testing service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Testing::Client#list_tests. It may require modification in order to execute successfully.",
       "file": "testing/list_tests.rb",
       "language": "RUBY",
       "client_method": {
@@ -1686,15 +1686,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 50,
+          "end": 53,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Testing_DeleteTest_sync",
-      "title": "Snippet for delete_test in Testing",
-      "description": "Basic snippet for delete_test in Testing",
+      "title": "Snippet for the delete_test call in the Testing service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Testing::Client#delete_test. It may require modification in order to execute successfully.",
       "file": "testing/delete_test.rb",
       "language": "RUBY",
       "client_method": {
@@ -1726,15 +1726,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "showcase_v0_generated_Testing_VerifyTest_sync",
-      "title": "Snippet for verify_test in Testing",
-      "description": "Basic snippet for verify_test in Testing",
+      "title": "Snippet for the verify_test call in the Testing service",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Showcase::V1beta1::Testing::Client#verify_test. It may require modification in order to execute successfully.",
       "file": "testing/verify_test.rb",
       "language": "RUBY",
       "client_method": {
@@ -1766,7 +1766,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/showcase/snippets/snippet_metadata_google.showcase.v1beta1.json
+++ b/shared/output/gapic/templates/showcase/snippets/snippet_metadata_google.showcase.v1beta1.json
@@ -446,7 +446,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 50,
+          "end": 52,
           "type": "FULL"
         }
       ]
@@ -526,7 +526,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 52,
+          "end": 50,
           "type": "FULL"
         }
       ]
@@ -886,7 +886,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 52,
+          "end": 50,
           "type": "FULL"
         }
       ]
@@ -1086,7 +1086,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 52,
+          "end": 50,
           "type": "FULL"
         }
       ]
@@ -1286,7 +1286,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 52,
+          "end": 50,
           "type": "FULL"
         }
       ]
@@ -1406,7 +1406,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 50,
+          "end": 52,
           "type": "FULL"
         }
       ]
@@ -1566,7 +1566,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 52,
+          "end": 50,
           "type": "FULL"
         }
       ]
@@ -1686,7 +1686,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 52,
+          "end": 50,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/showcase/snippets/testing/create_session.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/create_session.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Testing::Client#create_session
+# Snippet for the create_session call in the Testing service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#create_session. It may require
+# modification in order to execute successfully.
 #
 def create_session
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/testing/delete_session.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/delete_session.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Testing::Client#delete_session
+# Snippet for the delete_session call in the Testing service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#delete_session. It may require
+# modification in order to execute successfully.
 #
 def delete_session
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/testing/delete_test.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/delete_test.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Testing::Client#delete_test
+# Snippet for the delete_test call in the Testing service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#delete_test. It may require
+# modification in order to execute successfully.
 #
 def delete_test
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/testing/get_session.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/get_session.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Testing::Client#get_session
+# Snippet for the get_session call in the Testing service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#get_session. It may require
+# modification in order to execute successfully.
 #
 def get_session
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/testing/list_sessions.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/list_sessions.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Testing::Client#list_sessions
+# Snippet for the list_sessions call in the Testing service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#list_sessions. It may require
+# modification in order to execute successfully.
 #
 def list_sessions
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/testing/list_sessions.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/list_sessions.rb
@@ -41,13 +41,11 @@ def list_sessions
   # Call the list_sessions method.
   result = client.list_sessions request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Showcase::V1beta1::Session.
-    p response
+    p item
   end
 end
 # [END showcase_v0_generated_Testing_ListSessions_sync]

--- a/shared/output/gapic/templates/showcase/snippets/testing/list_tests.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/list_tests.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Testing::Client#list_tests
+# Snippet for the list_tests call in the Testing service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#list_tests. It may require
+# modification in order to execute successfully.
 #
 def list_tests
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/testing/list_tests.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/list_tests.rb
@@ -41,13 +41,11 @@ def list_tests
   # Call the list_tests method.
   result = client.list_tests request
 
-  # The returned object is of type Gapic::PagedEnumerable. You can
-  # iterate over all elements by calling #each, and the enumerable
-  # will lazily make API calls to fetch subsequent pages. Other
-  # methods are also available for managing paging directly.
-  result.each do |response|
+  # The returned object is of type Gapic::PagedEnumerable. You can iterate
+  # over elements, and API calls will be issued to fetch pages as needed.
+  result.each do |item|
     # Each element is of type ::Google::Showcase::V1beta1::Test.
-    p response
+    p item
   end
 end
 # [END showcase_v0_generated_Testing_ListTests_sync]

--- a/shared/output/gapic/templates/showcase/snippets/testing/report_session.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/report_session.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Testing::Client#report_session
+# Snippet for the report_session call in the Testing service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#report_session. It may require
+# modification in order to execute successfully.
 #
 def report_session
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/showcase/snippets/testing/verify_test.rb
+++ b/shared/output/gapic/templates/showcase/snippets/testing/verify_test.rb
@@ -28,8 +28,11 @@
 require "google/showcase/v1beta1"
 
 ##
-# Example demonstrating basic usage of
-# Google::Showcase::V1beta1::Testing::Client#verify_test
+# Snippet for the verify_test call in the Testing service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Google::Showcase::V1beta1::Testing::Client#verify_test. It may require
+# modification in order to execute successfully.
 #
 def verify_test
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/client.rb
@@ -473,14 +473,14 @@ module Testing
         #   # Call the aip_lro method.
         #   result = client.aip_lro request
         #
-        #   # The returned object is of type Gapic::Operation. You can use this
-        #   # object to check the status of an operation, cancel it, or wait
-        #   # for results. Here is how to block until completion:
+        #   # The returned object is of type Gapic::Operation. You can use it to
+        #   # check the status of an operation, cancel it, or wait for results.
+        #   # Here is how to wait for a response.
         #   result.wait_until_done! timeout: 60
         #   if result.response?
         #     p result.response
         #   else
-        #     puts "Error!"
+        #     puts "No response received."
         #   end
         #
         def aip_lro request, options = nil

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/operations.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/operations.rb
@@ -164,13 +164,11 @@ module Testing
         #   # Call the list_operations method.
         #   result = client.list_operations request
         #
-        #   # The returned object is of type Gapic::PagedEnumerable. You can
-        #   # iterate over all elements by calling #each, and the enumerable
-        #   # will lazily make API calls to fetch subsequent pages. Other
-        #   # methods are also available for managing paging directly.
-        #   result.each do |response|
+        #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+        #   # over elements, and API calls will be issued to fetch pages as needed.
+        #   result.each do |item|
         #     # Each element is of type ::Google::Longrunning::Operation.
-        #     p response
+        #     p item
         #   end
         #
         def list_operations request, options = nil
@@ -250,14 +248,14 @@ module Testing
         #   # Call the get_operation method.
         #   result = client.get_operation request
         #
-        #   # The returned object is of type Gapic::Operation. You can use this
-        #   # object to check the status of an operation, cancel it, or wait
-        #   # for results. Here is how to block until completion:
+        #   # The returned object is of type Gapic::Operation. You can use it to
+        #   # check the status of an operation, cancel it, or wait for results.
+        #   # Here is how to wait for a response.
         #   result.wait_until_done! timeout: 60
         #   if result.response?
         #     p result.response
         #   else
-        #     puts "Error!"
+        #     puts "No response received."
         #   end
         #
         def get_operation request, options = nil
@@ -531,14 +529,14 @@ module Testing
         #   # Call the wait_operation method.
         #   result = client.wait_operation request
         #
-        #   # The returned object is of type Gapic::Operation. You can use this
-        #   # object to check the status of an operation, cancel it, or wait
-        #   # for results. Here is how to block until completion:
+        #   # The returned object is of type Gapic::Operation. You can use it to
+        #   # check the status of an operation, cancel it, or wait for results.
+        #   # Here is how to wait for a response.
         #   result.wait_until_done! timeout: 60
         #   if result.response?
         #     p result.response
         #   else
-        #     puts "Error!"
+        #     puts "No response received."
         #   end
         #
         def wait_operation request, options = nil

--- a/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/aip_lro.rb
+++ b/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/aip_lro.rb
@@ -41,14 +41,14 @@ def aip_lro
   # Call the aip_lro method.
   result = client.aip_lro request
 
-  # The returned object is of type Gapic::Operation. You can use this
-  # object to check the status of an operation, cancel it, or wait
-  # for results. Here is how to block until completion:
+  # The returned object is of type Gapic::Operation. You can use it to
+  # check the status of an operation, cancel it, or wait for results.
+  # Here is how to wait for a response.
   result.wait_until_done! timeout: 60
   if result.response?
     p result.response
   else
-    puts "Error!"
+    puts "No response received."
   end
 end
 # [END testing_v0_generated_AllSubclientsConsumer_AipLRO_sync]

--- a/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/aip_lro.rb
+++ b/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/aip_lro.rb
@@ -28,8 +28,11 @@
 require "testing/nonstandard_lro_grpc"
 
 ##
-# Example demonstrating basic usage of
-# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#aip_lro
+# Snippet for the aip_lro call in the AllSubclientsConsumer service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#aip_lro. It may
+# require modification in order to execute successfully.
 #
 def aip_lro
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/another_lro_rpc.rb
+++ b/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/another_lro_rpc.rb
@@ -28,8 +28,11 @@
 require "testing/nonstandard_lro_grpc"
 
 ##
-# Example demonstrating basic usage of
-# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#another_lro_rpc
+# Snippet for the another_lro_rpc call in the AllSubclientsConsumer service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#another_lro_rpc. It
+# may require modification in order to execute successfully.
 #
 def another_lro_rpc
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/no_lro.rb
+++ b/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/no_lro.rb
@@ -28,8 +28,11 @@
 require "testing/nonstandard_lro_grpc"
 
 ##
-# Example demonstrating basic usage of
-# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#no_lro
+# Snippet for the no_lro call in the AllSubclientsConsumer service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#no_lro. It may
+# require modification in order to execute successfully.
 #
 def no_lro
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/non_copy_another_lro_rpc.rb
+++ b/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/non_copy_another_lro_rpc.rb
@@ -28,8 +28,11 @@
 require "testing/nonstandard_lro_grpc"
 
 ##
-# Example demonstrating basic usage of
-# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#non_copy_another_lro_rpc
+# Snippet for the non_copy_another_lro_rpc call in the AllSubclientsConsumer service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#non_copy_another_lro_rpc.
+# It may require modification in order to execute successfully.
 #
 def non_copy_another_lro_rpc
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/plain_lro_rpc.rb
+++ b/shared/output/gapic/templates/testing/snippets/all_subclients_consumer/plain_lro_rpc.rb
@@ -28,8 +28,11 @@
 require "testing/nonstandard_lro_grpc"
 
 ##
-# Example demonstrating basic usage of
-# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#plain_lro_rpc
+# Snippet for the plain_lro_rpc call in the AllSubclientsConsumer service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#plain_lro_rpc. It
+# may require modification in order to execute successfully.
 #
 def plain_lro_rpc
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/another_lro_provider/get_another.rb
+++ b/shared/output/gapic/templates/testing/snippets/another_lro_provider/get_another.rb
@@ -28,8 +28,11 @@
 require "testing/nonstandard_lro_grpc"
 
 ##
-# Example demonstrating basic usage of
-# Testing::NonstandardLroGrpc::AnotherLroProvider::Client#get_another
+# Snippet for the get_another call in the AnotherLroProvider service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::AnotherLroProvider::Client#get_another. It may
+# require modification in order to execute successfully.
 #
 def get_another
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/plain_lro_consumer/plain_lro_rpc.rb
+++ b/shared/output/gapic/templates/testing/snippets/plain_lro_consumer/plain_lro_rpc.rb
@@ -28,8 +28,11 @@
 require "testing/nonstandard_lro_grpc"
 
 ##
-# Example demonstrating basic usage of
-# Testing::NonstandardLroGrpc::PlainLroConsumer::Client#plain_lro_rpc
+# Snippet for the plain_lro_rpc call in the PlainLroConsumer service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::PlainLroConsumer::Client#plain_lro_rpc. It may
+# require modification in order to execute successfully.
 #
 def plain_lro_rpc
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/plain_lro_provider/get.rb
+++ b/shared/output/gapic/templates/testing/snippets/plain_lro_provider/get.rb
@@ -28,8 +28,11 @@
 require "testing/nonstandard_lro_grpc"
 
 ##
-# Example demonstrating basic usage of
-# Testing::NonstandardLroGrpc::PlainLroProvider::Client#get
+# Snippet for the get call in the PlainLroProvider service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::NonstandardLroGrpc::PlainLroProvider::Client#get. It may require
+# modification in order to execute successfully.
 #
 def get
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/service_explicit_headers/complex.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_explicit_headers/complex.rb
@@ -28,8 +28,11 @@
 require "testing/routing_headers"
 
 ##
-# Example demonstrating basic usage of
-# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#complex
+# Snippet for the complex call in the ServiceExplicitHeaders service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#complex. It may
+# require modification in order to execute successfully.
 #
 def complex
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/service_explicit_headers/plain_extract.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_explicit_headers/plain_extract.rb
@@ -28,8 +28,11 @@
 require "testing/routing_headers"
 
 ##
-# Example demonstrating basic usage of
-# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#plain_extract
+# Snippet for the plain_extract call in the ServiceExplicitHeaders service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#plain_extract. It may
+# require modification in order to execute successfully.
 #
 def plain_extract
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/service_explicit_headers/plain_full_field.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_explicit_headers/plain_full_field.rb
@@ -28,8 +28,11 @@
 require "testing/routing_headers"
 
 ##
-# Example demonstrating basic usage of
-# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#plain_full_field
+# Snippet for the plain_full_field call in the ServiceExplicitHeaders service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#plain_full_field. It
+# may require modification in order to execute successfully.
 #
 def plain_full_field
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/service_explicit_headers/plain_no_template.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_explicit_headers/plain_no_template.rb
@@ -28,8 +28,11 @@
 require "testing/routing_headers"
 
 ##
-# Example demonstrating basic usage of
-# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#plain_no_template
+# Snippet for the plain_no_template call in the ServiceExplicitHeaders service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#plain_no_template. It
+# may require modification in order to execute successfully.
 #
 def plain_no_template
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/service_explicit_headers/with_sub_message.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_explicit_headers/with_sub_message.rb
@@ -28,8 +28,11 @@
 require "testing/routing_headers"
 
 ##
-# Example demonstrating basic usage of
-# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#with_sub_message
+# Snippet for the with_sub_message call in the ServiceExplicitHeaders service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceExplicitHeaders::Client#with_sub_message. It
+# may require modification in order to execute successfully.
 #
 def with_sub_message
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/service_implicit_headers/plain.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_implicit_headers/plain.rb
@@ -28,8 +28,11 @@
 require "testing/routing_headers"
 
 ##
-# Example demonstrating basic usage of
-# Testing::RoutingHeaders::ServiceImplicitHeaders::Client#plain
+# Snippet for the plain call in the ServiceImplicitHeaders service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceImplicitHeaders::Client#plain. It may require
+# modification in order to execute successfully.
 #
 def plain
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/service_implicit_headers/with_multiple_levels.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_implicit_headers/with_multiple_levels.rb
@@ -28,8 +28,11 @@
 require "testing/routing_headers"
 
 ##
-# Example demonstrating basic usage of
-# Testing::RoutingHeaders::ServiceImplicitHeaders::Client#with_multiple_levels
+# Snippet for the with_multiple_levels call in the ServiceImplicitHeaders service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceImplicitHeaders::Client#with_multiple_levels.
+# It may require modification in order to execute successfully.
 #
 def with_multiple_levels
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/service_implicit_headers/with_sub_message.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_implicit_headers/with_sub_message.rb
@@ -28,8 +28,11 @@
 require "testing/routing_headers"
 
 ##
-# Example demonstrating basic usage of
-# Testing::RoutingHeaders::ServiceImplicitHeaders::Client#with_sub_message
+# Snippet for the with_sub_message call in the ServiceImplicitHeaders service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceImplicitHeaders::Client#with_sub_message. It
+# may require modification in order to execute successfully.
 #
 def with_sub_message
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/service_no_headers/plain.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_no_headers/plain.rb
@@ -28,8 +28,11 @@
 require "testing/routing_headers"
 
 ##
-# Example demonstrating basic usage of
-# Testing::RoutingHeaders::ServiceNoHeaders::Client#plain
+# Snippet for the plain call in the ServiceNoHeaders service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::RoutingHeaders::ServiceNoHeaders::Client#plain. It may require
+# modification in order to execute successfully.
 #
 def plain
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/service_no_retry/no_retry_method.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_no_retry/no_retry_method.rb
@@ -28,8 +28,11 @@
 require "testing/grpc_service_config"
 
 ##
-# Example demonstrating basic usage of
-# Testing::GrpcServiceConfig::ServiceNoRetry::Client#no_retry_method
+# Snippet for the no_retry_method call in the ServiceNoRetry service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::GrpcServiceConfig::ServiceNoRetry::Client#no_retry_method. It may
+# require modification in order to execute successfully.
 #
 def no_retry_method
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/service_with_loc/call_method.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_with_loc/call_method.rb
@@ -28,8 +28,11 @@
 require "testing/mixins"
 
 ##
-# Example demonstrating basic usage of
-# Testing::Mixins::ServiceWithLoc::Client#call_method
+# Snippet for the call_method call in the ServiceWithLoc service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::Mixins::ServiceWithLoc::Client#call_method. It may require
+# modification in order to execute successfully.
 #
 def call_method
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/service_with_retries/method_level_retry_method.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_with_retries/method_level_retry_method.rb
@@ -28,8 +28,11 @@
 require "testing/grpc_service_config"
 
 ##
-# Example demonstrating basic usage of
-# Testing::GrpcServiceConfig::ServiceWithRetries::Client#method_level_retry_method
+# Snippet for the method_level_retry_method call in the ServiceWithRetries service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::GrpcServiceConfig::ServiceWithRetries::Client#method_level_retry_method.
+# It may require modification in order to execute successfully.
 #
 def method_level_retry_method
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/service_with_retries/service_level_retry_method.rb
+++ b/shared/output/gapic/templates/testing/snippets/service_with_retries/service_level_retry_method.rb
@@ -28,8 +28,11 @@
 require "testing/grpc_service_config"
 
 ##
-# Example demonstrating basic usage of
-# Testing::GrpcServiceConfig::ServiceWithRetries::Client#service_level_retry_method
+# Snippet for the service_level_retry_method call in the ServiceWithRetries service
+#
+# This is an auto-generated example demonstrating basic usage of
+# Testing::GrpcServiceConfig::ServiceWithRetries::Client#service_level_retry_method.
+# It may require modification in order to execute successfully.
 #
 def service_level_retry_method
   # Create a client object. The client can be reused for multiple calls.

--- a/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.grpcserviceconfig.json
+++ b/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.grpcserviceconfig.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "testing_v0_generated_ServiceNoRetry_NoRetryMethod_sync",
-      "title": "Snippet for no_retry_method in ServiceNoRetry",
-      "description": "Basic snippet for no_retry_method in ServiceNoRetry",
+      "title": "Snippet for the no_retry_method call in the ServiceNoRetry service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::GrpcServiceConfig::ServiceNoRetry::Client#no_retry_method. It may require modification in order to execute successfully.",
       "file": "service_no_retry/no_retry_method.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_ServiceWithRetries_ServiceLevelRetryMethod_sync",
-      "title": "Snippet for service_level_retry_method in ServiceWithRetries",
-      "description": "Basic snippet for service_level_retry_method in ServiceWithRetries",
+      "title": "Snippet for the service_level_retry_method call in the ServiceWithRetries service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::GrpcServiceConfig::ServiceWithRetries::Client#service_level_retry_method. It may require modification in order to execute successfully.",
       "file": "service_with_retries/service_level_retry_method.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,15 +86,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_ServiceWithRetries_MethodLevelRetryMethod_sync",
-      "title": "Snippet for method_level_retry_method in ServiceWithRetries",
-      "description": "Basic snippet for method_level_retry_method in ServiceWithRetries",
+      "title": "Snippet for the method_level_retry_method call in the ServiceWithRetries service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::GrpcServiceConfig::ServiceWithRetries::Client#method_level_retry_method. It may require modification in order to execute successfully.",
       "file": "service_with_retries/method_level_retry_method.rb",
       "language": "RUBY",
       "client_method": {
@@ -126,7 +126,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.mixins.json
+++ b/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.mixins.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "testing_v0_generated_ServiceWithLoc_Method_sync",
-      "title": "Snippet for call_method in ServiceWithLoc",
-      "description": "Basic snippet for call_method in ServiceWithLoc",
+      "title": "Snippet for the call_method call in the ServiceWithLoc service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::Mixins::ServiceWithLoc::Client#call_method. It may require modification in order to execute successfully.",
       "file": "service_with_loc/call_method.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,7 +46,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.nonstandardlrogrpc.json
+++ b/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.nonstandardlrogrpc.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "testing_v0_generated_PlainLroConsumer_PlainLroRpc_sync",
-      "title": "Snippet for plain_lro_rpc in PlainLroConsumer",
-      "description": "Basic snippet for plain_lro_rpc in PlainLroConsumer",
+      "title": "Snippet for the plain_lro_rpc call in the PlainLroConsumer service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::NonstandardLroGrpc::PlainLroConsumer::Client#plain_lro_rpc. It may require modification in order to execute successfully.",
       "file": "plain_lro_consumer/plain_lro_rpc.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_PlainLroProvider_Get_sync",
-      "title": "Snippet for get in PlainLroProvider",
-      "description": "Basic snippet for get in PlainLroProvider",
+      "title": "Snippet for the get call in the PlainLroProvider service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::NonstandardLroGrpc::PlainLroProvider::Client#get. It may require modification in order to execute successfully.",
       "file": "plain_lro_provider/get.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,15 +86,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_AnotherLroProvider_GetAnother_sync",
-      "title": "Snippet for get_another in AnotherLroProvider",
-      "description": "Basic snippet for get_another in AnotherLroProvider",
+      "title": "Snippet for the get_another call in the AnotherLroProvider service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::NonstandardLroGrpc::AnotherLroProvider::Client#get_another. It may require modification in order to execute successfully.",
       "file": "another_lro_provider/get_another.rb",
       "language": "RUBY",
       "client_method": {
@@ -126,15 +126,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_AllSubclientsConsumer_PlainLroRpc_sync",
-      "title": "Snippet for plain_lro_rpc in AllSubclientsConsumer",
-      "description": "Basic snippet for plain_lro_rpc in AllSubclientsConsumer",
+      "title": "Snippet for the plain_lro_rpc call in the AllSubclientsConsumer service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#plain_lro_rpc. It may require modification in order to execute successfully.",
       "file": "all_subclients_consumer/plain_lro_rpc.rb",
       "language": "RUBY",
       "client_method": {
@@ -166,15 +166,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_AllSubclientsConsumer_AnotherLroRpc_sync",
-      "title": "Snippet for another_lro_rpc in AllSubclientsConsumer",
-      "description": "Basic snippet for another_lro_rpc in AllSubclientsConsumer",
+      "title": "Snippet for the another_lro_rpc call in the AllSubclientsConsumer service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#another_lro_rpc. It may require modification in order to execute successfully.",
       "file": "all_subclients_consumer/another_lro_rpc.rb",
       "language": "RUBY",
       "client_method": {
@@ -206,15 +206,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_AllSubclientsConsumer_NonCopyAnotherLroRpc_sync",
-      "title": "Snippet for non_copy_another_lro_rpc in AllSubclientsConsumer",
-      "description": "Basic snippet for non_copy_another_lro_rpc in AllSubclientsConsumer",
+      "title": "Snippet for the non_copy_another_lro_rpc call in the AllSubclientsConsumer service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#non_copy_another_lro_rpc. It may require modification in order to execute successfully.",
       "file": "all_subclients_consumer/non_copy_another_lro_rpc.rb",
       "language": "RUBY",
       "client_method": {
@@ -246,15 +246,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_AllSubclientsConsumer_AipLRO_sync",
-      "title": "Snippet for aip_lro in AllSubclientsConsumer",
-      "description": "Basic snippet for aip_lro in AllSubclientsConsumer",
+      "title": "Snippet for the aip_lro call in the AllSubclientsConsumer service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#aip_lro. It may require modification in order to execute successfully.",
       "file": "all_subclients_consumer/aip_lro.rb",
       "language": "RUBY",
       "client_method": {
@@ -286,15 +286,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 53,
+          "end": 56,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_AllSubclientsConsumer_NoLRO_sync",
-      "title": "Snippet for no_lro in AllSubclientsConsumer",
-      "description": "Basic snippet for no_lro in AllSubclientsConsumer",
+      "title": "Snippet for the no_lro call in the AllSubclientsConsumer service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::NonstandardLroGrpc::AllSubclientsConsumer::Client#no_lro. It may require modification in order to execute successfully.",
       "file": "all_subclients_consumer/no_lro.rb",
       "language": "RUBY",
       "client_method": {
@@ -326,7 +326,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]

--- a/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.routingheaders.json
+++ b/shared/output/gapic/templates/testing/snippets/snippet_metadata_testing.routingheaders.json
@@ -13,8 +13,8 @@
   "snippets": [
     {
       "region_tag": "testing_v0_generated_ServiceNoHeaders_Plain_sync",
-      "title": "Snippet for plain in ServiceNoHeaders",
-      "description": "Basic snippet for plain in ServiceNoHeaders",
+      "title": "Snippet for the plain call in the ServiceNoHeaders service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::RoutingHeaders::ServiceNoHeaders::Client#plain. It may require modification in order to execute successfully.",
       "file": "service_no_headers/plain.rb",
       "language": "RUBY",
       "client_method": {
@@ -46,15 +46,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_ServiceImplicitHeaders_Plain_sync",
-      "title": "Snippet for plain in ServiceImplicitHeaders",
-      "description": "Basic snippet for plain in ServiceImplicitHeaders",
+      "title": "Snippet for the plain call in the ServiceImplicitHeaders service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::RoutingHeaders::ServiceImplicitHeaders::Client#plain. It may require modification in order to execute successfully.",
       "file": "service_implicit_headers/plain.rb",
       "language": "RUBY",
       "client_method": {
@@ -86,15 +86,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_ServiceImplicitHeaders_WithSubMessage_sync",
-      "title": "Snippet for with_sub_message in ServiceImplicitHeaders",
-      "description": "Basic snippet for with_sub_message in ServiceImplicitHeaders",
+      "title": "Snippet for the with_sub_message call in the ServiceImplicitHeaders service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::RoutingHeaders::ServiceImplicitHeaders::Client#with_sub_message. It may require modification in order to execute successfully.",
       "file": "service_implicit_headers/with_sub_message.rb",
       "language": "RUBY",
       "client_method": {
@@ -126,15 +126,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_ServiceImplicitHeaders_WithMultipleLevels_sync",
-      "title": "Snippet for with_multiple_levels in ServiceImplicitHeaders",
-      "description": "Basic snippet for with_multiple_levels in ServiceImplicitHeaders",
+      "title": "Snippet for the with_multiple_levels call in the ServiceImplicitHeaders service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::RoutingHeaders::ServiceImplicitHeaders::Client#with_multiple_levels. It may require modification in order to execute successfully.",
       "file": "service_implicit_headers/with_multiple_levels.rb",
       "language": "RUBY",
       "client_method": {
@@ -166,15 +166,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_ServiceExplicitHeaders_PlainNoTemplate_sync",
-      "title": "Snippet for plain_no_template in ServiceExplicitHeaders",
-      "description": "Basic snippet for plain_no_template in ServiceExplicitHeaders",
+      "title": "Snippet for the plain_no_template call in the ServiceExplicitHeaders service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::RoutingHeaders::ServiceExplicitHeaders::Client#plain_no_template. It may require modification in order to execute successfully.",
       "file": "service_explicit_headers/plain_no_template.rb",
       "language": "RUBY",
       "client_method": {
@@ -206,15 +206,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_ServiceExplicitHeaders_PlainFullField_sync",
-      "title": "Snippet for plain_full_field in ServiceExplicitHeaders",
-      "description": "Basic snippet for plain_full_field in ServiceExplicitHeaders",
+      "title": "Snippet for the plain_full_field call in the ServiceExplicitHeaders service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::RoutingHeaders::ServiceExplicitHeaders::Client#plain_full_field. It may require modification in order to execute successfully.",
       "file": "service_explicit_headers/plain_full_field.rb",
       "language": "RUBY",
       "client_method": {
@@ -246,15 +246,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_ServiceExplicitHeaders_PlainExtract_sync",
-      "title": "Snippet for plain_extract in ServiceExplicitHeaders",
-      "description": "Basic snippet for plain_extract in ServiceExplicitHeaders",
+      "title": "Snippet for the plain_extract call in the ServiceExplicitHeaders service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::RoutingHeaders::ServiceExplicitHeaders::Client#plain_extract. It may require modification in order to execute successfully.",
       "file": "service_explicit_headers/plain_extract.rb",
       "language": "RUBY",
       "client_method": {
@@ -286,15 +286,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_ServiceExplicitHeaders_Complex_sync",
-      "title": "Snippet for complex in ServiceExplicitHeaders",
-      "description": "Basic snippet for complex in ServiceExplicitHeaders",
+      "title": "Snippet for the complex call in the ServiceExplicitHeaders service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::RoutingHeaders::ServiceExplicitHeaders::Client#complex. It may require modification in order to execute successfully.",
       "file": "service_explicit_headers/complex.rb",
       "language": "RUBY",
       "client_method": {
@@ -326,15 +326,15 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]
     },
     {
       "region_tag": "testing_v0_generated_ServiceExplicitHeaders_WithSubMessage_sync",
-      "title": "Snippet for with_sub_message in ServiceExplicitHeaders",
-      "description": "Basic snippet for with_sub_message in ServiceExplicitHeaders",
+      "title": "Snippet for the with_sub_message call in the ServiceExplicitHeaders service",
+      "description": "This is an auto-generated example demonstrating basic usage of Testing::RoutingHeaders::ServiceExplicitHeaders::Client#with_sub_message. It may require modification in order to execute successfully.",
       "file": "service_explicit_headers/with_sub_message.rb",
       "language": "RUBY",
       "client_method": {
@@ -366,7 +366,7 @@
       "segments": [
         {
           "start": 28,
-          "end": 46,
+          "end": 49,
           "type": "FULL"
         }
       ]


### PR DESCRIPTION
This PR updates the snippetgen templates using the phase 2 presenters, effectively merging the phase 1 and phase 2 codebases.

The first 4 commits are part of #890, and the next 7 commits are part of #891. If those PRs are not yet merged, reviewers can ignore those commits and review only the final 6 commits that are unique to this PR.

The commits that matter are as follows. It may be easiest to review each commit independently.

1. Added a render helper function that does line wrapping. This is for rendering description strings in comments.
2. This commit does the heavy lifting of moving the template over. It updates SnippetPresenter to create all the component presenters implemented in #891. It then updates the template to use those presenters. The template is now greatly simplified because all the rendering logic has been pushed down into the presenters.
3. Regenerate goldens to demonstrate the resulting changes. There are minor changes across the snippets, mostly names and comments.
4. Added one more presenter, for parameters for the snippet method. This will be used to render method declarations and documentation.
5. Updated the templates to use the parameter presenter. Also updated the templates to use the snippet name/title and description fields that are read from the configs.
6. Regenerated goldens one more time.