### PR TITLE
fix: Add warning regarding external credential sourcing

### DIFF
--- a/gapic-generator/templates/default/service/client/_config.erb
+++ b/gapic-generator/templates/default/service/client/_config.erb
@@ -46,6 +46,13 @@
 #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
 #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
 #    *  (`nil`) indicating no credentials
+#
+#   Warning: If you accept a credential configuration (JSON file or Hash) from an
+#   external source for authentication to Google Cloud, you must validate it before
+#   providing it to a Google API client library. Providing an unvalidated credential
+#   configuration to Google APIs can compromise the security of your systems and data.
+#   For more information, refer to [Validate credential configurations from external
+#   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
 #   @return [::Object]
 # @!attribute [rw] scope
 #   The OAuth scopes

--- a/gapic-generator/templates/default/service/rest/client/_config.erb
+++ b/gapic-generator/templates/default/service/rest/client/_config.erb
@@ -44,6 +44,13 @@
 #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
 #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
 #    *  (`nil`) indicating no credentials
+#
+#   Warning: If you accept a credential configuration (JSON file or Hash) from an
+#   external source for authentication to Google Cloud, you must validate it before
+#   providing it to a Google API client library. Providing an unvalidated credential
+#   configuration to Google APIs can compromise the security of your systems and data.
+#   For more information, refer to [Validate credential configurations from external
+#   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
 #   @return [::Object]
 # @!attribute [rw] scope
 #   The OAuth scopes

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v15/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v15/services/campaign_service/client.rb
@@ -357,6 +357,13 @@ module Google
               #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
               #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
               #    *  (`nil`) indicating no credentials
+              #
+              #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+              #   external source for authentication to Google Cloud, you must validate it before
+              #   providing it to a Google API client library. Providing an unvalidated credential
+              #   configuration to Google APIs can compromise the security of your systems and data.
+              #   For more information, refer to [Validate credential configurations from external
+              #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
               #   @return [::Object]
               # @!attribute [rw] scope
               #   The OAuth scopes

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/client.rb
@@ -713,6 +713,13 @@ module Google
               #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
               #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
               #    *  (`nil`) indicating no credentials
+              #
+              #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+              #   external source for authentication to Google Cloud, you must validate it before
+              #   providing it to a Google API client library. Providing an unvalidated credential
+              #   configuration to Google APIs can compromise the security of your systems and data.
+              #   For more information, refer to [Validate credential configurations from external
+              #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
               #   @return [::Object]
               # @!attribute [rw] scope
               #   The OAuth scopes

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/rest/client.rb
@@ -376,6 +376,13 @@ module Google
               #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
               #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
               #    *  (`nil`) indicating no credentials
+              #
+              #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+              #   external source for authentication to Google Cloud, you must validate it before
+              #   providing it to a Google API client library. Providing an unvalidated credential
+              #   configuration to Google APIs can compromise the security of your systems and data.
+              #   For more information, refer to [Validate credential configurations from external
+              #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
               #   @return [::Object]
               # @!attribute [rw] scope
               #   The OAuth scopes

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/client.rb
@@ -436,6 +436,13 @@ module Google
               #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
               #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
               #    *  (`nil`) indicating no credentials
+              #
+              #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+              #   external source for authentication to Google Cloud, you must validate it before
+              #   providing it to a Google API client library. Providing an unvalidated credential
+              #   configuration to Google APIs can compromise the security of your systems and data.
+              #   For more information, refer to [Validate credential configurations from external
+              #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
               #   @return [::Object]
               # @!attribute [rw] scope
               #   The OAuth scopes

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/client.rb
@@ -335,6 +335,13 @@ module Google
               #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
               #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
               #    *  (`nil`) indicating no credentials
+              #
+              #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+              #   external source for authentication to Google Cloud, you must validate it before
+              #   providing it to a Google API client library. Providing an unvalidated credential
+              #   configuration to Google APIs can compromise the security of your systems and data.
+              #   For more information, refer to [Validate credential configurations from external
+              #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
               #   @return [::Object]
               # @!attribute [rw] scope
               #   The OAuth scopes

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest/client.rb
@@ -568,6 +568,13 @@ module Google
               #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
               #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
               #    *  (`nil`) indicating no credentials
+              #
+              #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+              #   external source for authentication to Google Cloud, you must validate it before
+              #   providing it to a Google API client library. Providing an unvalidated credential
+              #   configuration to Google APIs can compromise the security of your systems and data.
+              #   For more information, refer to [Validate credential configurations from external
+              #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
               #   @return [::Object]
               # @!attribute [rw] scope
               #   The OAuth scopes

