### PR TITLE
feat: Disable universe domain check if credentials include an explicit request to do so

### DIFF
--- a/gapic-common/.rubocop.yml
+++ b/gapic-common/.rubocop.yml
@@ -6,19 +6,13 @@ AllCops:
     - "test/**/*"
 
 Metrics/ClassLength:
-  Exclude:
-    - "lib/gapic/generic_lro/operation.rb"
-    - "lib/gapic/rest/grpc_transcoder.rb"
+  Max: 200
 
 Metrics/CyclomaticComplexity:
-  Exclude:
-    - "lib/gapic/headers.rb"
-    - "lib/gapic/rest/client_stub.rb"
+  Max: 15
 
 Metrics/PerceivedComplexity:
-  Exclude:
-    - "lib/gapic/headers.rb"
-    - "lib/gapic/rest/client_stub.rb"
+  Max: 15
 
 Naming/FileName:
   Exclude:

--- a/gapic-common/lib/gapic/headers.rb
+++ b/gapic-common/lib/gapic/headers.rb
@@ -19,6 +19,8 @@ require "gapic/common/version"
 module Gapic
   # A collection of common header values.
   module Headers
+    # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+
     ##
     # @param ruby_version [String] The ruby version. Defaults to `RUBY_VERSION`.
     # @param lib_name [String] The client library name.
@@ -32,6 +34,7 @@ module Gapic
     #     `:grpc` to send the GRPC library version (if defined)
     #     `:rest` to send the REST library version (if defined)
     #   Defaults to `[:grpc]`
+    #
     def self.x_goog_api_client ruby_version: nil, lib_name: nil, lib_version: nil, gax_version: nil,
                                gapic_version: nil, grpc_version: nil, rest_version: nil, protobuf_version: nil,
                                transports_version_send: [:grpc]
@@ -52,4 +55,6 @@ module Gapic
       x_goog_api_client_header.join " ".freeze
     end
   end
+
+  # rubocop:enable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
 end

--- a/gapic-common/lib/gapic/universe_domain_concerns.rb
+++ b/gapic-common/lib/gapic/universe_domain_concerns.rb
@@ -63,10 +63,11 @@ module Gapic
       universe_domain ||= ENV["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] || "googleapis.com"
       endpoint ||= endpoint_template.sub ENDPOINT_SUBSTITUTION, universe_domain
 
-      if credentials.respond_to?(:universe_domain) && credentials.universe_domain != universe_domain &&
-         !(credentials.respond_to?(:disable_universe_domain_check) && credentials.disable_universe_domain_check)
-        raise UniverseDomainMismatch,
-              "Universe domain is #{universe_domain} but credentials are in #{credentials.universe_domain}"
+      unless credentials.respond_to?(:disable_universe_domain_check) && credentials.disable_universe_domain_check
+        if credentials.respond_to?(:universe_domain) && credentials.universe_domain != universe_domain
+          raise UniverseDomainMismatch,
+                "Universe domain is #{universe_domain} but credentials are in #{credentials.universe_domain}"
+        end
       end
 
       @universe_domain = universe_domain

--- a/gapic-common/lib/gapic/universe_domain_concerns.rb
+++ b/gapic-common/lib/gapic/universe_domain_concerns.rb
@@ -60,11 +60,11 @@ module Gapic
       raise ArgumentError, "endpoint or endpoint_template is required" if endpoint.nil? && endpoint_template.nil?
       raise ArgumentError, "credentials is required" if credentials.nil?
 
-      # TODO: The env logic should live in google-cloud-env
       universe_domain ||= ENV["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] || "googleapis.com"
       endpoint ||= endpoint_template.sub ENDPOINT_SUBSTITUTION, universe_domain
 
-      if credentials.respond_to?(:universe_domain) && credentials.universe_domain != universe_domain
+      if credentials.respond_to?(:universe_domain) && credentials.universe_domain != universe_domain &&
+         !(credentials.respond_to?(:disable_universe_domain_check) && credentials.disable_universe_domain_check)
         raise UniverseDomainMismatch,
               "Universe domain is #{universe_domain} but credentials are in #{credentials.universe_domain}"
       end

--- a/gapic-common/lib/gapic/universe_domain_concerns.rb
+++ b/gapic-common/lib/gapic/universe_domain_concerns.rb
@@ -63,11 +63,10 @@ module Gapic
       universe_domain ||= ENV["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] || "googleapis.com"
       endpoint ||= endpoint_template.sub ENDPOINT_SUBSTITUTION, universe_domain
 
-      unless credentials.respond_to?(:disable_universe_domain_check) && credentials.disable_universe_domain_check
-        if credentials.respond_to?(:universe_domain) && credentials.universe_domain != universe_domain
-          raise UniverseDomainMismatch,
-                "Universe domain is #{universe_domain} but credentials are in #{credentials.universe_domain}"
-        end
+      if !(credentials.respond_to?(:disable_universe_domain_check) && credentials.disable_universe_domain_check) &&
+         credentials.respond_to?(:universe_domain) && credentials.universe_domain != universe_domain
+        raise UniverseDomainMismatch,
+              "Universe domain is #{universe_domain} but credentials are in #{credentials.universe_domain}"
       end
 
       @universe_domain = universe_domain

--- a/gapic-common/test/gapic/grpc/service_stub_test.rb
+++ b/gapic-common/test/gapic/grpc/service_stub_test.rb
@@ -52,6 +52,12 @@ class ServiceStubTest < Minitest::Test
     end
   end
 
+  FakeCredentialsWithDisabledCheck = Class.new FakeCredentials do
+    def disable_universe_domain_check
+      true
+    end
+  end
+
   FakeRpcCall = Class.new do
     def initialize method_stub
       @method_stub = method_stub
@@ -268,6 +274,14 @@ class ServiceStubTest < Minitest::Test
                              endpoint_template: "myservice.$UNIVERSE_DOMAIN$",
                              credentials: creds
     end
+  end
+
+  def test_universe_domain_credentials_with_mismatch_disabled
+    creds = FakeCredentialsWithDisabledCheck.new universe_domain: "myuniverse.com"
+    service_stub = Gapic::ServiceStub.new FakeGrpcStub,
+                                          endpoint_template: "myservice.$UNIVERSE_DOMAIN$",
+                                          credentials: creds
+    assert_equal "googleapis.com", service_stub.universe_domain
   end
 
   def test_endpoint_override


### PR DESCRIPTION
This is Ruby's response to internal issue b/349488459. In a separate PR for the auth library (https://github.com/googleapis/google-auth-library-ruby/pull/493), we add a (temporary, optional) attribute (`disable_universe_domain_check`) to credential objects that signals the credential may incorrectly claim googleapis as its universe domain. This will be used for GCECredentials temporarily; when set (which for now it will be), GCECredentials will not query the metadata server for universe domain but will instead hard-code `googleapis.com`. Then, this PR for gapic-common will check for the `disable_universe_domain_check` attribute, and if present and set, will not perform the universe domain consistency check. This will effectively stop universe domain MDS calls and checks for GCE credentials while leaving them active for all other credential types. It will also not break existing normal (googleapis) users because those credential objects will continue to report `googleapis.com` as the universe. Early testers of non-googleapis universes will simply have to update both the googleauth and gapic-common gems.