### PR TITLE
fix: Remove html tags from description text parsed from service yaml

### DIFF
--- a/gapic-generator/lib/gapic/model/api_metadata.rb
+++ b/gapic-generator/lib/gapic/model/api_metadata.rb
@@ -111,11 +111,23 @@ module Gapic
       def standardize_descriptions!
         return unless summary || description
         @description ||= summary
-        @summary = summary.gsub(/\s+/, " ").strip if summary
-        @summary = "#{summary}." if summary && summary =~ /\w\z/
+        if summary
+          @summary = summary.gsub(/\s+/, " ").strip
+          @summary = "#{summary}." if summary =~ /\w\z/
+          @summary = remove_html_tags summary
+        end
         @description = description.gsub(/\s+/, " ").strip
         @description = "#{description}." if description =~ /\w\z/
+        @description = remove_html_tags description
         self
+      end
+
+      # @private
+      # Remove html tags and markdown links
+      def remove_html_tags str
+        str
+          .gsub(%r{</?[[:alpha:]]+(?:\s+[[:alpha:]]+\s*=\s*(?:"[^"]+"|'[^']+'|[^\s">]+))*\s*/?>}, "")
+          .gsub(%r{\[([^\]]+)\]\([^)]+\)}, "\\1")
       end
     end
   end

--- a/gapic-generator/test/gapic/model/api_metadata_test.rb
+++ b/gapic-generator/test/gapic/model/api_metadata_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+require "gapic/model/api_metadata"
+
+class ApiMetadataTest < Minitest::Test
+  def api_metadata
+    Gapic::Model::ApiMetadata.new
+  end
+
+  def test_remove_html_tags_removes_opening_tag
+    result = api_metadata.remove_html_tags "hello <html> world"
+    assert_equal "hello  world", result
+  end
+
+  def test_remove_html_tags_removes_closing_tag
+    result = api_metadata.remove_html_tags "hello </html> world"
+    assert_equal "hello  world", result
+  end
+
+  def test_remove_html_tags_removes_open_and_close_tag
+    result = api_metadata.remove_html_tags "hello <br/> world"
+    assert_equal "hello  world", result
+  end
+
+  def test_remove_html_tags_removes_open_and_close_tag_with_space
+    result = api_metadata.remove_html_tags "hello <br /> world"
+    assert_equal "hello  world", result
+  end
+
+  def test_remove_html_tags_removes_tag_with_attr
+    result = api_metadata.remove_html_tags "hello <a href=blah>ruby</a> world"
+    assert_equal "hello ruby world", result
+  end
+
+  def test_remove_html_tags_removes_tag_with_attr_single_quoted
+    result = api_metadata.remove_html_tags "hello <a href='blah'>ruby</a> world"
+    assert_equal "hello ruby world", result
+  end
+
+  def test_remove_html_tags_removes_tag_with_attr_double_quoted
+    result = api_metadata.remove_html_tags 'hello <a href="blah">ruby</a> world'
+    assert_equal "hello ruby world", result
+  end
+
+  def test_remove_html_tags_removes_markdown_link
+    result = api_metadata.remove_html_tags "hello [ruby](http) world"
+    assert_equal "hello ruby world", result
+  end
+end

--- a/gapic-generator/test/gapic/schema/service_config_parser_test.rb
+++ b/gapic-generator/test/gapic/schema/service_config_parser_test.rb
@@ -161,7 +161,7 @@ class ServiceConfigParserTest < Minitest::Test
       name: #{expected_name}
       title: #{expected_title} API
       documentation:
-        summary: #{expected_summary}
+        summary: This is the summary for <a href="blah">My Test API</a>.
         overview: '(== hello.md ==)'
       publishing:
         organization: CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED


### PR DESCRIPTION
fixes #933
fixes https://github.com/googleapis/google-cloud-ruby/issues/20567