### PR TITLE
feat(gapic-generator): Add clarifying notes to oneof members in proto_docs

### DIFF
--- a/gapic-generator/lib/gapic/schema/loader.rb
+++ b/gapic-generator/lib/gapic/schema/loader.rb
@@ -190,6 +190,7 @@ module Gapic
         fields = (descriptor.field || []).each_with_index.map do |f, i|
           load_field registry, f, address, docs, path + [2, i]
         end
+        fields.each { |field| field.populate_oneof_siblings! fields }
         extensions = (descriptor.extension || []).each_with_index.map do |e, i|
           load_field registry, e, address, docs, path + [6, i]
         end

--- a/gapic-generator/test/gapic/presenters/field_presenter_test.rb
+++ b/gapic-generator/test/gapic/presenters/field_presenter_test.rb
@@ -136,7 +136,11 @@ class FieldPresenterTest < PresenterTest
     assert_equal "oneof_multiple_enum", fp.name
     assert_equal "@!attribute [rw] oneof_multiple_enum", fp.doc_attribute_type
     assert_equal "::So::Much::Trash::GarbageEnum", fp.output_doc_types
-    assert_equal fp.doc_description, "This is a multiple-field oneof's enum field.\n"
+    expected_description = "This is a multiple-field oneof's enum field.\n\n" \
+      "Note: The following fields are mutually exclusive: `oneof_multiple_enum`, `oneof_multiple_message`, " \
+      "`oneof_multiple_bytes`, `oneof_multiple_double`. If a field in that set is populated, all other fields in " \
+      "the set will automatically be cleared."
+    assert_equal expected_description, fp.doc_description
     assert_equal ":DEFAULT_GARBAGE", fp.default_value
     assert_equal ".endless.trash.forever.GarbageEnum", fp.type_name
     assert_equal "::So::Much::Trash::GarbageEnum", fp.type_name_full

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v15/resources/campaign.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v15/resources/campaign.rb
@@ -267,60 +267,88 @@ module Google
           # @!attribute [rw] bidding_strategy
           #   @return [::String]
           #     Portfolio bidding strategy used by campaign.
+          #
+          #     Note: The following fields are mutually exclusive: `bidding_strategy`, `commission`, `manual_cpa`, `manual_cpc`, `manual_cpm`, `manual_cpv`, `maximize_conversions`, `maximize_conversion_value`, `target_cpa`, `target_impression_share`, `target_roas`, `target_spend`, `percent_cpc`, `target_cpm`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] commission
           #   @return [::Google::Ads::GoogleAds::V15::Common::Commission]
           #     Commission is an automatic bidding strategy in which the advertiser pays
           #     a certain portion of the conversion value.
+          #
+          #     Note: The following fields are mutually exclusive: `commission`, `bidding_strategy`, `manual_cpa`, `manual_cpc`, `manual_cpm`, `manual_cpv`, `maximize_conversions`, `maximize_conversion_value`, `target_cpa`, `target_impression_share`, `target_roas`, `target_spend`, `percent_cpc`, `target_cpm`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] manual_cpa
           #   @return [::Google::Ads::GoogleAds::V15::Common::ManualCpa]
           #     Standard Manual CPA bidding strategy.
           #     Manual bidding strategy that allows advertiser to set the bid per
           #     advertiser-specified action. Supported only for Local Services campaigns.
+          #
+          #     Note: The following fields are mutually exclusive: `manual_cpa`, `bidding_strategy`, `commission`, `manual_cpc`, `manual_cpm`, `manual_cpv`, `maximize_conversions`, `maximize_conversion_value`, `target_cpa`, `target_impression_share`, `target_roas`, `target_spend`, `percent_cpc`, `target_cpm`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] manual_cpc
           #   @return [::Google::Ads::GoogleAds::V15::Common::ManualCpc]
           #     Standard Manual CPC bidding strategy.
           #     Manual click-based bidding where user pays per click.
+          #
+          #     Note: The following fields are mutually exclusive: `manual_cpc`, `bidding_strategy`, `commission`, `manual_cpa`, `manual_cpm`, `manual_cpv`, `maximize_conversions`, `maximize_conversion_value`, `target_cpa`, `target_impression_share`, `target_roas`, `target_spend`, `percent_cpc`, `target_cpm`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] manual_cpm
           #   @return [::Google::Ads::GoogleAds::V15::Common::ManualCpm]
           #     Standard Manual CPM bidding strategy.
           #     Manual impression-based bidding where user pays per thousand
           #     impressions.
+          #
+          #     Note: The following fields are mutually exclusive: `manual_cpm`, `bidding_strategy`, `commission`, `manual_cpa`, `manual_cpc`, `manual_cpv`, `maximize_conversions`, `maximize_conversion_value`, `target_cpa`, `target_impression_share`, `target_roas`, `target_spend`, `percent_cpc`, `target_cpm`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] manual_cpv
           #   @return [::Google::Ads::GoogleAds::V15::Common::ManualCpv]
           #     A bidding strategy that pays a configurable amount per video view.
+          #
+          #     Note: The following fields are mutually exclusive: `manual_cpv`, `bidding_strategy`, `commission`, `manual_cpa`, `manual_cpc`, `manual_cpm`, `maximize_conversions`, `maximize_conversion_value`, `target_cpa`, `target_impression_share`, `target_roas`, `target_spend`, `percent_cpc`, `target_cpm`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] maximize_conversions
           #   @return [::Google::Ads::GoogleAds::V15::Common::MaximizeConversions]
           #     Standard Maximize Conversions bidding strategy that automatically
           #     maximizes number of conversions while spending your budget.
+          #
+          #     Note: The following fields are mutually exclusive: `maximize_conversions`, `bidding_strategy`, `commission`, `manual_cpa`, `manual_cpc`, `manual_cpm`, `manual_cpv`, `maximize_conversion_value`, `target_cpa`, `target_impression_share`, `target_roas`, `target_spend`, `percent_cpc`, `target_cpm`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] maximize_conversion_value
           #   @return [::Google::Ads::GoogleAds::V15::Common::MaximizeConversionValue]
           #     Standard Maximize Conversion Value bidding strategy that automatically
           #     sets bids to maximize revenue while spending your budget.
