### PR TITLE
chore: Disable safe navigation lint in gapic-generator

### DIFF
--- a/gapic-generator/.rubocop.yml
+++ b/gapic-generator/.rubocop.yml
@@ -17,6 +17,9 @@ Metrics/AbcSize:
     - test/gapic/schema/**/*_test.rb
     - test/gapic/routing_headers/**/*_test.rb
 
+Lint/SafeNavigationConsistency:
+  Enabled: false
+
 Metrics/ClassLength:
   Exclude:
     - lib/gapic/presenters/**/*


### PR DESCRIPTION
Currently failing in https://github.com/googleapis/gapic-generator-ruby/actions/runs/11507777942/job/32035472718?pr=1122