### PR TITLE
fix: Update wrapper configs for universe_domain support

### DIFF
--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/_main.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/_main.erb
@@ -14,7 +14,7 @@ require "google/cloud/config"
 
 # Set the default configuration
 ::Google::Cloud.configure.add_config! :<%= gem.google_cloud_short_name %> do |config|
-  config.add_field! :endpoint,      <%= gem.services.first&.client_endpoint.inspect %>, match: ::String
+  config.add_field! :endpoint,      nil, match: ::String
   config.add_field! :credentials,   nil, match: [::String, ::Hash, ::Google::Auth::Credentials]
   config.add_field! :scope,         nil, match: [::Array, ::String]
   config.add_field! :lib_name,      nil, match: ::String
@@ -26,6 +26,7 @@ require "google/cloud/config"
   config.add_field! :metadata,      nil, match: ::Hash
   config.add_field! :retry_policy,  nil, match: [::Hash, ::Proc]
   config.add_field! :quota_project, nil, match: ::String
+  config.add_field! :universe_domain, nil, match: ::String
 end
 <%- end -%>
 <% end %>

--- a/shared/output/cloud/compute_small_wrapper/lib/google/cloud/compute.rb
+++ b/shared/output/cloud/compute_small_wrapper/lib/google/cloud/compute.rb
@@ -29,7 +29,7 @@ require "google/cloud/config"
 
 # Set the default configuration
 ::Google::Cloud.configure.add_config! :compute do |config|
-  config.add_field! :endpoint,      "compute.googleapis.com", match: ::String
+  config.add_field! :endpoint,      nil, match: ::String
   config.add_field! :credentials,   nil, match: [::String, ::Hash, ::Google::Auth::Credentials]
   config.add_field! :scope,         nil, match: [::Array, ::String]
   config.add_field! :lib_name,      nil, match: ::String
@@ -38,6 +38,7 @@ require "google/cloud/config"
   config.add_field! :metadata,      nil, match: ::Hash
   config.add_field! :retry_policy,  nil, match: [::Hash, ::Proc]
   config.add_field! :quota_project, nil, match: ::String
+  config.add_field! :universe_domain, nil, match: ::String
 end
 
 module Google

--- a/shared/output/cloud/language_wrapper/lib/google/cloud/language.rb
+++ b/shared/output/cloud/language_wrapper/lib/google/cloud/language.rb
@@ -29,7 +29,7 @@ require "google/cloud/config"
 
 # Set the default configuration
 ::Google::Cloud.configure.add_config! :language do |config|
-  config.add_field! :endpoint,      "language.googleapis.com", match: ::String
+  config.add_field! :endpoint,      nil, match: ::String
   config.add_field! :credentials,   nil, match: [::String, ::Hash, ::Google::Auth::Credentials]
   config.add_field! :scope,         nil, match: [::Array, ::String]
   config.add_field! :lib_name,      nil, match: ::String
@@ -39,6 +39,7 @@ require "google/cloud/config"
   config.add_field! :metadata,      nil, match: ::Hash
   config.add_field! :retry_policy,  nil, match: [::Hash, ::Proc]
   config.add_field! :quota_project, nil, match: ::String
+  config.add_field! :universe_domain, nil, match: ::String
 end
 
 module Google

--- a/shared/output/cloud/secretmanager_wrapper/lib/google/cloud/secret_manager.rb
+++ b/shared/output/cloud/secretmanager_wrapper/lib/google/cloud/secret_manager.rb
@@ -29,7 +29,7 @@ require "google/cloud/config"
 
 # Set the default configuration
 ::Google::Cloud.configure.add_config! :secret_manager do |config|
-  config.add_field! :endpoint,      "secretmanager.googleapis.com", match: ::String
+  config.add_field! :endpoint,      nil, match: ::String
   config.add_field! :credentials,   nil, match: [::String, ::Hash, ::Google::Auth::Credentials]
   config.add_field! :scope,         nil, match: [::Array, ::String]
   config.add_field! :lib_name,      nil, match: ::String
@@ -39,6 +39,7 @@ require "google/cloud/config"
   config.add_field! :metadata,      nil, match: ::Hash
   config.add_field! :retry_policy,  nil, match: [::Hash, ::Proc]
   config.add_field! :quota_project, nil, match: ::String
+  config.add_field! :universe_domain, nil, match: ::String
 end
 
 module Google


### PR DESCRIPTION
Updates the configs for wrapper clients to "activate" universe domain support. This effectively ensures the endpoint (override) configuration defaults to nil so that the universe domain logic to determine the endpoint will kick in—that is, we no longer "override" the universe domain endpoint with the google default universe endpoint. It also provides a universe domain configuration at the wrapper level so that users can set a universe domain configuration in code that applies to all service versions under the wrapper.

NB. Wrappers generated with this change are _incompatible_ with GAPICs that do not have universe_domain support. This is because of an idiosyncrasy of how config overriding takes place: if a wrapper is present, its endpoint config actually provides the "final" default endpoint. Thus, by setting that default to nil, we remove that mechanism for defining the endpoint, and thus we _require_ that the corresponding GAPICs know how to set an endpoint using the universe domain. As a result, before (or when) putting this change into the production generator, we _must_ also set the dependencies to versions of all GAPICs that have universe_domain support. This is being done in internal change cl/597588187.