--- a/shared/output/cloud/grafeas_v1/lib/grafeas/v1/grafeas/client.rb
+++ b/shared/output/cloud/grafeas_v1/lib/grafeas/v1/grafeas/client.rb
@@ -1493,6 +1493,13 @@ module Grafeas
         #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
         #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
         #    *  (`nil`) indicating no credentials
+        #
+        #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+        #   external source for authentication to Google Cloud, you must validate it before
+        #   providing it to a Google API client library. Providing an unvalidated credential
+        #   configuration to Google APIs can compromise the security of your systems and data.
+        #   For more information, refer to [Validate credential configurations from external
+        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
@@ -1288,6 +1288,13 @@ module Google
             #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
             #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/rest/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/rest/client.rb
@@ -816,6 +816,13 @@ module Google
               #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
               #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
               #    *  (`nil`) indicating no credentials
+              #
+              #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+              #   external source for authentication to Google Cloud, you must validate it before
+              #   providing it to a Google API client library. Providing an unvalidated credential
+              #   configuration to Google APIs can compromise the security of your systems and data.
+              #   For more information, refer to [Validate credential configurations from external
+              #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
               #   @return [::Object]
               # @!attribute [rw] scope
               #   The OAuth scopes

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -550,6 +550,13 @@ module Google
             #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
             #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -789,6 +789,13 @@ module Google
             #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
             #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/location/lib/google/cloud/location/locations/client.rb
+++ b/shared/output/cloud/location/lib/google/cloud/location/locations/client.rb
@@ -408,6 +408,13 @@ module Google
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/cloud/location/lib/google/cloud/location/locations/rest/client.rb
+++ b/shared/output/cloud/location/lib/google/cloud/location/locations/rest/client.rb
@@ -389,6 +389,13 @@ module Google
             #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
             #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -1610,6 +1610,13 @@ module Google
             #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
             #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/adaptation/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/adaptation/client.rb
@@ -1230,6 +1230,13 @@ module Google
             #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
             #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -497,6 +497,13 @@ module Google
             #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
             #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -647,6 +647,13 @@ module Google
             #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
             #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -687,6 +687,13 @@ module Google
             #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
             #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -647,6 +647,13 @@ module Google
             #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
             #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/rest/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/rest/client.rb
@@ -683,6 +683,13 @@ module Google
               #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
               #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
               #    *  (`nil`) indicating no credentials
+              #
+              #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+              #   external source for authentication to Google Cloud, you must validate it before
+              #   providing it to a Google API client library. Providing an unvalidated credential
+              #   configuration to Google APIs can compromise the security of your systems and data.
+              #   For more information, refer to [Validate credential configurations from external
+              #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
               #   @return [::Object]
               # @!attribute [rw] scope
               #   The OAuth scopes

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/rest/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/rest/operations.rb
@@ -509,6 +509,13 @@ module Google
               #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
               #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
               #    *  (`nil`) indicating no credentials
+              #
+              #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+              #   external source for authentication to Google Cloud, you must validate it before
+              #   providing it to a Google API client library. Providing an unvalidated credential
+              #   configuration to Google APIs can compromise the security of your systems and data.
+              #   For more information, refer to [Validate credential configurations from external
+              #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
               #   @return [::Object]
               # @!attribute [rw] scope
               #   The OAuth scopes

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -2192,6 +2192,13 @@ module Google
             #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
             #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -647,6 +647,13 @@ module Google
             #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
             #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/client.rb
@@ -2051,6 +2051,13 @@ module Google
               #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
               #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
               #    *  (`nil`) indicating no credentials
+              #
+              #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+              #   external source for authentication to Google Cloud, you must validate it before
+              #   providing it to a Google API client library. Providing an unvalidated credential
+              #   configuration to Google APIs can compromise the security of your systems and data.
+              #   For more information, refer to [Validate credential configurations from external
+              #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
               #   @return [::Object]
               # @!attribute [rw] scope
               #   The OAuth scopes

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/operations.rb
@@ -509,6 +509,13 @@ module Google
               #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
               #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
               #    *  (`nil`) indicating no credentials
