### PR TITLE
feat: Honor metadata from the service yaml

### DIFF
--- a/gapic-generator-cloud/lib/gapic/presenters/cloud_gem_presenter.rb
+++ b/gapic-generator-cloud/lib/gapic/presenters/cloud_gem_presenter.rb
@@ -143,6 +143,7 @@ module Gapic
       def cloud_product?
         configured = gem_config :is_cloud_product
         return configured unless configured.nil?
+        return @api.api_metadata.organization == "CLOUD" if @api.api_metadata.organization
         return true if PSEUDO_CLOUD_GEMS.any? { |pattern| pattern === name }
         return false if NON_CLOUD_GEMS.any? { |pattern| pattern === name }
         services.any? do |service|

--- a/gapic-generator/lib/gapic/model/api_metadata.rb
+++ b/gapic-generator/lib/gapic/model/api_metadata.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Gapic
+  module Model
+    ##
+    # A collection of metadata about an API.
+    #
+    # This information generally comes from the service yaml rather than from
+    # proto input.
+    #
+    class ApiMetadata
+      ##
+      # @return [String] The full ID of the API, including `".googleapis.com"`.
+      #     For example, `"pubsub.googleapis.com"`.
+      #
+      attr_reader :name
+
+      ##
+      # @return [String] The shortname of the API, omitting `".googleapis.com"`.
+      #     For example, `"pubsub"`.
+      #
+      attr_reader :short_name
+
+      ##
+      # @return [String] A title of the API, including the version.
+      #     For example, `"Cloud Pub/Sub V1"`
+      #
+      attr_reader :title
+
+      ##
+      # @return [String] A short description of the API, suitable for the
+      #     RubyGems summary field.
+      #
+      attr_reader :summary
+
+      ##
+      # @return [String] A longer description of the API, suitable for the
+      #     RubyGems description field.
+      #
+      attr_reader :description
+
+      ##
+      # @return [String] The organization name, determining where the API's
+      #     documentation should be published, among other things. This value
+      #     is `"CLOUD"` for Google Cloud APIs.
+      #
+      attr_reader :organization
+
+      ##
+      # @return [String] The URL for the documentation.
+      #
+      attr_reader :documentation_url
+
+      ##
+      # @return [String] The prefix string for sample doc tags.
+      #
+      attr_reader :doc_tag_prefix
+
+      ######## Internal ########
+
+      # @private
+      def update! **keywords
+        keywords.each do |key, value|
+          instance_variable_set "@#{key}", value unless value.nil?
+        end
+        self
+      end
+
+      # @private
+      def standardize_names!
+        return unless name || short_name
+        @name ||= short_name
+        @short_name ||= name
+        @name = "#{name}.googleapis.com" unless name.include? "."
+        @short_name = short_name.split(".").first
+        @doc_tag_prefix ||= short_name
+        self
+      end
+
+      # @private
+      def standardize_title! gem_name:
+        return unless title
+        @title = title.sub %r{\s+API$}, ""
+        return if title =~ /\s+V\d+\w*$/
+        vers = gem_name.split("-").last
+        @title = "#{title} #{vers.upcase}" if vers =~ /^v\d+\w*$/
+        self
+      end
+
+      # @private
+      def standardize_descriptions!
+        return unless summary || description
+        @description ||= summary
+        @summary = summary.gsub(/\s+/, " ").strip if summary
+        @summary = "#{summary}." if summary && summary =~ /\w\z/
+        @description = description.gsub(/\s+/, " ").strip
+        @description = "#{description}." if description =~ /\w\z/
+        self
+      end
+    end
+  end
+end

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -84,6 +84,7 @@ module Gapic
 
       def title
         gem_config(:title) ||
+          @api.api_metadata.title ||
           namespace.split("::").join(" ")
       end
 
@@ -116,11 +117,13 @@ module Gapic
 
       def description
         gem_config(:description) ||
+          @api.api_metadata.description ||
           "#{name} is the official client library for the #{title} API."
       end
 
       def summary
         gem_config(:summary) ||
+          @api.api_metadata.summary ||
           "API Client library for the #{title} API"
       end
 
@@ -142,17 +145,21 @@ module Gapic
       end
 
       def product_documentation_url
-        gem_config :product_documentation_url
+        gem_config(:product_documentation_url) || @api.api_metadata.documentation_url
       end
 
       def api_id
-        raw_id = gem_config :api_id
+        raw_id = gem_config(:api_id) || @api.api_metadata.name
         return nil unless raw_id
         raw_id.include?(".") ? raw_id : "#{raw_id}.googleapis.com"
       end
 
       def api_shortname
-        gem_config :api_shortname
+        gem_config(:api_shortname) || @api.api_metadata.short_name
+      end
+
+      def doc_tag_prefix
+        @api.api_metadata.doc_tag_prefix || api_shortname || api_id&.split(".")&.first
       end
 
       def issue_tracker_url

