### PR TITLE
feat: Bump mixin minimum version to 0.3

### DIFF
--- a/gapic-generator/lib/gapic/model/mixins.rb
+++ b/gapic-generator/lib/gapic/model/mixins.rb
@@ -182,8 +182,8 @@ module Gapic
       # have these in lookup tables than to construct a ServicePresenter
 
       SERVICE_TO_DEPENDENCY = {
-        LOCATIONS_SERVICE => { "google-cloud-location" => [">= 0.0", "< 2.a"] },
-        IAM_SERVICE => { "google-iam-v1" => [">= 0.0", "< 2.a"] }
+        LOCATIONS_SERVICE => { "google-cloud-location" => [">= 0.3", "< 2.a"] },
+        IAM_SERVICE => { "google-iam-v1" => [">= 0.3", "< 2.a"] }
       }.freeze
 
       SERVICE_TO_REQUIRE_STR = {


### PR DESCRIPTION
Do not release until google-cloud-location and google-iam-v1 0.3 are released, of course.