### PR TITLE
fix: Path override now affects wrapper factory method names

### DIFF
--- a/gapic-generator-cloud/lib/gapic/presenters/wrapper_service_presenter.rb
+++ b/gapic-generator-cloud/lib/gapic/presenters/wrapper_service_presenter.rb
@@ -35,7 +35,7 @@ module Gapic
           suffix = gem.factory_method_suffix
           method_name = "#{method_name}#{suffix}" unless method_name.end_with? suffix
           method_name = "#{method_name}_client" if Gapic::RubyInfo.excluded_method_names.include? method_name
-          method_name
+          @api.fix_file_path method_name
         end
       end
 


### PR DESCRIPTION
fixes #895 

I audited existing usage and determined that, in addition to `google-cloud-gsuite_add_ons`, the `google-cloud-automl` wrapper is also affected. A factory method name will change from `auto_ml` to `automl`. Generally we do want this change, but I opened https://github.com/googleapis/google-cloud-ruby/pull/20587 to ensure backward compatibility.