### PR TITLE
fix(gapic-generator-ruby): add missing module import for universe_domain_concerns

### DIFF
--- a/gapic-common/lib/gapic/universe_domain_concerns.rb
+++ b/gapic-common/lib/gapic/universe_domain_concerns.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "gapic/common/error"
+
 module Gapic
   ##
   # A mixin module that provides methods for obtaining the effective universe


### PR DESCRIPTION
Fixes `uninitialized constant Gapic::Common (NameError)` in `class UniverseDomainMismatch < ::Gapic::Common::Error`