+          #
+          #     Note: The following fields are mutually exclusive: `maximize_conversion_value`, `bidding_strategy`, `commission`, `manual_cpa`, `manual_cpc`, `manual_cpm`, `manual_cpv`, `maximize_conversions`, `target_cpa`, `target_impression_share`, `target_roas`, `target_spend`, `percent_cpc`, `target_cpm`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] target_cpa
           #   @return [::Google::Ads::GoogleAds::V15::Common::TargetCpa]
           #     Standard Target CPA bidding strategy that automatically sets bids to
           #     help get as many conversions as possible at the target
           #     cost-per-acquisition (CPA) you set.
+          #
+          #     Note: The following fields are mutually exclusive: `target_cpa`, `bidding_strategy`, `commission`, `manual_cpa`, `manual_cpc`, `manual_cpm`, `manual_cpv`, `maximize_conversions`, `maximize_conversion_value`, `target_impression_share`, `target_roas`, `target_spend`, `percent_cpc`, `target_cpm`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] target_impression_share
           #   @return [::Google::Ads::GoogleAds::V15::Common::TargetImpressionShare]
           #     Target Impression Share bidding strategy. An automated bidding strategy
           #     that sets bids to achieve a chosen percentage of impressions.
+          #
+          #     Note: The following fields are mutually exclusive: `target_impression_share`, `bidding_strategy`, `commission`, `manual_cpa`, `manual_cpc`, `manual_cpm`, `manual_cpv`, `maximize_conversions`, `maximize_conversion_value`, `target_cpa`, `target_roas`, `target_spend`, `percent_cpc`, `target_cpm`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] target_roas
           #   @return [::Google::Ads::GoogleAds::V15::Common::TargetRoas]
           #     Standard Target ROAS bidding strategy that automatically maximizes
           #     revenue while averaging a specific target return on ad spend (ROAS).
+          #
+          #     Note: The following fields are mutually exclusive: `target_roas`, `bidding_strategy`, `commission`, `manual_cpa`, `manual_cpc`, `manual_cpm`, `manual_cpv`, `maximize_conversions`, `maximize_conversion_value`, `target_cpa`, `target_impression_share`, `target_spend`, `percent_cpc`, `target_cpm`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] target_spend
           #   @return [::Google::Ads::GoogleAds::V15::Common::TargetSpend]
           #     Standard Target Spend bidding strategy that automatically sets your bids
           #     to help get as many clicks as possible within your budget.
+          #
+          #     Note: The following fields are mutually exclusive: `target_spend`, `bidding_strategy`, `commission`, `manual_cpa`, `manual_cpc`, `manual_cpm`, `manual_cpv`, `maximize_conversions`, `maximize_conversion_value`, `target_cpa`, `target_impression_share`, `target_roas`, `percent_cpc`, `target_cpm`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] percent_cpc
           #   @return [::Google::Ads::GoogleAds::V15::Common::PercentCpc]
           #     Standard Percent Cpc bidding strategy where bids are a fraction of the
           #     advertised price for some good or service.
+          #
+          #     Note: The following fields are mutually exclusive: `percent_cpc`, `bidding_strategy`, `commission`, `manual_cpa`, `manual_cpc`, `manual_cpm`, `manual_cpv`, `maximize_conversions`, `maximize_conversion_value`, `target_cpa`, `target_impression_share`, `target_roas`, `target_spend`, `target_cpm`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] target_cpm
           #   @return [::Google::Ads::GoogleAds::V15::Common::TargetCpm]
           #     A bidding strategy that automatically optimizes cost per thousand
           #     impressions.
+          #
+          #     Note: The following fields are mutually exclusive: `target_cpm`, `bidding_strategy`, `commission`, `manual_cpa`, `manual_cpc`, `manual_cpm`, `manual_cpv`, `maximize_conversions`, `maximize_conversion_value`, `target_cpa`, `target_impression_share`, `target_roas`, `target_spend`, `percent_cpc`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           class Campaign
             include ::Google::Protobuf::MessageExts
             extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/ads/googleads/proto_docs/google/ads/googleads/v15/services/campaign_service.rb
+++ b/shared/output/ads/googleads/proto_docs/google/ads/googleads/v15/services/campaign_service.rb
@@ -56,16 +56,22 @@ module Google
           # @!attribute [rw] create
           #   @return [::Google::Ads::GoogleAds::V15::Resources::Campaign]
           #     Create operation: No resource name is expected for the new campaign.
+          #
+          #     Note: The following fields are mutually exclusive: `create`, `update`, `remove`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] update
           #   @return [::Google::Ads::GoogleAds::V15::Resources::Campaign]
           #     Update operation: The campaign is expected to have a valid
           #     resource name.
+          #
+          #     Note: The following fields are mutually exclusive: `update`, `create`, `remove`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           # @!attribute [rw] remove
           #   @return [::String]
           #     Remove operation: A resource name for the removed campaign is
           #     expected, in this format:
           #
           #     `customers/{customer_id}/campaigns/{campaign_id}`
+          #
+          #     Note: The following fields are mutually exclusive: `remove`, `create`, `update`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           class CampaignOperation
             include ::Google::Protobuf::MessageExts
             extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/grafeas_v1/proto_docs/google/protobuf/struct.rb
+++ b/shared/output/cloud/grafeas_v1/proto_docs/google/protobuf/struct.rb
@@ -53,21 +53,33 @@ module Google
     # @!attribute [rw] null_value
     #   @return [::Google::Protobuf::NullValue]
     #     Represents a null value.
+    #
+    #     Note: The following fields are mutually exclusive: `null_value`, `number_value`, `string_value`, `bool_value`, `struct_value`, `list_value`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] number_value
     #   @return [::Float]
     #     Represents a double value.
+    #
+    #     Note: The following fields are mutually exclusive: `number_value`, `null_value`, `string_value`, `bool_value`, `struct_value`, `list_value`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] string_value
     #   @return [::String]
     #     Represents a string value.
+    #
+    #     Note: The following fields are mutually exclusive: `string_value`, `null_value`, `number_value`, `bool_value`, `struct_value`, `list_value`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] bool_value
     #   @return [::Boolean]
     #     Represents a boolean value.
+    #
+    #     Note: The following fields are mutually exclusive: `bool_value`, `null_value`, `number_value`, `string_value`, `struct_value`, `list_value`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] struct_value
     #   @return [::Google::Protobuf::Struct]
     #     Represents a structured value.
+    #
+    #     Note: The following fields are mutually exclusive: `struct_value`, `null_value`, `number_value`, `string_value`, `bool_value`, `list_value`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] list_value
     #   @return [::Google::Protobuf::ListValue]
     #     Represents a repeated `Value`.