--- a/gapic-generator/lib/gapic/presenters/snippet_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/snippet_presenter.rb
@@ -146,22 +146,22 @@ module Gapic
 
       def region_tag
         gem_presenter = @method_presenter.service.gem
-        api_id = gem_presenter.api_shortname || gem_presenter.api_id&.split(".")&.first
+        prefix = gem_presenter.doc_tag_prefix
         names = gem_presenter.name.split "-"
         final_name = names.pop
         if final_name =~ /^v\d/
           api_version = final_name
-          api_id ||= names.last
+          prefix ||= names.last
         else
-          api_id ||= final_name
+          prefix ||= final_name
           api_version = "v0"
         end
-        api_id = api_id.downcase.gsub(/[^a-z0-9]/, "")
+        prefix = prefix.downcase.gsub(/[^a-z0-9]/, "")
         service_name = @method_presenter.service.module_name
         method_name = @method_presenter.method.name
         type = config? ? "config" : "generated"
         config_id = config? ? "#{@config.metadata.config_id}_" : ""
-        "#{api_id}_#{api_version}_#{type}_#{service_name}_#{method_name}_#{config_id}sync"
+        "#{prefix}_#{api_version}_#{type}_#{service_name}_#{method_name}_#{config_id}sync"
       end
 
       private

--- a/gapic-generator/lib/gapic/schema/api.rb
+++ b/gapic-generator/lib/gapic/schema/api.rb
@@ -21,6 +21,7 @@ require "gapic/schema/loader"
 require "gapic/schema/request_param_parser"
 require "gapic/grpc_service_config/parser"
 require "gapic/schema/service_config_parser"
+require "gapic/model/api_metadata"
 
 module Gapic
   module Schema
@@ -340,6 +341,19 @@ module Gapic
       # @return [Google::Api::Service]
       def service_config
         @service_config ||= Gapic::Schema::ServiceConfigParser.parse_service_yaml service_config_raw
+      end
+
+      # Parsed API Metadata model
+      # @return [Gapic::Model::ApiMetadata]
+      def api_metadata
+        @api_metadata ||= begin
+          api_metadata = Gapic::Model::ApiMetadata.new
+          Gapic::Schema::ServiceConfigParser.parse_api_metadata service_config_raw, api_metadata
+          api_metadata.standardize_names!
+          api_metadata.standardize_title! gem_name: configuration.fetch(:gem, nil)&.fetch(:name, "")
+          api_metadata.standardize_descriptions!
+          api_metadata
+        end
       end
 
       # Get a resource given its type string

--- a/gapic-generator/lib/gapic/schema/service_config_parser.rb
+++ b/gapic-generator/lib/gapic/schema/service_config_parser.rb
@@ -35,6 +35,14 @@ module Gapic
         HTTP_RULES_VERBS_ALLOWED = ["get", "post", "put", "patch", "delete"].freeze
         HTTP_RULES_BODY_KEY = "body"
         HTTP_RULES_ADDITIONAL_BINDINGS_KEY = "additional_bindings"
+        PUBS_KEY = "publishing"
+        PUBS_SHORTNAME_KEY = "api_short_name"
+        PUBS_ORGANIZATION_KEY = "organization"
+        PUBS_DOCURL_KEY = "documentation_uri"
+        PUBS_DOCTAG_KEY = "doc_tag_prefix"
+        DOCS_KEY = "documentation"
+        DOCS_SUMMARY_KEY = "summary"
+        DOCS_OVERVIEW_KEY = "overview"
 
         ##
         # Returns the parsed Google::Api::Service object.
@@ -60,6 +68,30 @@ module Gapic
           service.apis = parse_apis service_yaml[APIS_KEY] if service_yaml.key? APIS_KEY
           service.http = parse_http service_yaml[HTTP_KEY] if service_yaml.key? HTTP_KEY
           service
+        end
+
+        ##
+        # Populates Gapic::Model::ApiMetadata from a service yaml file.
+        #
+        # @param service_yaml_text [String] YAML content
+        # @param api_metadata [Gapic::Model::ApiMetadata] model to populate
+        #
+        def parse_api_metadata service_yaml_text, api_metadata = nil
+          api_metadata ||= Gapic::Model::ApiMetadata.new
+          if service_yaml_text && !service_yaml_text.empty?
+            service_yaml = YAML.safe_load service_yaml_text
+            pubs_yaml = service_yaml[PUBS_KEY] || {}
+            docs_yaml = service_yaml[DOCS_KEY] || {}
+            api_metadata.update! name: service_yaml[NAME_KEY],
+                                 short_name: pubs_yaml[PUBS_SHORTNAME_KEY],
+                                 title: service_yaml[TITLE_KEY],
+                                 summary: docs_yaml[DOCS_SUMMARY_KEY],
+                                 description: docs_yaml[DOCS_OVERVIEW_KEY],
+                                 organization: pubs_yaml[PUBS_ORGANIZATION_KEY],
+                                 documentation_url: pubs_yaml[PUBS_DOCURL_KEY],
+                                 doc_tag_prefix: pubs_yaml[PUBS_DOCTAG_KEY]
+          end
+          api_metadata
         end
 
         private

