### PR TITLE
feat(gapic-generator-ruby): add @deprecated tags to document items

### DIFF
--- a/gapic-generator/lib/gapic/presenters/enum_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/enum_presenter.rb
@@ -20,8 +20,14 @@ module Gapic
     # A presenter for proto enums.
     #
     class EnumPresenter
+      # @return [String] String representation of this presenter type.
+      attr_reader :type
+
+      ##
+      # @param enum [Gapic::Schema::Enum]
       def initialize enum
         @enum = enum
+        @type = "enum"
       end
 
       def name
@@ -34,6 +40,12 @@ module Gapic
 
       def values
         @values ||= @enum.values.map { |v| EnumValuePresenter.new v }
+      end
+
+      ##
+      # @return [Boolean] Whether the enum is marked as deprecated.
+      def is_deprecated?
+        @enum.is_deprecated?
       end
     end
   end

--- a/gapic-generator/lib/gapic/presenters/enum_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/enum_presenter.rb
@@ -25,6 +25,7 @@ module Gapic
 
       ##
       # @param enum [Gapic::Schema::Enum]
+      #
       def initialize enum
         @enum = enum
         @type = "enum"
@@ -44,6 +45,7 @@ module Gapic
 
       ##
       # @return [Boolean] Whether the enum is marked as deprecated.
+      #
       def is_deprecated?
         @enum.is_deprecated?
       end

--- a/gapic-generator/lib/gapic/presenters/field_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/field_presenter.rb
@@ -25,10 +25,18 @@ module Gapic
     class FieldPresenter
       include Gapic::Helpers::NamespaceHelper
 
+      # @return [String] String representation of this presenter type.
+      attr_reader :type
+
+      ##
+      # @param api [Gapic::Schema::Api]
+      # @param message [Gapic::Schema::Message]
+      # @param field [Gapic::Schema::Field]
       def initialize api, message, field
         @api = api
         @message = message
         @field = field
+        @type = "field"
       end
 
       def name
@@ -137,6 +145,12 @@ module Gapic
       # @return [String]
       def camel_name
         camel_name_for name
+      end
+
+      ##
+      # @return [Boolean] Whether the field is marked as deprecated.
+      def is_deprecated?
+        @field.is_deprecated?
       end
 
       protected

--- a/gapic-generator/lib/gapic/presenters/field_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/field_presenter.rb
@@ -32,6 +32,7 @@ module Gapic
       # @param api [Gapic::Schema::Api]
       # @param message [Gapic::Schema::Message]
       # @param field [Gapic::Schema::Field]
+      #
       def initialize api, message, field
         @api = api
         @message = message
@@ -141,14 +142,16 @@ module Gapic
       end
 
       ##
-      # Name of this field, camel-cased
+      # Name of this field, camel-cased.
       # @return [String]
+      #
       def camel_name
         camel_name_for name
       end
 
       ##
       # @return [Boolean] Whether the field is marked as deprecated.
+      #
       def is_deprecated?
         @field.is_deprecated?
       end

--- a/gapic-generator/lib/gapic/presenters/message_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/message_presenter.rb
@@ -32,6 +32,7 @@ module Gapic
       ##
       # @param api [Gapic::Schema::Api]
       # @param message [Gapic::Schema::Message]
+      #
       def initialize api, message
         @api = api
         @message = message
@@ -72,6 +73,7 @@ module Gapic
 
       ##
       # @return [Boolean] Whether the message is marked as deprecated.
+      #
       def is_deprecated?
         @message.is_deprecated?
       end

--- a/gapic-generator/lib/gapic/presenters/message_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/message_presenter.rb
@@ -26,9 +26,16 @@ module Gapic
     class MessagePresenter
       include Gapic::Helpers::NamespaceHelper
 
+      # @return [String] String representation of this presenter type.
+      attr_reader :type
+
+      ##
+      # @param api [Gapic::Schema::Api]
+      # @param message [Gapic::Schema::Message]
       def initialize api, message
         @api = api
         @message = message
+        @type = "message"
       end
 
       def name
@@ -61,6 +68,12 @@ module Gapic
 
       def nested_messages
         @nested_messages ||= @message.nested_messages.map { |m| MessagePresenter.new @api, m }
+      end
+
+      ##
+      # @return [Boolean] Whether the message is marked as deprecated.
+      def is_deprecated?
+        @message.is_deprecated?
       end
 
       protected

