### PR TITLE
feat: Update common dependencies for generated clients

### DIFF
--- a/gapic-generator/lib/gapic/model/mixins.rb
+++ b/gapic-generator/lib/gapic/model/mixins.rb
@@ -183,8 +183,8 @@ module Gapic
       # have these in lookup tables than to construct a ServicePresenter
 
       SERVICE_TO_DEPENDENCY = {
-        LOCATIONS_SERVICE => { "google-cloud-location" => [">= 0.7", "< 2.a"] },
-        IAM_SERVICE => { "google-iam-v1" => [">= 0.7", "< 2.a"] }
+        LOCATIONS_SERVICE => { "google-cloud-location" => ["~> 1.0"] },
+        IAM_SERVICE => { "google-iam-v1" => ["~> 1.3"] }
       }.freeze
       private_constant :SERVICE_TO_DEPENDENCY
 

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -256,8 +256,8 @@ module Gapic
 
       def dependencies
         @dependencies ||= begin
-          deps = { "gapic-common" => [">= 0.25.0", "< 2.a"] }
-          deps["grpc-google-iam-v1"] = "~> 1.1" if iam_dependency?
+          deps = { "gapic-common" => "~> 1.0" }
+          deps["grpc-google-iam-v1"] = "~> 1.11" if iam_dependency?
           extra_deps = gem_config_dependencies
           deps.merge! mixins_model.dependencies if mixins_model.mixins?
           # extra deps should be last, overriding mixins or defaults

--- a/shared/output/cloud/grafeas_v1/grafeas-v1.gemspec
+++ b/shared/output/cloud/grafeas_v1/grafeas-v1.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.1"
 
-  gem.add_dependency "gapic-common", ">= 0.25.0", "< 2.a"
+  gem.add_dependency "gapic-common", "~> 1.0"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
+++ b/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.1"
 
-  gem.add_dependency "gapic-common", ">= 0.25.0", "< 2.a"
+  gem.add_dependency "gapic-common", "~> 1.0"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
+++ b/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.1"
 
-  gem.add_dependency "gapic-common", ">= 0.25.0", "< 2.a"
+  gem.add_dependency "gapic-common", "~> 1.0"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
+++ b/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.1"
 
-  gem.add_dependency "gapic-common", ">= 0.25.0", "< 2.a"
+  gem.add_dependency "gapic-common", "~> 1.0"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/shared/output/cloud/location/google-cloud-location.gemspec
+++ b/shared/output/cloud/location/google-cloud-location.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.1"
 
-  gem.add_dependency "gapic-common", ">= 0.25.0", "< 2.a"
+  gem.add_dependency "gapic-common", "~> 1.0"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
+++ b/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.1"
 
-  gem.add_dependency "gapic-common", ">= 0.25.0", "< 2.a"
+  gem.add_dependency "gapic-common", "~> 1.0"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.11"
 end

--- a/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
+++ b/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.1"
 
-  gem.add_dependency "gapic-common", ">= 0.25.0", "< 2.a"
+  gem.add_dependency "gapic-common", "~> 1.0"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
+++ b/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.1"
 
-  gem.add_dependency "gapic-common", ">= 0.25.0", "< 2.a"
+  gem.add_dependency "gapic-common", "~> 1.0"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "google-cloud-location", ">= 0.7", "< 2.a"
+  gem.add_dependency "google-cloud-location", "~> 1.0"
 end

--- a/shared/output/gapic/templates/garbage/google-garbage.gemspec
+++ b/shared/output/gapic/templates/garbage/google-garbage.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.1"
 
-  gem.add_dependency "gapic-common", ">= 0.25.0", "< 2.a"
-  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
+  gem.add_dependency "gapic-common", "~> 1.0"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.11"
 end

--- a/shared/output/gapic/templates/noservice/google-garbage-noservice.gemspec
+++ b/shared/output/gapic/templates/noservice/google-garbage-noservice.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.1"
 
-  gem.add_dependency "gapic-common", ">= 0.25.0", "< 2.a"
+  gem.add_dependency "gapic-common", "~> 1.0"
 end

--- a/shared/output/gapic/templates/showcase/google-showcase.gemspec
+++ b/shared/output/gapic/templates/showcase/google-showcase.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.1"
 
-  gem.add_dependency "gapic-common", ">= 0.25.0", "< 2.a"
-  gem.add_dependency "google-cloud-location", ">= 0.7", "< 2.a"
-  gem.add_dependency "google-iam-v1", ">= 0.7", "< 2.a"
+  gem.add_dependency "gapic-common", "~> 1.0"
+  gem.add_dependency "google-cloud-location", "~> 1.0"
+  gem.add_dependency "google-iam-v1", "~> 1.3"
 end

--- a/shared/output/gapic/templates/testing/testing.gemspec
+++ b/shared/output/gapic/templates/testing/testing.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.1"
 
-  gem.add_dependency "gapic-common", ">= 0.25.0", "< 2.a"
+  gem.add_dependency "gapic-common", "~> 1.0"
   gem.add_dependency "google-cloud-common", "~> 1.0"
-  gem.add_dependency "google-cloud-location", ">= 0.7", "< 2.a"
+  gem.add_dependency "google-cloud-location", "~> 1.0"
 end


### PR DESCRIPTION
Updates common dependencies to latest (post-1.0) versions. Includes:

* gapic-common => `~> 1.0`
* google-cloud-location => `~> 1.0`
* google-iam-v1 => `~> 1.3`
* grpc-google-iam-v1 => `~> 1.11`
