### PR TITLE
chore: Update readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ tool. The following steps describe how do this.
 
 ### Prepare your Ruby environment
 
-The GAPIC Generator for Ruby is written in Ruby and requires the language and
-several related tools.
+The GAPIC Generator for Ruby is written in Ruby and requires the Ruby runtime
+and several related tools.
 
 First, install Ruby, version 3.1 or later, if you have not already done so.
 [This page](https://www.ruby-lang.org/en/documentation/installation/) on the
-official Ruby website includes installation information. We recommend using one
-of the Ruby version managers such as
+official Ruby website includes installation information. We recommend using a
+Ruby version manager such as
 [ASDF](https://www.ruby-lang.org/en/documentation/installation/#asdf-vm).
 
 You will need the [Bundler](https://rubygems.org/gems/bundler) and

--- a/gapic-generator-ads/README.md
+++ b/gapic-generator-ads/README.md
@@ -1,69 +1,105 @@
-# Ads Generator for Ruby
+# API Client Generator for Ruby
 
 Create Ruby clients from a protocol buffer description of an API.
 
-**Note** This project is a preview. Please try it out and let us know what you think,
-but there are currently no guarantees of stability or support.
+This code is used to generate client libraries for many Google APIs including
+Cloud and Ads services. The `gapic-generator` gem itself includes the main
+generator, whereas the `gapic-generator-cloud` and `gapic-generator-ads` gems
+provide modifications specific to Google Cloud and Google Ads APIs.
 
-## Usage
-### Install the Proto Compiler
-This generator relies on the Protocol Buffer Compiler to [orchestrate] the
-client generation.
+These gems can also be used to create clients for any other API, for Google or
+non-Google services, that use protocol buffers as the description language. The
+generators will work best for APIs that follow the design guidance documented
+in the [Google AIPs](https://aip.dev/). An API that is not AIP-compliant should
+still yield a usable client library, but it may be missing features such as
+idiomatic naming, pagination, or retry configuration.
 
-```sh
-# Declare the protobuf version to use.
-$ export PROTOBUF_VERSION=3.6.1
+**Important:** This is not an official Google project. While it is being used
+internally to generate official Google API client libraries, there is no
+guarantee of support or stability for any other use.
 
-# Declare the target installation system.
-# export SYSTEM=osx
-$ export SYSTEM=linux
+## Using the Ruby gem
 
-# Get the precompiled protobuf compiler.
-$ curl --location https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip > usr/src/protoc/protoc-${PROTOBUF_VERSION}.zip
-$ cd /usr/src/protoc/
-$ unzip protoc-${PROTOBUF_VERSION}.zip
-$ rm protoc-${PROTOBUF_VERSION}.zip
+This section provides a brief getting started guide for the Ruby gem. However,
+we do not release the Ruby gems often, and they may be substantially behind the
+current generator code. In most cases, we recommend generating from the
+GitHub repository directly. See the main README for
+https://github.com/googleapis/gapic-generator-ruby for more information.
 
-# Link the protoc to the path.
-$ ln -s /usr/src/protoc/bin/protoc /usr/local/bin/protoc
-$ mkdir -p /protos/
+### Install the Generator
 
-# Move the common protobuf files to the local include folder.
-$ cp -R /usr/src/protoc/include/* /usr/local/include/
+The generator is a plugin for **protoc**, the protocol buffers compiler, so
+you'll need to install it first, along with the standard protobuf and grpc
+plugins for Ruby. The easiest way to do this is to install the `grpc-tools` gem
+which will provide all three. You can also follow the
+[official install instructions](https://github.com/protocolbuffers/protobuf#protobuf-compiler-installation).
+Note that if you installed protoc using `grpc-tools`, the compiler binary name
+will be named `grpc_tools_ruby_protoc`; otherwise it will likely be `protoc`.
+
+Install the `gapic-generator` gem to get access to the gapic generator plugin.
+Since you are looking at the `gapic-generator-ads` gem's README, we will
+assume you want Ads-specific output, so also install `gapic-generator-ads`.
+
+Alternatively, add all the above to a Gemfile:
+
+```ruby
+# Gemfile
+source "https://rubygems.org/"
+
+gem "grpc-tools"
+gem "gapic-generator"
+gem "gapic-generator-ads"
 ```
 
-[orchestrate]: https://developers.google.com/protocol-buffers/docs/reference/ruby-generated
-
-### Build and Install the Generator
-This tool is in pre-alpha so it is not yet released to RubyGems. You will have to
-build the generator from scratch.
+And install using bundler:
 
 ```sh
-$ git clone https://github.com/googleapis/gapic-generator-ruby.git
-$ cd gapic-generator-ruby
-$ gem build gapic-generator.gemspec
-$ gem install gapic-generator-0.1.0.gem
-$ which protoc-gen-ruby_gapic
-> {Non-empty path}
+$ bundle install
 ```
 
 ### Generate an API
-Installing this generator exposes `protoc-gen-ruby_gapic` on the PATH. By doing
-so, it gives the protobuf compiler the CLI option `--ruby_gapic_out` on which
-you can specify an output path for this generator.
 
-If you want to experiment with an already-existing API, one example is available.
-Note: You need to clone the googleapis repository from GitHub, and change
-to a special branch:
+Installing the cloud-specific generator exposes `protoc-gen-ruby_ads` on the
+PATH. (Note that this name is different from the `protoc-gen-ruby_gapic` plugin
+exposed by the basic generator.) By doing so, it gives the protobuf compiler
+the CLI option `--ruby_ads_out` on which you can specify an output path for
+this generator.
+
+In most cases, in order to generate a functional client library, you must also
+include the Ruby proto and grpc plugins, using the CLI options `--ruby_out` and
+`--grpc_out`.
+
+If you want to experiment with an already-existing API, you can use one of the
+existing Google APIs from https://github.com/googleapis/googleapis.
+First you should get the protos and dependencies:
+
 ```sh
-# Get the protos and it's dependencies.
-$ git clone git@github.com:googleapis/api-common-protos.git
 $ git clone git@github.com:googleapis/googleapis.git
-$ cd googleapis
-$ git checkout --track -b input-contract origin/input-contract
-
-# Now you're ready to compile the API.
-$ protoc google/ads/vision/v1/*.proto \
-    --proto_path=../api-common-protos/ --proto_path=. \
-    --ruby_gapic_out=/dest/
 ```
+
+Now you're ready to compile the API. For example, to compile the Ads V15 API:
+
+```sh
+$ grpc_tools_ruby_protoc google/ads/googleads/v15/*/*.proto \
+    --proto_path=googleapis/ \
+    --ruby_out=/path/to/dest/ \
+    --grpc_out=/path/to/dest/ \
+    --ruby_ads_out=/path/to/dest/ \
+```
+
+Note: most real-world client libraries require additional options to be passed
+to the generator, via the `--ruby_ads_opt` flag. Those options are not covered
+in this document.
+
+## Support
+
+This is not an official Google project. While it is being used internally to
+generate official Google API client libraries, there is no guarantee of support
+or stability for any other use.
+
+As of January 2024, this generator can be run on Ruby 3.0 or later. In general,
+we will make an effort to ensure it is supported on non-end-of-life versions of
+Ruby.
+
+Issues can be filed on GitHub at
+https://github.com/googleapis/gapic-generator-ruby/issues.

--- a/gapic-generator-cloud/README.md
+++ b/gapic-generator-cloud/README.md
@@ -2,83 +2,104 @@
 
 Create Ruby clients from a protocol buffer description of an API.
 
-**Note** This project is a preview. Please try it out and let us know what you think,
-but there are currently no guarantees of stability or support.
+This code is used to generate client libraries for many Google APIs including
+Cloud and Ads services. The `gapic-generator` gem itself includes the main
+generator, whereas the `gapic-generator-cloud` and `gapic-generator-ads` gems
+provide modifications specific to Google Cloud and Google Ads APIs.
 
-## Usage
-### Install the Proto Compiler
-This generator relies on the Protocol Buffer Compiler to [orchestrate] the
-client generation.
+These gems can also be used to create clients for any other API, for Google or
+non-Google services, that use protocol buffers as the description language. The
+generators will work best for APIs that follow the design guidance documented
+in the [Google AIPs](https://aip.dev/). An API that is not AIP-compliant should
+still yield a usable client library, but it may be missing features such as
+idiomatic naming, pagination, or retry configuration.
 
-```sh
-# Declare the protobuf version to use.
-$ export PROTOBUF_VERSION=3.6.1
+**Important:** This is not an official Google project. While it is being used
+internally to generate official Google API client libraries, there is no
+guarantee of support or stability for any other use.
 
-# Declare the target installation system.
-# export SYSTEM=osx
-$ export SYSTEM=linux
+## Using the Ruby gem
 
-# Get the precompiled protobuf compiler.
-$ curl --location https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip > usr/src/protoc/protoc-${PROTOBUF_VERSION}.zip
-$ cd /usr/src/protoc/
-$ unzip protoc-${PROTOBUF_VERSION}.zip
-$ rm protoc-${PROTOBUF_VERSION}.zip
+This section provides a brief getting started guide for the Ruby gem. However,
+we do not release the Ruby gems often, and they may be substantially behind the
+current generator code. In most cases, we recommend generating from the
+GitHub repository directly. See the main README for
+https://github.com/googleapis/gapic-generator-ruby for more information.
 
-# Link the protoc to the path.
-$ ln -s /usr/src/protoc/bin/protoc /usr/local/bin/protoc
-$ mkdir -p /protos/
+### Install the Generator
 
-# Move the common protobuf files to the local include folder.
-$ cp -R /usr/src/protoc/include/* /usr/local/include/
+The generator is a plugin for **protoc**, the protocol buffers compiler, so
+you'll need to install it first, along with the standard protobuf and grpc
+plugins for Ruby. The easiest way to do this is to install the `grpc-tools` gem
+which will provide all three. You can also follow the
+[official install instructions](https://github.com/protocolbuffers/protobuf#protobuf-compiler-installation).
+Note that if you installed protoc using `grpc-tools`, the compiler binary name
+will be named `grpc_tools_ruby_protoc`; otherwise it will likely be `protoc`.
+
+Install the `gapic-generator` gem to get access to the gapic generator plugin.
+Since you are looking at the `gapic-generator-cloud` gem's README, we will
+assume you want Cloud-specific output, so also install `gapic-generator-cloud`.
+
+Alternatively, add all the above to a Gemfile:
+
+```ruby
+# Gemfile
+source "https://rubygems.org/"
+
+gem "grpc-tools"
+gem "gapic-generator"
+gem "gapic-generator-cloud"
 ```
 
-[orchestrate]: https://developers.google.com/protocol-buffers/docs/reference/ruby-generated
-
-### Build and Install the Generator
-This tool is in pre-alpha so it is not yet released to RubyGems. You will have to
-build the generator from scratch.
+And install using bundler:
 
 ```sh
-$ git clone https://github.com/googleapis/gapic-generator-ruby.git
-$ cd gapic-generator-ruby
-$ gem build gapic-generator.gemspec
-$ gem install gapic-generator-0.1.0.gem
-$ which protoc-gen-ruby_gapic
-> {Non-empty path}
+$ bundle install
 ```
 
 ### Generate an API
-Installing this generator exposes `protoc-gen-ruby_gapic` on the PATH. By doing
-so, it gives the protobuf compiler the CLI option `--ruby_gapic_out` on which
-you can specify an output path for this generator.
 
-If you want to experiment with an already-existing API, one example is available.
-Note: You need to clone the googleapis repository from GitHub, and change
-to a special branch:
+Installing the cloud-specific generator exposes `protoc-gen-ruby_cloud` on the
+PATH. (Note that this name is different from the `protoc-gen-ruby_gapic` plugin
+exposed by the basic generator.) By doing so, it gives the protobuf compiler
+the CLI option `--ruby_cloud_out` on which you can specify an output path for
+this generator.
+
+In most cases, in order to generate a functional client library, you must also
+include the Ruby proto and grpc plugins, using the CLI options `--ruby_out` and
+`--grpc_out`.
+
+If you want to experiment with an already-existing API, you can use one of the
+existing Google APIs from https://github.com/googleapis/googleapis.
+First you should get the protos and dependencies:
+
 ```sh
-# Get the protos and it's dependencies.
-$ git clone git@github.com:googleapis/api-common-protos.git
 $ git clone git@github.com:googleapis/googleapis.git
-$ cd googleapis
-$ git checkout --track -b input-contract origin/input-contract
-
-# Now you're ready to compile the API.
-$ protoc google/cloud/vision/v1/*.proto \
-    --proto_path=../api-common-protos/ --proto_path=. \
-    --ruby_gapic_out=/dest/
 ```
 
-## Contributing
+Now you're ready to compile the API. For example, to compile the Vision V1 API:
 
-Contributions to this library are always welcome and highly encouraged.
+```sh
+$ grpc_tools_ruby_protoc google/cloud/vision/v1/*.proto \
+    --proto_path=googleapis/ \
+    --ruby_out=/path/to/dest/ \
+    --grpc_out=/path/to/dest/ \
+    --ruby_cloud_out=/path/to/dest/ \
+```
 
-See the [CONTRIBUTING](CONTRIBUTING.md) documentation for more information on how to get started.
+Note: most real-world client libraries require additional options to be passed
+to the generator, via the `--ruby_cloud_opt` flag. Those options are not
+covered in this document.
 
-## Versioning
+## Support
 
-This library is currently a **preview** with no guarantees of stability or support. Please get
-involved and let us know if you find it useful and we'll work towards a stable version.
+This is not an official Google project. While it is being used internally to
+generate official Google API client libraries, there is no guarantee of support
+or stability for any other use.
 
-## Disclaimer
+As of January 2024, this generator can be run on Ruby 3.0 or later. In general,
+we will make an effort to ensure it is supported on non-end-of-life versions of
+Ruby.
 
-This is not an official Google product.
+Issues can be filed on GitHub at
+https://github.com/googleapis/gapic-generator-ruby/issues.

--- a/gapic-generator/README.md
+++ b/gapic-generator/README.md
@@ -2,24 +2,59 @@
 
 Create Ruby clients from a protocol buffer description of an API.
 
-**Note** This project is a preview. Please try it out and let us know what you think,
-but there are currently no guarantees of stability or support.
+This code is used to generate client libraries for many Google APIs including
+Cloud and Ads services. The `gapic-generator` gem itself includes the main
+generator, whereas the `gapic-generator-cloud` and `gapic-generator-ads` gems
+provide modifications specific to Google Cloud and Google Ads APIs.
 
-## Usage
+These gems can also be used to create clients for any other API, for Google or
+non-Google services, that use protocol buffers as the description language. The
+generators will work best for APIs that follow the design guidance documented
+in the [Google AIPs](https://aip.dev/). An API that is not AIP-compliant should
+still yield a usable client library, but it may be missing features such as
+idiomatic naming, pagination, or retry configuration.
+
+**Important:** This is not an official Google project. While it is being used
+internally to generate official Google API client libraries, there is no
+guarantee of support or stability for any other use.
+
+## Using the Ruby gem
+
+This section provides a brief getting started guide for the Ruby gem. However,
+we do not release the Ruby gems often, and they may be substantially behind the
+current generator code. In most cases, we recommend generating from the
+GitHub repository directly. See the main README for
+https://github.com/googleapis/gapic-generator-ruby for more information.
 
 ### Install the Generator
 
-This tool is in pre-alpha so it is not yet released to RubyGems.
+The generator is a plugin for **protoc**, the protocol buffers compiler, so
+you'll need to install it first, along with the standard protobuf and grpc
+plugins for Ruby. The easiest way to do this is to install the `grpc-tools` gem
+which will provide all three. You can also follow the
+[official install instructions](https://github.com/protocolbuffers/protobuf#protobuf-compiler-installation).
+Note that if you installed protoc using `grpc-tools`, the compiler binary name
+will be named `grpc_tools_ruby_protoc`; otherwise it will likely be `protoc`.
+
+Install the `gapic-generator` gem to get access to the gapic generator plugin.
+
+Optionally install either `gapic-generator-cloud` or `gapic-generator-ads` if
+you want access to cloud-specific or ads-specific output.
+
+Alternatively, add all the above to a Gemfile:
+
+```ruby
+# Gemfile
+source "https://rubygems.org/"
+
+gem "grpc-tools"
+gem "gapic-generator"
+```
+
+And install using bundler:
 
 ```sh
-$ git clone https://github.com/googleapis/gapic-generator-ruby.git
-$ cd gapic-generator-ruby
-$ git submodule update --init
-$ cd gapic-generator
 $ bundle install
-$ bundle exec rake install
-$ which protoc-gen-ruby_gapic
-> {Non-empty path}
 ```
 
 ### Generate an API
@@ -28,45 +63,44 @@ Installing this generator exposes `protoc-gen-ruby_gapic` on the PATH. By doing
 so, it gives the protobuf compiler the CLI option `--ruby_gapic_out` on which
 you can specify an output path for this generator.
 
-If you want to experiment with an already-existing API, one example is available.
+In most cases, in order to generate a functional client library, you must also
+include the Ruby proto and grpc plugins, using the CLI options `--ruby_out` and
+`--grpc_out`.
+
+If you want to experiment with an already-existing API, you can use one of the
+existing Google APIs from https://github.com/googleapis/googleapis.
 First you should get the protos and dependencies:
 
 ```sh
-$ git clone git@github.com:googleapis/api-common-protos.git
 $ git clone git@github.com:googleapis/googleapis.git
 ```
 
-Now you're ready to compile the API:
+Now you're ready to compile the API. For example, to compile the Vision V1 API:
 
 ```sh
-$ protoc google/cloud/vision/v1/*.proto \
-    --proto_path=api-common-protos/ \
-    --proto_path=googleapis/ \
-    --ruby_gapic_out=/dest/
-```
-
-Or, if you don't have `protoc` installed, you can use `grpc_tools_ruby_protoc`
-from the `grpc-tools` gem:
-
-```sh
-$ gem install grpc-tools
 $ grpc_tools_ruby_protoc google/cloud/vision/v1/*.proto \
-    --proto_path=api-common-protos/ \
     --proto_path=googleapis/ \
-    --ruby_gapic_out=/dest/
+    --ruby_out=/path/to/dest/ \
+    --grpc_out=/path/to/dest/ \
+    --ruby_gapic_out=/path/to/dest/ \
 ```
 
-## Contributing
+Note: most real-world client libraries require additional options to be passed
+to the generator, via the `--ruby_gapic_opt` flag. Those options are not
+covered in this document.
 
-Contributions to this library are always welcome and highly encouraged.
+If you want to use `gapic-generator-cloud` or `gapic-generator-ads`, see the
+README for that gem for specific information.
 
-See the [CONTRIBUTING](CONTRIBUTING.md) documentation for more information on how to get started.
+## Support
 
-## Versioning
+This is not an official Google project. While it is being used internally to
+generate official Google API client libraries, there is no guarantee of support
+or stability for any other use.
 
-This library is currently a **preview** with no guarantees of stability or support. Please get
-involved and let us know if you find it useful and we'll work towards a stable version.
+As of January 2024, this generator can be run on Ruby 3.0 or later. In general,
+we will make an effort to ensure it is supported on non-end-of-life versions of
+Ruby.
 
-## Disclaimer
-
-This is not an official Google product.
+Issues can be filed on GitHub at
+https://github.com/googleapis/gapic-generator-ruby/issues.

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,28 +1,91 @@
-# Shared files and tasks for Ruby API Client Generator gems
+# Test resources for Ruby API Client Generator gems
 
-This directory contains the tasks and files used for the gapic generator gems.
-Including the repository for the shared protos and their binary files, as well
-as the mechanism to generate new binary files.
+This directory contains test resources for the gapic generator gems, including
+the "golden" outputs used as the principal test cases. Specifically includes:
+
+* Repository submodules for source protos in the `googleapis` directory
+* Input protos for test cases that are not part of `googleapis`, in the
+  `protos` directory
+* Configuration files for golden outputs in the `config` directory and
+  `gem_defaults.rb` file
+* Proto input in binary format in the `input` directory, which can be fed
+  directly into the generator plugin without running `protoc`
+* Test inputs for the legacy samplegen system in the `samples` directory
+* Test inputs for snippetgen in the `snippet_config` directory
+* Golden outputs themselves in the `output` directory
+* Runtime tests of generated golden outputs in the `test` directory
 
 ## Usage
 
-### Generating Binary Input files
+### Generating golden outputs
 
-The binary input files can be generated using the `gen` rake task:
+Regenerate all golden outputs by running:
 
 ```sh
 $ cd shared
-$ bundle update
-$ bundle exec rake gen
+$ bundle install
+$ toys gen
 ```
 
-## Showcase Tests
+You can regenerate golden outputs for specific golden services by passing them
+as arguments to `toys gen`. You can also specify which generator to use.
+
+```sh
+$ cd shared
+$ bundle install
+$ toys gen --generator=cloud vision_v1
+```
+
+### Generating binary input files
+
+Regenerate all binary input files by running:
+
+```sh
+$ cd shared
+$ bundle install
+$ toys bin
+```
+
+You can regenerate binary inputs for specific golden services by passing them
+as arguments to `toys bin`. You can also specify which generator to use.
+
+```sh
+$ cd shared
+$ bundle install
+$ toys bin --generator=cloud vision_v1
+```
+
+### Running Tests
 
 This project includes a functional test suite for the Ruby GAPIC generator. See
 [Showcase](https://github.com/googleapis/gapic-showcase) for more details.
 
 ```sh
 $ cd shared
-$ bundle update
-$ bundle exec rake test:showcase
+$ bundle install
+$ toys test showcase
+```
+
+There are also a set of functional tests that use the vision golden output:
+
+```sh
+$ cd shared
+$ bundle install
+$ toys test vision
+```
+
+You can also run CI (test, rubocop, yard) on all generated goldens:
+
+```sh
+$ cd shared
+$ bundle install
+$ toys test output
+```
+
+Run all above tests by:
+
+```sh
+$ cd shared
+$ bundle install
+$ toys test
 ```


### PR DESCRIPTION
Reworks the readmes in the gapic-generator, gapic-generator-cloud, and gapic-generator-ads directories, so that:

* They are up to date for current usage
* They no longer reference rakefiles or other tools that are no longer present
* They make sense for the gem releases

Closes #1033.
