### PR TITLE
feat(gapic-showcase): remove dependency on gapic-showcase docker images for tests

### DIFF
--- a/shared/test/showcase/test_helper.rb
+++ b/shared/test/showcase/test_helper.rb
@@ -22,10 +22,6 @@ require "tmpdir"
 
 # @private
 GAPIC_SHOWCASE_VERSION = '0.30.0'
-# @private
-HOST_OS = 'linux'
-# @private
-HOST_ARCH = 'amd64'
 
 def generate_library_for_test imports, protos
   client_lib = Dir.mktmpdir
@@ -50,6 +46,23 @@ end
 
 def gapic_showcase_running?
   system("ps aux | grep 'gapic-showcase run' | grep -v grep > /dev/null")
+end
+
+def tar_file_name
+  file_name = "gapic-showcase-#{GAPIC_SHOWCASE_VERSION}-"
+  case RUBY_PLATFORM
+  when /x86_64-linux/
+    file_name += "linux-amd64.tar.gz"
+  when /x86_64-darwin-\d+/
+    file_name += "darwin-amd64.tar.gz"
+  when /arm-linux/
+    file_name += "linux-arm.tar.gz"
+  when /arm64-darwin-\d+/
+    file_name += "darwin-arm64.tar.gz"
+  else
+    raise "Generator not supported for platform #{RUBY_PLATFORM}."
+  end
+  file_name
 end
 
 class ShowcaseTest < Minitest::Test
@@ -90,7 +103,6 @@ class ShowcaseTest < Minitest::Test
     if ENV['CI'].nil?
       unless gapic_showcase_running?
         log_file = "/tmp/gapic-showcase.log"
-        tar_file_name = "gapic-showcase-#{GAPIC_SHOWCASE_VERSION}-#{HOST_OS}-#{HOST_ARCH}.tar.gz"
         url = "https://github.com/googleapis/gapic-showcase/releases/download/v#{GAPIC_SHOWCASE_VERSION}/#{tar_file_name}"
         _, status = Open3.capture2 "curl -sSL #{url} | tar -zx --directory /tmp/"
         raise "failed to start showcase" unless status.exitstatus.zero?

--- a/shared/test/showcase/test_helper.rb
+++ b/shared/test/showcase/test_helper.rb
@@ -53,11 +53,11 @@ def tar_file_name
   case RUBY_PLATFORM
   when /x86_64-linux/
     file_name += "linux-amd64.tar.gz"
-  when /x86_64-darwin-\d+/
+  when /x86_64-darwin\d+/
     file_name += "darwin-amd64.tar.gz"
   when /arm-linux/
     file_name += "linux-arm.tar.gz"
-  when /arm64-darwin-\d+/
+  when /arm64-darwin\d+/
     file_name += "darwin-arm64.tar.gz"
   else
     raise "Generator not supported for platform #{RUBY_PLATFORM}."
@@ -102,11 +102,12 @@ class ShowcaseTest < Minitest::Test
     server_id = nil
     if ENV['CI'].nil?
       unless gapic_showcase_running?
-        log_file = "/tmp/gapic-showcase.log"
+        tmp_dir = Dir.mktmpdir "gapic-show-case-#{Time.now.to_i}"
+        log_file = "#{tmp_dir}/gapic-showcase.log"
         url = "https://github.com/googleapis/gapic-showcase/releases/download/v#{GAPIC_SHOWCASE_VERSION}/#{tar_file_name}"
-        _, status = Open3.capture2 "curl -sSL #{url} | tar -zx --directory /tmp/"
+        _, status = Open3.capture2 "curl -sSL #{url} | tar -zx --directory #{tmp_dir}/"
         raise "failed to start showcase" unless status.exitstatus.zero?
-        server_id = Process.spawn('/tmp/gapic-showcase run', :out => [log_file, "w"])
+        server_id = Process.spawn("#{tmp_dir}/gapic-showcase run", :out => [log_file, "w"])
         puts "Started showcase server (id: #{server_id}) > #{log_file}." if ENV["VERBOSE"]
       else
         puts "Existing showcase server is available. Continuing..." if ENV["VERBOSE"]

--- a/shared/test/showcase/test_helper.rb
+++ b/shared/test/showcase/test_helper.rb
@@ -95,9 +95,9 @@ class ShowcaseTest < Minitest::Test
         _, status = Open3.capture2 "curl -sSL #{url} | tar -zx --directory /tmp/"
         raise "failed to start showcase" unless status.exitstatus.zero?
         server_id = Process.spawn('/tmp/gapic-showcase run', :out => [log_file, "w"])
-        puts "Started showcase server (id: #{server_id}) > #{log_file}."
+        puts "Started showcase server (id: #{server_id}) > #{log_file}." if ENV["VERBOSE"]
       else
-        puts "Existing showcase server is available. Continuing..."
+        puts "Existing showcase server is available. Continuing..." if ENV["VERBOSE"]
       end
     end
 
@@ -116,7 +116,7 @@ class ShowcaseTest < Minitest::Test
     FileUtils.remove_dir @showcase_library, true
 
     unless @showcase_id.nil?
-      puts "Stopping showcase server (id: #{@showcase_id})..."
+      puts "Stopping showcase server (id: #{@showcase_id})..." if ENV["VERBOSE"]
       _, status = Open3.capture2 "kill #{@showcase_id}"
       raise "failed to kill showcase" unless status.exitstatus.zero?
     end


### PR DESCRIPTION
Fetches and executes `gapic-showcase` based on releases instead of relying on docker images. This approach is used in other generators already (such as in `gapic-generator-go`).

Added logic to not spawn a new server if one is already running.

Fixes #1038