### PR TITLE
feat: Update Ruby to 3.2.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Checkout submodules

--- a/gapic-generator-ads/Gemfile.lock
+++ b/gapic-generator-ads/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
     grpc-tools (1.60.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    json (2.11.2)
+    json (2.11.3)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     loofah (2.24.0)
@@ -96,7 +96,7 @@ GEM
     rainbow (3.1.1)
     redcarpet (3.6.1)
     regexp_parser (2.10.0)
-    rubocop (1.75.3)
+    rubocop (1.75.4)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -134,4 +134,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.5.22
+   2.4.19

--- a/gapic-generator-cloud/Gemfile.lock
+++ b/gapic-generator-cloud/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
     grpc-tools (1.60.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    json (2.11.2)
+    json (2.11.3)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     loofah (2.24.0)
@@ -96,7 +96,7 @@ GEM
     rainbow (3.1.1)
     redcarpet (3.6.1)
     regexp_parser (2.10.0)
-    rubocop (1.75.3)
+    rubocop (1.75.4)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -134,4 +134,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.5.22
+   2.4.19

--- a/gapic-generator/Gemfile.lock
+++ b/gapic-generator/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
     grpc-tools (1.60.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    json (2.11.2)
+    json (2.11.3)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     loofah (2.24.0)
@@ -90,7 +90,7 @@ GEM
     rainbow (3.1.1)
     redcarpet (3.6.1)
     regexp_parser (2.10.0)
-    rubocop (1.75.3)
+    rubocop (1.75.4)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -127,4 +127,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.5.22
+   2.4.19

--- a/rules_ruby_gapic/gapic-generator-ads/repositories.bzl
+++ b/rules_ruby_gapic/gapic-generator-ads/repositories.bzl
@@ -26,10 +26,10 @@ def gapic_generator_ads_repositories():
   # Create the ruby runtime
   ruby_runtime(
     name = "gapic_generator_ads_ruby_runtime",
-    urls = ["https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz"],
-    strip_prefix = "ruby-3.1.3",
+    urls = ["https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.8.tar.gz"],
+    strip_prefix = "ruby-3.2.8",
     prebuilt_rubys = [
-      "@gapic_generator_ruby//rules_ruby_gapic:prebuilt/ruby-3.1.3_glinux_x86_64.tar.gz",
+      "@gapic_generator_ruby//rules_ruby_gapic:prebuilt/ruby-3.2.8_glinux_x86_64.tar.gz",
     ],
     gemfile_lock = "@gapic_generator_ruby//:gapic-generator-ads/Gemfile.lock",
     gems_to_install = {},

--- a/rules_ruby_gapic/gapic-generator-cloud/repositories.bzl
+++ b/rules_ruby_gapic/gapic-generator-cloud/repositories.bzl
@@ -22,10 +22,10 @@ def gapic_generator_cloud_repositories():
   # Create the ruby runtime
   ruby_runtime(
     name = "gapic_generator_cloud_ruby_runtime",
-    urls = ["https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz"],
-    strip_prefix = "ruby-3.1.3",
+    urls = ["https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.8.tar.gz"],
+    strip_prefix = "ruby-3.2.8",
     prebuilt_rubys = [
-      "@gapic_generator_ruby//rules_ruby_gapic:prebuilt/ruby-3.1.3_glinux_x86_64.tar.gz",
+      "@gapic_generator_ruby//rules_ruby_gapic:prebuilt/ruby-3.2.8_glinux_x86_64.tar.gz",
     ],
     gemfile_lock = "@gapic_generator_ruby//:gapic-generator-cloud/Gemfile.lock",
     gems_to_install = {},

--- a/rules_ruby_gapic/gapic-generator/repositories.bzl
+++ b/rules_ruby_gapic/gapic-generator/repositories.bzl
@@ -26,10 +26,10 @@ def gapic_generator_repositories():
   # Create the ruby runtime
   ruby_runtime(
     name = "gapic_generator_ruby_runtime",
-    urls = ["https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz"],
-    strip_prefix = "ruby-3.1.3",
+    urls = ["https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.8.tar.gz"],
+    strip_prefix = "ruby-3.2.8",
     prebuilt_rubys = [
-      "@gapic_generator_ruby//rules_ruby_gapic:prebuilt/ruby-3.1.3_glinux_x86_64.tar.gz",
+      "@gapic_generator_ruby//rules_ruby_gapic:prebuilt/ruby-3.2.8_glinux_x86_64.tar.gz",
     ],
     gemfile_lock = "@gapic_generator_ruby//:gapic-generator/Gemfile.lock",
     gems_to_install = {},

--- a/rules_ruby_gapic/prebuilt/pack_prebuilt_ruby.sh
+++ b/rules_ruby_gapic/prebuilt/pack_prebuilt_ruby.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # A script demonstrating how to pack a ruby_runtime prebuild
-VERSION="3.1.3"
+VERSION="3.2.8"
 
 mkdir -p /tmp/pack_prebuilt_ruby/ruby-${VERSION}
 rm -rf /tmp/pack_prebuilt_ruby/ruby-${VERSION}/*
@@ -26,6 +26,6 @@ cp -r ~/src/gapic-generator-ruby/bazel-gapic-generator-ruby/external/ruby_runtim
 # alternative location -- from the bazel_example sub-workspace
 # cp -r ~/src/gapic-generator-ruby/bazel_example/bazel-bazel_example/external/ruby_runtime/* ./ruby-${VERSION}/
 
-tar -czf ruby-${VERSION}_linux_x86_64.tar.gz ruby-${VERSION}/bin ruby-${VERSION}/lib ruby-${VERSION}/include
-cp ./ruby-${VERSION}_linux_x86_64.tar.gz ~/src/gapic-generator-ruby/rules_ruby_gapic/prebuilt/
+tar -czf ruby-${VERSION}_glinux_x86_64.tar.gz ruby-${VERSION}/bin ruby-${VERSION}/lib ruby-${VERSION}/include
+cp ./ruby-${VERSION}_glinux_x86_64.tar.gz ~/src/gapic-generator-ruby/rules_ruby_gapic/prebuilt/
 popd

--- a/rules_ruby_gapic/repositories.bzl
+++ b/rules_ruby_gapic/repositories.bzl
@@ -34,7 +34,7 @@ def gapic_generator_ruby_repositories():
 # list_of_gems: a dictionary of gem name -> version strings to be loaded when the ruby_runtime dependency builds
 #
 def gapic_generator_ruby_customgems(list_of_gems):
-  _protobuf_version = "3.13.0"
+  _protobuf_version = "3.25.6"
   _protobuf_version_in_link = "v%s" % _protobuf_version
   _maybe(
     http_archive,
@@ -62,12 +62,12 @@ def gapic_generator_ruby_customgems(list_of_gems):
   # Create the common ruby runtime used for checks
   ruby_runtime(
     name = "ruby_runtime",
-    urls = ["https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz"],
-    strip_prefix = "ruby-3.1.3",
+    urls = ["https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.8.tar.gz"],
+    strip_prefix = "ruby-3.2.8",
     prebuilt_rubys = [
-      "@gapic_generator_ruby//rules_ruby_gapic:prebuilt/ruby-3.1.3_glinux_x86_64.tar.gz",
+      "@gapic_generator_ruby//rules_ruby_gapic:prebuilt/ruby-3.2.8_glinux_x86_64.tar.gz",
     ],
-    bundler_version_to_install = "2.4.4",
+    bundler_version_to_install = "2.6.8",
     gems_to_install = list_of_gems,
   )
 


### PR DESCRIPTION
Change the Ruby version used by Bazel to 3.2.8. Also updates the gemfiles to reflect the default bundler on Ruby 3.2.8, and updates the CI to test against Ruby 3.2.

Includes a prebuilt binary for Ruby 3.2.8, but this will need to be updated (in a separate PR) for the docker container used by bazelbot.

This is intended as an interim update. The goal is to update Rails to 8.0 (see #1173) and Ruby to 3.4, but we cannot do either of those immediately because Rails 8.0 cannot run on the current Ruby 3.1.3, and the current Rails 5.2 cannot run on Ruby 3.4. So we will first update Ruby to 3.2, then update Rails, then finally update Ruby again to 3.4.