### PR TITLE
fix: Added logger methods to generated dummy stub classes in generated tests

### DIFF
--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/client_test.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/client_test.erb
@@ -24,6 +24,10 @@ class <%= gem.namespace %>::ClientConstructionMinitest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
 <%- start_line_spacer -%>

--- a/gapic-generator/templates/default/service/rest/test/method/_setup.erb
+++ b/gapic-generator/templates/default/service/rest/test/method/_setup.erb
@@ -47,4 +47,8 @@ class ClientStub
   def stub_logger
     nil
   end
+
+  def logger
+    nil
+  end
 end

--- a/gapic-generator/templates/default/service/test/client_paths.erb
+++ b/gapic-generator/templates/default/service/test/client_paths.erb
@@ -19,6 +19,10 @@ class <%= service.client_name_full %>PathsTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
 <%- start_line_spacer -%>

--- a/gapic-generator/templates/default/service/test/method/_setup.erb
+++ b/gapic-generator/templates/default/service/test/method/_setup.erb
@@ -31,4 +31,8 @@ class ClientStub
   def stub_logger
     nil
   end
+
+  def logger
+    nil
+  end
 end

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/addresses_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/addresses_rest_test.rb
@@ -72,6 +72,10 @@ class ::Google::Cloud::Compute::V1::Addresses::Rest::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_aggregated_list

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/global_operations_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/global_operations_rest_test.rb
@@ -72,6 +72,10 @@ class ::Google::Cloud::Compute::V1::GlobalOperations::Rest::ClientTest < Minites
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_delete

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/networks_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/networks_rest_test.rb
@@ -72,6 +72,10 @@ class ::Google::Cloud::Compute::V1::Networks::Rest::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_list_peering_routes

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_instance_group_managers_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_instance_group_managers_rest_test.rb
@@ -72,6 +72,10 @@ class ::Google::Cloud::Compute::V1::RegionInstanceGroupManagers::Rest::ClientTes
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_resize

--- a/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_operations_rest_test.rb
+++ b/shared/output/cloud/compute_small/test/google/cloud/compute/v1/region_operations_rest_test.rb
@@ -72,6 +72,10 @@ class ::Google::Cloud::Compute::V1::RegionOperations::Rest::ClientTest < Minites
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_delete

--- a/shared/output/cloud/compute_small_wrapper/test/google/cloud/compute/client_test.rb
+++ b/shared/output/cloud/compute_small_wrapper/test/google/cloud/compute/client_test.rb
@@ -34,6 +34,10 @@ class Google::Cloud::Compute::ClientConstructionMinitest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_addresses_rest

--- a/shared/output/cloud/grafeas_v1/test/grafeas/v1/grafeas_paths_test.rb
+++ b/shared/output/cloud/grafeas_v1/test/grafeas/v1/grafeas_paths_test.rb
@@ -35,6 +35,10 @@ class ::Grafeas::V1::Grafeas::ClientPathsTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_note_path

--- a/shared/output/cloud/grafeas_v1/test/grafeas/v1/grafeas_test.rb
+++ b/shared/output/cloud/grafeas_v1/test/grafeas/v1/grafeas_test.rb
@@ -58,6 +58,10 @@ class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_get_occurrence

--- a/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_rest_test.rb
+++ b/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_rest_test.rb
@@ -72,6 +72,10 @@ class ::Google::Cloud::Language::V1::LanguageService::Rest::ClientTest < Minites
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_analyze_sentiment

--- a/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
+++ b/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
@@ -58,6 +58,10 @@ class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Tes
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_analyze_sentiment

--- a/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
@@ -58,6 +58,10 @@ class ::Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_analyze_sentiment

--- a/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
@@ -58,6 +58,10 @@ class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_analyze_sentiment

--- a/shared/output/cloud/language_wrapper/test/google/cloud/language/client_test.rb
+++ b/shared/output/cloud/language_wrapper/test/google/cloud/language/client_test.rb
@@ -35,6 +35,10 @@ class Google::Cloud::Language::ClientConstructionMinitest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_language_service_grpc

--- a/shared/output/cloud/location/test/google/cloud/location/locations_rest_test.rb
+++ b/shared/output/cloud/location/test/google/cloud/location/locations_rest_test.rb
@@ -72,6 +72,10 @@ class ::Google::Cloud::Location::Locations::Rest::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_list_locations

--- a/shared/output/cloud/location/test/google/cloud/location/locations_test.rb
+++ b/shared/output/cloud/location/test/google/cloud/location/locations_test.rb
@@ -58,6 +58,10 @@ class ::Google::Cloud::Location::Locations::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_list_locations