+    #
+    #     Note: The following fields are mutually exclusive: `list_value`, `null_value`, `number_value`, `string_value`, `bool_value`, `struct_value`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     class Value
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/grafeas_v1/proto_docs/grafeas/v1/grafeas.rb
+++ b/shared/output/cloud/grafeas_v1/proto_docs/grafeas/v1/grafeas.rb
@@ -50,37 +50,59 @@ module Grafeas
     # @!attribute [rw] vulnerability
     #   @return [::Grafeas::V1::VulnerabilityOccurrence]
     #     Describes a security vulnerability.
+    #
+    #     Note: The following fields are mutually exclusive: `vulnerability`, `build`, `image`, `package`, `deployment`, `discovery`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] build
     #   @return [::Grafeas::V1::BuildOccurrence]
     #     Describes a verifiable build.
+    #
+    #     Note: The following fields are mutually exclusive: `build`, `vulnerability`, `image`, `package`, `deployment`, `discovery`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] image
     #   @return [::Grafeas::V1::ImageOccurrence]
     #     Describes how this resource derives from the basis in the associated
     #     note.
+    #
+    #     Note: The following fields are mutually exclusive: `image`, `vulnerability`, `build`, `package`, `deployment`, `discovery`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] package
     #   @return [::Grafeas::V1::PackageOccurrence]
     #     Describes the installation of a package on the linked resource.
+    #
+    #     Note: The following fields are mutually exclusive: `package`, `vulnerability`, `build`, `image`, `deployment`, `discovery`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] deployment
     #   @return [::Grafeas::V1::DeploymentOccurrence]
     #     Describes the deployment of an artifact on a runtime.
+    #
+    #     Note: The following fields are mutually exclusive: `deployment`, `vulnerability`, `build`, `image`, `package`, `discovery`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] discovery
     #   @return [::Grafeas::V1::DiscoveryOccurrence]
     #     Describes when a resource was discovered.
+    #
+    #     Note: The following fields are mutually exclusive: `discovery`, `vulnerability`, `build`, `image`, `package`, `deployment`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] attestation
     #   @return [::Grafeas::V1::AttestationOccurrence]
     #     Describes an attestation of an artifact.
+    #
+    #     Note: The following fields are mutually exclusive: `attestation`, `vulnerability`, `build`, `image`, `package`, `deployment`, `discovery`, `upgrade`, `compliance`, `dsse_attestation`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] upgrade
     #   @return [::Grafeas::V1::UpgradeOccurrence]
     #     Describes an available package upgrade on the linked resource.
+    #
+    #     Note: The following fields are mutually exclusive: `upgrade`, `vulnerability`, `build`, `image`, `package`, `deployment`, `discovery`, `attestation`, `compliance`, `dsse_attestation`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] compliance
     #   @return [::Grafeas::V1::ComplianceOccurrence]
     #     Describes a compliance violation on a linked resource.
+    #
+    #     Note: The following fields are mutually exclusive: `compliance`, `vulnerability`, `build`, `image`, `package`, `deployment`, `discovery`, `attestation`, `upgrade`, `dsse_attestation`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] dsse_attestation
     #   @return [::Grafeas::V1::DSSEAttestationOccurrence]
     #     Describes an attestation of an artifact using dsse.
+    #
+    #     Note: The following fields are mutually exclusive: `dsse_attestation`, `vulnerability`, `build`, `image`, `package`, `deployment`, `discovery`, `attestation`, `upgrade`, `compliance`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] sbom_reference
     #   @return [::Grafeas::V1::SBOMReferenceOccurrence]
     #     Describes a specific SBOM reference occurrences.
+    #
+    #     Note: The following fields are mutually exclusive: `sbom_reference`, `vulnerability`, `build`, `image`, `package`, `deployment`, `discovery`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] envelope
     #   @return [::Grafeas::V1::Envelope]
     #     https://github.com/secure-systems-lab/dsse
@@ -124,39 +146,63 @@ module Grafeas
     # @!attribute [rw] vulnerability
     #   @return [::Grafeas::V1::VulnerabilityNote]
     #     A note describing a package vulnerability.
+    #
+    #     Note: The following fields are mutually exclusive: `vulnerability`, `build`, `image`, `package`, `deployment`, `discovery`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `vulnerability_assessment`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] build
     #   @return [::Grafeas::V1::BuildNote]
     #     A note describing build provenance for a verifiable build.
+    #
+    #     Note: The following fields are mutually exclusive: `build`, `vulnerability`, `image`, `package`, `deployment`, `discovery`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `vulnerability_assessment`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] image
     #   @return [::Grafeas::V1::ImageNote]
     #     A note describing a base image.
+    #
+    #     Note: The following fields are mutually exclusive: `image`, `vulnerability`, `build`, `package`, `deployment`, `discovery`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `vulnerability_assessment`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] package
     #   @return [::Grafeas::V1::PackageNote]
     #     A note describing a package hosted by various package managers.
+    #
+    #     Note: The following fields are mutually exclusive: `package`, `vulnerability`, `build`, `image`, `deployment`, `discovery`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `vulnerability_assessment`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] deployment
     #   @return [::Grafeas::V1::DeploymentNote]
     #     A note describing something that can be deployed.
+    #
+    #     Note: The following fields are mutually exclusive: `deployment`, `vulnerability`, `build`, `image`, `package`, `discovery`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `vulnerability_assessment`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] discovery
     #   @return [::Grafeas::V1::DiscoveryNote]
     #     A note describing the initial analysis of a resource.
+    #
+    #     Note: The following fields are mutually exclusive: `discovery`, `vulnerability`, `build`, `image`, `package`, `deployment`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `vulnerability_assessment`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] attestation
     #   @return [::Grafeas::V1::AttestationNote]
     #     A note describing an attestation role.
+    #
+    #     Note: The following fields are mutually exclusive: `attestation`, `vulnerability`, `build`, `image`, `package`, `deployment`, `discovery`, `upgrade`, `compliance`, `dsse_attestation`, `vulnerability_assessment`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] upgrade
     #   @return [::Grafeas::V1::UpgradeNote]
     #     A note describing available package upgrades.
+    #
+    #     Note: The following fields are mutually exclusive: `upgrade`, `vulnerability`, `build`, `image`, `package`, `deployment`, `discovery`, `attestation`, `compliance`, `dsse_attestation`, `vulnerability_assessment`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] compliance
     #   @return [::Grafeas::V1::ComplianceNote]
     #     A note describing a compliance check.
