### PR TITLE
feat(gapic-generator): Change REGAPIC pagination algorithm to the standard algorithm for non-compute clients

### DIFF
--- a/gapic-generator-cloud/test/gapic/presenters/method/regapic_paged_test.rb
+++ b/gapic-generator-cloud/test/gapic/presenters/method/regapic_paged_test.rb
@@ -53,6 +53,6 @@ class MethodPresenterRegapicPagedTest < PresenterTest
     assert_equal "::Google::Cloud::Compute::V1::AddressAggregatedList", presenter.return_type
 
     assert presenter.rest.paged?
-    assert presenter.rest.pagination.repeated_field_is_a_map?
+    assert presenter.rest.compute_pagination.repeated_field_is_a_map?
   end
 end

--- a/gapic-generator/lib/gapic/presenters/method_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/method_presenter.rb
@@ -312,6 +312,18 @@ module Gapic
       end
 
       ##
+      # @return [String] The name of the repeated field in paginated responses
+      #
+      def paged_response_repeated_field_name
+        return nil unless paged_response? @method.output
+
+        repeated_field = @method.output.fields.find do |f|
+          f.label == :LABEL_REPEATED && f.type == :TYPE_MESSAGE
+        end
+        repeated_field.name
+      end
+
+      ##
       # @return [Array<String>] The segment key names.
       #
       def routing_params

--- a/gapic-generator/lib/gapic/presenters/method_rest_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/method_rest_presenter.rb
@@ -95,8 +95,7 @@ module Gapic
       def doc_response_type
         return "::Gapic::Operation" if lro?
         if paged?
-          elem_type = compute_pagination&.paged_element_doc_type
-          elem_type ||= (lro? ? "::Gapic::Operation" : @main_method.paged_response_type)
+          elem_type = compute_pagination&.paged_element_doc_type || @main_method.paged_response_type
           return "::Gapic::Rest::PagedEnumerable<#{elem_type}>"
         end
         return "::Gapic::GenericLRO::Operation" if nonstandard_lro?

--- a/gapic-generator/lib/gapic/presenters/method_rest_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/method_rest_presenter.rb
@@ -23,7 +23,7 @@ module Gapic
     #
     class MethodRestPresenter
       # @return [Gapic::Presenters::Method::RestPaginationInfo]
-      attr_reader :pagination
+      attr_reader :compute_pagination
 
       attr_reader :http_bindings
 
@@ -37,7 +37,10 @@ module Gapic
       def initialize main_method, api
         @main_method = main_method
         @http_bindings = main_method.http_bindings
-        @pagination = Gapic::Presenters::Method::RestPaginationInfo.new main_method.method, api
+        @compute_pagination =
+          if @main_method.service.special_compute_behavior?
+            Gapic::Presenters::Method::RestPaginationInfo.new main_method.method, api
+          end
         @type = "method"
       end
 
@@ -91,9 +94,24 @@ module Gapic
       #
       def doc_response_type
         return "::Gapic::Operation" if lro?
-        return "::Gapic::Rest::PagedEnumerable<#{pagination.paged_element_doc_type}>" if paged?
+        if paged?
+          elem_type = compute_pagination&.paged_element_doc_type
+          elem_type ||= (lro? ? "::Gapic::Operation" : @main_method.paged_response_type)
+          return "::Gapic::Rest::PagedEnumerable<#{elem_type}>"
+        end
         return "::Gapic::GenericLRO::Operation" if nonstandard_lro?
         return_type
+      end
+
+      ##
+      # @return [String] The name of the repeated field in paginated responses
+      #
+      def paged_response_repeated_field_name
+        if compute_pagination
+          compute_pagination.response_repeated_field_name
+        else
+          @main_method.paged_response_repeated_field_name
+        end
       end
 
       ##
@@ -102,7 +120,7 @@ module Gapic
       # @return [Boolean]
       #
       def paged?
-        @pagination.paged?
+        compute_pagination ? compute_pagination.paged? : @main_method.paged?
       end
 
       def lro?

--- a/gapic-generator/lib/gapic/presenters/service_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_presenter.rb
@@ -61,6 +61,10 @@ module Gapic
         PackagePresenter.new @gem_presenter, @api, @service.parent.package
       end
 
