### PR TITLE
fix: Require OpenStruct in CloudApiTest

### DIFF
--- a/gapic-generator-cloud/test/test_helper.rb
+++ b/gapic-generator-cloud/test/test_helper.rb
@@ -25,6 +25,7 @@ require "action_view"
 
 require "minitest/autorun"
 require "minitest/focus"
+require "ostruct"
 
 class GeneratorTest < Minitest::Test
   ##


### PR DESCRIPTION
We are still missing requiring it in test_helper for CloudApiTest. This unblocks a generator release (v0.30.0, PR #1067): https://github.com/googleapis/gapic-generator-ruby/actions/runs/8823686423/job/24224662659?pr=1067