### PR TITLE
feat: Support local binding for variables with keyword collision

### DIFF
--- a/gapic-generator/lib/gapic/path_pattern/parser.rb
+++ b/gapic-generator/lib/gapic/path_pattern/parser.rb
@@ -118,7 +118,7 @@ module Gapic
         match = simple_resource_id_regex.match url_pattern
         segment_pattern = match[:segment_pattern]
 
-        resource_name = format_variable match[:resource_name]
+        resource_name = ActiveSupport::Inflector.underscore match[:resource_name]
         resource_pattern = match[:resource_pattern] if match.names.include? "resource_pattern"
         resource_patterns = resource_pattern.nil? ? [] : [resource_pattern]
 
@@ -147,17 +147,8 @@ module Gapic
       # @private
       def self.format_pattern pattern
         pattern.gsub(/\{([a-zA-Z0-9_]+)\}/) do
-          "{#{format_variable(::Regexp.last_match(1))}}"
+          "{#{ActiveSupport::Inflector.underscore ::Regexp.last_match(1)}}"
         end
-      end
-
-      # Formats path pattern variables to snake case and resolves
-      # naming conflicts with reserved keywords.
-      # @private
-      def self.format_variable name
-        name = ActiveSupport::Inflector.underscore name
-        name = "#{name}_param" if Gapic::RubyInfo.keywords.include? name
-        name
       end
     end
   end

--- a/gapic-generator/lib/gapic/path_pattern/segment.rb
+++ b/gapic-generator/lib/gapic/path_pattern/segment.rb
@@ -210,7 +210,13 @@ module Gapic
       # Path string for this segment
       # @return [String]
       def path_string
-        type == :simple_resource_id ? "\#{#{resource_names[0]}}" : pattern.gsub("{", "\#{")
+        if type == :simple_resource_id
+          name = resource_names[0]
+          name = "binding.local_variable_get :#{name}" if Gapic::RubyInfo.keywords.include? name
+          "\#{#{name}}"
+        else
+          pattern.gsub "{", "\#{"
+        end
       end
 
       ##

--- a/gapic-generator/test/gapic/presenters/pattern_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/pattern_presenter_test.rb
@@ -75,8 +75,8 @@ class PatternPresenterTest < PresenterTest
   def test_reserved_keyword_segment_pattern
     pattern = "modules/{module}/cases/{case}"
     presenter = Gapic::Presenters::ResourcePresenter::PatternPresenter.new pattern
-    assert_equal ["module_param", "case_param"], presenter.arguments
-    assert_equal "modules/{module_param}/cases/{case_param}", presenter.pattern
-    assert_equal "modules/\#{module_param}/cases/\#{case_param}", presenter.path_string
+    assert_equal ["module", "case"], presenter.arguments
+    assert_equal "modules/{module}/cases/{case}", presenter.pattern
+    assert_equal "modules/\#{binding.local_variable_get :module}/cases/\#{binding.local_variable_get :case}", presenter.path_string
   end
 end

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/paths.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/paths.rb
@@ -186,13 +186,13 @@ module So
           #
           #   @param request [String]
           #
-          # @overload resource_name_pattern_request_path(customer:, case_param:)
+          # @overload resource_name_pattern_request_path(customer:, case:)
           #   The resource will be in the following format:
           #
-          #   `customers/{customer}/cases/{case_param}`
+          #   `customers/{customer}/cases/{case}`
           #
           #   @param customer [String]
-          #   @param case_param [String]
+          #   @param case [String]
           #
           # @return [::String]
           def resource_name_pattern_request_path **args
@@ -205,10 +205,10 @@ module So
               "request" => (proc do |request:|
                 "patternrequests/#{request}"
               end),
-              "case_param:customer" => (proc do |customer:, case_param:|
+              "case:customer" => (proc do |customer:, case:|
                 raise ::ArgumentError, "customer cannot contain /" if customer.to_s.include? "/"
 
-                "customers/#{customer}/cases/#{case_param}"
+                "customers/#{customer}/cases/#{binding.local_variable_get :case}"
               end)
             }
 

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_paths_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_paths_test.rb
@@ -120,7 +120,7 @@ class ::So::Much::Trash::ResourceNames::ClientPathsTest < Minitest::Test
       path = client.resource_name_pattern_request_path request: "value0"
       assert_equal "patternrequests/value0", path
 
-      path = client.resource_name_pattern_request_path customer: "value0", case_param: "value1"
+      path = client.resource_name_pattern_request_path customer: "value0", case: "value1"
       assert_equal "customers/value0/cases/value1", path
     end
   end


### PR DESCRIPTION
Reverting changes from https://github.com/googleapis/gapic-generator-ruby/pull/1096 and adding `binding.local_variable_get` for collisions from the generator.