### PR TITLE
feat: Use module name to prevent keyword collision with enum values

### DIFF
--- a/gapic-generator/lib/gapic/presenters/enum_value_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/enum_value_presenter.rb
@@ -28,7 +28,7 @@ module Gapic
 
       # @return [String] The enum value name without keyword collision.
       def name
-        Gapic::RubyInfo.keywords.include?(@value.name) ? "self::#{@value.name}" : @value.name
+        Gapic::RubyInfo.keywords.include?(@value.name) ? "#{@value.parent.name}::#{@value.name}" : @value.name
       end
 
       def doc_description

--- a/gapic-generator/test/gapic/presenters/enum_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/enum_presenter_test.rb
@@ -18,17 +18,17 @@ require "test_helper"
 
 class EnumValuePresenterTest < PresenterTest
   def typical_garbage_enum_value enum_value
-    enum_value_presenter :garbage, "garbage/garbage.proto", "GarbageEnum", enum_value 
+    enum_value_presenter :garbage, "garbage/garbage.proto", "GarbageEnum", enum_value
   end
-  
+
   def test_enum_value_name_no_keyword_collision
     evp = typical_garbage_enum_value 3
     assert_equal "DUMPSTER", evp.name
   end
 
+  focus
   def test_enum_value_name_with_keyword_collision
     evp = typical_garbage_enum_value 4
-    assert_equal "self::END", evp.name
+    assert_equal "GarbageEnum::END", evp.name
   end
 end
-

--- a/gapic-generator/test/gapic/presenters/enum_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/enum_presenter_test.rb
@@ -26,7 +26,6 @@ class EnumValuePresenterTest < PresenterTest
     assert_equal "DUMPSTER", evp.name
   end
 
-  focus
   def test_enum_value_name_with_keyword_collision
     evp = typical_garbage_enum_value 4
     assert_equal "GarbageEnum::END", evp.name

--- a/shared/output/gapic/templates/garbage/proto_docs/garbage/garbage.rb
+++ b/shared/output/gapic/templates/garbage/proto_docs/garbage/garbage.rb
@@ -456,7 +456,7 @@ module So
         DUMPSTER = 3
 
         # The end of garbage.
-        self::END = 4
+        GarbageEnum::END = 4
       end
     end
   end


### PR DESCRIPTION
A slight change from #1061 in order to be compatible with yard. It now uses the module name instead of `self`.