--- a/gapic-generator/lib/gapic/presenters/method_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/method_presenter.rb
@@ -44,6 +44,9 @@ module Gapic
       # @return [Gapic::Model::Method::AipLro, Gapic::Model::Method::NonStandardLro, Gapic::Model::Method::NoLro]
       attr_accessor :lro
 
+      # @return [String] String representation of this presenter type.
+      attr_reader :type
+
       ##
       # @param service_presenter [Gapic::Presenters::ServicePresenter]
       # @param api [Gapic::Schema::Api]
@@ -52,12 +55,13 @@ module Gapic
         @service_presenter = service_presenter
         @api = api
         @method = method
+        @type = "method"
 
         # Service config override should only happen for Operations.
         # For the main services we expect service config overrides to be rolled into the protos by the publisher.
         # For all other mixins, since we do not generate them for the service,
         # the overrides should get configured separately.
-        is_lro =  @service_presenter.address.join(".") == Gapic::Model::Mixins::LRO_SERVICE
+        is_lro = @service_presenter.address.join(".") == Gapic::Model::Mixins::LRO_SERVICE
         service_config_override_http = is_lro ? @api.service_config : nil
         @http = Gapic::Model::Method::HttpAnnotation.create_with_override @method, service_config_override_http
 

--- a/gapic-generator/lib/gapic/presenters/method_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/method_presenter.rb
@@ -51,6 +51,7 @@ module Gapic
       # @param service_presenter [Gapic::Presenters::ServicePresenter]
       # @param api [Gapic::Schema::Api]
       # @param method [Gapic::Schema::Method]
+      #
       def initialize service_presenter, api, method
         @service_presenter = service_presenter
         @api = api
@@ -160,7 +161,7 @@ module Gapic
       end
 
       ##
-      # @return [Boolean]
+      # @return [Boolean] Whether the method is marked as deprecated.
       #
       def is_deprecated?
         @method.is_deprecated?

--- a/gapic-generator/lib/gapic/presenters/method_rest_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/method_rest_presenter.rb
@@ -33,6 +33,7 @@ module Gapic
       ##
       # @param main_method [Gapic::Presenters::MethodPresenter] the main presenter for this method.
       # @param api [Gapic::Schema::Api]
+      #
       def initialize main_method, api
         @main_method = main_method
         @http_bindings = main_method.http_bindings
@@ -151,6 +152,7 @@ module Gapic
 
       ##
       # @return [Boolean] Whether the method is marked as deprecated.
+      #
       def is_deprecated?
         @main_method.is_deprecated?
       end

--- a/gapic-generator/lib/gapic/presenters/method_rest_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/method_rest_presenter.rb
@@ -27,14 +27,17 @@ module Gapic
 
       attr_reader :http_bindings
 
+      # @return [String] String representation of this presenter type.
+      attr_reader :type
+
       ##
       # @param main_method [Gapic::Presenters::MethodPresenter] the main presenter for this method.
       # @param api [Gapic::Schema::Api]
-      #
       def initialize main_method, api
         @main_method = main_method
         @http_bindings = main_method.http_bindings
         @pagination = Gapic::Presenters::Method::RestPaginationInfo.new main_method.method, api
+        @type = "method"
       end
 
       ##
@@ -144,6 +147,12 @@ module Gapic
       #
       def server_streaming?
         @main_method.server_streaming?
+      end
+
+      ##
+      # @return [Boolean] Whether the method is marked as deprecated.
+      def is_deprecated?
+        @main_method.is_deprecated?
       end
     end
   end

--- a/gapic-generator/lib/gapic/presenters/service_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_presenter.rb
@@ -38,6 +38,7 @@ module Gapic
       # @param api [Gapic::Schema::Api]
       # @param service [Gapic::Presenters::ServicePresenter]
       # @param parent_service [Gapic::Presenters::ServicePresenter]
+      #
       def initialize gem_presenter, api, service, parent_service: nil
         @gem_presenter = gem_presenter
         @api = api

--- a/gapic-generator/lib/gapic/presenters/service_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_presenter.rb
@@ -30,6 +30,14 @@ module Gapic
       # @return [Gapic::Presenters::ServiceRestPresenter]
       attr_reader :rest
 