--- a/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_paths_test.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_paths_test.rb
@@ -35,6 +35,10 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientPaths
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_project_path

--- a/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
@@ -58,6 +58,10 @@ class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest 
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_list_secrets

--- a/shared/output/cloud/secretmanager_wrapper/test/google/cloud/secret_manager/client_test.rb
+++ b/shared/output/cloud/secretmanager_wrapper/test/google/cloud/secret_manager/client_test.rb
@@ -34,6 +34,10 @@ class Google::Cloud::SecretManager::ClientConstructionMinitest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_secret_manager_service_grpc

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/adaptation_paths_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/adaptation_paths_test.rb
@@ -35,6 +35,10 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientPathsTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_custom_class_path

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/adaptation_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/adaptation_test.rb
@@ -58,6 +58,10 @@ class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_create_phrase_set

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_operations_test.rb
@@ -58,6 +58,10 @@ class ::Google::Cloud::Speech::V1::Speech::OperationsTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_list_operations

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_paths_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_paths_test.rb
@@ -35,6 +35,10 @@ class ::Google::Cloud::Speech::V1::Speech::ClientPathsTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_custom_class_path

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
@@ -58,6 +58,10 @@ class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_recognize

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -58,6 +58,10 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_list_operations

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_paths_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_paths_test.rb
@@ -35,6 +35,10 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientPathsTest < Minitest::T
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_product_set_path

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_rest_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_rest_test.rb
@@ -72,6 +72,10 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ClientTest < Minitest::
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_batch_annotate_images

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -58,6 +58,10 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_batch_annotate_images

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -58,6 +58,10 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_list_operations

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_paths_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_paths_test.rb
@@ -35,6 +35,10 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientPathsTest < Minitest::Te
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_product_path

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_rest_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_rest_test.rb
@@ -72,6 +72,10 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_create_product_set

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
@@ -58,6 +58,10 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_create_product_set

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/deprecated_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/deprecated_service_test.rb
@@ -66,6 +66,10 @@ class ::So::Much::Trash::DeprecatedService::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_deprecated_get

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_operations_test.rb
@@ -66,6 +66,10 @@ class ::So::Much::Trash::GarbageService::OperationsTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_list_operations

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_paths_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_paths_test.rb
@@ -43,6 +43,10 @@ class ::So::Much::Trash::GarbageService::ClientPathsTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_project_path

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
@@ -66,6 +66,10 @@ class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_get_empty_garbage

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/iam_policy_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/iam_policy_test.rb
@@ -66,6 +66,10 @@ class ::So::Much::Trash::IAMPolicy::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_set_iam_policy

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/really_renamed_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/really_renamed_service_test.rb
@@ -66,6 +66,10 @@ class ::So::Much::Trash::ReallyRenamedService::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_get_empty_garbage

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_paths_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_paths_test.rb
@@ -43,6 +43,10 @@ class ::So::Much::Trash::ResourceNames::ClientPathsTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_complex_pattern_log_parent_path

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_test.rb
@@ -66,6 +66,10 @@ class ::So::Much::Trash::ResourceNames::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_simple_pattern_method

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_rest_test.rb
@@ -80,6 +80,10 @@ class ::Google::Showcase::V1beta1::Compliance::Rest::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_repeat_data_body

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_test.rb
@@ -66,6 +66,10 @@ class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_repeat_data_body

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_operations_test.rb
@@ -66,6 +66,10 @@ class ::Google::Showcase::V1beta1::Echo::OperationsTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_list_operations

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_rest_test.rb
@@ -80,6 +80,10 @@ class ::Google::Showcase::V1beta1::Echo::Rest::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_echo

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -66,6 +66,10 @@ class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_echo

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_paths_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_paths_test.rb
@@ -43,6 +43,10 @@ class ::Google::Showcase::V1beta1::Identity::ClientPathsTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_user_path

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_rest_test.rb
@@ -80,6 +80,10 @@ class ::Google::Showcase::V1beta1::Identity::Rest::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_create_user

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -66,6 +66,10 @@ class ::Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_create_user

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_operations_test.rb
@@ -66,6 +66,10 @@ class ::Google::Showcase::V1beta1::Messaging::OperationsTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_list_operations

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_paths_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_paths_test.rb
@@ -43,6 +43,10 @@ class ::Google::Showcase::V1beta1::Messaging::ClientPathsTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_blurb_path

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_rest_test.rb
@@ -80,6 +80,10 @@ class ::Google::Showcase::V1beta1::Messaging::Rest::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_create_room

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -66,6 +66,10 @@ class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_create_room

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_paths_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_paths_test.rb
@@ -43,6 +43,10 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientPathsTest < Minitest::
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_sequence_path

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_rest_test.rb
@@ -80,6 +80,10 @@ class ::Google::Showcase::V1beta1::SequenceService::Rest::ClientTest < Minitest:
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_create_sequence

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_test.rb
@@ -66,6 +66,10 @@ class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_create_sequence

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_paths_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_paths_test.rb
@@ -43,6 +43,10 @@ class ::Google::Showcase::V1beta1::Testing::ClientPathsTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_session_path

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_rest_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_rest_test.rb
@@ -80,6 +80,10 @@ class ::Google::Showcase::V1beta1::Testing::Rest::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_create_session

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -66,6 +66,10 @@ class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_create_session

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_rest_test.rb
@@ -80,6 +80,10 @@ class ::Testing::GrpcServiceConfig::ServiceNoRetry::Rest::ClientTest < Minitest:
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_no_retry_method

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_test.rb
@@ -66,6 +66,10 @@ class ::Testing::GrpcServiceConfig::ServiceNoRetry::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_no_retry_method

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_rest_test.rb
@@ -80,6 +80,10 @@ class ::Testing::GrpcServiceConfig::ServiceWithRetries::Rest::ClientTest < Minit
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_service_level_retry_method

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_test.rb
@@ -66,6 +66,10 @@ class ::Testing::GrpcServiceConfig::ServiceWithRetries::ClientTest < Minitest::T
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_service_level_retry_method

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_rest_test.rb
@@ -80,6 +80,10 @@ class ::Testing::Mixins::ServiceWithLoc::Rest::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_call_method

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_test.rb
@@ -66,6 +66,10 @@ class ::Testing::Mixins::ServiceWithLoc::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_call_method

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_operations_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_operations_test.rb
@@ -66,6 +66,10 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::OperationsTest < Min
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_list_operations

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_rest_test.rb
@@ -80,6 +80,10 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::Rest::ClientTest < M
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_plain_lro_rpc

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_test.rb
@@ -66,6 +66,10 @@ class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::ClientTest < Minites
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_plain_lro_rpc

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_rest_test.rb
@@ -80,6 +80,10 @@ class ::Testing::NonstandardLroGrpc::AnotherLroProvider::Rest::ClientTest < Mini
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_get_another

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_test.rb
@@ -66,6 +66,10 @@ class ::Testing::NonstandardLroGrpc::AnotherLroProvider::ClientTest < Minitest::
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_get_another

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_rest_test.rb
@@ -80,6 +80,10 @@ class ::Testing::NonstandardLroGrpc::PlainLroConsumer::Rest::ClientTest < Minite
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_plain_lro_rpc

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_test.rb
@@ -66,6 +66,10 @@ class ::Testing::NonstandardLroGrpc::PlainLroConsumer::ClientTest < Minitest::Te
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_plain_lro_rpc

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_rest_test.rb
@@ -80,6 +80,10 @@ class ::Testing::NonstandardLroGrpc::PlainLroProvider::Rest::ClientTest < Minite
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_get

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_test.rb
@@ -66,6 +66,10 @@ class ::Testing::NonstandardLroGrpc::PlainLroProvider::ClientTest < Minitest::Te
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_get

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_rest_test.rb
@@ -80,6 +80,10 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::Rest::ClientTest < Mini
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_plain_no_template

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_test.rb
@@ -66,6 +66,10 @@ class ::Testing::RoutingHeaders::ServiceExplicitHeaders::ClientTest < Minitest::
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_plain_no_template

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_rest_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_rest_test.rb
@@ -80,6 +80,10 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::Rest::ClientTest < Mini
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_plain

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_test.rb
@@ -66,6 +66,10 @@ class ::Testing::RoutingHeaders::ServiceImplicitHeaders::ClientTest < Minitest::
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_plain

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_no_headers_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_no_headers_test.rb
@@ -66,6 +66,10 @@ class ::Testing::RoutingHeaders::ServiceNoHeaders::ClientTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_plain


### PR DESCRIPTION
Fixes test failures such as the ones here: https://github.com/googleapis/google-cloud-ruby/actions/runs/12266216522/job/34223911771?pr=28062

This has no bearing on production, but handles the case where a test needs to configure a mixin and attempts to call the `logger` method on a stub class. In many tests, the stub class is mocked, and the mock needs to be able to respond to both `stub_logger` and `logger`.