### PR TITLE
fix: Remove unnecessary services import from tests

### DIFF
--- a/gapic-generator/templates/default/service/test/client.text.erb
+++ b/gapic-generator/templates/default/service/test/client.text.erb
@@ -5,7 +5,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "<%= service.proto_service_require %>"
-require "<%= service.proto_services_require %>"
 require "<%= service.service_require %>"
 
 class <%= service.client_name_full %>Test < Minitest::Test

--- a/shared/output/cloud/grafeas_v1/test/grafeas/v1/grafeas_test.rb
+++ b/shared/output/cloud/grafeas_v1/test/grafeas/v1/grafeas_test.rb
@@ -21,7 +21,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "grafeas/v1/grafeas_pb"
-require "grafeas/v1/grafeas_services_pb"
 require "grafeas/v1/grafeas"
 
 class ::Grafeas::V1::Grafeas::ClientTest < Minitest::Test

--- a/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
+++ b/shared/output/cloud/language_v1/test/google/cloud/language/v1/language_service_test.rb
@@ -21,7 +21,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/cloud/language/v1/language_service_pb"
-require "google/cloud/language/v1/language_service_services_pb"
 require "google/cloud/language/v1/language_service"
 
 class ::Google::Cloud::Language::V1::LanguageService::ClientTest < Minitest::Test

--- a/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta1/test/google/cloud/language/v1beta1/language_service_test.rb
@@ -21,7 +21,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/cloud/language/v1beta1/language_service_pb"
-require "google/cloud/language/v1beta1/language_service_services_pb"
 require "google/cloud/language/v1beta1/language_service"
 
 class ::Google::Cloud::Language::V1beta1::LanguageService::ClientTest < Minitest::Test

--- a/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
+++ b/shared/output/cloud/language_v1beta2/test/google/cloud/language/v1beta2/language_service_test.rb
@@ -21,7 +21,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/cloud/language/v1beta2/language_service_pb"
-require "google/cloud/language/v1beta2/language_service_services_pb"
 require "google/cloud/language/v1beta2/language_service"
 
 class ::Google::Cloud::Language::V1beta2::LanguageService::ClientTest < Minitest::Test

--- a/shared/output/cloud/location/test/google/cloud/location/locations_test.rb
+++ b/shared/output/cloud/location/test/google/cloud/location/locations_test.rb
@@ -21,7 +21,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/cloud/location/locations_pb"
-require "google/cloud/location/locations_services_pb"
 require "google/cloud/location/locations"
 
 class ::Google::Cloud::Location::Locations::ClientTest < Minitest::Test

--- a/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/test/google/cloud/secret_manager/v1beta1/secret_manager_service_test.rb
@@ -21,7 +21,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/cloud/secrets/v1beta1/service_pb"
-require "google/cloud/secrets/v1beta1/service_services_pb"
 require "google/cloud/secret_manager/v1beta1/secret_manager_service"
 
 class ::Google::Cloud::SecretManager::V1beta1::SecretManagerService::ClientTest < Minitest::Test

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/adaptation_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/adaptation_test.rb
@@ -21,7 +21,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/cloud/speech/v1/cloud_speech_adaptation_pb"
-require "google/cloud/speech/v1/cloud_speech_adaptation_services_pb"
 require "google/cloud/speech/v1/adaptation"
 
 class ::Google::Cloud::Speech::V1::Adaptation::ClientTest < Minitest::Test

--- a/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
+++ b/shared/output/cloud/speech_v1/test/google/cloud/speech/v1/speech_test.rb
@@ -21,7 +21,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/cloud/speech/v1/cloud_speech_pb"
-require "google/cloud/speech/v1/cloud_speech_services_pb"
 require "google/cloud/speech/v1/speech"
 
 class ::Google::Cloud::Speech::V1::Speech::ClientTest < Minitest::Test

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -21,7 +21,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/cloud/vision/v1/image_annotator_pb"
-require "google/cloud/vision/v1/image_annotator_services_pb"
 require "google/cloud/vision/v1/image_annotator"
 
 class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test

--- a/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
+++ b/shared/output/cloud/vision_v1/test/google/cloud/vision/v1/product_search_test.rb
@@ -21,7 +21,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/cloud/vision/v1/product_search_service_pb"
-require "google/cloud/vision/v1/product_search_service_services_pb"
 require "google/cloud/vision/v1/product_search"
 
 class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/deprecated_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/deprecated_service_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "garbage/garbage_pb"
-require "garbage/garbage_services_pb"
 require "so/much/trash/deprecated_service"
 
 class ::So::Much::Trash::DeprecatedService::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/garbage_service_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "garbage/garbage_pb"
-require "garbage/garbage_services_pb"
 require "so/much/trash/garbage_service"
 
 class ::So::Much::Trash::GarbageService::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/iam_policy_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/iam_policy_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/iam/v1/iam_policy_pb"
-require "google/iam/v1/iam_policy_services_pb"
 require "so/much/trash/iam_policy"
 
 class ::So::Much::Trash::IAMPolicy::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/really_renamed_service_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/really_renamed_service_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "garbage/garbage_pb"
-require "garbage/garbage_services_pb"
 require "so/much/trash/really_renamed_service"
 
 class ::So::Much::Trash::ReallyRenamedService::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_test.rb
+++ b/shared/output/gapic/templates/garbage/test/so/much/trash/resource_names_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "garbage/resource_names_pb"
-require "garbage/resource_names_services_pb"
 require "so/much/trash/resource_names"
 
 class ::So::Much::Trash::ResourceNames::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/compliance_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/showcase/v1beta1/compliance_pb"