--- a/gapic-generator/test/gapic/presenters/gem/showcase_test.rb
+++ b/gapic-generator/test/gapic/presenters/gem/showcase_test.rb
@@ -24,15 +24,15 @@ class ShowcaseGemPresenterTest < PresenterTest
   def test_showcase
     assert_equal "google-showcase", presenter.name
     assert_equal "Google::Showcase", presenter.namespace
-    assert_equal "Google Showcase", presenter.title
+    assert_equal "Client Libraries Showcase", presenter.title
     assert_equal "0.0.1", presenter.version
     assert_equal "google/showcase/version", presenter.version_require
     assert_equal "google/showcase/version.rb", presenter.version_file_path
     assert_equal "Google::Showcase::VERSION", presenter.version_name_full
     assert_equal ["Google LLC"], presenter.authors
     assert_equal "googleapis-packages@google.com", presenter.email
-    assert_equal "google-showcase is the official client library for the Google Showcase API.", presenter.description
-    assert_equal "API Client library for the Google Showcase API", presenter.summary
+    assert_equal "google-showcase is the official client library for the Client Libraries Showcase API.", presenter.description
+    assert_equal "API Client library for the Client Libraries Showcase API", presenter.summary
     assert_equal "https://github.com/googleapis/googleapis", presenter.homepage
     assert_equal "SHOWCASE", presenter.env_prefix
 

--- a/gapic-generator/test/gapic/schema/service_config_parser_test.rb
+++ b/gapic-generator/test/gapic/schema/service_config_parser_test.rb
@@ -105,4 +105,46 @@ class ServiceConfigParserTest < Minitest::Test
     end
     refute_nil method2_addbind
   end
+
+  def test_parse_api_metadata
+    expected_name = "testapi.googleapis.com"
+    expected_shortname = "testapi"
+    expected_url = "https://example.com/my-docs"
+    expected_title = "My Test"
+    expected_organization = "CLOUD"
+    expected_summary = "This is the summary for My Test API."
+    expected_description = "This is the description for My Test API."
+    expected_doctag = "testapitag"
+
+    yaml = <<~YAML
+      type: google.api.Service
+      config_version: 3
+      name: #{expected_name}
+      title: #{expected_title} API
+      documentation:
+        summary: #{expected_summary}
+        overview: |-
+          This is the description
+          for My Test API
+      publishing:
+        organization: #{expected_organization}
+        documentation_uri: '#{expected_url}'
+        api_short_name: #{expected_shortname}
+        doc_tag_prefix: #{expected_doctag}
+    YAML
+
+    metadata = Gapic::Schema::ServiceConfigParser.parse_api_metadata yaml
+    metadata.standardize_names!
+    metadata.standardize_title! gem_name: "google-testapi-v9"
+    metadata.standardize_descriptions!
+
+    assert_equal expected_name, metadata.name
+    assert_equal expected_shortname, metadata.short_name
+    assert_equal "#{expected_title} V9", metadata.title
+    assert_equal expected_summary, metadata.summary
+    assert_equal expected_description, metadata.description
+    assert_equal expected_organization, metadata.organization
+    assert_equal expected_url, metadata.documentation_url
+    assert_equal expected_doctag, metadata.doc_tag_prefix
+  end
 end

--- a/shared/output/cloud/vision_v1/.repo-metadata.json
+++ b/shared/output/cloud/vision_v1/.repo-metadata.json
@@ -1,14 +1,16 @@
 {
-    "api_shortname": "unknown",
+    "api_id": "vision.googleapis.com",
+    "api_shortname": "vision",
     "client_documentation": "https://cloud.google.com/ruby/docs/reference/google-cloud-vision-v1/latest",
     "distribution_name": "google-cloud-vision-v1",
     "is_cloud": true,
     "language": "ruby",
-    "name_pretty": "Google Cloud Vision V1 API",
+    "name": "vision",
+    "name_pretty": "Cloud Vision V1 API",
     "release_level": "unreleased",
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
-    "ruby-cloud-description": "google-cloud-vision-v1 is the official client library for the Google Cloud Vision V1 API. Note that google-cloud-vision-v1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-vision instead. See the readme for more details.",
+    "ruby-cloud-description": "Integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications. Note that google-cloud-vision-v1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-vision instead. See the readme for more details.",
     "ruby-cloud-env-prefix": "VISION",
     "library_type": "GAPIC_AUTO"
 }