+              #
+              #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+              #   external source for authentication to Google Cloud, you must validate it before
+              #   providing it to a Google API client library. Providing an unvalidated credential
+              #   configuration to Google APIs can compromise the security of your systems and data.
+              #   For more information, refer to [Validate credential configurations from external
+              #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
               #   @return [::Object]
               # @!attribute [rw] scope
               #   The OAuth scopes

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/deprecated_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/deprecated_service/client.rb
@@ -289,6 +289,13 @@ module So
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -1742,6 +1742,13 @@ module So
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -645,6 +645,13 @@ module So
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/client.rb
@@ -531,6 +531,13 @@ module So
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/really_renamed_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/really_renamed_service/client.rb
@@ -289,6 +289,13 @@ module So
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/client.rb
@@ -591,6 +591,13 @@ module So
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/compliance/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/compliance/client.rb
@@ -1176,6 +1176,13 @@ module Google
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/compliance/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/compliance/rest/client.rb
@@ -1153,6 +1153,13 @@ module Google
             #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
             #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -1190,6 +1190,13 @@ module Google
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -637,6 +637,13 @@ module Google
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/client.rb
@@ -1020,6 +1020,13 @@ module Google
             #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
             #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/operations.rb
@@ -517,6 +517,13 @@ module Google
             #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
             #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -671,6 +671,13 @@ module Google
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/rest/client.rb
@@ -656,6 +656,13 @@ module Google
             #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
             #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -1477,6 +1477,13 @@ module Google
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -637,6 +637,13 @@ module Google
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/rest/client.rb
@@ -1275,6 +1275,13 @@ module Google
             #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
             #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/rest/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/rest/operations.rb
@@ -517,6 +517,13 @@ module Google
             #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
             #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/sequence_service/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/sequence_service/client.rb
@@ -743,6 +743,13 @@ module Google
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/sequence_service/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/sequence_service/rest/client.rb
@@ -723,6 +723,13 @@ module Google
             #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
             #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -948,6 +948,13 @@ module Google
           #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
           #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/rest/client.rb
@@ -918,6 +918,13 @@ module Google
             #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
             #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
             #    *  (`nil`) indicating no credentials
+            #
+            #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+            #   external source for authentication to Google Cloud, you must validate it before
+            #   providing it to a Google API client library. Providing an unvalidated credential
+            #   configuration to Google APIs can compromise the security of your systems and data.
+            #   For more information, refer to [Validate credential configurations from external
+            #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
             #   @return [::Object]
             # @!attribute [rw] scope
             #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_no_retry/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_no_retry/client.rb
@@ -302,6 +302,13 @@ module Testing
         #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
         #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
         #    *  (`nil`) indicating no credentials
+        #
+        #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+        #   external source for authentication to Google Cloud, you must validate it before
+        #   providing it to a Google API client library. Providing an unvalidated credential
+        #   configuration to Google APIs can compromise the security of your systems and data.
+        #   For more information, refer to [Validate credential configurations from external
+        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_no_retry/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_no_retry/rest/client.rb
@@ -297,6 +297,13 @@ module Testing
           #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
           #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_with_retries/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_with_retries/client.rb
@@ -379,6 +379,13 @@ module Testing
         #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
         #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
         #    *  (`nil`) indicating no credentials
+        #
+        #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+        #   external source for authentication to Google Cloud, you must validate it before
+        #   providing it to a Google API client library. Providing an unvalidated credential
+        #   configuration to Google APIs can compromise the security of your systems and data.
+        #   For more information, refer to [Validate credential configurations from external
+        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_with_retries/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_with_retries/rest/client.rb
@@ -375,6 +375,13 @@ module Testing
           #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
           #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc/client.rb
@@ -302,6 +302,13 @@ module Testing
         #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
         #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
         #    *  (`nil`) indicating no credentials
+        #
+        #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+        #   external source for authentication to Google Cloud, you must validate it before
+        #   providing it to a Google API client library. Providing an unvalidated credential
+        #   configuration to Google APIs can compromise the security of your systems and data.
+        #   For more information, refer to [Validate credential configurations from external
+        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc/rest/client.rb
@@ -297,6 +297,13 @@ module Testing
           #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
           #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/client.rb
@@ -681,6 +681,13 @@ module Testing
         #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
         #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
         #    *  (`nil`) indicating no credentials
+        #
+        #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+        #   external source for authentication to Google Cloud, you must validate it before
+        #   providing it to a Google API client library. Providing an unvalidated credential
+        #   configuration to Google APIs can compromise the security of your systems and data.
+        #   For more information, refer to [Validate credential configurations from external
+        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/operations.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/operations.rb
@@ -636,6 +636,13 @@ module Testing
         #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
         #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
         #    *  (`nil`) indicating no credentials
+        #
+        #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+        #   external source for authentication to Google Cloud, you must validate it before
+        #   providing it to a Google API client library. Providing an unvalidated credential
+        #   configuration to Google APIs can compromise the security of your systems and data.
+        #   For more information, refer to [Validate credential configurations from external
+        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/client.rb
@@ -687,6 +687,13 @@ module Testing
           #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
           #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/operations.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/operations.rb
