### PR TITLE
feat(cloud): Wrapper clients provide better introspection to determine availability of client objects

### DIFF
--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/_main.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/_main.erb
@@ -46,6 +46,11 @@ end
 # the `transport` parameter.
 <%- end -%>
 #
+# Raises an exception if the currently installed versioned client gem for the
+# given API version does not support the <% if service.supports_multiple_transports? %>given transport of the <% end %><%= service.module_name %> service.
+# You can determine whether the method will succeed by calling
+# {<%= gem.namespace %>.<%= service.factory_method_name %>_available?}.
+#
 <%- if service.doc_description -%>
 # ## About <%= service.module_name %>
 #
@@ -73,6 +78,44 @@ def self.<%= service.factory_method_name %> version: :<%= gem.default_version %>
 <%- else -%>
   service_module<% if service.generate_rest_clients? %>.const_get(:Rest)<% end %>.const_get(:Client).new(&block)
 <%- end -%>
+end
+
+##
+# Determines whether the <%= service.module_name %> service is supported by the current client.
+# If true, you can retrieve a client object by calling {<%= gem.namespace %>.<%= service.factory_method_name %>}.
+# If false, that method will raise an exception. This could happen if the given
+# API version does not exist or does not support the <%= service.module_name %> service,
+# or if the versioned client gem needs an update to support the <%= service.module_name %> service.
+#
+# @param version [::String, ::Symbol] The API version to connect to. Optional.
+#   Defaults to `:<%= gem.default_version %>`.
+<%- if service.supports_multiple_transports? -%>
+# @param transport [:grpc, :rest] The transport to use. Defaults to `<%= gem.default_transport.inspect %>`.
+<%- end -%>
+# @return [boolean] Whether the service is available.
+#
+def self.<%= service.factory_method_name %>_available? version: :<%= gem.default_version %><% if service.supports_multiple_transports? %>, transport: <%= gem.default_transport.inspect %><% end %>
+  require "<%= gem.namespace_require %>/#{version.to_s.downcase}"
+  package_name = <%= gem.namespace %>
+                  .constants
+                  .select { |sym| sym.to_s.downcase == version.to_s.downcase.tr("_", "") }
+                  .first
+  return false unless package_name
+  service_module = <%= gem.namespace %>.const_get package_name
+  return false unless service_module.const_defined? :<%= service.module_name %>
+  service_module = service_module.const_get :<%= service.module_name %>
+<%- if service.supports_multiple_transports? -%>
+  if transport == :rest
+    return false unless service_module.const_defined? :Rest
+    service_module = service_module.const_get :Rest
+  end
+<%- elsif service.generate_rest_clients? -%>
+  return false unless service_module.const_defined? :Rest
+  service_module = service_module.const_get :Rest
+<%- end -%>
+  service_module.const_defined? :Client
+rescue ::LoadError
+  false
 end
 
 <%- end -%>

--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/client_test.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/client_test.erb
@@ -34,6 +34,7 @@ class <%= gem.namespace %>::ClientConstructionMinitest < Minitest::Test
 <%- gem.services.each do |service| -%>
 <%- if service.generate_grpc_clients? -%>
 <%= line_spacer %>  def test_<%= service.factory_method_name %>_grpc
+    skip unless <%= gem.namespace %>.<%= service.factory_method_name %>_available?<% if service.supports_multiple_transports? %> transport: :grpc<% end %>
     Gapic::ServiceStub.stub :new, DummyStub.new do
       grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
       client = <%= gem.namespace %>.<%= service.factory_method_name %><% if service.supports_multiple_transports? %> transport: :grpc<% end %> do |config|
@@ -45,6 +46,7 @@ class <%= gem.namespace %>::ClientConstructionMinitest < Minitest::Test
 <%- end -%>
 <%- if service.generate_rest_clients? -%>
 <%= line_spacer %>  def test_<%= service.factory_method_name %>_rest
+    skip unless <%= gem.namespace %>.<%= service.factory_method_name %>_available?<% if service.supports_multiple_transports? %> transport: :rest<% end %>
     Gapic::Rest::ClientStub.stub :new, DummyStub.new do
       client = <%= gem.namespace %>.<%= service.factory_method_name %><% if service.supports_multiple_transports? %> transport: :rest<% end %> do |config|
         config.credentials = :dummy_credentials