+    #
+    #     Note: The following fields are mutually exclusive: `compliance`, `vulnerability`, `build`, `image`, `package`, `deployment`, `discovery`, `attestation`, `upgrade`, `dsse_attestation`, `vulnerability_assessment`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] dsse_attestation
     #   @return [::Grafeas::V1::DSSEAttestationNote]
     #     A note describing a dsse attestation note.
+    #
+    #     Note: The following fields are mutually exclusive: `dsse_attestation`, `vulnerability`, `build`, `image`, `package`, `deployment`, `discovery`, `attestation`, `upgrade`, `compliance`, `vulnerability_assessment`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] vulnerability_assessment
     #   @return [::Grafeas::V1::VulnerabilityAssessmentNote]
     #     A note describing a vulnerability assessment.
+    #
+    #     Note: The following fields are mutually exclusive: `vulnerability_assessment`, `vulnerability`, `build`, `image`, `package`, `deployment`, `discovery`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `sbom_reference`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] sbom_reference
     #   @return [::Grafeas::V1::SBOMReferenceNote]
     #     A note describing an SBOM reference.
+    #
+    #     Note: The following fields are mutually exclusive: `sbom_reference`, `vulnerability`, `build`, `image`, `package`, `deployment`, `discovery`, `attestation`, `upgrade`, `compliance`, `dsse_attestation`, `vulnerability_assessment`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     class Note
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/grafeas_v1/proto_docs/grafeas/v1/intoto_statement.rb
+++ b/shared/output/cloud/grafeas_v1/proto_docs/grafeas/v1/intoto_statement.rb
@@ -33,10 +33,13 @@ module Grafeas
     #     `https://slsa.dev/provenance/v0.1` for SlsaProvenance.
     # @!attribute [rw] provenance
     #   @return [::Grafeas::V1::InTotoProvenance]
+    #     Note: The following fields are mutually exclusive: `provenance`, `slsa_provenance`, `slsa_provenance_zero_two`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] slsa_provenance
     #   @return [::Grafeas::V1::SlsaProvenance]
+    #     Note: The following fields are mutually exclusive: `slsa_provenance`, `provenance`, `slsa_provenance_zero_two`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] slsa_provenance_zero_two
     #   @return [::Grafeas::V1::SlsaProvenanceZeroTwo]
+    #     Note: The following fields are mutually exclusive: `slsa_provenance_zero_two`, `provenance`, `slsa_provenance`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     class InTotoStatement
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/grafeas_v1/proto_docs/grafeas/v1/provenance.rb
+++ b/shared/output/cloud/grafeas_v1/proto_docs/grafeas/v1/provenance.rb
@@ -190,12 +190,18 @@ module Grafeas
     # @!attribute [rw] cloud_repo
     #   @return [::Grafeas::V1::CloudRepoSourceContext]
     #     A SourceContext referring to a revision in a Google Cloud Source Repo.
+    #
+    #     Note: The following fields are mutually exclusive: `cloud_repo`, `gerrit`, `git`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] gerrit
     #   @return [::Grafeas::V1::GerritSourceContext]
     #     A SourceContext referring to a Gerrit project.
+    #
+    #     Note: The following fields are mutually exclusive: `gerrit`, `cloud_repo`, `git`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] git
     #   @return [::Grafeas::V1::GitSourceContext]
     #     A SourceContext referring to any third party Git repo (e.g., GitHub).
+    #
+    #     Note: The following fields are mutually exclusive: `git`, `cloud_repo`, `gerrit`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] labels
     #   @return [::Google::Protobuf::Map{::String => ::String}]
     #     Labels with user defined metadata.
@@ -249,9 +255,13 @@ module Grafeas
     # @!attribute [rw] revision_id
     #   @return [::String]
     #     A revision ID.
+    #
+    #     Note: The following fields are mutually exclusive: `revision_id`, `alias_context`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] alias_context
     #   @return [::Grafeas::V1::AliasContext]
     #     An alias, which may be a branch or tag.
+    #
+    #     Note: The following fields are mutually exclusive: `alias_context`, `revision_id`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     class CloudRepoSourceContext
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods
@@ -269,9 +279,13 @@ module Grafeas
     # @!attribute [rw] revision_id
     #   @return [::String]
     #     A revision (commit) ID.
+    #
+    #     Note: The following fields are mutually exclusive: `revision_id`, `alias_context`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] alias_context
     #   @return [::Grafeas::V1::AliasContext]
     #     An alias, which may be a branch or tag.
+    #
+    #     Note: The following fields are mutually exclusive: `alias_context`, `revision_id`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     class GerritSourceContext
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods
@@ -294,9 +308,13 @@ module Grafeas
     # @!attribute [rw] project_repo_id
     #   @return [::Grafeas::V1::ProjectRepoId]
     #     A combination of a project ID and a repo name.
+    #
+    #     Note: The following fields are mutually exclusive: `project_repo_id`, `uid`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] uid
     #   @return [::String]
     #     A server-assigned, globally unique identifier.
+    #
+    #     Note: The following fields are mutually exclusive: `uid`, `project_repo_id`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     class RepoId
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/language_v1/proto_docs/google/cloud/language/v1/language_service.rb
+++ b/shared/output/cloud/language_v1/proto_docs/google/cloud/language/v1/language_service.rb
@@ -30,12 +30,16 @@ module Google
         #   @return [::String]
         #     The content of the input in string format.
         #     Cloud audit logging exempt since it is based on user data.
+        #
+        #     Note: The following fields are mutually exclusive: `content`, `gcs_content_uri`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         # @!attribute [rw] gcs_content_uri
         #   @return [::String]
         #     The Google Cloud Storage URI where the file content is located.
         #     This URI must be of the form: gs://bucket_name/object_name. For more
         #     details, see https://cloud.google.com/storage/docs/reference-uris.
         #     NOTE: Cloud Storage object versioning is not supported.
+        #
+        #     Note: The following fields are mutually exclusive: `gcs_content_uri`, `content`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         # @!attribute [rw] language
         #   @return [::String]
         #     The language of the document (if not specified, the language is
@@ -906,10 +910,14 @@ module Google
         #     Setting this field will use the V1 model and V1 content categories
         #     version. The V1 model is a legacy model; support for this will be
         #     discontinued in the future.
+        #
+        #     Note: The following fields are mutually exclusive: `v1_model`, `v2_model`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         # @!attribute [rw] v2_model
         #   @return [::Google::Cloud::Language::V1::ClassificationModelOptions::V2Model]
         #     Setting this field will use the V2 model with the appropriate content
         #     categories version. The V2 model is a better performing model.