+      # @return [String] String representation of this presenter type.
+      attr_reader :type
+
+      ##
+      # @param gem_presenter [Gapic::Presenters::GemPresenter]
+      # @param api [Gapic::Schema::Api]
+      # @param service [Gapic::Presenters::ServicePresenter]
+      # @param parent_service [Gapic::Presenters::ServicePresenter]
       def initialize gem_presenter, api, service, parent_service: nil
         @gem_presenter = gem_presenter
         @api = api
@@ -37,6 +45,7 @@ module Gapic
         @parent_service = parent_service
         @rest = ServiceRestPresenter.new self, api
         @nonstandard_lro = api.nonstandard_lro_model_for service.full_name
+        @type = "service"
       end
 
       def gem
@@ -52,7 +61,7 @@ module Gapic
       end
 
       ##
-      # @return [Boolean]
+      # @return [Boolean] Whether the service is marked as deprecated.
       #
       def is_deprecated?
         @service.is_deprecated?

--- a/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
@@ -43,10 +43,10 @@ module Gapic
       ##
       # @param main_service [Gapic::Presenters::ServicePresenter]
       # @param api [Gapic::Schema::Api]
-      #
       def initialize main_service, api
         @main_service = main_service
         @api = api
+        @type = "service"
       end
 
       ##
@@ -369,12 +369,20 @@ module Gapic
         main_service.gem.rest_numeric_enums?
       end
 
+      ##
+      # @return [Boolean] Whether the service is marked as deprecated.
+      def is_deprecated?
+        @main_service.is_deprecated?
+      end
+
       private
 
       # @return [Gapic::Presenters::ServicePresenter]
       attr_reader :main_service
       # @return [Gapic::Schema::Api]
       attr_reader :api
+      # @return [String] String representation of this presenter type.
+      attr_reader :type
     end
   end
 end

--- a/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_rest_presenter.rb
@@ -43,6 +43,7 @@ module Gapic
       ##
       # @param main_service [Gapic::Presenters::ServicePresenter]
       # @param api [Gapic::Schema::Api]
+      #
       def initialize main_service, api
         @main_service = main_service
         @api = api
@@ -371,6 +372,7 @@ module Gapic
 
       ##
       # @return [Boolean] Whether the service is marked as deprecated.
+      #
       def is_deprecated?
         @main_service.is_deprecated?
       end

--- a/gapic-generator/lib/gapic/schema/wrappers.rb
+++ b/gapic-generator/lib/gapic/schema/wrappers.rb
@@ -318,7 +318,7 @@ module Gapic
       end
 
       # @return [Boolean] True if this service is marked as deprecated, false
-      # otherwise.
+      #   otherwise.
       def is_deprecated?
         option_named "deprecated"
       end
@@ -591,6 +591,12 @@ module Gapic
         @values.each { |v| v.parent = self }
       end
 
+      # @return [Boolean] True if this enum is marked as deprecated, false
+      #   otherwise.
+      def is_deprecated?
+        option_named "deprecated"
+      end
+
       # @!method name
       #   @return [String] the unqualified name of the Enum.
       # @!method options
@@ -696,6 +702,12 @@ module Gapic
       #   which also reference full proto name.
       def full_name
         @address.join "."
+      end
+
+      # @return [Boolean] True if this message is marked as deprecated, false
+      #   otherwise.
+      def is_deprecated?
+        option_named "deprecated"
       end
 
       # @!method name
@@ -942,6 +954,12 @@ module Gapic
       # Denotes a field as proto3 optional
       def proto3_optional?
         @descriptor.proto3_optional
+      end
+
+      # @return [Boolean] True if this field is marked as deprecated, false
+      #   otherwise.
+      def is_deprecated?
+        option_named "deprecated"
       end
 
       # @!method name

--- a/gapic-generator/lib/google/cloud/tools/snippetgen/configlanguage/v1/snippet_config_language_pb.rb
+++ b/gapic-generator/lib/google/cloud/tools/snippetgen/configlanguage/v1/snippet_config_language_pb.rb
@@ -13,7 +13,7 @@ pool = Google::Protobuf::DescriptorPool.generated_pool
 
 begin
   pool.add_serialized_file(descriptor_data)
-rescue TypeError => e
+rescue TypeError
   # Compatibility code: will be removed in the next major version.
   require 'google/protobuf/descriptor_pb'
   parsed = Google::Protobuf::FileDescriptorProto.decode(descriptor_data)