@@ -516,6 +516,13 @@ module Testing
           #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
           #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/another_lro_provider/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/another_lro_provider/client.rb
@@ -310,6 +310,13 @@ module Testing
         #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
         #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
         #    *  (`nil`) indicating no credentials
+        #
+        #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+        #   external source for authentication to Google Cloud, you must validate it before
+        #   providing it to a Google API client library. Providing an unvalidated credential
+        #   configuration to Google APIs can compromise the security of your systems and data.
+        #   For more information, refer to [Validate credential configurations from external
+        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/another_lro_provider/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/another_lro_provider/rest/client.rb
@@ -305,6 +305,13 @@ module Testing
           #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
           #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/client.rb
@@ -333,6 +333,13 @@ module Testing
         #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
         #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
         #    *  (`nil`) indicating no credentials
+        #
+        #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+        #   external source for authentication to Google Cloud, you must validate it before
+        #   providing it to a Google API client library. Providing an unvalidated credential
+        #   configuration to Google APIs can compromise the security of your systems and data.
+        #   For more information, refer to [Validate credential configurations from external
+        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/rest/client.rb
@@ -328,6 +328,13 @@ module Testing
           #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
           #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_provider/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_provider/client.rb
@@ -310,6 +310,13 @@ module Testing
         #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
         #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
         #    *  (`nil`) indicating no credentials
+        #
+        #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+        #   external source for authentication to Google Cloud, you must validate it before
+        #   providing it to a Google API client library. Providing an unvalidated credential
+        #   configuration to Google APIs can compromise the security of your systems and data.
+        #   For more information, refer to [Validate credential configurations from external
+        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_provider/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_provider/rest/client.rb
@@ -305,6 +305,13 @@ module Testing
           #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
           #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_explicit_headers/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_explicit_headers/client.rb
@@ -729,6 +729,13 @@ module Testing
         #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
         #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
         #    *  (`nil`) indicating no credentials
+        #
+        #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+        #   external source for authentication to Google Cloud, you must validate it before
+        #   providing it to a Google API client library. Providing an unvalidated credential
+        #   configuration to Google APIs can compromise the security of your systems and data.
+        #   For more information, refer to [Validate credential configurations from external
+        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_explicit_headers/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_explicit_headers/rest/client.rb
@@ -659,6 +659,13 @@ module Testing
           #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
           #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_implicit_headers/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_implicit_headers/client.rb
@@ -511,6 +511,13 @@ module Testing
         #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
         #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
         #    *  (`nil`) indicating no credentials
+        #
+        #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+        #   external source for authentication to Google Cloud, you must validate it before
+        #   providing it to a Google API client library. Providing an unvalidated credential
+        #   configuration to Google APIs can compromise the security of your systems and data.
+        #   For more information, refer to [Validate credential configurations from external
+        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_implicit_headers/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_implicit_headers/rest/client.rb
@@ -487,6 +487,13 @@ module Testing
           #    *  (`Signet::OAuth2::Client`) A signet oauth2 client object
           #       (see the [signet docs](https://rubydoc.info/gems/signet/Signet/OAuth2/Client))
           #    *  (`nil`) indicating no credentials
+          #
+          #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+          #   external source for authentication to Google Cloud, you must validate it before
+          #   providing it to a Google API client library. Providing an unvalidated credential
+          #   configuration to Google APIs can compromise the security of your systems and data.
+          #   For more information, refer to [Validate credential configurations from external
+          #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
           #   @return [::Object]
           # @!attribute [rw] scope
           #   The OAuth scopes

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_no_headers/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_no_headers/client.rb
@@ -320,6 +320,13 @@ module Testing
         #    *  (`GRPC::Core::Channel`) a gRPC channel with included credentials
         #    *  (`GRPC::Core::ChannelCredentials`) a gRPC credentails object
         #    *  (`nil`) indicating no credentials
+        #
+        #   Warning: If you accept a credential configuration (JSON file or Hash) from an
+        #   external source for authentication to Google Cloud, you must validate it before
+        #   providing it to a Google API client library. Providing an unvalidated credential
+        #   configuration to Google APIs can compromise the security of your systems and data.
+        #   For more information, refer to [Validate credential configurations from external
+        #   sources](https://cloud.google.com/docs/authentication/external/externally-sourced-credentials).
         #   @return [::Object]
         # @!attribute [rw] scope
         #   The OAuth scopes


### PR DESCRIPTION
This is an ask from the auth team. The first commit includes the template changes, and the second includes the regenerated goldens.