### PR TITLE
chore: Add toys tools for various workflows

### DIFF
--- a/.toys/.toys.rb
+++ b/.toys/.toys.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mixin "repo_info" do
+  ##
+  # Helper method that iterates over directories with bundles, i.e. all gems
+  # plus the shared directory. For each directory, it runs the given block,
+  # with the current directory set to that directory, and also passing the
+  # directory name to the block.
+  #
+  def in_directories_with_bundles
+    Dir.chdir context_directory do
+      Dir.glob "*/Gemfile" do |gemfile|
+        dir = File.dirname gemfile
+        Dir.chdir dir do
+          yield dir
+        end
+      end
+    end
+  end
+
+  ##
+  # Helper method that determines if a given named tool is defined in the
+  # current directory.
+  #
+  def tool_defined? name
+    result = exec_separate_tool ["system", "tools", "show", "--local", name], e: false, out: :null
+    result.success?
+  end
+end
+
+expand :clean, paths: :gitignore
+
+tool "bundle" do
+  ["install", "update"].each do |task_name|
+    tool task_name do
+      desc "Runs bundle #{task_name} in all directories"
+
+      include :exec, e: true
+      include :terminal
+      include "repo_info"
+      static :task_name, task_name
+
+      def run
+        in_directories_with_bundles do |dirname|
+          puts "Bundle #{task_name} in #{dirname}", :cyan, :bold
+          exec ["bundle", task_name, "--retry=3"]
+        end
+      end
+    end
+  end
+end
+
+["test", "rubocop"].each do |task_name|
+  tool task_name do
+    desc "Runs #{task_name} in all directories"
+
+    include :exec, e: true
+    include :terminal
+    include "repo_info"
+    static :task_name, task_name
+
+    def run
+      in_directories_with_bundles do |dirname|
+        if tool_defined? task_name
+          puts "Running #{task_name} in #{dirname}", :cyan, :bold
+          exec_separate_tool [task_name]
+        else
+          puts "No #{task_name} task defined in #{dirname}", :yellow
+        end
+      end
+    end
+  end
+end
+
+tool "ci" do
+  desc "Runs CI in all directories"
+
+  include :exec
+  include :terminal
+  include "repo_info"
+
+  def run
+    failures = []
+    in_directories_with_bundles do |dirname|
+      ["test", "rubocop"].each do |task_name|
+        if tool_defined? task_name
+          puts "Running #{task_name} in #{dirname}", :cyan, :bold
+          result = exec_separate_tool [task_name]
+          unless result.success?
+            failures << "#{dirname}: #{task_name}"
+            puts "FAILED: #{dirname} #{task_name}", :red, :bold
+          end
+        else
+          puts "No #{task_name} task defined in #{dirname}", :yellow
+        end
+      end
+    end
+    return if failures.empty?
+    puts "FAILURES:", :bold
+    failures.each { |failure| puts failure, :bold }
+    exit 1
+  end
+end
+
+tool "gen" do
+  desc "Runs the generator for all goldens"
+
+  include :exec, e: true
+  include :terminal
+  include "repo_info"
+
+  def run
+    in_directories_with_bundles do |dirname|
+      next if dirname == "shared"
+      puts "Generating in #{dirname}", :cyan, :bold
+      exec ["bundle", "exec", "rake", "gen"]
+    end
+  end
+
+  ["garbage", "showcase"].each do |name|
+    tool name do
+      desc "Runs the generator for #{name}"
+
+      include :exec, e: true
+      static :name, name
+  
+      def run
+        Dir.chdir "#{context_directory}/gapic-generator" do
+          exec ["bundle", "exec", "rake", "gen:#{name}"]
+        end
+      end
+    end
+  end
+end
+
+tool "bin" do
+  desc "Generates binary input for all goldens"
+
+  include :exec, e: true
+
+  def run
+    Dir.chdir "#{context_directory}/shared" do
+      exec ["bundle", "exec", "rake", "gen"]
+    end
+  end
+
+  ["garbage", "showcase"].each do |name|
+    tool name do
+      desc "Generates binary input for #{name}"
+
+      include :exec, e: true
+      static :name, name
+  
+      def run
+        Dir.chdir "#{context_directory}/shared" do
+          exec ["bundle", "exec", "rake", "gen:#{name}"]
+        end
+      end
+    end
+  end
+end

--- a/gapic-common/.toys.rb
+++ b/gapic-common/.toys.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+expand :rubocop, bundler: true
+
+expand :minitest do |t|
+  t.libs = ["lib", "test"]
+  t.files = ["test/**/*_test.rb"]
+  t.bundler = true
+end

--- a/gapic-generator-ads/.toys.rb
+++ b/gapic-generator-ads/.toys.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+expand :rubocop, bundler: true
+
+expand :minitest do |t|
+  t.libs = ["lib", "test"]
+  t.files = ["test/**/*_test.rb"]
+  t.bundler = true
+end

--- a/gapic-generator-cloud/.toys.rb
+++ b/gapic-generator-cloud/.toys.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+expand :rubocop, bundler: true
+
+expand :minitest do |t|
+  t.libs = ["lib", "test"]
+  t.files = ["test/**/*_test.rb"]
+  t.bundler = true
+end

--- a/gapic-generator/.toys.rb
+++ b/gapic-generator/.toys.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+expand :rubocop, bundler: true
+
+expand :minitest do |t|
+  t.libs = ["lib", "test"]
+  t.files = ["test/**/*_test.rb"]
+  t.bundler = true
+end

--- a/gapic/.toys.rb
+++ b/gapic/.toys.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+expand :rubocop, bundler: true
+
+expand :minitest do |t|
+  t.libs = ["lib", "test"]
+  t.files = ["test/**/*_test.rb"]
+  t.bundler = true
+end

--- a/shared/.toys.rb
+++ b/shared/.toys.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+expand :minitest do |t|
+  t.libs = ["test"]
+  t.files = ["test/**/*_test.rb"]
+  t.bundler = true
+end


### PR DESCRIPTION
Implements:

* `toys bundle install` to replace `bundle exec rake bundle`.
* `toys bundle update` to replace `bundle exec rake bundleupdate`.
* `toys ci` to replace `bundle exec rake ci`
* `toys test` to replace `bundle exec rake test`
* `toys rubocop` to replace `bundle exec rake rubocop`
* `toys gen` to replace `bundle exec rake gen`. There is also `toys gen showcase` and `toys gen garbage`.
* `toys bin` to replace `bundle exec rake bin`. There is also `toys bin showcase` and `toys bin garbage`.

Also implements `toys test` and `toys rubocop` within each directory. However, per-directory `gen` and `bin` are still implemented as rake tasks.

Note also that toys does not require a toplevel bundle. Once we have all toplevel rake tasks ported, we can get rid of the toplevel Gemfile. Currently, only `rake build` and `rake install` at the toplevel are not ported, and we might end up just throwing those away since they're not as important.