+        #
+        #     Note: The following fields are mutually exclusive: `v2_model`, `v1_model`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         class ClassificationModelOptions
           include ::Google::Protobuf::MessageExts
           extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/language_v1beta1/proto_docs/google/cloud/language/v1beta1/language_service.rb
+++ b/shared/output/cloud/language_v1beta1/proto_docs/google/cloud/language/v1beta1/language_service.rb
@@ -29,12 +29,16 @@ module Google
         # @!attribute [rw] content
         #   @return [::String]
         #     The content of the input in string format.
+        #
+        #     Note: The following fields are mutually exclusive: `content`, `gcs_content_uri`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         # @!attribute [rw] gcs_content_uri
         #   @return [::String]
         #     The Google Cloud Storage URI where the file content is located.
         #     This URI must be of the form: gs://bucket_name/object_name. For more
         #     details, see https://cloud.google.com/storage/docs/reference-uris.
         #     NOTE: Cloud Storage object versioning is not supported.
+        #
+        #     Note: The following fields are mutually exclusive: `gcs_content_uri`, `content`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         # @!attribute [rw] language
         #   @return [::String]
         #     The language of the document (if not specified, the language is

--- a/shared/output/cloud/language_v1beta2/proto_docs/google/cloud/language/v1beta2/language_service.rb
+++ b/shared/output/cloud/language_v1beta2/proto_docs/google/cloud/language/v1beta2/language_service.rb
@@ -30,12 +30,16 @@ module Google
         #   @return [::String]
         #     The content of the input in string format.
         #     Cloud audit logging exempt since it is based on user data.
+        #
+        #     Note: The following fields are mutually exclusive: `content`, `gcs_content_uri`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         # @!attribute [rw] gcs_content_uri
         #   @return [::String]
         #     The Google Cloud Storage URI where the file content is located.
         #     This URI must be of the form: gs://bucket_name/object_name. For more
         #     details, see https://cloud.google.com/storage/docs/reference-uris.
         #     NOTE: Cloud Storage object versioning is not supported.
+        #
+        #     Note: The following fields are mutually exclusive: `gcs_content_uri`, `content`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         # @!attribute [rw] language
         #   @return [::String]
         #     The language of the document (if not specified, the language is
@@ -925,10 +929,14 @@ module Google
         #     Setting this field will use the V1 model and V1 content categories
         #     version. The V1 model is a legacy model; support for this will be
         #     discontinued in the future.
+        #
+        #     Note: The following fields are mutually exclusive: `v1_model`, `v2_model`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         # @!attribute [rw] v2_model
         #   @return [::Google::Cloud::Language::V1beta2::ClassificationModelOptions::V2Model]
         #     Setting this field will use the V2 model with the appropriate content
         #     categories version. The V2 model is a better performing model.
+        #
+        #     Note: The following fields are mutually exclusive: `v2_model`, `v1_model`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         class ClassificationModelOptions
           include ::Google::Protobuf::MessageExts
           extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/cloud/secrets/v1beta1/resources.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/proto_docs/google/cloud/secrets/v1beta1/resources.rb
@@ -110,9 +110,13 @@ module Google
         # @!attribute [rw] automatic
         #   @return [::Google::Cloud::SecretManager::V1beta1::Replication::Automatic]
         #     The {::Google::Cloud::SecretManager::V1beta1::Secret Secret} will automatically be replicated without any restrictions.
+        #
+        #     Note: The following fields are mutually exclusive: `automatic`, `user_managed`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         # @!attribute [rw] user_managed
         #   @return [::Google::Cloud::SecretManager::V1beta1::Replication::UserManaged]
         #     The {::Google::Cloud::SecretManager::V1beta1::Secret Secret} will only be replicated into the locations specified.
+        #
+        #     Note: The following fields are mutually exclusive: `user_managed`, `automatic`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         class Replication
           include ::Google::Protobuf::MessageExts
           extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/speech_v1/proto_docs/google/cloud/speech/v1/cloud_speech.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/cloud/speech/v1/cloud_speech.rb
@@ -72,6 +72,8 @@ module Google
         #     Provides information to the recognizer that specifies how to process the
         #     request. The first `StreamingRecognizeRequest` message must contain a
         #     `streaming_config`  message.
+        #
+        #     Note: The following fields are mutually exclusive: `streaming_config`, `audio_content`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         # @!attribute [rw] audio_content
         #   @return [::String]
         #     The audio data to be recognized. Sequential chunks of audio data are sent
@@ -82,6 +84,8 @@ module Google
         #     `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
         #     pure binary representation (not base64). See
         #     [content limits](https://cloud.google.com/speech-to-text/quotas#content).
+        #
+        #     Note: The following fields are mutually exclusive: `audio_content`, `streaming_config`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         class StreamingRecognizeRequest
           include ::Google::Protobuf::MessageExts
           extend ::Google::Protobuf::MessageExts::ClassMethods
@@ -630,6 +634,8 @@ module Google
         #     The audio data bytes encoded as specified in
         #     `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
         #     pure binary representation, whereas JSON representations use base64.
+        #
+        #     Note: The following fields are mutually exclusive: `content`, `uri`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         # @!attribute [rw] uri
         #   @return [::String]
         #     URI that points to a file that contains audio data bytes as specified in
@@ -640,6 +646,8 @@ module Google
         #     [google.rpc.Code.INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT]).
         #     For more information, see [Request
         #     URIs](https://cloud.google.com/storage/docs/reference-uris).
+        #
+        #     Note: The following fields are mutually exclusive: `uri`, `content`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         class RecognitionAudio
           include ::Google::Protobuf::MessageExts
           extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/speech_v1/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/cloud/speech_v1/proto_docs/google/longrunning/operations.rb
@@ -40,6 +40,8 @@ module Google
     # @!attribute [rw] error
     #   @return [::Google::Rpc::Status]
     #     The error result of the operation in case of failure or cancellation.
+    #
+    #     Note: The following fields are mutually exclusive: `error`, `response`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] response
     #   @return [::Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
@@ -50,6 +52,8 @@ module Google
     #     is the original method name.  For example, if the original method name
     #     is `TakeSnapshot()`, the inferred response type is
     #     `TakeSnapshotResponse`.
+    #
+    #     Note: The following fields are mutually exclusive: `response`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     class Operation
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -2060,9 +2060,13 @@ module Google
             #
             #   @param product_set_purge_config [::Google::Cloud::Vision::V1::ProductSetPurgeConfig, ::Hash]
             #     Specify which ProductSet contains the Products to be deleted.
