### PR TITLE
fix: Add missing local binding in resource path methods

### DIFF
--- a/gapic-generator/lib/gapic/presenters/resource_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/resource_presenter.rb
@@ -77,7 +77,7 @@ module Gapic
 
         # @return [String] The conflicting argument name escaped with local binding.
         def escape_argument arg
-          Gapic::RubyInfo.keywords.include?(arg) ? "binding.local_variable_get :#{arg}" : arg
+          Gapic::RubyInfo.keywords.include?(arg) ? "binding.local_variable_get(:#{arg})" : arg
         end
 
         def formal_arguments

--- a/gapic-generator/lib/gapic/presenters/resource_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/resource_presenter.rb
@@ -75,6 +75,11 @@ module Gapic
           @parsed_pattern.arguments
         end
 
+        # @return [String] The conflicting argument name escaped with local binding.
+        def escape_argument arg
+          Gapic::RubyInfo.keywords.include?(arg) ? "binding.local_variable_get :#{arg}" : arg
+        end
+
         def formal_arguments
           @parsed_pattern.arguments.map { |name| "#{name}:" }.join ", "
         end

--- a/gapic-generator/templates/default/service/client/resource/_def.erb
+++ b/gapic-generator/templates/default/service/client/resource/_def.erb
@@ -1,6 +1,7 @@
 <%- assert_locals pattern -%>
 <%- pattern.arguments[0...-1].each do |arg| -%>
-raise ::ArgumentError, "<%= arg %> cannot contain /" if <%= arg %>.to_s.include? "/"
+<% escaped_argument = pattern.escape_argument arg %>
+raise ::ArgumentError, "<%= arg %> cannot contain /" if <%= escaped_argument %>.to_s.include? "/"
 <%- end -%>
 
 "<%= pattern.path_string %>"

--- a/gapic-generator/test/gapic/presenters/pattern_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/pattern_presenter_test.rb
@@ -76,7 +76,7 @@ class PatternPresenterTest < PresenterTest
     pattern = "modules/{module}/cases/{case}"
     presenter = Gapic::Presenters::ResourcePresenter::PatternPresenter.new pattern
     assert_equal ["module", "case"], presenter.arguments
-    assert_equal ["binding.local_variable_get :module", "binding.local_variable_get :case"], presenter.arguments.map { |arg| presenter.escape_argument arg }
+    assert_equal ["binding.local_variable_get(:module)", "binding.local_variable_get(:case)"], presenter.arguments.map { |arg| presenter.escape_argument arg }
     assert_equal "modules/{module}/cases/{case}", presenter.pattern
     assert_equal "modules/\#{binding.local_variable_get :module}/cases/\#{binding.local_variable_get :case}", presenter.path_string
   end

--- a/gapic-generator/test/gapic/presenters/pattern_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/pattern_presenter_test.rb
@@ -76,6 +76,7 @@ class PatternPresenterTest < PresenterTest
     pattern = "modules/{module}/cases/{case}"
     presenter = Gapic::Presenters::ResourcePresenter::PatternPresenter.new pattern
     assert_equal ["module", "case"], presenter.arguments
+    assert_equal ["binding.local_variable_get :module", "binding.local_variable_get :case"], presenter.arguments.map { |arg| presenter.escape_argument arg }
     assert_equal "modules/{module}/cases/{case}", presenter.pattern
     assert_equal "modules/\#{binding.local_variable_get :module}/cases/\#{binding.local_variable_get :case}", presenter.path_string
   end


### PR DESCRIPTION
Addressing the last part of local binding causing an issue in https://github.com/googleapis/google-cloud-ruby/pull/27013

The name needs to be the original argument name within the string, so I am creating a separate method within the presenter to escape it.

This is part of `resource/_def.erb`.

Previous implementation in #1110