--- a/shared/output/cloud/vision_v1/.yardopts
+++ b/shared/output/cloud/vision_v1/.yardopts
@@ -1,5 +1,5 @@
 --no-private
---title="Google Cloud Vision V1 API"
+--title="Cloud Vision V1 API"
 --exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet

--- a/shared/output/cloud/vision_v1/README.md
+++ b/shared/output/cloud/vision_v1/README.md
@@ -1,13 +1,13 @@
-# Ruby Client for the Google Cloud Vision V1 API
+# Ruby Client for the Cloud Vision V1 API
 
-API Client library for the Google Cloud Vision V1 API
+Integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.
 
-google-cloud-vision-v1 is the official client library for the Google Cloud Vision V1 API.
+Integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications.
 
 https://github.com/googleapis/google-cloud-ruby
 
 This gem is a _versioned_ client. It provides basic client classes for a
-specific version of the Google Cloud Vision V1 API. Most users should consider using
+specific version of the Cloud Vision V1 API. Most users should consider using
 the main client gem,
 [google-cloud-vision](https://rubygems.org/gems/google-cloud-vision).
 See the section below titled *Which client should I use?* for more information.
@@ -24,6 +24,7 @@ In order to use this library, you first need to go through the following steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
+1. [Enable the API.](https://console.cloud.google.com/apis/library/vision.googleapis.com)
 1. [Set up authentication.](AUTHENTICATION.md)
 
 ## Quick Start

--- a/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
+++ b/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |gem|
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
-  gem.description   = "google-cloud-vision-v1 is the official client library for the Google Cloud Vision V1 API. Note that google-cloud-vision-v1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-vision instead. See the readme for more details."
-  gem.summary       = "API Client library for the Google Cloud Vision V1 API"
+  gem.description   = "Integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications. Note that google-cloud-vision-v1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-vision instead. See the readme for more details."
+  gem.summary       = "Integrates Google Vision features, including image labeling, face, logo, and landmark detection, optical character recognition (OCR), and detection of explicit content, into applications."
   gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 

--- a/shared/output/cloud/vision_v1/proto_docs/README.md
+++ b/shared/output/cloud/vision_v1/proto_docs/README.md
@@ -1,4 +1,4 @@
-# Google Cloud Vision V1 Protocol Buffer Documentation
+# Cloud Vision V1 Protocol Buffer Documentation
 
 These files are for the YARD documentation of the generated protobuf files.
 They are not intended to be required or loaded at runtime.

--- a/shared/output/gapic/templates/showcase/.yardopts
+++ b/shared/output/gapic/templates/showcase/.yardopts
@@ -1,5 +1,5 @@
 --no-private
---title="Google Showcase"
+--title="Client Libraries Showcase"
 --exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet

--- a/shared/output/gapic/templates/showcase/README.md
+++ b/shared/output/gapic/templates/showcase/README.md
@@ -1,8 +1,8 @@
-# Ruby Client for the Google Showcase API
+# Ruby Client for the Client Libraries Showcase API
 
-API Client library for the Google Showcase API
+API Client library for the Client Libraries Showcase API
 
-google-showcase is the official client library for the Google Showcase API.
+google-showcase is the official client library for the Client Libraries Showcase API.
 
 https://github.com/googleapis/googleapis
 

--- a/shared/output/gapic/templates/showcase/google-showcase.gemspec
+++ b/shared/output/gapic/templates/showcase/google-showcase.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |gem|
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
-  gem.description   = "google-showcase is the official client library for the Google Showcase API."
-  gem.summary       = "API Client library for the Google Showcase API"
+  gem.description   = "google-showcase is the official client library for the Client Libraries Showcase API."
+  gem.summary       = "API Client library for the Client Libraries Showcase API"
   gem.homepage      = "https://github.com/googleapis/googleapis"
   gem.license       = "MIT"
 

--- a/shared/output/gapic/templates/showcase/proto_docs/README.md
+++ b/shared/output/gapic/templates/showcase/proto_docs/README.md
@@ -1,4 +1,4 @@
-# Google Showcase Protocol Buffer Documentation
+# Client Libraries Showcase Protocol Buffer Documentation
 
 These files are for the YARD documentation of the generated protobuf files.
 They are not intended to be required or loaded at runtime.


### PR DESCRIPTION
The intent here is to pull as much metadata as possible from service_yaml so we don't have to set fields in the bazel build rules when onboarding new clients. This pulls service yaml information into the `Gapic::Model::ApiMetadata` object, which is then queried from the presenters. Currently, information from configs (i.e. from bazel rules) still takes precedence, but then ApiMetadata is consulted.