+            #
+            #     Note: The following fields are mutually exclusive: `product_set_purge_config`, `delete_orphan_products`. If a field in that set is populated, all other fields in the set will automatically be cleared.
             #   @param delete_orphan_products [::Boolean]
             #     If delete_orphan_products is true, all Products that are not in any
             #     ProductSet will be deleted.
+            #
+            #     Note: The following fields are mutually exclusive: `delete_orphan_products`, `product_set_purge_config`. If a field in that set is populated, all other fields in the set will automatically be cleared.
             #   @param parent [::String]
             #     Required. The project and location in which the Products should be deleted.
             #

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/client.rb
@@ -1928,9 +1928,13 @@ module Google
               #
               #   @param product_set_purge_config [::Google::Cloud::Vision::V1::ProductSetPurgeConfig, ::Hash]
               #     Specify which ProductSet contains the Products to be deleted.
+              #
+              #     Note: The following fields are mutually exclusive: `product_set_purge_config`, `delete_orphan_products`. If a field in that set is populated, all other fields in the set will automatically be cleared.
               #   @param delete_orphan_products [::Boolean]
               #     If delete_orphan_products is true, all Products that are not in any
               #     ProductSet will be deleted.
+              #
+              #     Note: The following fields are mutually exclusive: `delete_orphan_products`, `product_set_purge_config`. If a field in that set is populated, all other fields in the set will automatically be cleared.
               #   @param parent [::String]
               #     Required. The project and location in which the Products should be deleted.
               #

--- a/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/product_search_service.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/cloud/vision/v1/product_search_service.rb
@@ -651,10 +651,14 @@ module Google
         # @!attribute [rw] product_set_purge_config
         #   @return [::Google::Cloud::Vision::V1::ProductSetPurgeConfig]
         #     Specify which ProductSet contains the Products to be deleted.
+        #
+        #     Note: The following fields are mutually exclusive: `product_set_purge_config`, `delete_orphan_products`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         # @!attribute [rw] delete_orphan_products
         #   @return [::Boolean]
         #     If delete_orphan_products is true, all Products that are not in any
         #     ProductSet will be deleted.
+        #
+        #     Note: The following fields are mutually exclusive: `delete_orphan_products`, `product_set_purge_config`. If a field in that set is populated, all other fields in the set will automatically be cleared.
         # @!attribute [rw] parent
         #   @return [::String]
         #     Required. The project and location in which the Products should be deleted.

--- a/shared/output/cloud/vision_v1/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/cloud/vision_v1/proto_docs/google/longrunning/operations.rb
@@ -40,6 +40,8 @@ module Google
     # @!attribute [rw] error
     #   @return [::Google::Rpc::Status]
     #     The error result of the operation in case of failure or cancellation.
+    #
+    #     Note: The following fields are mutually exclusive: `error`, `response`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] response
     #   @return [::Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
@@ -50,6 +52,8 @@ module Google
     #     is the original method name.  For example, if the original method name
     #     is `TakeSnapshot()`, the inferred response type is
     #     `TakeSnapshotResponse`.
+    #
+    #     Note: The following fields are mutually exclusive: `response`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     class Operation
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -716,16 +716,28 @@ module So
           #     This is a one-field oneof's string field.
           #   @param oneof_pair_int32 [::Integer]
           #     This is a pair oneof's int32 field.
+          #
+          #     Note: The following fields are mutually exclusive: `oneof_pair_int32`, `oneof_pair_float`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #   @param oneof_pair_float [::Float]
           #     This is a pair oneof's float field.
+          #
+          #     Note: The following fields are mutually exclusive: `oneof_pair_float`, `oneof_pair_int32`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #   @param oneof_multiple_message [::So::Much::Trash::SimpleGarbageItem, ::Hash]
           #     This is a multiple-field oneof's message field.
+          #
+          #     Note: The following fields are mutually exclusive: `oneof_multiple_message`, `oneof_multiple_bytes`, `oneof_multiple_enum`, `oneof_multiple_double`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #   @param oneof_multiple_bytes [::String]
           #     This is a multiple-field oneof's bytes field.
+          #
+          #     Note: The following fields are mutually exclusive: `oneof_multiple_bytes`, `oneof_multiple_message`, `oneof_multiple_enum`, `oneof_multiple_double`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #   @param oneof_multiple_enum [::So::Much::Trash::GarbageEnum]
           #     This is a multiple-field oneof's enum field.
+          #
+          #     Note: The following fields are mutually exclusive: `oneof_multiple_enum`, `oneof_multiple_message`, `oneof_multiple_bytes`, `oneof_multiple_double`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #   @param oneof_multiple_double [::Float]
           #     This is a multiple-field oneof's double field.
+          #
+          #     Note: The following fields are mutually exclusive: `oneof_multiple_double`, `oneof_multiple_message`, `oneof_multiple_bytes`, `oneof_multiple_enum`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #   @param optional_int32 [::Integer]
           #   @param case [::String]
           #     This field tests for collisions against Ruby reserved keywords.

--- a/shared/output/gapic/templates/garbage/proto_docs/garbage/garbage.rb
+++ b/shared/output/gapic/templates/garbage/proto_docs/garbage/garbage.rb
@@ -102,9 +102,13 @@ module So
       # @!attribute [rw] a
       #   @return [::String]
       #     The string item.
+      #
+      #     Note: The following fields are mutually exclusive: `a`, `b`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] b
       #   @return [::Integer]
       #     The integer item.
+      #
+      #     Note: The following fields are mutually exclusive: `b`, `a`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       class GarbageItem
         include ::Google::Protobuf::MessageExts
         extend ::Google::Protobuf::MessageExts::ClassMethods
@@ -131,8 +135,10 @@ module So
       #     The name of the garbage this item belongs to.
       # @!attribute [rw] a
       #   @return [::String]
+      #     Note: The following fields are mutually exclusive: `a`, `b`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] b
       #   @return [::Integer]
+      #     Note: The following fields are mutually exclusive: `b`, `a`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       class SimpleGarbageItem
         include ::Google::Protobuf::MessageExts
         extend ::Google::Protobuf::MessageExts::ClassMethods
@@ -186,21 +192,33 @@ module So
       # @!attribute [rw] oneof_pair_int32
       #   @return [::Integer]
       #     This is a pair oneof's int32 field.
+      #
+      #     Note: The following fields are mutually exclusive: `oneof_pair_int32`, `oneof_pair_float`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] oneof_pair_float
       #   @return [::Float]
       #     This is a pair oneof's float field.
