### PR TITLE
chore: Grant needed permissions to actions

### DIFF
--- a/.github/workflows/tag-generators.yml
+++ b/.github/workflows/tag-generators.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      packages: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
The googleapis org changed the github actions token permissions to the restricted setting, which broke several of our actions that require certain write permissions. This PR restores functionality of the tag-generators action by specifying the needed permissions explicitly.