### PR TITLE
feat(gapic-common): Honor universe domain in stubs

### DIFF
--- a/gapic-common/lib/gapic/universe_domain_concerns.rb
+++ b/gapic-common/lib/gapic/universe_domain_concerns.rb
@@ -1,0 +1,82 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Gapic
+  ##
+  # A mixin module that provides methods for obtaining the effective universe
+  # domain, endpoint, and credentials for a stub. This is included in
+  # Grpc::ServiceStub and Rest::ClientStub.
+  #
+  module UniverseDomainConcerns
+    ##
+    # A substitution string for the universe domain in an endpoint template
+    # @return [String]
+    #
+    ENDPOINT_SUBSTITUTION = "$UNIVERSE_DOMAIN$".freeze
+
+    ##
+    # The effective endpoint
+    # @return [String]
+    #
+    attr_reader :endpoint
+
+    ##
+    # The effective universe domain
+    # @return [String]
+    #
+    attr_reader :universe_domain
+
+    ##
+    # The effective credentials
+    #
+    # @return [Google::Auth::Credentials, Signet::OAuth2::Client, Proc,
+    #   ::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials]
+    #
+    attr_reader :credentials
+
+    protected
+
+    ##
+    # @private
+    # Called from the stub constructor to populate the data.
+    #
+    def setup_universe_domain universe_domain: nil,
+                              endpoint: nil,
+                              endpoint_template: nil,
+                              credentials: nil
+      raise ArgumentError, "endpoint or endpoint_template is required" if endpoint.nil? && endpoint_template.nil?
+      raise ArgumentError, "credentials is required" if credentials.nil?
+
+      # TODO: The env logic should live in google-cloud-env
+      universe_domain ||= ENV["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] || "googleapis.com"
+      endpoint ||= endpoint_template.sub ENDPOINT_SUBSTITUTION, universe_domain
+
+      if credentials.respond_to?(:universe_domain) && credentials.universe_domain != universe_domain
+        raise UniverseDomainMismatch,
+              "Universe domain is #{universe_domain} but credentials are in #{credentials.universe_domain}"
+      end
+
+      @universe_domain = universe_domain
+      @endpoint = endpoint
+      @credentials = credentials
+    end
+  end
+
+  ##
+  # Raised when the configured universe domain does not match the universe
+  # domain of the credentials.
+  #
+  class UniverseDomainMismatch < ::Gapic::Common::Error
+  end
+end

--- a/gapic-common/test/gapic/grpc/stub_test.rb
+++ b/gapic-common/test/gapic/grpc/stub_test.rb
@@ -44,6 +44,10 @@ class GrpcStubTest < Minitest::Spec
     def updater_proc
       ->{}
     end
+
+    def universe_domain
+      "googleapis.com"
+    end
   end
 
   def test_with_channel


### PR DESCRIPTION
Partial support for universe domains in GAPICs. This pull request includes changes to gapic-common.

* Adds optional `universe_domain` and `endpoint_template` arguments to stub class constructors. The former is the universe domain in which the call should take place (falling back to the `GOOGLE_CLOUD_UNIVERSE_DOMAIN` environment variable, then defaulting to `googleapis.com`). The latter is a template of the endpoint host in which the universe domain component has been replaced with `$UNIVERSE_DOMAIN$` (expressed in the constant `Gapic::UniverseDomainConcerns::ENDPOINT_SUBSTITUTION`). If the latter is not present, the existing `endpoint` argument is used.
* Implements determining the endpoint given the universe domain and template.
* Provides accessors for the universe domain and endpoint that the client object can use to implement its own accessors.
* Checks credential universe domain for mismatch against configured universe domain.
* Requires googleauth 1.9 which implements universe domain support.