### PR TITLE
fix: Throw the correct result object for REST with nonstandard LRO

### DIFF
--- a/gapic-generator/templates/default/service/rest/client/method/def/_response_nonstandard_lro.erb
+++ b/gapic-generator/templates/default/service/rest/client/method/def/_response_nonstandard_lro.erb
@@ -20,5 +20,5 @@
     options: options
   )
   yield result, response if block_given?
-  result
+  throw :response, result
 end

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/client.rb
@@ -383,7 +383,7 @@ module Google
                     options: options
                   )
                   yield result, response if block_given?
-                  result
+                  throw :response, result
                 end
               rescue ::Gapic::Rest::Error => e
                 raise ::Google::Cloud::Error.from_error(e)
@@ -563,7 +563,7 @@ module Google
                     options: options
                   )
                   yield result, response if block_given?
-                  result
+                  throw :response, result
                 end
               rescue ::Gapic::Rest::Error => e
                 raise ::Google::Cloud::Error.from_error(e)

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/client.rb
@@ -388,7 +388,7 @@ module Google
                     options: options
                   )
                   yield result, response if block_given?
-                  result
+                  throw :response, result
                 end
               rescue ::Gapic::Rest::Error => e
                 raise ::Google::Cloud::Error.from_error(e)

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/client.rb
@@ -287,7 +287,7 @@ module Google
                     options: options
                   )
                   yield result, response if block_given?
-                  result
+                  throw :response, result
                 end
               rescue ::Gapic::Rest::Error => e
                 raise ::Google::Cloud::Error.from_error(e)

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/client.rb
@@ -311,7 +311,7 @@ module Testing
                 options: options
               )
               yield result, response if block_given?
-              result
+              throw :response, result
             end
           rescue ::Faraday::Error => e
             raise ::Gapic::Rest::Error.wrap_faraday_error e
@@ -397,7 +397,7 @@ module Testing
                 options: options
               )
               yield result, response if block_given?
-              result
+              throw :response, result
             end
           rescue ::Faraday::Error => e
             raise ::Gapic::Rest::Error.wrap_faraday_error e
@@ -476,7 +476,7 @@ module Testing
                 options: options
               )
               yield result, response if block_given?
-              result
+              throw :response, result
             end
           rescue ::Faraday::Error => e
             raise ::Gapic::Rest::Error.wrap_faraday_error e

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/rest/client.rb
@@ -280,7 +280,7 @@ module Testing
                 options: options
               )
               yield result, response if block_given?
-              result
+              throw :response, result
             end
           rescue ::Faraday::Error => e
             raise ::Gapic::Rest::Error.wrap_faraday_error e


### PR DESCRIPTION
The logging work changed the way RPC methods should specify custom result objects. Instead of returning the new object out of the block (which short-circuits the postprocessing that the logging depends on), we instead `throw` the new object which is then caught by new code in gapic-common. So all the code paths that want to change the result object should have been changed to throw the new object. Unfortunately I missed the REST case with nonstandard LRO. This is the reason the acceptance tests on https://github.com/googleapis/google-cloud-ruby/pull/27799 are currently failing: because the wrong object is being returned from methods that use nonstandard LROs.