--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/readme.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/readme.erb
@@ -88,6 +88,14 @@ service such as [Google Cloud Run](https://cloud.google.com/run), this generally
 results in logs appearing alongside your application logs in the
 [Google Cloud Logging](https://cloud.google.com/logging/) service.
 
+Debug logging also requires that the versioned clients for this service be
+sufficiently recent, released after about Dec 10, 2024. If logging is not
+working, try updating the versioned clients in your bundle or installed gems:
+<%- last_index = gem.versioned_gems.size - 1 -%>
+<%- gem.versioned_gems.each_with_index do |name, i| -%>
+<%= gem.docs_link gem_name: name, text: name %><%= i == last_index ? "." : "," %>
+<%- end -%>
+
 ## Supported Ruby Versions
 
 This library is supported on Ruby 2.7+.

--- a/shared/output/cloud/compute_small_wrapper/README.md
+++ b/shared/output/cloud/compute_small_wrapper/README.md
@@ -55,6 +55,11 @@ service such as [Google Cloud Run](https://cloud.google.com/run), this generally
 results in logs appearing alongside your application logs in the
 [Google Cloud Logging](https://cloud.google.com/logging/) service.
 
+Debug logging also requires that the versioned clients for this service be
+sufficiently recent, released after about Dec 10, 2024. If logging is not
+working, try updating the versioned clients in your bundle or installed gems:
+[google-cloud-compute-v1](https://cloud.google.com/ruby/docs/reference/google-cloud-compute-v1/latest).
+
 ## Supported Ruby Versions
 
 This library is supported on Ruby 2.7+.

--- a/shared/output/cloud/compute_small_wrapper/lib/google/cloud/compute.rb
+++ b/shared/output/cloud/compute_small_wrapper/lib/google/cloud/compute.rb
@@ -55,6 +55,11 @@ module Google
       # supported by that API version, and the corresponding gem is available, the
       # appropriate versioned client will be returned.
       #
+      # Raises an exception if the currently installed versioned client gem for the
+      # given API version does not support the Addresses service.
+      # You can determine whether the method will succeed by calling
+      # {Google::Cloud::Compute.addresses_available?}.
+      #
       # ## About Addresses
       #
       # The Addresses API.
@@ -75,6 +80,34 @@ module Google
       end
 
       ##
+      # Determines whether the Addresses service is supported by the current client.
+      # If true, you can retrieve a client object by calling {Google::Cloud::Compute.addresses}.
+      # If false, that method will raise an exception. This could happen if the given
+      # API version does not exist or does not support the Addresses service,
+      # or if the versioned client gem needs an update to support the Addresses service.
+      #
+      # @param version [::String, ::Symbol] The API version to connect to. Optional.
+      #   Defaults to `:v1`.
+      # @return [boolean] Whether the service is available.
+      #
+      def self.addresses_available? version: :v1
+        require "google/cloud/compute/#{version.to_s.downcase}"
+        package_name = Google::Cloud::Compute
+                       .constants
+                       .select { |sym| sym.to_s.downcase == version.to_s.downcase.tr("_", "") }
+                       .first
+        return false unless package_name
+        service_module = Google::Cloud::Compute.const_get package_name
+        return false unless service_module.const_defined? :Addresses
+        service_module = service_module.const_get :Addresses
+        return false unless service_module.const_defined? :Rest
+        service_module = service_module.const_get :Rest
+        service_module.const_defined? :Client
+      rescue ::LoadError
+        false
+      end
+
+      ##
       # Create a new client object for RegionOperations.
       #
       # By default, this returns an instance of
@@ -84,6 +117,11 @@ module Google
       # `version` parameter. If the RegionOperations service is
       # supported by that API version, and the corresponding gem is available, the
       # appropriate versioned client will be returned.
+      #
+      # Raises an exception if the currently installed versioned client gem for the
+      # given API version does not support the RegionOperations service.
+      # You can determine whether the method will succeed by calling
+      # {Google::Cloud::Compute.region_operations_available?}.
       #
       # ## About RegionOperations
       #
@@ -105,6 +143,34 @@ module Google
       end
 
       ##
+      # Determines whether the RegionOperations service is supported by the current client.
+      # If true, you can retrieve a client object by calling {Google::Cloud::Compute.region_operations}.
+      # If false, that method will raise an exception. This could happen if the given
+      # API version does not exist or does not support the RegionOperations service,
+      # or if the versioned client gem needs an update to support the RegionOperations service.
+      #
+      # @param version [::String, ::Symbol] The API version to connect to. Optional.
+      #   Defaults to `:v1`.
+      # @return [boolean] Whether the service is available.
+      #
+      def self.region_operations_available? version: :v1
+        require "google/cloud/compute/#{version.to_s.downcase}"
+        package_name = Google::Cloud::Compute
+                       .constants
+                       .select { |sym| sym.to_s.downcase == version.to_s.downcase.tr("_", "") }
+                       .first
+        return false unless package_name
+        service_module = Google::Cloud::Compute.const_get package_name
+        return false unless service_module.const_defined? :RegionOperations
+        service_module = service_module.const_get :RegionOperations
+        return false unless service_module.const_defined? :Rest
+        service_module = service_module.const_get :Rest
+        service_module.const_defined? :Client
+      rescue ::LoadError
+        false
+      end
+
+      ##
       # Create a new client object for RegionInstanceGroupManagers.
       #
       # By default, this returns an instance of
@@ -114,6 +180,11 @@ module Google
       # `version` parameter. If the RegionInstanceGroupManagers service is
       # supported by that API version, and the corresponding gem is available, the
       # appropriate versioned client will be returned.
+      #
+      # Raises an exception if the currently installed versioned client gem for the
+      # given API version does not support the RegionInstanceGroupManagers service.
+      # You can determine whether the method will succeed by calling
+      # {Google::Cloud::Compute.region_instance_group_managers_available?}.
       #
       # ## About RegionInstanceGroupManagers
       #
@@ -135,6 +206,34 @@ module Google
       end
 
       ##
+      # Determines whether the RegionInstanceGroupManagers service is supported by the current client.
+      # If true, you can retrieve a client object by calling {Google::Cloud::Compute.region_instance_group_managers}.
+      # If false, that method will raise an exception. This could happen if the given
+      # API version does not exist or does not support the RegionInstanceGroupManagers service,
+      # or if the versioned client gem needs an update to support the RegionInstanceGroupManagers service.
+      #
+      # @param version [::String, ::Symbol] The API version to connect to. Optional.
+      #   Defaults to `:v1`.
+      # @return [boolean] Whether the service is available.
+      #
+      def self.region_instance_group_managers_available? version: :v1
+        require "google/cloud/compute/#{version.to_s.downcase}"
+        package_name = Google::Cloud::Compute
+                       .constants
+                       .select { |sym| sym.to_s.downcase == version.to_s.downcase.tr("_", "") }
+                       .first
+        return false unless package_name
+        service_module = Google::Cloud::Compute.const_get package_name
+        return false unless service_module.const_defined? :RegionInstanceGroupManagers
+        service_module = service_module.const_get :RegionInstanceGroupManagers
+        return false unless service_module.const_defined? :Rest
+        service_module = service_module.const_get :Rest
+        service_module.const_defined? :Client
+      rescue ::LoadError
+        false
+      end
+
+      ##
       # Create a new client object for Networks.
       #
       # By default, this returns an instance of
@@ -144,6 +243,11 @@ module Google
       # `version` parameter. If the Networks service is
       # supported by that API version, and the corresponding gem is available, the
       # appropriate versioned client will be returned.
+      #
+      # Raises an exception if the currently installed versioned client gem for the
+      # given API version does not support the Networks service.
+      # You can determine whether the method will succeed by calling
+      # {Google::Cloud::Compute.networks_available?}.
       #
       # ## About Networks
       #
@@ -165,6 +269,34 @@ module Google
       end
 
       ##
+      # Determines whether the Networks service is supported by the current client.
+      # If true, you can retrieve a client object by calling {Google::Cloud::Compute.networks}.
+      # If false, that method will raise an exception. This could happen if the given
+      # API version does not exist or does not support the Networks service,
+      # or if the versioned client gem needs an update to support the Networks service.
+      #
+      # @param version [::String, ::Symbol] The API version to connect to. Optional.
+      #   Defaults to `:v1`.
+      # @return [boolean] Whether the service is available.
+      #
+      def self.networks_available? version: :v1
+        require "google/cloud/compute/#{version.to_s.downcase}"
+        package_name = Google::Cloud::Compute
+                       .constants
+                       .select { |sym| sym.to_s.downcase == version.to_s.downcase.tr("_", "") }
+                       .first
+        return false unless package_name
+        service_module = Google::Cloud::Compute.const_get package_name
+        return false unless service_module.const_defined? :Networks
+        service_module = service_module.const_get :Networks
+        return false unless service_module.const_defined? :Rest
+        service_module = service_module.const_get :Rest
+        service_module.const_defined? :Client
+      rescue ::LoadError
+        false
+      end
+
+      ##
       # Create a new client object for GlobalOperations.
       #
       # By default, this returns an instance of
@@ -174,6 +306,11 @@ module Google
       # `version` parameter. If the GlobalOperations service is
       # supported by that API version, and the corresponding gem is available, the
       # appropriate versioned client will be returned.
+      #
+      # Raises an exception if the currently installed versioned client gem for the
+      # given API version does not support the GlobalOperations service.
+      # You can determine whether the method will succeed by calling
+      # {Google::Cloud::Compute.global_operations_available?}.
       #
       # ## About GlobalOperations
       #
@@ -192,6 +329,34 @@ module Google
                        .first
         service_module = Google::Cloud::Compute.const_get(package_name).const_get(:GlobalOperations)
         service_module.const_get(:Rest).const_get(:Client).new(&block)
+      end
+
+      ##
+      # Determines whether the GlobalOperations service is supported by the current client.
+      # If true, you can retrieve a client object by calling {Google::Cloud::Compute.global_operations}.
+      # If false, that method will raise an exception. This could happen if the given
+      # API version does not exist or does not support the GlobalOperations service,
+      # or if the versioned client gem needs an update to support the GlobalOperations service.
+      #
+      # @param version [::String, ::Symbol] The API version to connect to. Optional.
+      #   Defaults to `:v1`.
+      # @return [boolean] Whether the service is available.
+      #
+      def self.global_operations_available? version: :v1
+        require "google/cloud/compute/#{version.to_s.downcase}"
+        package_name = Google::Cloud::Compute
+                       .constants
+                       .select { |sym| sym.to_s.downcase == version.to_s.downcase.tr("_", "") }
+                       .first
+        return false unless package_name
+        service_module = Google::Cloud::Compute.const_get package_name
+        return false unless service_module.const_defined? :GlobalOperations
+        service_module = service_module.const_get :GlobalOperations
+        return false unless service_module.const_defined? :Rest
+        service_module = service_module.const_get :Rest
+        service_module.const_defined? :Client
+      rescue ::LoadError
+        false
       end
 
       ##

--- a/shared/output/cloud/compute_small_wrapper/test/google/cloud/compute/client_test.rb
+++ b/shared/output/cloud/compute_small_wrapper/test/google/cloud/compute/client_test.rb
@@ -41,6 +41,7 @@ class Google::Cloud::Compute::ClientConstructionMinitest < Minitest::Test
   end
 
   def test_addresses_rest
+    skip unless Google::Cloud::Compute.addresses_available?
     Gapic::Rest::ClientStub.stub :new, DummyStub.new do
       client = Google::Cloud::Compute.addresses do |config|
         config.credentials = :dummy_credentials
@@ -50,6 +51,7 @@ class Google::Cloud::Compute::ClientConstructionMinitest < Minitest::Test
   end
 
   def test_region_operations_rest
+    skip unless Google::Cloud::Compute.region_operations_available?
     Gapic::Rest::ClientStub.stub :new, DummyStub.new do
       client = Google::Cloud::Compute.region_operations do |config|
         config.credentials = :dummy_credentials
@@ -59,6 +61,7 @@ class Google::Cloud::Compute::ClientConstructionMinitest < Minitest::Test
   end
 
   def test_region_instance_group_managers_rest
+    skip unless Google::Cloud::Compute.region_instance_group_managers_available?
     Gapic::Rest::ClientStub.stub :new, DummyStub.new do
       client = Google::Cloud::Compute.region_instance_group_managers do |config|
         config.credentials = :dummy_credentials
@@ -68,6 +71,7 @@ class Google::Cloud::Compute::ClientConstructionMinitest < Minitest::Test
   end
 
   def test_networks_rest
+    skip unless Google::Cloud::Compute.networks_available?
     Gapic::Rest::ClientStub.stub :new, DummyStub.new do
       client = Google::Cloud::Compute.networks do |config|
         config.credentials = :dummy_credentials
@@ -77,6 +81,7 @@ class Google::Cloud::Compute::ClientConstructionMinitest < Minitest::Test
   end
 
   def test_global_operations_rest
+    skip unless Google::Cloud::Compute.global_operations_available?
     Gapic::Rest::ClientStub.stub :new, DummyStub.new do
       client = Google::Cloud::Compute.global_operations do |config|
         config.credentials = :dummy_credentials

--- a/shared/output/cloud/language_wrapper/README.md
+++ b/shared/output/cloud/language_wrapper/README.md
@@ -59,6 +59,11 @@ service such as [Google Cloud Run](https://cloud.google.com/run), this generally
 results in logs appearing alongside your application logs in the
 [Google Cloud Logging](https://cloud.google.com/logging/) service.
 
+Debug logging also requires that the versioned clients for this service be
+sufficiently recent, released after about Dec 10, 2024. If logging is not
+working, try updating the versioned clients in your bundle or installed gems:
+[google-cloud-language-v1](https://cloud.google.com/ruby/docs/reference/google-cloud-language-v1/latest).
+
 ## Supported Ruby Versions
 
 This library is supported on Ruby 2.7+.

--- a/shared/output/cloud/language_wrapper/lib/google/cloud/language.rb
+++ b/shared/output/cloud/language_wrapper/lib/google/cloud/language.rb
@@ -58,6 +58,11 @@ module Google
       # You can also specify a different transport by passing `:rest` or `:grpc` in
       # the `transport` parameter.
       #
+      # Raises an exception if the currently installed versioned client gem for the
+      # given API version does not support the given transport of the LanguageService service.
+      # You can determine whether the method will succeed by calling
+      # {Google::Cloud::Language.language_service_available?}.
+      #
       # ## About LanguageService
       #
       # Provides text analysis operations such as sentiment analysis and entity
@@ -78,6 +83,37 @@ module Google
         service_module = Google::Cloud::Language.const_get(package_name).const_get(:LanguageService)
         service_module = service_module.const_get(:Rest) if transport == :rest
         service_module.const_get(:Client).new(&block)
+      end
+
+      ##
+      # Determines whether the LanguageService service is supported by the current client.
+      # If true, you can retrieve a client object by calling {Google::Cloud::Language.language_service}.
+      # If false, that method will raise an exception. This could happen if the given
+      # API version does not exist or does not support the LanguageService service,
+      # or if the versioned client gem needs an update to support the LanguageService service.
+      #
+      # @param version [::String, ::Symbol] The API version to connect to. Optional.
+      #   Defaults to `:v1`.
+      # @param transport [:grpc, :rest] The transport to use. Defaults to `:grpc`.
+      # @return [boolean] Whether the service is available.
+      #
+      def self.language_service_available? version: :v1, transport: :grpc
+        require "google/cloud/language/#{version.to_s.downcase}"
+        package_name = Google::Cloud::Language
+                       .constants
+                       .select { |sym| sym.to_s.downcase == version.to_s.downcase.tr("_", "") }
+                       .first
+        return false unless package_name
+        service_module = Google::Cloud::Language.const_get package_name
+        return false unless service_module.const_defined? :LanguageService
+        service_module = service_module.const_get :LanguageService
+        if transport == :rest
+          return false unless service_module.const_defined? :Rest
+          service_module = service_module.const_get :Rest
+        end
+        service_module.const_defined? :Client
+      rescue ::LoadError
+        false
       end
 
       ##

--- a/shared/output/cloud/language_wrapper/test/google/cloud/language/client_test.rb
+++ b/shared/output/cloud/language_wrapper/test/google/cloud/language/client_test.rb
@@ -42,6 +42,7 @@ class Google::Cloud::Language::ClientConstructionMinitest < Minitest::Test
   end
 
   def test_language_service_grpc
+    skip unless Google::Cloud::Language.language_service_available? transport: :grpc
     Gapic::ServiceStub.stub :new, DummyStub.new do
       grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
       client = Google::Cloud::Language.language_service transport: :grpc do |config|
@@ -52,6 +53,7 @@ class Google::Cloud::Language::ClientConstructionMinitest < Minitest::Test
   end
 
   def test_language_service_rest
+    skip unless Google::Cloud::Language.language_service_available? transport: :rest
     Gapic::Rest::ClientStub.stub :new, DummyStub.new do
       client = Google::Cloud::Language.language_service transport: :rest do |config|
         config.credentials = :dummy_credentials

--- a/shared/output/cloud/secretmanager_wrapper/README.md
+++ b/shared/output/cloud/secretmanager_wrapper/README.md
@@ -68,6 +68,12 @@ service such as [Google Cloud Run](https://cloud.google.com/run), this generally
 results in logs appearing alongside your application logs in the
 [Google Cloud Logging](https://cloud.google.com/logging/) service.
 
+Debug logging also requires that the versioned clients for this service be
+sufficiently recent, released after about Dec 10, 2024. If logging is not
+working, try updating the versioned clients in your bundle or installed gems:
+[google-cloud-secret_manager-v1](https://cloud.google.com/ruby/docs/reference/google-cloud-secret_manager-v1/latest),
+[google-cloud-secret_manager-v1beta1](https://cloud.google.com/ruby/docs/reference/google-cloud-secret_manager-v1beta1/latest).
+
 ## Supported Ruby Versions
 
 This library is supported on Ruby 2.7+.

--- a/shared/output/cloud/secretmanager_wrapper/lib/google/cloud/secret_manager.rb
+++ b/shared/output/cloud/secretmanager_wrapper/lib/google/cloud/secret_manager.rb
@@ -56,6 +56,11 @@ module Google
       # supported by that API version, and the corresponding gem is available, the
       # appropriate versioned client will be returned.
       #
+      # Raises an exception if the currently installed versioned client gem for the
+      # given API version does not support the SecretManagerService service.
+      # You can determine whether the method will succeed by calling
+      # {Google::Cloud::SecretManager.secret_manager_service_available?}.
+      #
       # ## About SecretManagerService
       #
       # Secret Manager Service
@@ -79,6 +84,32 @@ module Google
                        .first
         service_module = Google::Cloud::SecretManager.const_get(package_name).const_get(:SecretManagerService)
         service_module.const_get(:Client).new(&block)
+      end
+
+      ##
+      # Determines whether the SecretManagerService service is supported by the current client.
+      # If true, you can retrieve a client object by calling {Google::Cloud::SecretManager.secret_manager_service}.
+      # If false, that method will raise an exception. This could happen if the given
+      # API version does not exist or does not support the SecretManagerService service,
+      # or if the versioned client gem needs an update to support the SecretManagerService service.
+      #
+      # @param version [::String, ::Symbol] The API version to connect to. Optional.
+      #   Defaults to `:v1beta1`.
+      # @return [boolean] Whether the service is available.
+      #
+      def self.secret_manager_service_available? version: :v1beta1
+        require "google/cloud/secret_manager/#{version.to_s.downcase}"
+        package_name = Google::Cloud::SecretManager
+                       .constants
+                       .select { |sym| sym.to_s.downcase == version.to_s.downcase.tr("_", "") }
+                       .first
+        return false unless package_name
+        service_module = Google::Cloud::SecretManager.const_get package_name
+        return false unless service_module.const_defined? :SecretManagerService
+        service_module = service_module.const_get :SecretManagerService
+        service_module.const_defined? :Client
+      rescue ::LoadError
+        false
       end
 
       ##

--- a/shared/output/cloud/secretmanager_wrapper/test/google/cloud/secret_manager/client_test.rb
+++ b/shared/output/cloud/secretmanager_wrapper/test/google/cloud/secret_manager/client_test.rb
@@ -41,6 +41,7 @@ class Google::Cloud::SecretManager::ClientConstructionMinitest < Minitest::Test
   end
 
   def test_secret_manager_service_grpc
+    skip unless Google::Cloud::SecretManager.secret_manager_service_available?
     Gapic::ServiceStub.stub :new, DummyStub.new do
       grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
       client = Google::Cloud::SecretManager.secret_manager_service do |config|


### PR DESCRIPTION
Currently the client object factory methods in wrapper clients just expect that the underlying GAPIC provides the correct classes, and will raise LoadErrors or NameErrors if used with an out-of-date GAPIC. In particular, the unit tests for wrappers will fail if the GAPIC is out of date. This causes problems when a new service is added to an API, and gets added to the GAPIC and wrapper simultaneously. The wrapper tests fail until the GAPIC is updated and released, and we also typically go through the extra step of updating the version requirement in the dependency. This is a recurring source of toil.

This PR improves the situation by:

* Providing additional documentation calling out that an out-of-date GAPIC could cause the wrapper's factory method to fail, and noting what should be done.
* Providing new methods in the wrapper to test whether a service is available in the given API version and transport type.
* Updating the wrapper unit tests to skip tests when a service is unavailable.

This PR also updates the wrapper README with a clarification that debug logging also requires a recent GAPIC.