+      def special_compute_behavior?
+        address[0] == "google" && address[1] == "cloud" && address[2] == "compute" && address[3] == "v1"
+      end
+
       ##
       # @return [Boolean] Whether the service is marked as deprecated.
       #

--- a/gapic-generator/lib/gapic/presenters/service_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/service_presenter.rb
@@ -62,7 +62,7 @@ module Gapic
       end
 
       def special_compute_behavior?
-        address[0] == "google" && address[1] == "cloud" && address[2] == "compute" && address[3] == "v1"
+        address[0] == "google" && address[1] == "cloud" && address[2] == "compute" && !address[3].to_s.empty?
       end
 
       ##

--- a/gapic-generator/templates/default/service/rest/client/method/def/_response_paged.erb
+++ b/gapic-generator/templates/default/service/rest/client/method/def/_response_paged.erb
@@ -1,7 +1,7 @@
 <%- assert_locals method -%>
 <%- boverr_str = method.service.rest.is_main_mixin_service? ? ", bindings_override: bindings_override" : "" -%>
 @<%= method.service.stub_name %>.<%= method.name %> request, options<%= boverr_str %> do |result, operation|
-  result = ::Gapic::Rest::PagedEnumerable.new @<%= method.service.stub_name %>, :<%= method.name %>, "<%= method.rest.pagination.response_repeated_field_name %>", request, result, options
+  result = ::Gapic::Rest::PagedEnumerable.new @<%= method.service.stub_name %>, :<%= method.name %>, "<%= method.rest.paged_response_repeated_field_name %>", request, result, options
   yield result, operation if block_given?
   throw :response, result
 end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/client.rb
@@ -633,10 +633,10 @@ module Google
             #   @param page_token [::String]
             #     The position of the page to be returned.
             # @yield [result, operation] Access the result along with the TransportOperation object
-            # @yieldparam result [::Gapic::Rest::PagedEnumerable<::Google::Showcase::V1beta1::EchoResponse>]
+            # @yieldparam result [::Google::Showcase::V1beta1::PagedExpandResponse]
             # @yieldparam operation [::Gapic::Rest::TransportOperation]
             #
-            # @return [::Gapic::Rest::PagedEnumerable<::Google::Showcase::V1beta1::EchoResponse>]
+            # @return [::Google::Showcase::V1beta1::PagedExpandResponse]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
             #
@@ -684,10 +684,7 @@ module Google
                                      retry_policy: @config.retry_policy
 
               @echo_stub.paged_expand_legacy request, options do |result, operation|
-                result = ::Gapic::Rest::PagedEnumerable.new @echo_stub, :paged_expand_legacy, "responses", request,
-                                                            result, options
                 yield result, operation if block_given?
-                throw :response, result
               end
             rescue ::Faraday::Error => e
               raise ::Gapic::Rest::Error.wrap_faraday_error e
@@ -722,10 +719,10 @@ module Google
             #   @param page_token [::String]
             #     The position of the page to be returned.
             # @yield [result, operation] Access the result along with the TransportOperation object
-            # @yieldparam result [::Gapic::Rest::PagedEnumerable<::String, ::Google::Showcase::V1beta1::PagedExpandResponseList>]
+            # @yieldparam result [::Gapic::Rest::PagedEnumerable<::Google::Showcase::V1beta1::PagedExpandLegacyMappedResponse::AlphabetizedEntry>]
             # @yieldparam operation [::Gapic::Rest::TransportOperation]
             #
-            # @return [::Gapic::Rest::PagedEnumerable<::String, ::Google::Showcase::V1beta1::PagedExpandResponseList>]
+            # @return [::Gapic::Rest::PagedEnumerable<::Google::Showcase::V1beta1::PagedExpandLegacyMappedResponse::AlphabetizedEntry>]
             #
             # @raise [::Gapic::Rest::Error] if the REST call is aborted.
             #


### PR DESCRIPTION
See internal issue b/382502247. This updates the pagination detection algorithm for REST/REGAPIC clients so it complies with AIP-158. It does not affect compute, which should remain on the custom algorithm.

This will cause breaking changes in 70-ish GAPICs, where pagination behavior for some REST RPC methods will change. Thus, this should be merged and applied with care.