--- a/gapic-generator/lib/google/cloud/tools/snippetgen/snippetindex/v1/snippet_index_pb.rb
+++ b/gapic-generator/lib/google/cloud/tools/snippetgen/snippetindex/v1/snippet_index_pb.rb
@@ -11,7 +11,7 @@ pool = Google::Protobuf::DescriptorPool.generated_pool
 
 begin
   pool.add_serialized_file(descriptor_data)
-rescue TypeError => e
+rescue TypeError
   # Compatibility code: will be removed in the next major version.
   require 'google/protobuf/descriptor_pb'
   parsed = Google::Protobuf::FileDescriptorProto.decode(descriptor_data)

--- a/gapic-generator/lib/google/protobuf/compiler/plugin_pb.rb
+++ b/gapic-generator/lib/google/protobuf/compiler/plugin_pb.rb
@@ -13,7 +13,7 @@ pool = Google::Protobuf::DescriptorPool.generated_pool
 
 begin
   pool.add_serialized_file(descriptor_data)
-rescue TypeError => e
+rescue TypeError
   # Compatibility code: will be removed in the next major version.
   require 'google/protobuf/descriptor_pb'
   parsed = Google::Protobuf::FileDescriptorProto.decode(descriptor_data)

--- a/gapic-generator/templates/default/lib/_service.erb
+++ b/gapic-generator/templates/default/lib/_service.erb
@@ -33,6 +33,7 @@ require "<%= service.rest.service_rest_require %>"
 <%= indent service.doc_description, "# " %>
 #
 <%- end -%>
+<%= render partial: "proto_docs/deprecated", locals: { presenter: service, newline: true } -%>
 <%- if service.generate_grpc_clients? -%>
 # @example Load this service and instantiate a gRPC client
 #

--- a/gapic-generator/templates/default/proto_docs/_deprecated.erb
+++ b/gapic-generator/templates/default/proto_docs/_deprecated.erb
@@ -1,0 +1,9 @@
+<%- assert_locals presenter -%>
+<% newline ||= false %>
+<% indentation ||= "# " %>
+<%- if presenter.is_deprecated? -%>
+<%= indent "@deprecated This #{presenter.type} is deprecated and may be removed in the next major version update.\n", indentation %>
+<%- if newline -%>
+<%= indentation %>
+<%- end -%>
+<%- end -%>

--- a/gapic-generator/templates/default/proto_docs/_enum.erb
+++ b/gapic-generator/templates/default/proto_docs/_enum.erb
@@ -2,6 +2,7 @@
 <%- if enum.doc_description -%>
 <%= indent enum.doc_description, "# " %>
 <%- end -%>
+<%= render partial: "proto_docs/deprecated", locals: { presenter: enum } -%>
 module <%= enum.name %>
   <%- enum.values.each do |value| -%>
 

--- a/gapic-generator/templates/default/proto_docs/_message.erb
+++ b/gapic-generator/templates/default/proto_docs/_message.erb
@@ -2,8 +2,10 @@
 <%- if message.doc_description -%>
 <%= indent message.doc_description, "# " %>
 <%- end -%>
+<%= render partial: "proto_docs/deprecated", locals: { presenter: message } -%>
 <%- message.fields.each do |field| -%>
 <%= indent field.doc_attribute_type, "# " %>
+<%= render(partial: "proto_docs/deprecated", locals: { presenter:field, indentation: "#   " }) -%>
 #   @return [<%= field.output_doc_types %>]
 <%- if field.doc_description -%>
 <%= indent field.doc_description, "#     " %>

--- a/gapic-generator/templates/default/service/client/_client.erb
+++ b/gapic-generator/templates/default/service/client/_client.erb
@@ -30,11 +30,8 @@ class <%= service.client_name %>
   #
   # See {<%= service.client_name_full %>::Configuration}
   # for a description of the configuration fields.
-<%- if service.is_deprecated? -%>
   #
-  # @deprecated This service is deprecated and may be removed in the next major version update.
-<%- end -%>
-  #
+<%= render partial: "proto_docs/deprecated", locals: { presenter: service, newline: true } -%>
   # @example
   #
   #   # Modify the configuration for all <%= service.name %> clients

--- a/gapic-generator/templates/default/service/client/method/_def.erb
+++ b/gapic-generator/templates/default/service/client/method/_def.erb
@@ -4,7 +4,7 @@
 <%= indent method.doc_description(transport: :grpc), "# " %>
 #
 <%- end -%>