-require "google/showcase/v1beta1/compliance_services_pb"
 require "google/showcase/v1beta1/compliance"
 
 class ::Google::Showcase::V1beta1::Compliance::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/echo_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/showcase/v1beta1/echo_pb"
-require "google/showcase/v1beta1/echo_services_pb"
 require "google/showcase/v1beta1/echo"
 
 class ::Google::Showcase::V1beta1::Echo::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/identity_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/showcase/v1beta1/identity_pb"
-require "google/showcase/v1beta1/identity_services_pb"
 require "google/showcase/v1beta1/identity"
 
 class ::Google::Showcase::V1beta1::Identity::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/messaging_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/showcase/v1beta1/messaging_pb"
-require "google/showcase/v1beta1/messaging_services_pb"
 require "google/showcase/v1beta1/messaging"
 
 class ::Google::Showcase::V1beta1::Messaging::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/sequence_service_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/showcase/v1beta1/sequence_pb"
-require "google/showcase/v1beta1/sequence_services_pb"
 require "google/showcase/v1beta1/sequence_service"
 
 class ::Google::Showcase::V1beta1::SequenceService::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
+++ b/shared/output/gapic/templates/showcase/test/google/showcase/v1beta1/testing_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "google/showcase/v1beta1/testing_pb"
-require "google/showcase/v1beta1/testing_services_pb"
 require "google/showcase/v1beta1/testing"
 
 class ::Google::Showcase::V1beta1::Testing::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_no_retry_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "testing/grpc_service_config/grpc_service_config_pb"
-require "testing/grpc_service_config/grpc_service_config_services_pb"
 require "testing/grpc_service_config/service_no_retry"
 
 class ::Testing::GrpcServiceConfig::ServiceNoRetry::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/grpc_service_config/service_with_retries_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "testing/grpc_service_config/grpc_service_config_pb"
-require "testing/grpc_service_config/grpc_service_config_services_pb"
 require "testing/grpc_service_config/service_with_retries"
 
 class ::Testing::GrpcServiceConfig::ServiceWithRetries::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_and_non_rest_ops_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "testing/mixins/mixins_pb"
-require "testing/mixins/mixins_services_pb"
 require "testing/mixins/service_with_loc_and_non_rest_ops"
 
 class ::Testing::Mixins::ServiceWithLocAndNonRestOps::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/mixins/service_with_loc_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "testing/mixins/mixins_pb"
-require "testing/mixins/mixins_services_pb"
 require "testing/mixins/service_with_loc"
 
 class ::Testing::Mixins::ServiceWithLoc::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/all_subclients_consumer_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "testing/nonstandard_lro_grpc/nonstandard_lro_grpc_pb"
-require "testing/nonstandard_lro_grpc/nonstandard_lro_grpc_services_pb"
 require "testing/nonstandard_lro_grpc/all_subclients_consumer"
 
 class ::Testing::NonstandardLroGrpc::AllSubclientsConsumer::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/another_lro_provider_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "testing/nonstandard_lro_grpc/nonstandard_lro_grpc_pb"
-require "testing/nonstandard_lro_grpc/nonstandard_lro_grpc_services_pb"
 require "testing/nonstandard_lro_grpc/another_lro_provider"
 
 class ::Testing::NonstandardLroGrpc::AnotherLroProvider::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_consumer_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "testing/nonstandard_lro_grpc/nonstandard_lro_grpc_pb"
-require "testing/nonstandard_lro_grpc/nonstandard_lro_grpc_services_pb"
 require "testing/nonstandard_lro_grpc/plain_lro_consumer"
 
 class ::Testing::NonstandardLroGrpc::PlainLroConsumer::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/nonstandard_lro_grpc/plain_lro_provider_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "testing/nonstandard_lro_grpc/nonstandard_lro_grpc_pb"
-require "testing/nonstandard_lro_grpc/nonstandard_lro_grpc_services_pb"
 require "testing/nonstandard_lro_grpc/plain_lro_provider"
 
 class ::Testing::NonstandardLroGrpc::PlainLroProvider::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_explicit_headers_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "testing/routing_headers/routing_headers_pb"
-require "testing/routing_headers/routing_headers_services_pb"
 require "testing/routing_headers/service_explicit_headers"
 
 class ::Testing::RoutingHeaders::ServiceExplicitHeaders::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_implicit_headers_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "testing/routing_headers/routing_headers_pb"
-require "testing/routing_headers/routing_headers_services_pb"
 require "testing/routing_headers/service_implicit_headers"
 
 class ::Testing::RoutingHeaders::ServiceImplicitHeaders::ClientTest < Minitest::Test

--- a/shared/output/gapic/templates/testing/test/testing/routing_headers/service_no_headers_test.rb
+++ b/shared/output/gapic/templates/testing/test/testing/routing_headers/service_no_headers_test.rb
@@ -29,7 +29,6 @@ require "helper"
 require "gapic/grpc/service_stub"
 
 require "testing/routing_headers/routing_headers_pb"
-require "testing/routing_headers/routing_headers_services_pb"
 require "testing/routing_headers/service_no_headers"
 
 class ::Testing::RoutingHeaders::ServiceNoHeaders::ClientTest < Minitest::Test


### PR DESCRIPTION
This is a fix to remove manual changes from https://github.com/googleapis/google-cloud-ruby/blob/main/google-cloud-pubsub-v1/.owlbot.rb