+      #
+      #     Note: The following fields are mutually exclusive: `oneof_pair_float`, `oneof_pair_int32`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] oneof_multiple_message
       #   @return [::So::Much::Trash::SimpleGarbageItem]
       #     This is a multiple-field oneof's message field.
+      #
+      #     Note: The following fields are mutually exclusive: `oneof_multiple_message`, `oneof_multiple_bytes`, `oneof_multiple_enum`, `oneof_multiple_double`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] oneof_multiple_bytes
       #   @return [::String]
       #     This is a multiple-field oneof's bytes field.
+      #
+      #     Note: The following fields are mutually exclusive: `oneof_multiple_bytes`, `oneof_multiple_message`, `oneof_multiple_enum`, `oneof_multiple_double`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] oneof_multiple_enum
       #   @return [::So::Much::Trash::GarbageEnum]
       #     This is a multiple-field oneof's enum field.
+      #
+      #     Note: The following fields are mutually exclusive: `oneof_multiple_enum`, `oneof_multiple_message`, `oneof_multiple_bytes`, `oneof_multiple_double`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] oneof_multiple_double
       #   @return [::Float]
       #     This is a multiple-field oneof's double field.
+      #
+      #     Note: The following fields are mutually exclusive: `oneof_multiple_double`, `oneof_multiple_message`, `oneof_multiple_bytes`, `oneof_multiple_enum`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] optional_int32
       #   @return [::Integer]
       # @!attribute [rw] case

--- a/shared/output/gapic/templates/garbage/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/gapic/templates/garbage/proto_docs/google/longrunning/operations.rb
@@ -48,6 +48,8 @@ module Google
     # @!attribute [rw] error
     #   @return [::Google::Rpc::Status]
     #     The error result of the operation in case of failure or cancellation.
+    #
+    #     Note: The following fields are mutually exclusive: `error`, `response`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] response
     #   @return [::Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
@@ -58,6 +60,8 @@ module Google
     #     is the original method name.  For example, if the original method name
     #     is `TakeSnapshot()`, the inferred response type is
     #     `TakeSnapshotResponse`.
+    #
+    #     Note: The following fields are mutually exclusive: `response`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     class Operation
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -253,8 +253,12 @@ module Google
           #
           #   @param content [::String]
           #     The content to be echoed by the server.
+          #
+          #     Note: The following fields are mutually exclusive: `content`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #   @param error [::Google::Rpc::Status, ::Hash]
           #     The error to be thrown by the server.
+          #
+          #     Note: The following fields are mutually exclusive: `error`, `content`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #   @param severity [::Google::Showcase::V1beta1::Severity]
           #     The severity to be echoed by the server.
           #   @param header [::String]
@@ -977,13 +981,21 @@ module Google
           #
           #   @param end_time [::Google::Protobuf::Timestamp, ::Hash]
           #     The time that this operation will complete.
+          #
+          #     Note: The following fields are mutually exclusive: `end_time`, `ttl`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #   @param ttl [::Google::Protobuf::Duration, ::Hash]
           #     The duration of this operation.
+          #
+          #     Note: The following fields are mutually exclusive: `ttl`, `end_time`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #   @param error [::Google::Rpc::Status, ::Hash]
           #     The error that will be returned by the server. If this code is specified
           #     to be the OK rpc code, an empty response will be returned.
+          #
+          #     Note: The following fields are mutually exclusive: `error`, `success`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #   @param success [::Google::Showcase::V1beta1::WaitResponse, ::Hash]
           #     The response to be returned on operation completion.
+          #
+          #     Note: The following fields are mutually exclusive: `success`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [::Gapic::Operation]
@@ -1073,8 +1085,12 @@ module Google
           #   @param error [::Google::Rpc::Status, ::Hash]
           #     The error that will be returned by the server. If this code is specified
           #     to be the OK rpc code, an empty response will be returned.
+          #
+          #     Note: The following fields are mutually exclusive: `error`, `success`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #   @param success [::Google::Showcase::V1beta1::BlockResponse, ::Hash]
           #     The response to be returned that will signify successful method call.
+          #
+          #     Note: The following fields are mutually exclusive: `success`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
           #
           # @yield [response, operation] Access the result along with the RPC operation
           # @yieldparam response [::Google::Showcase::V1beta1::BlockResponse]

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/client.rb
@@ -248,8 +248,12 @@ module Google
             #
             #   @param content [::String]
             #     The content to be echoed by the server.
+            #
+            #     Note: The following fields are mutually exclusive: `content`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
             #   @param error [::Google::Rpc::Status, ::Hash]
             #     The error to be thrown by the server.
+            #
+            #     Note: The following fields are mutually exclusive: `error`, `content`. If a field in that set is populated, all other fields in the set will automatically be cleared.
             #   @param severity [::Google::Showcase::V1beta1::Severity]
             #     The severity to be echoed by the server.
             #   @param header [::String]
@@ -803,13 +807,21 @@ module Google
             #
             #   @param end_time [::Google::Protobuf::Timestamp, ::Hash]
             #     The time that this operation will complete.
+            #
+            #     Note: The following fields are mutually exclusive: `end_time`, `ttl`. If a field in that set is populated, all other fields in the set will automatically be cleared.
             #   @param ttl [::Google::Protobuf::Duration, ::Hash]
             #     The duration of this operation.
+            #
+            #     Note: The following fields are mutually exclusive: `ttl`, `end_time`. If a field in that set is populated, all other fields in the set will automatically be cleared.
             #   @param error [::Google::Rpc::Status, ::Hash]
             #     The error that will be returned by the server. If this code is specified
             #     to be the OK rpc code, an empty response will be returned.
+            #
+            #     Note: The following fields are mutually exclusive: `error`, `success`. If a field in that set is populated, all other fields in the set will automatically be cleared.
             #   @param success [::Google::Showcase::V1beta1::WaitResponse, ::Hash]
             #     The response to be returned on operation completion.
+            #
+            #     Note: The following fields are mutually exclusive: `success`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
             # @yield [result, operation] Access the result along with the TransportOperation object
             # @yieldparam result [::Gapic::Operation]
             # @yieldparam operation [::Gapic::Rest::TransportOperation]
@@ -902,8 +914,12 @@ module Google
             #   @param error [::Google::Rpc::Status, ::Hash]
             #     The error that will be returned by the server. If this code is specified
             #     to be the OK rpc code, an empty response will be returned.
+            #
+            #     Note: The following fields are mutually exclusive: `error`, `success`. If a field in that set is populated, all other fields in the set will automatically be cleared.
             #   @param success [::Google::Showcase::V1beta1::BlockResponse, ::Hash]
             #     The response to be returned that will signify successful method call.
