### PR TITLE
Fix handling of optional fields in coerce

### DIFF
--- a/gapic-common/lib/gapic/protobuf.rb
+++ b/gapic-common/lib/gapic/protobuf.rb
@@ -31,6 +31,7 @@ module Gapic
     # @return [Object] An instance of the given message class.
     def self.coerce hash, to:
       return hash if hash.is_a? to
+      return nil if hash.nil?
 
       # Special case handling of certain types
       return time_to_timestamp hash if to == Google::Protobuf::Timestamp && hash.is_a?(Time)

--- a/gapic-common/test/gapic/protobuf/coerce_test.rb
+++ b/gapic-common/test/gapic/protobuf/coerce_test.rb
@@ -35,6 +35,15 @@ class ProtobufCoerceTest < Minitest::Spec
     _(user.type).must_equal USER_TYPE
   end
 
+  it "handles optional fields in a simple hash" do
+    hash = { name: USER_NAME, type: USER_TYPE, timestamp: nil }
+    user = Gapic::Protobuf.coerce hash, to: Gapic::Examples::User
+    _(user).must_be_kind_of Gapic::Examples::User
+    _(user.name).must_equal USER_NAME
+    _(user.type).must_equal USER_TYPE
+    _(user.timestamp).must_be_nil
+  end
+
   it "creates a protobuf message from a hash with a nested message" do
     request_hash = { name: REQUEST_NAME, user: Gapic::Examples::User.new(name: USER_NAME, type: USER_TYPE) }
     request = Gapic::Protobuf.coerce request_hash, to: Gapic::Examples::Request


### PR DESCRIPTION
A field that appears in a Hash as nil breaks coercing the Hash with an error like: "Value  must be a Hash or a Foo (ArgumentError)".

For example, the version `0.19.0` of `gapic-common` breaks `google-cloud-firestore`.

Running this:

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'dotenv'
  gem 'gapic-common', '0.19.0'
  gem 'google-cloud-firestore', '2.13.0'
end

require 'dotenv/load'
require 'google/cloud/firestore'

firestore = Google::Cloud::Firestore.new(project_id: ENV.fetch('PROJECT_ID'))
doc = firestore.doc(ENV.fetch('DOCUMENT_ID'))
puts doc.get
```

Results in an error like:
```
/home/psyho/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/gapic-common-0.19.0/lib/gapic/protobuf.rb:39:in `coerce': Value  must be a Hash or a Google::Cloud::Firestore::V1::DocumentMask (ArgumentError)
        from /home/psyho/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/gapic-common-0.19.0/lib/gapic/protobuf.rb:99:in `coerce_submessage'
        from /home/psyho/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/gapic-common-0.19.0/lib/gapic/protobuf.rb:61:in `block in coerce_submessages'
        from /home/psyho/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/gapic-common-0.19.0/lib/gapic/protobuf.rb:57:in `each'
        from /home/psyho/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/gapic-common-0.19.0/lib/gapic/protobuf.rb:57:in `coerce_submessages'
        from /home/psyho/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/gapic-common-0.19.0/lib/gapic/protobuf.rb:41:in `coerce'
        from /home/psyho/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/google-cloud-firestore-v1-0.10.0/lib/google/cloud/firestore/v1/firestore/client.rb:749:in `batch_get_documents'
        from /home/psyho/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/google-cloud-firestore-2.13.0/lib/google/cloud/firestore/service.rb:74:in `get_documents'
        from /home/psyho/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/google-cloud-firestore-2.13.0/lib/google/cloud/firestore/client.rb:348:in `get_all'
        from /home/psyho/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/google-cloud-firestore-2.13.0/lib/google/cloud/firestore/document_reference.rb:168:in `each'
        from /home/psyho/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/google-cloud-firestore-2.13.0/lib/google/cloud/firestore/document_reference.rb:168:in `first'
        from /home/psyho/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/google-cloud-firestore-2.13.0/lib/google/cloud/firestore/document_reference.rb:168:in `get'
        from ./gapic:18:in `<main>'
```

