### PR TITLE
feat: Disable xrefs for README files

### DIFF
--- a/gapic-generator-cloud/lib/gapic/presenters/wrapper_gem_presenter.rb
+++ b/gapic-generator-cloud/lib/gapic/presenters/wrapper_gem_presenter.rb
@@ -66,6 +66,18 @@ module Gapic
         gem_config :migration_version
       end
 
+      ##
+      # Generates a description text for README files, accounting for markdown
+      # rendering, properly escaping variables and disabling xrefs in the wrapper.
+      #
+      # @return [Array<String>] The description text as an array of lines.
+      #
+      def readme_description
+        has_markdown = description.strip.start_with? "#"
+        desc = has_markdown ? description.split("\n") : [description.gsub(/\s+/, " ").strip]
+        Gapic::FormattingUtils.format_doc_lines @api, desc, disable_xrefs: true
+      end
+
       # A description of the versions prior to the migration version.
       # Could be "a.x" if the migration version is 1.0 or later, otherwise
       # falls back to "pre-a.b".

--- a/gapic-generator-cloud/test/gapic/presenters/wrapper_gem_presenter_test.rb
+++ b/gapic-generator-cloud/test/gapic/presenters/wrapper_gem_presenter_test.rb
@@ -142,4 +142,13 @@ class WrapperGemPresenterTest < PresenterTest
     presenter_param = Gapic::Presenters::WrapperGemPresenter.new api_param
     refute_includes presenter_param.services.map { |s| s.address.join "." }, "google.cloud.location.Locations"
   end
+
+  def test_gem_readme_disabled_xrefs
+    complex_version_param = {
+      ":gem.:description" => "Typical Garbage Service using [MixIns][testing.mixins.ServiceWithLoc]"
+    }
+    api_param = api :testing, params_override: complex_version_param
+    presenter_param = Gapic::Presenters::WrapperGemPresenter.new api_param
+    assert_equal ["Typical Garbage Service using MixIns"], presenter_param.readme_description
+  end
 end

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -134,7 +134,7 @@ module Gapic
       def readme_description
         has_markdown = description.strip.start_with? "#"
         desc = has_markdown ? description.split("\n") : [description.gsub(/\s+/, " ").strip]
-        Gapic::FormattingUtils.format_doc_lines @api, desc
+        Gapic::FormattingUtils.format_doc_lines @api, desc, disable_xrefs: true
       end
 
       def summary

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -134,7 +134,7 @@ module Gapic
       def readme_description
         has_markdown = description.strip.start_with? "#"
         desc = has_markdown ? description.split("\n") : [description.gsub(/\s+/, " ").strip]
-        Gapic::FormattingUtils.format_doc_lines @api, desc, disable_xrefs: true
+        Gapic::FormattingUtils.format_doc_lines @api, desc
       end
 
       def summary

--- a/gapic-generator/test/gapic/formatting_utils_test.rb
+++ b/gapic-generator/test/gapic/formatting_utils_test.rb
@@ -387,6 +387,16 @@ class FormattingUtilsTest < Minitest::Test
     assert_equal ["Hello, {::Google::Cloud::Example::Earth::Client World}!\n"], result
   end
 
+  def test_disable_xref_for_service
+    api = FakeApi.new do |api|
+      api.add_file! "google.cloud.example" do
+        api.add_service! "Earth"
+      end
+    end
+    result = Gapic::FormattingUtils.format_doc_lines api, ["Hello, [World][google.cloud.example.Earth]!\n"], disable_xrefs: true
+    assert_equal ["Hello, World!\n"], result
+  end
+
   def test_xref_service_rest
     api = FakeApi.new do |api|
       api.add_file! "google.cloud.example" do


### PR DESCRIPTION
Relates to https://github.com/googleapis/google-cloud-ruby/pull/26629

Pass a `true` value for `disable_xrefs` in other to avoid broken reference to versioned gems, from the wrapper gems.