+            #
+            #     Note: The following fields are mutually exclusive: `success`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
             # @yield [result, operation] Access the result along with the TransportOperation object
             # @yieldparam result [::Google::Showcase::V1beta1::BlockResponse]
             # @yieldparam operation [::Gapic::Rest::TransportOperation]

--- a/shared/output/gapic/templates/showcase/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/longrunning/operations.rb
@@ -48,6 +48,8 @@ module Google
     # @!attribute [rw] error
     #   @return [::Google::Rpc::Status]
     #     The error result of the operation in case of failure or cancellation.
+    #
+    #     Note: The following fields are mutually exclusive: `error`, `response`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] response
     #   @return [::Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
@@ -58,6 +60,8 @@ module Google
     #     is the original method name.  For example, if the original method name
     #     is `TakeSnapshot()`, the inferred response type is
     #     `TakeSnapshotResponse`.
+    #
+    #     Note: The following fields are mutually exclusive: `response`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     class Operation
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/gapic/templates/showcase/proto_docs/google/showcase/v1beta1/echo.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/showcase/v1beta1/echo.rb
@@ -35,9 +35,13 @@ module Google
       # @!attribute [rw] content
       #   @return [::String]
       #     The content to be echoed by the server.
+      #
+      #     Note: The following fields are mutually exclusive: `content`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] error
       #   @return [::Google::Rpc::Status]
       #     The error to be thrown by the server.
+      #
+      #     Note: The following fields are mutually exclusive: `error`, `content`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] severity
       #   @return [::Google::Showcase::V1beta1::Severity]
       #     The severity to be echoed by the server.
@@ -223,16 +227,24 @@ module Google
       # @!attribute [rw] end_time
       #   @return [::Google::Protobuf::Timestamp]
       #     The time that this operation will complete.
+      #
+      #     Note: The following fields are mutually exclusive: `end_time`, `ttl`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] ttl
       #   @return [::Google::Protobuf::Duration]
       #     The duration of this operation.
+      #
+      #     Note: The following fields are mutually exclusive: `ttl`, `end_time`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] error
       #   @return [::Google::Rpc::Status]
       #     The error that will be returned by the server. If this code is specified
       #     to be the OK rpc code, an empty response will be returned.
+      #
+      #     Note: The following fields are mutually exclusive: `error`, `success`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] success
       #   @return [::Google::Showcase::V1beta1::WaitResponse]
       #     The response to be returned on operation completion.
+      #
+      #     Note: The following fields are mutually exclusive: `success`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       class WaitRequest
         include ::Google::Protobuf::MessageExts
         extend ::Google::Protobuf::MessageExts::ClassMethods
@@ -264,9 +276,13 @@ module Google
       #   @return [::Google::Rpc::Status]
       #     The error that will be returned by the server. If this code is specified
       #     to be the OK rpc code, an empty response will be returned.
+      #
+      #     Note: The following fields are mutually exclusive: `error`, `success`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] success
       #   @return [::Google::Showcase::V1beta1::BlockResponse]
       #     The response to be returned that will signify successful method call.
+      #
+      #     Note: The following fields are mutually exclusive: `success`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       class BlockRequest
         include ::Google::Protobuf::MessageExts
         extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/gapic/templates/showcase/proto_docs/google/showcase/v1beta1/messaging.rb
+++ b/shared/output/gapic/templates/showcase/proto_docs/google/showcase/v1beta1/messaging.rb
@@ -136,9 +136,13 @@ module Google
       # @!attribute [rw] text
       #   @return [::String]
       #     The textual content of this blurb.
+      #
+      #     Note: The following fields are mutually exclusive: `text`, `image`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] image
       #   @return [::String]
       #     The image content of this blurb.
+      #
+      #     Note: The following fields are mutually exclusive: `image`, `text`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [r] create_time
       #   @return [::Google::Protobuf::Timestamp]
       #     The timestamp at which the blurb was created.
@@ -150,11 +154,15 @@ module Google
       #     The legacy id of the room. This field is used to signal
       #     the use of the compound resource pattern
       #     `rooms/{room}/blurbs/legacy/{legacy_room}.{blurb}`
+      #
+      #     Note: The following fields are mutually exclusive: `legacy_room_id`, `legacy_user_id`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] legacy_user_id
       #   @return [::String]
       #     The legacy id of the user. This field is used to signal
       #     the use of the compound resource pattern
       #     `users/{user}/profile/blurbs/legacy/{legacy_user}~{blurb}`
+      #
+      #     Note: The following fields are mutually exclusive: `legacy_user_id`, `legacy_room_id`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       class Blurb
         include ::Google::Protobuf::MessageExts
         extend ::Google::Protobuf::MessageExts::ClassMethods
@@ -352,9 +360,13 @@ module Google
       #   @return [::Google::Showcase::V1beta1::ConnectRequest::ConnectConfig]
       #     Provides information that specifies how to process subsequent requests.
       #     The first `ConnectRequest` message must contain a `config`  message.
+      #
+      #     Note: The following fields are mutually exclusive: `config`, `blurb`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       # @!attribute [rw] blurb
       #   @return [::Google::Showcase::V1beta1::Blurb]
       #     The blurb to be created.
+      #
+      #     Note: The following fields are mutually exclusive: `blurb`, `config`. If a field in that set is populated, all other fields in the set will automatically be cleared.
       class ConnectRequest
         include ::Google::Protobuf::MessageExts
         extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/shared/output/gapic/templates/testing/proto_docs/google/longrunning/operations.rb
+++ b/shared/output/gapic/templates/testing/proto_docs/google/longrunning/operations.rb
@@ -48,6 +48,8 @@ module Google
     # @!attribute [rw] error
     #   @return [::Google::Rpc::Status]
     #     The error result of the operation in case of failure or cancellation.
+    #
+    #     Note: The following fields are mutually exclusive: `error`, `response`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     # @!attribute [rw] response
     #   @return [::Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
@@ -58,6 +60,8 @@ module Google
     #     is the original method name.  For example, if the original method name
     #     is `TakeSnapshot()`, the inferred response type is
     #     `TakeSnapshotResponse`.
+    #
+    #     Note: The following fields are mutually exclusive: `response`, `error`. If a field in that set is populated, all other fields in the set will automatically be cleared.
     class Operation
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods


### PR DESCRIPTION
The interesting commit is the first. (The second commit is just regeneration of the goldens based on the changes in the first.)