### PR TITLE
feat: Support timeout-based polling

### DIFF
--- a/gapic-common/lib/gapic/common/polling_harness.rb
+++ b/gapic-common/lib/gapic/common/polling_harness.rb
@@ -43,15 +43,15 @@ module Gapic
       #
       # Errors are raised if not listed in `retry_codes`, and re-attempted otherwise.
       #
-      # The retry policy's `timeout` value is _NOT_ taken into consideration. The block
-      # will be re-attempted indefinitely as long as the retry conditions above
-      # passes.
+      # The block will be re-attempted indefinitely as long as the retry condition
+      # passes or while a timeout has not been reached.
       #
       # @yieldreturn [Object, nil] Custom logic to be retriable.
       def wait
         unless block_given?
           raise ArgumentError, "No callback provided to wait method."
         end
+        retry_policy.update_deadline!
         loop do
           begin
             response = yield
@@ -60,6 +60,7 @@ module Gapic
             raise unless retry_policy.retry_error? e
           end
           retry_policy.perform_delay!
+          return response unless retry_policy.retry_with_deadline?
         end
       end
     end

--- a/gapic-common/test/gapic/common/polling_harness_test.rb
+++ b/gapic-common/test/gapic/common/polling_harness_test.rb
@@ -101,4 +101,15 @@ class PollingHarnessTest < Minitest::Test
       polling_harness.wait
     end
   end
+
+  def test_wait_with_timeout
+    retry_policy = Gapic::Common::RetryPolicy.new initial_delay: 2, multiplier: 1, timeout: 3
+    polling_harness = Gapic::Common::PollingHarness.new retry_policy: retry_policy
+    wait_count = 0
+    polling_harness.wait do
+      wait_count += 1
+      nil
+    end
+    assert_equal 2, wait_count
+  end
 end

--- a/gapic-common/test/gapic/common/retry_policy_test.rb
+++ b/gapic-common/test/gapic/common/retry_policy_test.rb
@@ -58,4 +58,11 @@ class RetryPolicyTest < Minitest::Test
     retry_policy.perform_delay!
     assert_equal 12, retry_policy.delay
   end
+
+  def test_retry_policy_deadline_init
+    Process.stub :clock_gettime, 123456789.0 do
+      retry_policy = Gapic::Common::RetryPolicy.new timeout: 10
+      assert_equal 123456799.0, retry_policy.send(:deadline)
+    end
+  end
 end


### PR DESCRIPTION
Re-opening this PR after moving all changes to a new `gapic-polling-harness` branch. The polling harness logic was originally reverted in #1083. We will keep all changes in `gapic-polling-harness` for later usage.

**Original PR #1081 description:**

Start supporting timeouts in the gapic polling harness. 

It removes the need for clients to keep track of their own time variables, as it is done [here](https://github.com/googleapis/google-cloud-ruby/blob/2408f6614065c56046f557b67a29dffc6c43c931/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb#L569) in bigtable.

Note: timeout deadline is calculated based on when the method `wait` is called. Late initialization can cause off-by-one errors.

Next PR integrates this change for testing in bigtable.