### PR TITLE
fix: Fix snippet generation for REGAPIC clients

### DIFF
--- a/gapic-generator/lib/gapic/package_snippets.rb
+++ b/gapic-generator/lib/gapic/package_snippets.rb
@@ -88,6 +88,7 @@ module Gapic
     private
 
     def build_snippet_object snippet_presenter, method_presenter, service_presenter, snippet_lines
+      service_presenter = service_presenter.rest if snippet_presenter.transport == :rest
       SnippetIndex::Snippet.new(
         region_tag: snippet_presenter.region_tag,
         title: snippet_presenter.snippet_name,
@@ -107,7 +108,7 @@ module Gapic
         name: "request"
       )
       client = SnippetIndex::ServiceClient.new(
-        short_name: "#{service_presenter.module_name}::#{service_presenter.client_name}",
+        short_name: service_presenter.client_suffix_for_default_transport,
         full_name: service_presenter.client_name_full
       )
       SnippetIndex::ClientMethod.new(

--- a/gapic-generator/lib/gapic/presenters/method_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/method_presenter.rb
@@ -80,17 +80,17 @@ module Gapic
       # inline snippets.
       # @return [Gapic::Presenters::SnippetPresenter]
       #
-      def snippet
+      def snippet transport: nil
         configs = @api.snippet_configs_for @method.full_name
-        SnippetPresenter.new self, @api, configs.first
+        SnippetPresenter.new self, @api, config: configs.first, transport: transport
       end
 
       ##
       # @return [Array<Gapic::Presenters::SnippetPresenter>]
       #
-      def all_snippets
+      def all_snippets transport: nil
         configs = @api.snippet_configs_for(@method.full_name) + [nil]
-        configs.map { |config| SnippetPresenter.new self, @api, config }
+        configs.map { |config| SnippetPresenter.new self, @api, config: config, transport: transport }
       end
 
       def generate_yardoc_snippets?

--- a/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
@@ -31,7 +31,8 @@ module Gapic
       extend Forwardable
       def_delegators :@main_service, :name, :helpers_file_name, :is_hosted_mixin?, :is_main_mixin_service?, :mixins?,
                      :mixin_binding_overrides?, :grpc_service_config, :grpc_service_config_presenter, :lro_service,
-                     :lro_client_var, :nonstandard_lro_provider?, :credentials_class_xref, :client_name
+                     :lro_client_var, :nonstandard_lro_provider?, :credentials_class_xref, :client_name, :module_name,
+                     :grpc_full_name, :client_suffix_for_default_transport
 
       # The namespace of the service. (not the client)
       # Intentionally does not include "Rest", since

--- a/gapic-generator/lib/gapic/presenters/snippet_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/snippet_presenter.rb
@@ -31,14 +31,16 @@ module Gapic
     # A presenter for snippets.
     #
     class SnippetPresenter
-      def initialize method_presenter, api, config = nil
+      def initialize method_presenter, api, config: nil, transport: nil
         @method_presenter = method_presenter
         @api = api
         @config = config
+        @transport = transport || @api.default_transport
         analyze_config
       end
 
       attr_reader :config
+      attr_reader :transport
 
       def config?
         !config.nil?
@@ -73,7 +75,9 @@ module Gapic
       end
 
       def client_type
-        @method_presenter.service.client_name_full.sub(/^::/, "")
+        service = @method_presenter.service
+        service = service.rest if transport == :rest
+        service.client_name_full.sub(/^::/, "")
       end
 
       def service_name_short

--- a/gapic-generator/templates/default/service/client/method/docs/_snippets.erb
+++ b/gapic-generator/templates/default/service/client/method/docs/_snippets.erb
@@ -1,6 +1,6 @@
 <%- assert_locals method -%>
 <%- if method.generate_yardoc_snippets? -%>
 # @example Basic example
-<%= indent render(partial: "snippets/snippet/inline", locals: { snippet: method.snippet }), "#   " %>
+<%= indent render(partial: "snippets/snippet/inline", locals: { snippet: method.snippet(transport: :grpc) }), "#   " %>
 #
 <%- end -%>

--- a/gapic-generator/templates/default/service/rest/client/method/_def.erb
+++ b/gapic-generator/templates/default/service/rest/client/method/_def.erb
@@ -8,6 +8,8 @@
 <%= render partial: "service/rest/client/method/docs/result", locals: { method: method } -%>
 #
 <%= render partial: "service/rest/client/method/docs/error", locals: { method: method } -%>
+#
+<%= render partial: "service/rest/client/method/docs/snippets", locals: { method: method } -%>
 def <%= method.name %> request, options = nil
 <%= indent render(partial: "service/client/method/def/request", locals: { method: method }), 2 %>
 

--- a/gapic-generator/templates/default/service/rest/client/method/docs/_snippets.erb
+++ b/gapic-generator/templates/default/service/rest/client/method/docs/_snippets.erb
@@ -1,0 +1,6 @@
+<%- assert_locals method -%>
+<%- if method.generate_yardoc_snippets? -%>
+# @example Basic example
+<%= indent render(partial: "snippets/snippet/inline", locals: { snippet: method.snippet(transport: :rest) }), "#   " %>
+#
+<%- end -%>

--- a/gapic-generator/test/gapic/package_snippets_test.rb
+++ b/gapic-generator/test/gapic/package_snippets_test.rb
@@ -19,9 +19,10 @@ require "gapic/package_snippets"
 require "google/protobuf/compiler/plugin.pb"
 
 describe Gapic::PackageSnippets do
-  FakeServicePresenter = Struct.new :client_name, :client_name_full, :grpc_full_name, :module_name, :name
+  FakeServicePresenter = Struct.new :client_name, :client_name_full, :grpc_full_name, :module_name, :name,
+                                    :client_suffix_for_default_transport
   FakeMethodPresenter = Struct.new :grpc_full_name, :grpc_name, :name, :request_type, :return_type, :service
-  FakeSnippetPresenter = Struct.new :description, :region_tag, :service, :snippet_file_path, :snippet_name
+  FakeSnippetPresenter = Struct.new :description, :region_tag, :service, :snippet_file_path, :snippet_name, :transport
 
   let(:proto_package) { "google.snippetstest.v1" }
   let(:gem_name) { "google-snippets_test-v1" }
@@ -47,11 +48,14 @@ describe Gapic::PackageSnippets do
   let(:snippet_name2) { "set_foo name" }
   let(:snippet_file_fullpath1) { "snippets/#{snippet_file_path1}" }
   let(:snippet_file_fullpath2) { "snippets/#{snippet_file_path2}" }
+  let(:snippet_transport) { :grpc }
   let(:service_client_name) { "Client" }
   let(:service_module_name) { service_protoname }
   let(:service_client_name_full) { "Google::SnippetsTest::#{service_module_name}::#{service_client_name}" }
+  let(:service_client_suffix) { "#{service_module_name}::#{service_client_name}" }
   let(:service_presenter) do
-    FakeServicePresenter.new service_client_name, service_client_name_full, service_protoname_full, service_module_name, service_protoname
+    FakeServicePresenter.new service_client_name, service_client_name_full, service_protoname_full, service_module_name,
+                             service_protoname, service_client_suffix
   end
   let(:method_presenter1) do
     FakeMethodPresenter.new method_protoname_full1, method_protoname1, method_name1, request_type1, return_type, service_presenter
@@ -60,10 +64,10 @@ describe Gapic::PackageSnippets do
     FakeMethodPresenter.new method_protoname_full2, method_protoname2, method_name2, request_type2, return_type, service_presenter
   end
   let(:snippet_presenter1) do
-    FakeSnippetPresenter.new description1, region_tag1, service_presenter, snippet_file_path1, snippet_name1
+    FakeSnippetPresenter.new description1, region_tag1, service_presenter, snippet_file_path1, snippet_name1, snippet_transport
   end
   let(:snippet_presenter2) do
-    FakeSnippetPresenter.new description2, region_tag2, service_presenter, snippet_file_path2, snippet_name2
+    FakeSnippetPresenter.new description2, region_tag2, service_presenter, snippet_file_path2, snippet_name2, snippet_transport
   end
   let(:snippet_content1) do
     <<~CONTENT
@@ -147,7 +151,7 @@ describe Gapic::PackageSnippets do
             ],
             "result_type" => return_type,
             "client" => {
-              "short_name" => "#{service_module_name}::#{service_client_name}",
+              "short_name" => service_client_suffix,
               "full_name" => service_client_name_full
             },
             "method" => {
@@ -187,7 +191,7 @@ describe Gapic::PackageSnippets do
             ],
             "result_type" => return_type,
             "client" => {
-              "short_name" => "#{service_module_name}::#{service_client_name}",
+              "short_name" => service_client_suffix,
               "full_name" => service_client_name_full
             },
             "method" => {

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/client.rb
@@ -196,6 +196,22 @@ module Google
               # @return [::Gapic::Rest::PagedEnumerable<::String, ::Google::Cloud::Compute::V1::AddressesScopedList>]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::Addresses::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::AggregatedListAddressesRequest.new
+              #
+              #   # Call the aggregated_list method.
+              #   result = client.aggregated_list request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::AddressAggregatedList.
+              #   p result
+              #
               def aggregated_list request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -269,6 +285,22 @@ module Google
               # @return [::Gapic::GenericLRO::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::Addresses::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::DeleteAddressRequest.new
+              #
+              #   # Call the delete method.
+              #   result = client.delete request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::Operation.
+              #   p result
+              #
               def delete request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -344,6 +376,22 @@ module Google
               # @return [::Google::Cloud::Compute::V1::Address]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::Addresses::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::GetAddressRequest.new
+              #
+              #   # Call the get method.
+              #   result = client.get request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::Address.
+              #   p result
+              #
               def get request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -416,6 +464,22 @@ module Google
               # @return [::Gapic::GenericLRO::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::Addresses::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::InsertAddressRequest.new
+              #
+              #   # Call the insert method.
+              #   result = client.insert request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::Operation.
+              #   p result
+              #
               def insert request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -509,6 +573,22 @@ module Google
               # @return [::Gapic::Rest::PagedEnumerable<::Google::Cloud::Compute::V1::Address>]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::Addresses::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::ListAddressesRequest.new
+              #
+              #   # Call the list method.
+              #   result = client.list request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::AddressList.
+              #   p result
+              #
               def list request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/rest/client.rb
@@ -162,6 +162,22 @@ module Google
               # @return [::Google::Cloud::Compute::V1::DeleteGlobalOperationResponse]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::GlobalOperations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::DeleteGlobalOperationRequest.new
+              #
+              #   # Call the delete method.
+              #   result = client.delete request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::DeleteGlobalOperationResponse.
+              #   p result
+              #
               def delete request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -226,6 +242,22 @@ module Google
               # @return [::Google::Cloud::Compute::V1::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::GlobalOperations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::GetGlobalOperationRequest.new
+              #
+              #   # Call the get method.
+              #   result = client.get request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::Operation.
+              #   p result
+              #
               def get request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/client.rb
@@ -202,6 +202,22 @@ module Google
               # @return [::Gapic::Rest::PagedEnumerable<::Google::Cloud::Compute::V1::ExchangedPeeringRoute>]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::Networks::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::ListPeeringRoutesNetworksRequest.new
+              #
+              #   # Call the list_peering_routes method.
+              #   result = client.list_peering_routes request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::ExchangedPeeringRoutesList.
+              #   p result
+              #
               def list_peering_routes request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -275,6 +291,22 @@ module Google
               # @return [::Gapic::GenericLRO::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::Networks::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::RemovePeeringNetworkRequest.new
+              #
+              #   # Call the remove_peering method.
+              #   result = client.remove_peering request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::Operation.
+              #   p result
+              #
               def remove_peering request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/client.rb
@@ -190,6 +190,22 @@ module Google
               # @return [::Gapic::GenericLRO::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::ResizeRegionInstanceGroupManagerRequest.new
+              #
+              #   # Call the resize method.
+              #   result = client.resize request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::Operation.
+              #   p result
+              #
               def resize request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest/client.rb
@@ -164,6 +164,22 @@ module Google
               # @return [::Google::Cloud::Compute::V1::DeleteRegionOperationResponse]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::DeleteRegionOperationRequest.new
+              #
+              #   # Call the delete method.
+              #   result = client.delete request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::DeleteRegionOperationResponse.
+              #   p result
+              #
               def delete request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -230,6 +246,22 @@ module Google
               # @return [::Google::Cloud::Compute::V1::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::GetRegionOperationRequest.new
+              #
+              #   # Call the get method.
+              #   result = client.get request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::Operation.
+              #   p result
+              #
               def get request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -314,6 +346,22 @@ module Google
               # @return [::Gapic::Rest::PagedEnumerable<::Google::Cloud::Compute::V1::Operation>]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::ListRegionOperationsRequest.new
+              #
+              #   # Call the list method.
+              #   result = client.list request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::OperationList.
+              #   p result
+              #
               def list request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -385,6 +433,22 @@ module Google
               # @return [::Google::Cloud::Compute::V1::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/compute/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Compute::V1::WaitRegionOperationRequest.new
+              #
+              #   # Call the wait method.
+              #   result = client.wait request
+              #
+              #   # The returned object is of type Google::Cloud::Compute::V1::Operation.
+              #   p result
+              #
               def wait request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/cloud/compute_small/snippets/addresses/aggregated_list.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/aggregated_list.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the aggregated_list call in the Addresses service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Addresses::Client#aggregated_list. It may require
-# modification in order to execute successfully.
+# Google::Cloud::Compute::V1::Addresses::Rest::Client#aggregated_list. It may
+# require modification in order to execute successfully.
 #
 def aggregated_list
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::Addresses::Client.new
+  client = Google::Cloud::Compute::V1::Addresses::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::AggregatedListAddressesRequest.new

--- a/shared/output/cloud/compute_small/snippets/addresses/delete.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/delete.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the delete call in the Addresses service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Addresses::Client#delete. It may require
+# Google::Cloud::Compute::V1::Addresses::Rest::Client#delete. It may require
 # modification in order to execute successfully.
 #
 def delete
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::Addresses::Client.new
+  client = Google::Cloud::Compute::V1::Addresses::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::DeleteAddressRequest.new

--- a/shared/output/cloud/compute_small/snippets/addresses/get.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/get.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the get call in the Addresses service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Addresses::Client#get. It may require modification
-# in order to execute successfully.
+# Google::Cloud::Compute::V1::Addresses::Rest::Client#get. It may require
+# modification in order to execute successfully.
 #
 def get
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::Addresses::Client.new
+  client = Google::Cloud::Compute::V1::Addresses::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::GetAddressRequest.new

--- a/shared/output/cloud/compute_small/snippets/addresses/insert.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/insert.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the insert call in the Addresses service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Addresses::Client#insert. It may require
+# Google::Cloud::Compute::V1::Addresses::Rest::Client#insert. It may require
 # modification in order to execute successfully.
 #
 def insert
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::Addresses::Client.new
+  client = Google::Cloud::Compute::V1::Addresses::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::InsertAddressRequest.new

--- a/shared/output/cloud/compute_small/snippets/addresses/list.rb
+++ b/shared/output/cloud/compute_small/snippets/addresses/list.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the list call in the Addresses service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Addresses::Client#list. It may require
+# Google::Cloud::Compute::V1::Addresses::Rest::Client#list. It may require
 # modification in order to execute successfully.
 #
 def list
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::Addresses::Client.new
+  client = Google::Cloud::Compute::V1::Addresses::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::ListAddressesRequest.new

--- a/shared/output/cloud/compute_small/snippets/global_operations/delete.rb
+++ b/shared/output/cloud/compute_small/snippets/global_operations/delete.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the delete call in the GlobalOperations service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::GlobalOperations::Client#delete. It may require
-# modification in order to execute successfully.
+# Google::Cloud::Compute::V1::GlobalOperations::Rest::Client#delete. It may
+# require modification in order to execute successfully.
 #
 def delete
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::GlobalOperations::Client.new
+  client = Google::Cloud::Compute::V1::GlobalOperations::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::DeleteGlobalOperationRequest.new

--- a/shared/output/cloud/compute_small/snippets/global_operations/get.rb
+++ b/shared/output/cloud/compute_small/snippets/global_operations/get.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the get call in the GlobalOperations service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::GlobalOperations::Client#get. It may require
+# Google::Cloud::Compute::V1::GlobalOperations::Rest::Client#get. It may require
 # modification in order to execute successfully.
 #
 def get
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::GlobalOperations::Client.new
+  client = Google::Cloud::Compute::V1::GlobalOperations::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::GetGlobalOperationRequest.new

--- a/shared/output/cloud/compute_small/snippets/networks/list_peering_routes.rb
+++ b/shared/output/cloud/compute_small/snippets/networks/list_peering_routes.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the list_peering_routes call in the Networks service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Networks::Client#list_peering_routes. It may
+# Google::Cloud::Compute::V1::Networks::Rest::Client#list_peering_routes. It may
 # require modification in order to execute successfully.
 #
 def list_peering_routes
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::Networks::Client.new
+  client = Google::Cloud::Compute::V1::Networks::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::ListPeeringRoutesNetworksRequest.new

--- a/shared/output/cloud/compute_small/snippets/networks/remove_peering.rb
+++ b/shared/output/cloud/compute_small/snippets/networks/remove_peering.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the remove_peering call in the Networks service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::Networks::Client#remove_peering. It may require
-# modification in order to execute successfully.
+# Google::Cloud::Compute::V1::Networks::Rest::Client#remove_peering. It may
+# require modification in order to execute successfully.
 #
 def remove_peering
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::Networks::Client.new
+  client = Google::Cloud::Compute::V1::Networks::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::RemovePeeringNetworkRequest.new

--- a/shared/output/cloud/compute_small/snippets/region_instance_group_managers/resize.rb
+++ b/shared/output/cloud/compute_small/snippets/region_instance_group_managers/resize.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the resize call in the RegionInstanceGroupManagers service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Client#resize. It may
-# require modification in order to execute successfully.
+# Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::Client#resize.
+# It may require modification in order to execute successfully.
 #
 def resize
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Client.new
+  client = Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::ResizeRegionInstanceGroupManagerRequest.new

--- a/shared/output/cloud/compute_small/snippets/region_operations/delete.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/delete.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the delete call in the RegionOperations service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::RegionOperations::Client#delete. It may require
-# modification in order to execute successfully.
+# Google::Cloud::Compute::V1::RegionOperations::Rest::Client#delete. It may
+# require modification in order to execute successfully.
 #
 def delete
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::RegionOperations::Client.new
+  client = Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::DeleteRegionOperationRequest.new

--- a/shared/output/cloud/compute_small/snippets/region_operations/get.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/get.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the get call in the RegionOperations service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::RegionOperations::Client#get. It may require
+# Google::Cloud::Compute::V1::RegionOperations::Rest::Client#get. It may require
 # modification in order to execute successfully.
 #
 def get
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::RegionOperations::Client.new
+  client = Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::GetRegionOperationRequest.new

--- a/shared/output/cloud/compute_small/snippets/region_operations/list.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/list.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the list call in the RegionOperations service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::RegionOperations::Client#list. It may require
-# modification in order to execute successfully.
+# Google::Cloud::Compute::V1::RegionOperations::Rest::Client#list. It may
+# require modification in order to execute successfully.
 #
 def list
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::RegionOperations::Client.new
+  client = Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::ListRegionOperationsRequest.new

--- a/shared/output/cloud/compute_small/snippets/region_operations/wait.rb
+++ b/shared/output/cloud/compute_small/snippets/region_operations/wait.rb
@@ -23,12 +23,12 @@ require "google/cloud/compute/v1"
 # Snippet for the wait call in the RegionOperations service
 #
 # This is an auto-generated example demonstrating basic usage of
-# Google::Cloud::Compute::V1::RegionOperations::Client#wait. It may require
-# modification in order to execute successfully.
+# Google::Cloud::Compute::V1::RegionOperations::Rest::Client#wait. It may
+# require modification in order to execute successfully.
 #
 def wait
   # Create a client object. The client can be reused for multiple calls.
-  client = Google::Cloud::Compute::V1::RegionOperations::Client.new
+  client = Google::Cloud::Compute::V1::RegionOperations::Rest::Client.new
 
   # Create a request. To set request fields, pass in keyword arguments.
   request = Google::Cloud::Compute::V1::WaitRegionOperationRequest.new

--- a/shared/output/cloud/compute_small/snippets/snippet_metadata_google.cloud.compute.v1.json
+++ b/shared/output/cloud/compute_small/snippets/snippet_metadata_google.cloud.compute.v1.json
@@ -14,12 +14,12 @@
     {
       "region_tag": "compute_v1_generated_Addresses_AggregatedList_sync",
       "title": "Snippet for the aggregated_list call in the Addresses service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Client#aggregated_list. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Rest::Client#aggregated_list. It may require modification in order to execute successfully.",
       "file": "addresses/aggregated_list.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "aggregated_list",
-        "full_name": "::Google::Cloud::Compute::V1::Addresses::Client#aggregated_list",
+        "full_name": "::Google::Cloud::Compute::V1::Addresses::Rest::Client#aggregated_list",
         "async": false,
         "parameters": [
           {
@@ -29,8 +29,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::AddressAggregatedList",
         "client": {
-          "short_name": "Addresses::Client",
-          "full_name": "::Google::Cloud::Compute::V1::Addresses::Client"
+          "short_name": "Addresses::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::Addresses::Rest::Client"
         },
         "method": {
           "short_name": "AggregatedList",
@@ -54,12 +54,12 @@
     {
       "region_tag": "compute_v1_generated_Addresses_Delete_sync",
       "title": "Snippet for the delete call in the Addresses service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Client#delete. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Rest::Client#delete. It may require modification in order to execute successfully.",
       "file": "addresses/delete.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "delete",
-        "full_name": "::Google::Cloud::Compute::V1::Addresses::Client#delete",
+        "full_name": "::Google::Cloud::Compute::V1::Addresses::Rest::Client#delete",
         "async": false,
         "parameters": [
           {
@@ -69,8 +69,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::Operation",
         "client": {
-          "short_name": "Addresses::Client",
-          "full_name": "::Google::Cloud::Compute::V1::Addresses::Client"
+          "short_name": "Addresses::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::Addresses::Rest::Client"
         },
         "method": {
           "short_name": "Delete",
@@ -94,12 +94,12 @@
     {
       "region_tag": "compute_v1_generated_Addresses_Get_sync",
       "title": "Snippet for the get call in the Addresses service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Client#get. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Rest::Client#get. It may require modification in order to execute successfully.",
       "file": "addresses/get.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "get",
-        "full_name": "::Google::Cloud::Compute::V1::Addresses::Client#get",
+        "full_name": "::Google::Cloud::Compute::V1::Addresses::Rest::Client#get",
         "async": false,
         "parameters": [
           {
@@ -109,8 +109,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::Address",
         "client": {
-          "short_name": "Addresses::Client",
-          "full_name": "::Google::Cloud::Compute::V1::Addresses::Client"
+          "short_name": "Addresses::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::Addresses::Rest::Client"
         },
         "method": {
           "short_name": "Get",
@@ -134,12 +134,12 @@
     {
       "region_tag": "compute_v1_generated_Addresses_Insert_sync",
       "title": "Snippet for the insert call in the Addresses service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Client#insert. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Rest::Client#insert. It may require modification in order to execute successfully.",
       "file": "addresses/insert.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "insert",
-        "full_name": "::Google::Cloud::Compute::V1::Addresses::Client#insert",
+        "full_name": "::Google::Cloud::Compute::V1::Addresses::Rest::Client#insert",
         "async": false,
         "parameters": [
           {
@@ -149,8 +149,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::Operation",
         "client": {
-          "short_name": "Addresses::Client",
-          "full_name": "::Google::Cloud::Compute::V1::Addresses::Client"
+          "short_name": "Addresses::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::Addresses::Rest::Client"
         },
         "method": {
           "short_name": "Insert",
@@ -174,12 +174,12 @@
     {
       "region_tag": "compute_v1_generated_Addresses_List_sync",
       "title": "Snippet for the list call in the Addresses service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Client#list. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Addresses::Rest::Client#list. It may require modification in order to execute successfully.",
       "file": "addresses/list.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "list",
-        "full_name": "::Google::Cloud::Compute::V1::Addresses::Client#list",
+        "full_name": "::Google::Cloud::Compute::V1::Addresses::Rest::Client#list",
         "async": false,
         "parameters": [
           {
@@ -189,8 +189,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::AddressList",
         "client": {
-          "short_name": "Addresses::Client",
-          "full_name": "::Google::Cloud::Compute::V1::Addresses::Client"
+          "short_name": "Addresses::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::Addresses::Rest::Client"
         },
         "method": {
           "short_name": "List",
@@ -214,12 +214,12 @@
     {
       "region_tag": "compute_v1_generated_RegionOperations_Delete_sync",
       "title": "Snippet for the delete call in the RegionOperations service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionOperations::Client#delete. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionOperations::Rest::Client#delete. It may require modification in order to execute successfully.",
       "file": "region_operations/delete.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "delete",
-        "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Client#delete",
+        "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Rest::Client#delete",
         "async": false,
         "parameters": [
           {
@@ -229,8 +229,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::DeleteRegionOperationResponse",
         "client": {
-          "short_name": "RegionOperations::Client",
-          "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Client"
+          "short_name": "RegionOperations::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Rest::Client"
         },
         "method": {
           "short_name": "Delete",
@@ -254,12 +254,12 @@
     {
       "region_tag": "compute_v1_generated_RegionOperations_Get_sync",
       "title": "Snippet for the get call in the RegionOperations service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionOperations::Client#get. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionOperations::Rest::Client#get. It may require modification in order to execute successfully.",
       "file": "region_operations/get.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "get",
-        "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Client#get",
+        "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Rest::Client#get",
         "async": false,
         "parameters": [
           {
@@ -269,8 +269,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::Operation",
         "client": {
-          "short_name": "RegionOperations::Client",
-          "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Client"
+          "short_name": "RegionOperations::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Rest::Client"
         },
         "method": {
           "short_name": "Get",
@@ -294,12 +294,12 @@
     {
       "region_tag": "compute_v1_generated_RegionOperations_List_sync",
       "title": "Snippet for the list call in the RegionOperations service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionOperations::Client#list. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionOperations::Rest::Client#list. It may require modification in order to execute successfully.",
       "file": "region_operations/list.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "list",
-        "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Client#list",
+        "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Rest::Client#list",
         "async": false,
         "parameters": [
           {
@@ -309,8 +309,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::OperationList",
         "client": {
-          "short_name": "RegionOperations::Client",
-          "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Client"
+          "short_name": "RegionOperations::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Rest::Client"
         },
         "method": {
           "short_name": "List",
@@ -334,12 +334,12 @@
     {
       "region_tag": "compute_v1_generated_RegionOperations_Wait_sync",
       "title": "Snippet for the wait call in the RegionOperations service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionOperations::Client#wait. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionOperations::Rest::Client#wait. It may require modification in order to execute successfully.",
       "file": "region_operations/wait.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "wait",
-        "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Client#wait",
+        "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Rest::Client#wait",
         "async": false,
         "parameters": [
           {
@@ -349,8 +349,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::Operation",
         "client": {
-          "short_name": "RegionOperations::Client",
-          "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Client"
+          "short_name": "RegionOperations::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::RegionOperations::Rest::Client"
         },
         "method": {
           "short_name": "Wait",
@@ -374,12 +374,12 @@
     {
       "region_tag": "compute_v1_generated_RegionInstanceGroupManagers_Resize_sync",
       "title": "Snippet for the resize call in the RegionInstanceGroupManagers service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Client#resize. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::Client#resize. It may require modification in order to execute successfully.",
       "file": "region_instance_group_managers/resize.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "resize",
-        "full_name": "::Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Client#resize",
+        "full_name": "::Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::Client#resize",
         "async": false,
         "parameters": [
           {
@@ -389,8 +389,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::Operation",
         "client": {
-          "short_name": "RegionInstanceGroupManagers::Client",
-          "full_name": "::Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Client"
+          "short_name": "RegionInstanceGroupManagers::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::Client"
         },
         "method": {
           "short_name": "Resize",
@@ -414,12 +414,12 @@
     {
       "region_tag": "compute_v1_generated_Networks_ListPeeringRoutes_sync",
       "title": "Snippet for the list_peering_routes call in the Networks service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Networks::Client#list_peering_routes. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Networks::Rest::Client#list_peering_routes. It may require modification in order to execute successfully.",
       "file": "networks/list_peering_routes.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "list_peering_routes",
-        "full_name": "::Google::Cloud::Compute::V1::Networks::Client#list_peering_routes",
+        "full_name": "::Google::Cloud::Compute::V1::Networks::Rest::Client#list_peering_routes",
         "async": false,
         "parameters": [
           {
@@ -429,8 +429,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::ExchangedPeeringRoutesList",
         "client": {
-          "short_name": "Networks::Client",
-          "full_name": "::Google::Cloud::Compute::V1::Networks::Client"
+          "short_name": "Networks::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::Networks::Rest::Client"
         },
         "method": {
           "short_name": "ListPeeringRoutes",
@@ -454,12 +454,12 @@
     {
       "region_tag": "compute_v1_generated_Networks_RemovePeering_sync",
       "title": "Snippet for the remove_peering call in the Networks service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Networks::Client#remove_peering. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::Networks::Rest::Client#remove_peering. It may require modification in order to execute successfully.",
       "file": "networks/remove_peering.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "remove_peering",
-        "full_name": "::Google::Cloud::Compute::V1::Networks::Client#remove_peering",
+        "full_name": "::Google::Cloud::Compute::V1::Networks::Rest::Client#remove_peering",
         "async": false,
         "parameters": [
           {
@@ -469,8 +469,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::Operation",
         "client": {
-          "short_name": "Networks::Client",
-          "full_name": "::Google::Cloud::Compute::V1::Networks::Client"
+          "short_name": "Networks::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::Networks::Rest::Client"
         },
         "method": {
           "short_name": "RemovePeering",
@@ -494,12 +494,12 @@
     {
       "region_tag": "compute_v1_generated_GlobalOperations_Delete_sync",
       "title": "Snippet for the delete call in the GlobalOperations service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::GlobalOperations::Client#delete. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::GlobalOperations::Rest::Client#delete. It may require modification in order to execute successfully.",
       "file": "global_operations/delete.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "delete",
-        "full_name": "::Google::Cloud::Compute::V1::GlobalOperations::Client#delete",
+        "full_name": "::Google::Cloud::Compute::V1::GlobalOperations::Rest::Client#delete",
         "async": false,
         "parameters": [
           {
@@ -509,8 +509,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::DeleteGlobalOperationResponse",
         "client": {
-          "short_name": "GlobalOperations::Client",
-          "full_name": "::Google::Cloud::Compute::V1::GlobalOperations::Client"
+          "short_name": "GlobalOperations::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::GlobalOperations::Rest::Client"
         },
         "method": {
           "short_name": "Delete",
@@ -534,12 +534,12 @@
     {
       "region_tag": "compute_v1_generated_GlobalOperations_Get_sync",
       "title": "Snippet for the get call in the GlobalOperations service",
-      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::GlobalOperations::Client#get. It may require modification in order to execute successfully.",
+      "description": "This is an auto-generated example demonstrating basic usage of Google::Cloud::Compute::V1::GlobalOperations::Rest::Client#get. It may require modification in order to execute successfully.",
       "file": "global_operations/get.rb",
       "language": "RUBY",
       "client_method": {
         "short_name": "get",
-        "full_name": "::Google::Cloud::Compute::V1::GlobalOperations::Client#get",
+        "full_name": "::Google::Cloud::Compute::V1::GlobalOperations::Rest::Client#get",
         "async": false,
         "parameters": [
           {
@@ -549,8 +549,8 @@
         ],
         "result_type": "::Google::Cloud::Compute::V1::Operation",
         "client": {
-          "short_name": "GlobalOperations::Client",
-          "full_name": "::Google::Cloud::Compute::V1::GlobalOperations::Client"
+          "short_name": "GlobalOperations::Rest::Client",
+          "full_name": "::Google::Cloud::Compute::V1::GlobalOperations::Rest::Client"
         },
         "method": {
           "short_name": "Get",

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/rest/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/rest/client.rb
@@ -193,6 +193,22 @@ module Google
               # @return [::Google::Cloud::Language::V1::AnalyzeSentimentResponse]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/language/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Language::V1::LanguageService::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Language::V1::AnalyzeSentimentRequest.new
+              #
+              #   # Call the analyze_sentiment method.
+              #   result = client.analyze_sentiment request
+              #
+              #   # The returned object is of type Google::Cloud::Language::V1::AnalyzeSentimentResponse.
+              #   p result
+              #
               def analyze_sentiment request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -259,6 +275,22 @@ module Google
               # @return [::Google::Cloud::Language::V1::AnalyzeEntitiesResponse]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/language/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Language::V1::LanguageService::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Language::V1::AnalyzeEntitiesRequest.new
+              #
+              #   # Call the analyze_entities method.
+              #   result = client.analyze_entities request
+              #
+              #   # The returned object is of type Google::Cloud::Language::V1::AnalyzeEntitiesResponse.
+              #   p result
+              #
               def analyze_entities request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -326,6 +358,22 @@ module Google
               # @return [::Google::Cloud::Language::V1::AnalyzeEntitySentimentResponse]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/language/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Language::V1::LanguageService::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Language::V1::AnalyzeEntitySentimentRequest.new
+              #
+              #   # Call the analyze_entity_sentiment method.
+              #   result = client.analyze_entity_sentiment request
+              #
+              #   # The returned object is of type Google::Cloud::Language::V1::AnalyzeEntitySentimentResponse.
+              #   p result
+              #
               def analyze_entity_sentiment request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -392,6 +440,22 @@ module Google
               # @return [::Google::Cloud::Language::V1::AnalyzeSyntaxResponse]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/language/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Language::V1::LanguageService::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Language::V1::AnalyzeSyntaxRequest.new
+              #
+              #   # Call the analyze_syntax method.
+              #   result = client.analyze_syntax request
+              #
+              #   # The returned object is of type Google::Cloud::Language::V1::AnalyzeSyntaxResponse.
+              #   p result
+              #
               def analyze_syntax request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -457,6 +521,22 @@ module Google
               # @return [::Google::Cloud::Language::V1::ClassifyTextResponse]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/language/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Language::V1::LanguageService::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Language::V1::ClassifyTextRequest.new
+              #
+              #   # Call the classify_text method.
+              #   result = client.classify_text request
+              #
+              #   # The returned object is of type Google::Cloud::Language::V1::ClassifyTextResponse.
+              #   p result
+              #
               def classify_text request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -519,6 +599,22 @@ module Google
               # @return [::Google::Cloud::Language::V1::ModerateTextResponse]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/language/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Language::V1::LanguageService::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Language::V1::ModerateTextRequest.new
+              #
+              #   # Call the moderate_text method.
+              #   result = client.moderate_text request
+              #
+              #   # The returned object is of type Google::Cloud::Language::V1::ModerateTextResponse.
+              #   p result
+              #
               def moderate_text request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -586,6 +682,22 @@ module Google
               # @return [::Google::Cloud::Language::V1::AnnotateTextResponse]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/language/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Language::V1::LanguageService::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Language::V1::AnnotateTextRequest.new
+              #
+              #   # Call the annotate_text method.
+              #   result = client.annotate_text request
+              #
+              #   # The returned object is of type Google::Cloud::Language::V1::AnnotateTextResponse.
+              #   p result
+              #
               def annotate_text request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/cloud/location/lib/google/cloud/location/locations/rest/client.rb
+++ b/shared/output/cloud/location/lib/google/cloud/location/locations/rest/client.rb
@@ -167,6 +167,26 @@ module Google
             # @return [::Gapic::Rest::PagedEnumerable<::Google::Cloud::Location::Location>]
             #
             # @raise [::Google::Cloud::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/cloud/location"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Cloud::Location::Locations::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Cloud::Location::ListLocationsRequest.new
+            #
+            #   # Call the list_locations method.
+            #   result = client.list_locations request
+            #
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
+            #     # Each element is of type ::Google::Cloud::Location::Location.
+            #     p item
+            #   end
+            #
             def list_locations request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -232,6 +252,22 @@ module Google
             # @return [::Google::Cloud::Location::Location]
             #
             # @raise [::Google::Cloud::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/cloud/location"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Cloud::Location::Locations::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Cloud::Location::GetLocationRequest.new
+            #
+            #   # Call the get_location method.
+            #   result = client.get_location request
+            #
+            #   # The returned object is of type Google::Cloud::Location::Location.
+            #   p result
+            #
             def get_location request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/rest/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/rest/client.rb
@@ -205,6 +205,22 @@ module Google
               # @return [::Google::Cloud::Vision::V1::BatchAnnotateImagesResponse]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new
+              #
+              #   # Call the batch_annotate_images method.
+              #   result = client.batch_annotate_images request
+              #
+              #   # The returned object is of type Google::Cloud::Vision::V1::BatchAnnotateImagesResponse.
+              #   p result
+              #
               def batch_annotate_images request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -287,6 +303,22 @@ module Google
               # @return [::Google::Cloud::Vision::V1::BatchAnnotateFilesResponse]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new
+              #
+              #   # Call the batch_annotate_files method.
+              #   result = client.batch_annotate_files request
+              #
+              #   # The returned object is of type Google::Cloud::Vision::V1::BatchAnnotateFilesResponse.
+              #   p result
+              #
               def batch_annotate_files request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -372,6 +404,29 @@ module Google
               # @return [::Gapic::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new
+              #
+              #   # Call the async_batch_annotate_images method.
+              #   result = client.async_batch_annotate_images request
+              #
+              #   # The returned object is of type Gapic::Operation. You can use it to
+              #   # check the status of an operation, cancel it, or wait for results.
+              #   # Here is how to wait for a response.
+              #   result.wait_until_done! timeout: 60
+              #   if result.response?
+              #     p result.response
+              #   else
+              #     puts "No response received."
+              #   end
+              #
               def async_batch_annotate_images request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -453,6 +508,29 @@ module Google
               # @return [::Gapic::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new
+              #
+              #   # Call the async_batch_annotate_files method.
+              #   result = client.async_batch_annotate_files request
+              #
+              #   # The returned object is of type Gapic::Operation. You can use it to
+              #   # check the status of an operation, cancel it, or wait for results.
+              #   # Here is how to wait for a response.
+              #   result.wait_until_done! timeout: 60
+              #   if result.response?
+              #     p result.response
+              #   else
+              #     puts "No response received."
+              #   end
+              #
               def async_batch_annotate_files request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/rest/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/rest/operations.rb
@@ -136,6 +136,26 @@ module Google
               # @return [::Gapic::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/longrunning"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Longrunning::Operations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Longrunning::ListOperationsRequest.new
+              #
+              #   # Call the list_operations method.
+              #   result = client.list_operations request
+              #
+              #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+              #   # over elements, and API calls will be issued to fetch pages as needed.
+              #   result.each do |item|
+              #     # Each element is of type ::Google::Longrunning::Operation.
+              #     p item
+              #   end
+              #
               def list_operations request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -201,6 +221,29 @@ module Google
               # @return [::Gapic::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/longrunning"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Longrunning::Operations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Longrunning::GetOperationRequest.new
+              #
+              #   # Call the get_operation method.
+              #   result = client.get_operation request
+              #
+              #   # The returned object is of type Gapic::Operation. You can use it to
+              #   # check the status of an operation, cancel it, or wait for results.
+              #   # Here is how to wait for a response.
+              #   result.wait_until_done! timeout: 60
+              #   if result.response?
+              #     p result.response
+              #   else
+              #     puts "No response received."
+              #   end
+              #
               def get_operation request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -267,6 +310,22 @@ module Google
               # @return [::Google::Protobuf::Empty]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/longrunning"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Longrunning::Operations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Longrunning::DeleteOperationRequest.new
+              #
+              #   # Call the delete_operation method.
+              #   result = client.delete_operation request
+              #
+              #   # The returned object is of type Google::Protobuf::Empty.
+              #   p result
+              #
               def delete_operation request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -338,6 +397,22 @@ module Google
               # @return [::Google::Protobuf::Empty]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/longrunning"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Longrunning::Operations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Longrunning::CancelOperationRequest.new
+              #
+              #   # Call the cancel_operation method.
+              #   result = client.cancel_operation request
+              #
+              #   # The returned object is of type Google::Protobuf::Empty.
+              #   p result
+              #
               def cancel_operation request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/client.rb
@@ -217,6 +217,22 @@ module Google
               # @return [::Google::Cloud::Vision::V1::ProductSet]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::CreateProductSetRequest.new
+              #
+              #   # Call the create_product_set method.
+              #   result = client.create_product_set request
+              #
+              #   # The returned object is of type Google::Cloud::Vision::V1::ProductSet.
+              #   p result
+              #
               def create_product_set request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -290,6 +306,26 @@ module Google
               # @return [::Gapic::Rest::PagedEnumerable<::Google::Cloud::Vision::V1::ProductSet>]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::ListProductSetsRequest.new
+              #
+              #   # Call the list_product_sets method.
+              #   result = client.list_product_sets request
+              #
+              #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+              #   # over elements, and API calls will be issued to fetch pages as needed.
+              #   result.each do |item|
+              #     # Each element is of type ::Google::Cloud::Vision::V1::ProductSet.
+              #     p item
+              #   end
+              #
               def list_product_sets request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -360,6 +396,22 @@ module Google
               # @return [::Google::Cloud::Vision::V1::ProductSet]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::GetProductSetRequest.new
+              #
+              #   # Call the get_product_set method.
+              #   result = client.get_product_set request
+              #
+              #   # The returned object is of type Google::Cloud::Vision::V1::ProductSet.
+              #   p result
+              #
               def get_product_set request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -434,6 +486,22 @@ module Google
               # @return [::Google::Cloud::Vision::V1::ProductSet]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::UpdateProductSetRequest.new
+              #
+              #   # Call the update_product_set method.
+              #   result = client.update_product_set request
+              #
+              #   # The returned object is of type Google::Cloud::Vision::V1::ProductSet.
+              #   p result
+              #
               def update_product_set request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -502,6 +570,22 @@ module Google
               # @return [::Google::Protobuf::Empty]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::DeleteProductSetRequest.new
+              #
+              #   # Call the delete_product_set method.
+              #   result = client.delete_product_set request
+              #
+              #   # The returned object is of type Google::Protobuf::Empty.
+              #   p result
+              #
               def delete_product_set request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -581,6 +665,22 @@ module Google
               # @return [::Google::Cloud::Vision::V1::Product]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::CreateProductRequest.new
+              #
+              #   # Call the create_product method.
+              #   result = client.create_product request
+              #
+              #   # The returned object is of type Google::Cloud::Vision::V1::Product.
+              #   p result
+              #
               def create_product request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -654,6 +754,26 @@ module Google
               # @return [::Gapic::Rest::PagedEnumerable<::Google::Cloud::Vision::V1::Product>]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::ListProductsRequest.new
+              #
+              #   # Call the list_products method.
+              #   result = client.list_products request
+              #
+              #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+              #   # over elements, and API calls will be issued to fetch pages as needed.
+              #   result.each do |item|
+              #     # Each element is of type ::Google::Cloud::Vision::V1::Product.
+              #     p item
+              #   end
+              #
               def list_products request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -724,6 +844,22 @@ module Google
               # @return [::Google::Cloud::Vision::V1::Product]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::GetProductRequest.new
+              #
+              #   # Call the get_product method.
+              #   result = client.get_product request
+              #
+              #   # The returned object is of type Google::Cloud::Vision::V1::Product.
+              #   p result
+              #
               def get_product request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -807,6 +943,22 @@ module Google
               # @return [::Google::Cloud::Vision::V1::Product]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::UpdateProductRequest.new
+              #
+              #   # Call the update_product method.
+              #   result = client.update_product request
+              #
+              #   # The returned object is of type Google::Cloud::Vision::V1::Product.
+              #   p result
+              #
               def update_product request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -876,6 +1028,22 @@ module Google
               # @return [::Google::Protobuf::Empty]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::DeleteProductRequest.new
+              #
+              #   # Call the delete_product method.
+              #   result = client.delete_product request
+              #
+              #   # The returned object is of type Google::Protobuf::Empty.
+              #   p result
+              #
               def delete_product request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -967,6 +1135,22 @@ module Google
               # @return [::Google::Cloud::Vision::V1::ReferenceImage]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::CreateReferenceImageRequest.new
+              #
+              #   # Call the create_reference_image method.
+              #   result = client.create_reference_image request
+              #
+              #   # The returned object is of type Google::Cloud::Vision::V1::ReferenceImage.
+              #   p result
+              #
               def create_reference_image request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -1038,6 +1222,22 @@ module Google
               # @return [::Google::Protobuf::Empty]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new
+              #
+              #   # Call the delete_reference_image method.
+              #   result = client.delete_reference_image request
+              #
+              #   # The returned object is of type Google::Protobuf::Empty.
+              #   p result
+              #
               def delete_reference_image request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -1116,6 +1316,26 @@ module Google
               # @return [::Gapic::Rest::PagedEnumerable<::Google::Cloud::Vision::V1::ReferenceImage>]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::ListReferenceImagesRequest.new
+              #
+              #   # Call the list_reference_images method.
+              #   result = client.list_reference_images request
+              #
+              #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+              #   # over elements, and API calls will be issued to fetch pages as needed.
+              #   result.each do |item|
+              #     # Each element is of type ::Google::Cloud::Vision::V1::ReferenceImage.
+              #     p item
+              #   end
+              #
               def list_reference_images request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -1186,6 +1406,22 @@ module Google
               # @return [::Google::Cloud::Vision::V1::ReferenceImage]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::GetReferenceImageRequest.new
+              #
+              #   # Call the get_reference_image method.
+              #   result = client.get_reference_image request
+              #
+              #   # The returned object is of type Google::Cloud::Vision::V1::ReferenceImage.
+              #   p result
+              #
               def get_reference_image request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -1263,6 +1499,22 @@ module Google
               # @return [::Google::Protobuf::Empty]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::AddProductToProductSetRequest.new
+              #
+              #   # Call the add_product_to_product_set method.
+              #   result = client.add_product_to_product_set request
+              #
+              #   # The returned object is of type Google::Protobuf::Empty.
+              #   p result
+              #
               def add_product_to_product_set request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -1333,6 +1585,22 @@ module Google
               # @return [::Google::Protobuf::Empty]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new
+              #
+              #   # Call the remove_product_from_product_set method.
+              #   result = client.remove_product_from_product_set request
+              #
+              #   # The returned object is of type Google::Protobuf::Empty.
+              #   p result
+              #
               def remove_product_from_product_set request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -1408,6 +1676,26 @@ module Google
               # @return [::Gapic::Rest::PagedEnumerable<::Google::Cloud::Vision::V1::Product>]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new
+              #
+              #   # Call the list_products_in_product_set method.
+              #   result = client.list_products_in_product_set request
+              #
+              #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+              #   # over elements, and API calls will be issued to fetch pages as needed.
+              #   result.each do |item|
+              #     # Each element is of type ::Google::Cloud::Vision::V1::Product.
+              #     p item
+              #   end
+              #
               def list_products_in_product_set request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -1485,6 +1773,29 @@ module Google
               # @return [::Gapic::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::ImportProductSetsRequest.new
+              #
+              #   # Call the import_product_sets method.
+              #   result = client.import_product_sets request
+              #
+              #   # The returned object is of type Gapic::Operation. You can use it to
+              #   # check the status of an operation, cancel it, or wait for results.
+              #   # Here is how to wait for a response.
+              #   result.wait_until_done! timeout: 60
+              #   if result.response?
+              #     p result.response
+              #   else
+              #     puts "No response received."
+              #   end
+              #
               def import_product_sets request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -1581,6 +1892,29 @@ module Google
               # @return [::Gapic::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/cloud/vision/v1"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Cloud::Vision::V1::PurgeProductsRequest.new
+              #
+              #   # Call the purge_products method.
+              #   result = client.purge_products request
+              #
+              #   # The returned object is of type Gapic::Operation. You can use it to
+              #   # check the status of an operation, cancel it, or wait for results.
+              #   # Here is how to wait for a response.
+              #   result.wait_until_done! timeout: 60
+              #   if result.response?
+              #     p result.response
+              #   else
+              #     puts "No response received."
+              #   end
+              #
               def purge_products request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/operations.rb
@@ -136,6 +136,26 @@ module Google
               # @return [::Gapic::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/longrunning"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Longrunning::Operations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Longrunning::ListOperationsRequest.new
+              #
+              #   # Call the list_operations method.
+              #   result = client.list_operations request
+              #
+              #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+              #   # over elements, and API calls will be issued to fetch pages as needed.
+              #   result.each do |item|
+              #     # Each element is of type ::Google::Longrunning::Operation.
+              #     p item
+              #   end
+              #
               def list_operations request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -201,6 +221,29 @@ module Google
               # @return [::Gapic::Operation]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/longrunning"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Longrunning::Operations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Longrunning::GetOperationRequest.new
+              #
+              #   # Call the get_operation method.
+              #   result = client.get_operation request
+              #
+              #   # The returned object is of type Gapic::Operation. You can use it to
+              #   # check the status of an operation, cancel it, or wait for results.
+              #   # Here is how to wait for a response.
+              #   result.wait_until_done! timeout: 60
+              #   if result.response?
+              #     p result.response
+              #   else
+              #     puts "No response received."
+              #   end
+              #
               def get_operation request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -267,6 +310,22 @@ module Google
               # @return [::Google::Protobuf::Empty]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/longrunning"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Longrunning::Operations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Longrunning::DeleteOperationRequest.new
+              #
+              #   # Call the delete_operation method.
+              #   result = client.delete_operation request
+              #
+              #   # The returned object is of type Google::Protobuf::Empty.
+              #   p result
+              #
               def delete_operation request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -338,6 +397,22 @@ module Google
               # @return [::Google::Protobuf::Empty]
               #
               # @raise [::Google::Cloud::Error] if the REST call is aborted.
+              #
+              # @example Basic example
+              #   require "google/longrunning"
+              #
+              #   # Create a client object. The client can be reused for multiple calls.
+              #   client = Google::Longrunning::Operations::Rest::Client.new
+              #
+              #   # Create a request. To set request fields, pass in keyword arguments.
+              #   request = Google::Longrunning::CancelOperationRequest.new
+              #
+              #   # Call the cancel_operation method.
+              #   result = client.cancel_operation request
+              #
+              #   # The returned object is of type Google::Protobuf::Empty.
+              #   p result
+              #
               def cancel_operation request, options = nil
                 raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/compliance/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/compliance/rest/client.rb
@@ -175,6 +175,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::RepeatResponse]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Compliance::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::RepeatRequest.new
+            #
+            #   # Call the repeat_data_body method.
+            #   result = client.repeat_data_body request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+            #   p result
+            #
             def repeat_data_body request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -252,6 +268,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::RepeatResponse]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Compliance::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::RepeatRequest.new
+            #
+            #   # Call the repeat_data_body_info method.
+            #   result = client.repeat_data_body_info request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+            #   p result
+            #
             def repeat_data_body_info request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -328,6 +360,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::RepeatResponse]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Compliance::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::RepeatRequest.new
+            #
+            #   # Call the repeat_data_query method.
+            #   result = client.repeat_data_query request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+            #   p result
+            #
             def repeat_data_query request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -405,6 +453,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::RepeatResponse]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Compliance::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::RepeatRequest.new
+            #
+            #   # Call the repeat_data_simple_path method.
+            #   result = client.repeat_data_simple_path request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+            #   p result
+            #
             def repeat_data_simple_path request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -480,6 +544,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::RepeatResponse]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Compliance::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::RepeatRequest.new
+            #
+            #   # Call the repeat_data_path_resource method.
+            #   result = client.repeat_data_path_resource request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+            #   p result
+            #
             def repeat_data_path_resource request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -555,6 +635,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::RepeatResponse]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Compliance::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::RepeatRequest.new
+            #
+            #   # Call the repeat_data_path_trailing_resource method.
+            #   result = client.repeat_data_path_trailing_resource request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+            #   p result
+            #
             def repeat_data_path_trailing_resource request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -630,6 +726,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::RepeatResponse]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Compliance::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::RepeatRequest.new
+            #
+            #   # Call the repeat_data_body_put method.
+            #   result = client.repeat_data_body_put request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+            #   p result
+            #
             def repeat_data_body_put request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -705,6 +817,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::RepeatResponse]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Compliance::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::RepeatRequest.new
+            #
+            #   # Call the repeat_data_body_patch method.
+            #   result = client.repeat_data_body_patch request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::RepeatResponse.
+            #   p result
+            #
             def repeat_data_body_patch request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/client.rb
@@ -187,6 +187,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::EchoResponse]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Echo::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::EchoRequest.new
+            #
+            #   # Call the echo method.
+            #   result = client.echo request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::EchoResponse.
+            #   p result
+            #
             def echo request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -248,6 +264,25 @@ module Google
             # @return [::Enumerable<::Google::Showcase::V1beta1::EchoResponse>]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Echo::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::ExpandRequest.new
+            #
+            #   # Call the expand method to start streaming.
+            #   output = client.expand request
+            #
+            #   # The returned object is a streamed enumerable yielding elements of type
+            #   # ::Google::Showcase::V1beta1::EchoResponse
+            #   output.each do |current_response|
+            #     p current_response
+            #   end
+            #
             def expand request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -320,6 +355,26 @@ module Google
             # @return [::Gapic::Rest::PagedEnumerable<::Google::Showcase::V1beta1::EchoResponse>]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Echo::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::PagedExpandRequest.new
+            #
+            #   # Call the paged_expand method.
+            #   result = client.paged_expand request
+            #
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
+            #     # Each element is of type ::Google::Showcase::V1beta1::EchoResponse.
+            #     p item
+            #   end
+            #
             def paged_expand request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -392,6 +447,22 @@ module Google
             # @return [::Gapic::Rest::PagedEnumerable<::Google::Showcase::V1beta1::EchoResponse>]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Echo::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::PagedExpandLegacyRequest.new
+            #
+            #   # Call the paged_expand_legacy method.
+            #   result = client.paged_expand_legacy request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::PagedExpandResponse.
+            #   p result
+            #
             def paged_expand_legacy request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -464,6 +535,26 @@ module Google
             # @return [::Gapic::Rest::PagedEnumerable<::String, ::Google::Showcase::V1beta1::PagedExpandResponseList>]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Echo::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::PagedExpandRequest.new
+            #
+            #   # Call the paged_expand_legacy_mapped method.
+            #   result = client.paged_expand_legacy_mapped request
+            #
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
+            #     # Each element is of type ::Google::Showcase::V1beta1::PagedExpandLegacyMappedResponse::AlphabetizedEntry.
+            #     p item
+            #   end
+            #
             def paged_expand_legacy_mapped request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -536,6 +627,29 @@ module Google
             # @return [::Gapic::Operation]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Echo::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::WaitRequest.new
+            #
+            #   # Call the wait method.
+            #   result = client.wait request
+            #
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
+            #   result.wait_until_done! timeout: 60
+            #   if result.response?
+            #     p result.response
+            #   else
+            #     puts "No response received."
+            #   end
+            #
             def wait request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -606,6 +720,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::BlockResponse]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Echo::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::BlockRequest.new
+            #
+            #   # Call the block method.
+            #   result = client.block request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::BlockResponse.
+            #   p result
+            #
             def block request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/operations.rb
@@ -143,6 +143,26 @@ module Google
             # @return [::Gapic::Operation]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/longrunning"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Longrunning::Operations::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Longrunning::ListOperationsRequest.new
+            #
+            #   # Call the list_operations method.
+            #   result = client.list_operations request
+            #
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
+            #     # Each element is of type ::Google::Longrunning::Operation.
+            #     p item
+            #   end
+            #
             def list_operations request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -209,6 +229,29 @@ module Google
             # @return [::Gapic::Operation]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/longrunning"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Longrunning::Operations::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Longrunning::GetOperationRequest.new
+            #
+            #   # Call the get_operation method.
+            #   result = client.get_operation request
+            #
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
+            #   result.wait_until_done! timeout: 60
+            #   if result.response?
+            #     p result.response
+            #   else
+            #     puts "No response received."
+            #   end
+            #
             def get_operation request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -275,6 +318,22 @@ module Google
             # @return [::Google::Protobuf::Empty]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/longrunning"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Longrunning::Operations::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Longrunning::DeleteOperationRequest.new
+            #
+            #   # Call the delete_operation method.
+            #   result = client.delete_operation request
+            #
+            #   # The returned object is of type Google::Protobuf::Empty.
+            #   p result
+            #
             def delete_operation request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -346,6 +405,22 @@ module Google
             # @return [::Google::Protobuf::Empty]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/longrunning"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Longrunning::Operations::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Longrunning::CancelOperationRequest.new
+            #
+            #   # Call the cancel_operation method.
+            #   result = client.cancel_operation request
+            #
+            #   # The returned object is of type Google::Protobuf::Empty.
+            #   p result
+            #
             def cancel_operation request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/rest/client.rb
@@ -162,6 +162,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::User]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Identity::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::CreateUserRequest.new
+            #
+            #   # Call the create_user method.
+            #   result = client.create_user request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::User.
+            #   p result
+            #
             def create_user request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -224,6 +240,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::User]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Identity::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::GetUserRequest.new
+            #
+            #   # Call the get_user method.
+            #   result = client.get_user request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::User.
+            #   p result
+            #
             def get_user request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -289,6 +321,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::User]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Identity::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::UpdateUserRequest.new
+            #
+            #   # Call the update_user method.
+            #   result = client.update_user request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::User.
+            #   p result
+            #
             def update_user request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -351,6 +399,22 @@ module Google
             # @return [::Google::Protobuf::Empty]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Identity::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::DeleteUserRequest.new
+            #
+            #   # Call the delete_user method.
+            #   result = client.delete_user request
+            #
+            #   # The returned object is of type Google::Protobuf::Empty.
+            #   p result
+            #
             def delete_user request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -418,6 +482,26 @@ module Google
             # @return [::Gapic::Rest::PagedEnumerable<::Google::Showcase::V1beta1::User>]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Identity::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::ListUsersRequest.new
+            #
+            #   # Call the list_users method.
+            #   result = client.list_users request
+            #
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
+            #     # Each element is of type ::Google::Showcase::V1beta1::User.
+            #     p item
+            #   end
+            #
             def list_users request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/rest/client.rb
@@ -178,6 +178,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::Room]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Messaging::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::CreateRoomRequest.new
+            #
+            #   # Call the create_room method.
+            #   result = client.create_room request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::Room.
+            #   p result
+            #
             def create_room request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -240,6 +256,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::Room]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Messaging::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::GetRoomRequest.new
+            #
+            #   # Call the get_room method.
+            #   result = client.get_room request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::Room.
+            #   p result
+            #
             def get_room request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -305,6 +337,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::Room]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Messaging::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::UpdateRoomRequest.new
+            #
+            #   # Call the update_room method.
+            #   result = client.update_room request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::Room.
+            #   p result
+            #
             def update_room request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -367,6 +415,22 @@ module Google
             # @return [::Google::Protobuf::Empty]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Messaging::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::DeleteRoomRequest.new
+            #
+            #   # Call the delete_room method.
+            #   result = client.delete_room request
+            #
+            #   # The returned object is of type Google::Protobuf::Empty.
+            #   p result
+            #
             def delete_room request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -434,6 +498,26 @@ module Google
             # @return [::Gapic::Rest::PagedEnumerable<::Google::Showcase::V1beta1::Room>]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Messaging::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::ListRoomsRequest.new
+            #
+            #   # Call the list_rooms method.
+            #   result = client.list_rooms request
+            #
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
+            #     # Each element is of type ::Google::Showcase::V1beta1::Room.
+            #     p item
+            #   end
+            #
             def list_rooms request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -503,6 +587,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::Blurb]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Messaging::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::CreateBlurbRequest.new
+            #
+            #   # Call the create_blurb method.
+            #   result = client.create_blurb request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::Blurb.
+            #   p result
+            #
             def create_blurb request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -565,6 +665,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::Blurb]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Messaging::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::GetBlurbRequest.new
+            #
+            #   # Call the get_blurb method.
+            #   result = client.get_blurb request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::Blurb.
+            #   p result
+            #
             def get_blurb request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -630,6 +746,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::Blurb]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Messaging::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::UpdateBlurbRequest.new
+            #
+            #   # Call the update_blurb method.
+            #   result = client.update_blurb request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::Blurb.
+            #   p result
+            #
             def update_blurb request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -692,6 +824,22 @@ module Google
             # @return [::Google::Protobuf::Empty]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Messaging::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::DeleteBlurbRequest.new
+            #
+            #   # Call the delete_blurb method.
+            #   result = client.delete_blurb request
+            #
+            #   # The returned object is of type Google::Protobuf::Empty.
+            #   p result
+            #
             def delete_blurb request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -763,6 +911,26 @@ module Google
             # @return [::Gapic::Rest::PagedEnumerable<::Google::Showcase::V1beta1::Blurb>]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Messaging::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::ListBlurbsRequest.new
+            #
+            #   # Call the list_blurbs method.
+            #   result = client.list_blurbs request
+            #
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
+            #     # Each element is of type ::Google::Showcase::V1beta1::Blurb.
+            #     p item
+            #   end
+            #
             def list_blurbs request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -842,6 +1010,29 @@ module Google
             # @return [::Gapic::Operation]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Messaging::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::SearchBlurbsRequest.new
+            #
+            #   # Call the search_blurbs method.
+            #   result = client.search_blurbs request
+            #
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
+            #   result.wait_until_done! timeout: 60
+            #   if result.response?
+            #     p result.response
+            #   else
+            #     puts "No response received."
+            #   end
+            #
             def search_blurbs request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -904,6 +1095,25 @@ module Google
             # @return [::Enumerable<::Google::Showcase::V1beta1::StreamBlurbsResponse>]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Messaging::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::StreamBlurbsRequest.new
+            #
+            #   # Call the stream_blurbs method to start streaming.
+            #   output = client.stream_blurbs request
+            #
+            #   # The returned object is a streamed enumerable yielding elements of type
+            #   # ::Google::Showcase::V1beta1::StreamBlurbsResponse
+            #   output.each do |current_response|
+            #     p current_response
+            #   end
+            #
             def stream_blurbs request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/rest/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/rest/operations.rb
@@ -143,6 +143,26 @@ module Google
             # @return [::Gapic::Operation]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/longrunning"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Longrunning::Operations::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Longrunning::ListOperationsRequest.new
+            #
+            #   # Call the list_operations method.
+            #   result = client.list_operations request
+            #
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
+            #     # Each element is of type ::Google::Longrunning::Operation.
+            #     p item
+            #   end
+            #
             def list_operations request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -209,6 +229,29 @@ module Google
             # @return [::Gapic::Operation]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/longrunning"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Longrunning::Operations::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Longrunning::GetOperationRequest.new
+            #
+            #   # Call the get_operation method.
+            #   result = client.get_operation request
+            #
+            #   # The returned object is of type Gapic::Operation. You can use it to
+            #   # check the status of an operation, cancel it, or wait for results.
+            #   # Here is how to wait for a response.
+            #   result.wait_until_done! timeout: 60
+            #   if result.response?
+            #     p result.response
+            #   else
+            #     puts "No response received."
+            #   end
+            #
             def get_operation request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -275,6 +318,22 @@ module Google
             # @return [::Google::Protobuf::Empty]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/longrunning"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Longrunning::Operations::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Longrunning::DeleteOperationRequest.new
+            #
+            #   # Call the delete_operation method.
+            #   result = client.delete_operation request
+            #
+            #   # The returned object is of type Google::Protobuf::Empty.
+            #   p result
+            #
             def delete_operation request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -346,6 +405,22 @@ module Google
             # @return [::Google::Protobuf::Empty]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/longrunning"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Longrunning::Operations::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Longrunning::CancelOperationRequest.new
+            #
+            #   # Call the cancel_operation method.
+            #   result = client.cancel_operation request
+            #
+            #   # The returned object is of type Google::Protobuf::Empty.
+            #   p result
+            #
             def cancel_operation request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/rest/client.rb
@@ -165,6 +165,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::Session]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Testing::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::CreateSessionRequest.new
+            #
+            #   # Call the create_session method.
+            #   result = client.create_session request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::Session.
+            #   p result
+            #
             def create_session request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -227,6 +243,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::Session]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Testing::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::GetSessionRequest.new
+            #
+            #   # Call the get_session method.
+            #   result = client.get_session request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::Session.
+            #   p result
+            #
             def get_session request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -291,6 +323,26 @@ module Google
             # @return [::Gapic::Rest::PagedEnumerable<::Google::Showcase::V1beta1::Session>]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Testing::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::ListSessionsRequest.new
+            #
+            #   # Call the list_sessions method.
+            #   result = client.list_sessions request
+            #
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
+            #     # Each element is of type ::Google::Showcase::V1beta1::Session.
+            #     p item
+            #   end
+            #
             def list_sessions request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -355,6 +407,22 @@ module Google
             # @return [::Google::Protobuf::Empty]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Testing::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::DeleteSessionRequest.new
+            #
+            #   # Call the delete_session method.
+            #   result = client.delete_session request
+            #
+            #   # The returned object is of type Google::Protobuf::Empty.
+            #   p result
+            #
             def delete_session request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -419,6 +487,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::ReportSessionResponse]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Testing::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::ReportSessionRequest.new
+            #
+            #   # Call the report_session method.
+            #   result = client.report_session request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::ReportSessionResponse.
+            #   p result
+            #
             def report_session request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -485,6 +569,26 @@ module Google
             # @return [::Gapic::Rest::PagedEnumerable<::Google::Showcase::V1beta1::Test>]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Testing::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::ListTestsRequest.new
+            #
+            #   # Call the list_tests method.
+            #   result = client.list_tests request
+            #
+            #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+            #   # over elements, and API calls will be issued to fetch pages as needed.
+            #   result.each do |item|
+            #     # Each element is of type ::Google::Showcase::V1beta1::Test.
+            #     p item
+            #   end
+            #
             def list_tests request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -554,6 +658,22 @@ module Google
             # @return [::Google::Protobuf::Empty]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Testing::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::DeleteTestRequest.new
+            #
+            #   # Call the delete_test method.
+            #   result = client.delete_test request
+            #
+            #   # The returned object is of type Google::Protobuf::Empty.
+            #   p result
+            #
             def delete_test request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -623,6 +743,22 @@ module Google
             # @return [::Google::Showcase::V1beta1::VerifyTestResponse]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+            #
+            # @example Basic example
+            #   require "google/showcase/v1beta1"
+            #
+            #   # Create a client object. The client can be reused for multiple calls.
+            #   client = Google::Showcase::V1beta1::Testing::Rest::Client.new
+            #
+            #   # Create a request. To set request fields, pass in keyword arguments.
+            #   request = Google::Showcase::V1beta1::VerifyTestRequest.new
+            #
+            #   # Call the verify_test method.
+            #   result = client.verify_test request
+            #
+            #   # The returned object is of type Google::Showcase::V1beta1::VerifyTestResponse.
+            #   p result
+            #
             def verify_test request, options = nil
               raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_no_retry/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_no_retry/rest/client.rb
@@ -162,6 +162,22 @@ module Testing
           # @return [::Testing::GrpcServiceConfig::Response]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/grpc_service_config"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::GrpcServiceConfig::ServiceNoRetry::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::GrpcServiceConfig::Request.new
+          #
+          #   # Call the no_retry_method method.
+          #   result = client.no_retry_method request
+          #
+          #   # The returned object is of type Testing::GrpcServiceConfig::Response.
+          #   p result
+          #
           def no_retry_method request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_with_retries/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_with_retries/rest/client.rb
@@ -172,6 +172,22 @@ module Testing
           # @return [::Testing::GrpcServiceConfig::Response]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/grpc_service_config"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::GrpcServiceConfig::ServiceWithRetries::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::GrpcServiceConfig::Request.new
+          #
+          #   # Call the service_level_retry_method method.
+          #   result = client.service_level_retry_method request
+          #
+          #   # The returned object is of type Testing::GrpcServiceConfig::Response.
+          #   p result
+          #
           def service_level_retry_method request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -224,6 +240,22 @@ module Testing
           # @return [::Testing::GrpcServiceConfig::Response]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/grpc_service_config"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::GrpcServiceConfig::ServiceWithRetries::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::GrpcServiceConfig::Request.new
+          #
+          #   # Call the method_level_retry_method method.
+          #   result = client.method_level_retry_method request
+          #
+          #   # The returned object is of type Testing::GrpcServiceConfig::Response.
+          #   p result
+          #
           def method_level_retry_method request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc/rest/client.rb
@@ -162,6 +162,22 @@ module Testing
           # @return [::Testing::Mixins::Response]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/mixins"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::Mixins::ServiceWithLoc::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::Mixins::Request.new
+          #
+          #   # Call the call_method method.
+          #   result = client.call_method request
+          #
+          #   # The returned object is of type Testing::Mixins::Response.
+          #   p result
+          #
           def call_method request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/client.rb
@@ -212,6 +212,22 @@ module Testing
           # @return [::Gapic::GenericLRO::Operation]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/nonstandard_lro_grpc"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::NonstandardLroGrpc::Request.new
+          #
+          #   # Call the plain_lro_rpc method.
+          #   result = client.plain_lro_rpc request
+          #
+          #   # The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
+          #   p result
+          #
           def plain_lro_rpc request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -281,6 +297,22 @@ module Testing
           # @return [::Gapic::GenericLRO::Operation]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/nonstandard_lro_grpc"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::NonstandardLroGrpc::AnotherRequest.new
+          #
+          #   # Call the another_lro_rpc method.
+          #   result = client.another_lro_rpc request
+          #
+          #   # The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
+          #   p result
+          #
           def another_lro_rpc request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -345,6 +377,22 @@ module Testing
           # @return [::Gapic::GenericLRO::Operation]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/nonstandard_lro_grpc"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::NonstandardLroGrpc::NonCopyRequest.new
+          #
+          #   # Call the non_copy_another_lro_rpc method.
+          #   result = client.non_copy_another_lro_rpc request
+          #
+          #   # The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
+          #   p result
+          #
           def non_copy_another_lro_rpc request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -412,6 +460,29 @@ module Testing
           # @return [::Gapic::Operation]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/nonstandard_lro_grpc"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::NonstandardLroGrpc::Request.new
+          #
+          #   # Call the aip_lro method.
+          #   result = client.aip_lro request
+          #
+          #   # The returned object is of type Gapic::Operation. You can use it to
+          #   # check the status of an operation, cancel it, or wait for results.
+          #   # Here is how to wait for a response.
+          #   result.wait_until_done! timeout: 60
+          #   if result.response?
+          #     p result.response
+          #   else
+          #     puts "No response received."
+          #   end
+          #
           def aip_lro request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -474,6 +545,22 @@ module Testing
           # @return [::Testing::NonstandardLroGrpc::Response]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/nonstandard_lro_grpc"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::NonstandardLroGrpc::Request.new
+          #
+          #   # Call the no_lro method.
+          #   result = client.no_lro request
+          #
+          #   # The returned object is of type Testing::NonstandardLroGrpc::Response.
+          #   p result
+          #
           def no_lro request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/operations.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/operations.rb
@@ -142,6 +142,26 @@ module Testing
           # @return [::Gapic::Operation]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "google/longrunning"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Google::Longrunning::Operations::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Google::Longrunning::ListOperationsRequest.new
+          #
+          #   # Call the list_operations method.
+          #   result = client.list_operations request
+          #
+          #   # The returned object is of type Gapic::PagedEnumerable. You can iterate
+          #   # over elements, and API calls will be issued to fetch pages as needed.
+          #   result.each do |item|
+          #     # Each element is of type ::Google::Longrunning::Operation.
+          #     p item
+          #   end
+          #
           def list_operations request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -208,6 +228,29 @@ module Testing
           # @return [::Gapic::Operation]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "google/longrunning"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Google::Longrunning::Operations::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Google::Longrunning::GetOperationRequest.new
+          #
+          #   # Call the get_operation method.
+          #   result = client.get_operation request
+          #
+          #   # The returned object is of type Gapic::Operation. You can use it to
+          #   # check the status of an operation, cancel it, or wait for results.
+          #   # Here is how to wait for a response.
+          #   result.wait_until_done! timeout: 60
+          #   if result.response?
+          #     p result.response
+          #   else
+          #     puts "No response received."
+          #   end
+          #
           def get_operation request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -274,6 +317,22 @@ module Testing
           # @return [::Google::Protobuf::Empty]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "google/longrunning"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Google::Longrunning::Operations::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Google::Longrunning::DeleteOperationRequest.new
+          #
+          #   # Call the delete_operation method.
+          #   result = client.delete_operation request
+          #
+          #   # The returned object is of type Google::Protobuf::Empty.
+          #   p result
+          #
           def delete_operation request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -345,6 +404,22 @@ module Testing
           # @return [::Google::Protobuf::Empty]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "google/longrunning"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Google::Longrunning::Operations::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Google::Longrunning::CancelOperationRequest.new
+          #
+          #   # Call the cancel_operation method.
+          #   result = client.cancel_operation request
+          #
+          #   # The returned object is of type Google::Protobuf::Empty.
+          #   p result
+          #
           def cancel_operation request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/another_lro_provider/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/another_lro_provider/rest/client.rb
@@ -170,6 +170,22 @@ module Testing
           # @return [::Testing::NonstandardLroGrpc::NonstandardOperation]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/nonstandard_lro_grpc"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::NonstandardLroGrpc::AnotherLroProvider::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::NonstandardLroGrpc::LroAnotherGetRequest.new
+          #
+          #   # Call the get_another method.
+          #   result = client.get_another request
+          #
+          #   # The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
+          #   p result
+          #
           def get_another request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/rest/client.rb
@@ -183,6 +183,22 @@ module Testing
           # @return [::Gapic::GenericLRO::Operation]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/nonstandard_lro_grpc"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::NonstandardLroGrpc::PlainLroConsumer::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::NonstandardLroGrpc::Request.new
+          #
+          #   # Call the plain_lro_rpc method.
+          #   result = client.plain_lro_rpc request
+          #
+          #   # The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
+          #   p result
+          #
           def plain_lro_rpc request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_provider/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_provider/rest/client.rb
@@ -170,6 +170,22 @@ module Testing
           # @return [::Testing::NonstandardLroGrpc::NonstandardOperation]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/nonstandard_lro_grpc"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::NonstandardLroGrpc::PlainLroProvider::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::NonstandardLroGrpc::LroGetRequest.new
+          #
+          #   # Call the get method.
+          #   result = client.get request
+          #
+          #   # The returned object is of type Testing::NonstandardLroGrpc::NonstandardOperation.
+          #   p result
+          #
           def get request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_explicit_headers/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_explicit_headers/rest/client.rb
@@ -180,6 +180,22 @@ module Testing
           # @return [::Testing::RoutingHeaders::Response]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/routing_headers"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::RoutingHeaders::Request.new
+          #
+          #   # Call the plain_no_template method.
+          #   result = client.plain_no_template request
+          #
+          #   # The returned object is of type Testing::RoutingHeaders::Response.
+          #   p result
+          #
           def plain_no_template request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -250,6 +266,22 @@ module Testing
           # @return [::Testing::RoutingHeaders::Response]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/routing_headers"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::RoutingHeaders::Request.new
+          #
+          #   # Call the plain_full_field method.
+          #   result = client.plain_full_field request
+          #
+          #   # The returned object is of type Testing::RoutingHeaders::Response.
+          #   p result
+          #
           def plain_full_field request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -320,6 +352,22 @@ module Testing
           # @return [::Testing::RoutingHeaders::Response]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/routing_headers"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::RoutingHeaders::Request.new
+          #
+          #   # Call the plain_extract method.
+          #   result = client.plain_extract request
+          #
+          #   # The returned object is of type Testing::RoutingHeaders::Response.
+          #   p result
+          #
           def plain_extract request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -390,6 +438,22 @@ module Testing
           # @return [::Testing::RoutingHeaders::Response]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/routing_headers"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::RoutingHeaders::Request.new
+          #
+          #   # Call the complex method.
+          #   result = client.complex request
+          #
+          #   # The returned object is of type Testing::RoutingHeaders::Response.
+          #   p result
+          #
           def complex request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -460,6 +524,22 @@ module Testing
           # @return [::Testing::RoutingHeaders::Response]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/routing_headers"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::RoutingHeaders::Request.new
+          #
+          #   # Call the with_sub_message method.
+          #   result = client.with_sub_message request
+          #
+          #   # The returned object is of type Testing::RoutingHeaders::Response.
+          #   p result
+          #
           def with_sub_message request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_implicit_headers/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_implicit_headers/rest/client.rb
@@ -180,6 +180,22 @@ module Testing
           # @return [::Testing::RoutingHeaders::Response]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/routing_headers"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::RoutingHeaders::Request.new
+          #
+          #   # Call the plain method.
+          #   result = client.plain request
+          #
+          #   # The returned object is of type Testing::RoutingHeaders::Response.
+          #   p result
+          #
           def plain request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -250,6 +266,22 @@ module Testing
           # @return [::Testing::RoutingHeaders::Response]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/routing_headers"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::RoutingHeaders::Request.new
+          #
+          #   # Call the with_sub_message method.
+          #   result = client.with_sub_message request
+          #
+          #   # The returned object is of type Testing::RoutingHeaders::Response.
+          #   p result
+          #
           def with_sub_message request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 
@@ -320,6 +352,22 @@ module Testing
           # @return [::Testing::RoutingHeaders::Response]
           #
           # @raise [::Gapic::Rest::Error] if the REST call is aborted.
+          #
+          # @example Basic example
+          #   require "testing/routing_headers"
+          #
+          #   # Create a client object. The client can be reused for multiple calls.
+          #   client = Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::Client.new
+          #
+          #   # Create a request. To set request fields, pass in keyword arguments.
+          #   request = Testing::RoutingHeaders::Request.new
+          #
+          #   # Call the with_multiple_levels method.
+          #   result = client.with_multiple_levels request
+          #
+          #   # The returned object is of type Testing::RoutingHeaders::Response.
+          #   p result
+          #
           def with_multiple_levels request, options = nil
             raise ::ArgumentError, "request must be provided" if request.nil?
 


### PR DESCRIPTION
The goal here is to:

* Fix generated standalone snippets for REGAPIC clients so they reflect the correct REST client classes
* Add support for inline snippets on REST clients

We accomplish this by:

* Support setting the transport when creating a SnippetPresenter
* Ensure both ServicePresenter and ServiceRestPresenter support the same set of methods that could be called from SnippetPresenter and PackageSnippets.
* Adding the appropriate template for inline REST snippets
* Updating all the goldens