### PR TITLE
chore: Resolve BigDecimal warning

### DIFF
--- a/gapic-generator/gapic-generator.gemspec
+++ b/gapic-generator/gapic-generator.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.7"
 
   spec.add_dependency "actionpack", "~> 5.2"
+  spec.add_dependency "bigdecimal", "~> 3.0"
   spec.add_dependency "googleapis-common-protos-types", "~> 1.8"
   spec.add_dependency "google-cloud-common", "~> 1.2"
   spec.add_dependency "google-protobuf", "~> 3.25", ">= 3.25.1"


### PR DESCRIPTION
This PR updates the gemspec to add an explicit dependency on the [bigdecimal gem](https://rubygems.org/gems/bigdecimal). This resolves the following warning:

```
warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec.
```
