### PR TITLE
fix: fix wrapper gem tests by stubbing the stub_logger method

### DIFF
--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/client_test.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/client_test.erb
@@ -20,6 +20,10 @@ class <%= gem.namespace %>::ClientConstructionMinitest < Minitest::Test
     def universe_domain
       "example.com"
     end
+
+    def stub_logger
+      nil
+    end
   end
 
 <%- start_line_spacer -%>

--- a/gapic-generator/lib/gapic/model/service/nonstandard_lro_provider.rb
+++ b/gapic-generator/lib/gapic/model/service/nonstandard_lro_provider.rb
@@ -114,7 +114,6 @@ module Gapic
                        operation_err_code_field,
                        operation_err_msg_field,
                        operation_response_fields
-
           @service_full_name = service_full_name
           @polling_method_name = polling_method_name
           @lro_object_full_name = lro_object_full_name

--- a/shared/output/cloud/compute_small_wrapper/test/google/cloud/compute/client_test.rb
+++ b/shared/output/cloud/compute_small_wrapper/test/google/cloud/compute/client_test.rb
@@ -30,6 +30,10 @@ class Google::Cloud::Compute::ClientConstructionMinitest < Minitest::Test
     def universe_domain
       "example.com"
     end
+
+    def stub_logger
+      nil
+    end
   end
 
   def test_addresses_rest

--- a/shared/output/cloud/language_wrapper/test/google/cloud/language/client_test.rb
+++ b/shared/output/cloud/language_wrapper/test/google/cloud/language/client_test.rb
@@ -31,6 +31,10 @@ class Google::Cloud::Language::ClientConstructionMinitest < Minitest::Test
     def universe_domain
       "example.com"
     end
+
+    def stub_logger
+      nil
+    end
   end
 
   def test_language_service_grpc

--- a/shared/output/cloud/secretmanager_wrapper/test/google/cloud/secret_manager/client_test.rb
+++ b/shared/output/cloud/secretmanager_wrapper/test/google/cloud/secret_manager/client_test.rb
@@ -30,6 +30,10 @@ class Google::Cloud::SecretManager::ClientConstructionMinitest < Minitest::Test
     def universe_domain
       "example.com"
     end
+
+    def stub_logger
+      nil
+    end
   end
 
   def test_secret_manager_service_grpc


### PR DESCRIPTION
Necessary for wrapper gem tests when the corresponding gapic has logger methods