-<%= render partial: "service/client/method/docs/deprecated", locals: { method: method } -%>
+<%= render partial: "proto_docs/deprecated", locals: { presenter: method , newline: true} -%>
 <%= render partial: "service/client/method/docs/request", locals: { method: method } -%>
 #
 <%= render partial: "service/client/method/docs/response", locals: { method: method } -%>

--- a/gapic-generator/templates/default/service/client/method/docs/_deprecated.erb
+++ b/gapic-generator/templates/default/service/client/method/docs/_deprecated.erb
@@ -1,5 +1,0 @@
-<%- assert_locals method -%>
-<%- if method.is_deprecated? -%>
-# @deprecated This method is deprecated and may be removed in the next major version update.
-#
-<%- end -%>

--- a/gapic-generator/templates/default/service/rest/client/_client.erb
+++ b/gapic-generator/templates/default/service/rest/client/_client.erb
@@ -31,10 +31,7 @@ class <%= service.rest.client_name %>
   #
   # See {<%= service.rest.client_name_full %>::Configuration}
   # for a description of the configuration fields.
-<%- if service.is_deprecated? -%>
-  #
-  # @deprecated This service is deprecated and may be removed in the next major version update.
-<%- end -%>
+<%= render partial: "proto_docs/deprecated", locals: { presenter: service } -%>
   #
   # @example
   #

--- a/gapic-generator/templates/default/service/rest/service_stub/_service_stub.erb
+++ b/gapic-generator/templates/default/service/rest/service_stub/_service_stub.erb
@@ -7,6 +7,7 @@ require "<%= service.proto_service_require %>"
 # Service stub contains baseline method implementations
 # including transcoding, making the REST call, and deserialing the response.
 #
+<%= render partial: "proto_docs/deprecated", locals: { presenter: service } -%>
 class <%= service.rest.service_stub_name %>
   def initialize endpoint:, credentials:
     # These require statements are intentionally placed here to initialize

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v12/common/bidding.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v12/common/bidding.rb
@@ -196,6 +196,7 @@ module Google
           # An automated bid strategy that sets your bids to help get as many clicks
           # as possible within your budget.
           # @!attribute [rw] target_spend_micros
+          #   @deprecated This field is deprecated and may be removed in the next major version update.
           #   @return [::Integer]
           #     The spend target under which to maximize clicks.
           #     A TargetSpend bidder will attempt to spend the smaller of this value

--- a/shared/output/cloud/speech_v1/proto_docs/google/cloud/speech/v1/cloud_speech.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/cloud/speech/v1/cloud_speech.rb
@@ -439,6 +439,7 @@ module Google
         #     flexibility by allowing the system to automatically determine the correct
         #     number of speakers. If not set, the default value is 6.
         # @!attribute [r] speaker_tag
+        #   @deprecated This field is deprecated and may be removed in the next major version update.
         #   @return [::Integer]
         #     Output only. Unused.
         class SpeakerDiarizationConfig
@@ -447,6 +448,7 @@ module Google
         end
 
         # Description of audio data to be recognized.
+        # @deprecated This message is deprecated and may be removed in the next major version update.
         # @!attribute [rw] interaction_type
         #   @return [::Google::Cloud::Speech::V1::RecognitionMetadata::InteractionType]
         #     The use case most closely describing the audio content to be recognized.

--- a/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/image_annotator.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/image_annotator.rb
@@ -378,6 +378,7 @@ module Google
         #   @return [::Float]
         #     Overall score of the result. Range [0, 1].
         # @!attribute [rw] confidence
+        #   @deprecated This field is deprecated and may be removed in the next major version update.
         #   @return [::Float]
         #     **Deprecated. Use `score` instead.**
         #     The accuracy of the entity detection in an image.

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/deprecated_service.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/deprecated_service.rb
@@ -37,6 +37,8 @@ module So
   module Much
     module Trash
       ##
+      # @deprecated This service is deprecated and may be removed in the next major version update.
+      #
       # @example Load this service and instantiate a gRPC client
       #
       #     require "so/much/trash/deprecated_service"


### PR DESCRIPTION
Changelog:
- Generates @deprecated tag based on proto inputs.
- Some rubocop fixes & other docstring formatting.

Closes #992