### PR TITLE
feat: add retry jitter configuration

### DIFF
--- a/gapic-generator-cloud/templates/cloud/wrapper_gem/_main.text.erb
+++ b/gapic-generator-cloud/templates/cloud/wrapper_gem/_main.text.erb
@@ -145,6 +145,7 @@ end
 #     * `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
 #     * `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
 #     * `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+#     * `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
 #     * `:retry_codes` (*type:* `Array<String>`) -
 #       The error codes that should trigger a retry.
 #

--- a/gapic-generator/lib/gapic/presenters/gem_presenter.rb
+++ b/gapic-generator/lib/gapic/presenters/gem_presenter.rb
@@ -256,7 +256,7 @@ module Gapic
 
       def dependencies
         @dependencies ||= begin
-          deps = { "gapic-common" => "~> 1.2" }
+          deps = { "gapic-common" => "~> 1.3" }
           deps["grpc-google-iam-v1"] = "~> 1.11" if iam_dependency?
           extra_deps = gem_config_dependencies
           deps.merge! mixins_model.dependencies if mixins_model.mixins?

--- a/gapic-generator/templates/default/service/client/_config.text.erb
+++ b/gapic-generator/templates/default/service/client/_config.text.erb
@@ -98,6 +98,7 @@
 #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
 #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
 #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+#    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
 #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
 #       trigger a retry.
 #   @return [::Hash]
@@ -181,6 +182,7 @@ class Configuration
   #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
   #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
   #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+  #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
   #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
   #         trigger a retry.
   # 

--- a/gapic-generator/templates/default/service/rest/client/_config.text.erb
+++ b/gapic-generator/templates/default/service/rest/client/_config.text.erb
@@ -72,6 +72,7 @@
 #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
 #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
 #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+#    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
 #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
 #       trigger a retry.
 #   @return [::Hash]
@@ -153,6 +154,7 @@ class Configuration
   #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
   #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
   #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+  #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
   #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
   #         trigger a retry.
   # 

--- a/shared/output/ads/googleads/lib/google/ads/google_ads/v19/services/campaign_service/client.rb
+++ b/shared/output/ads/googleads/lib/google/ads/google_ads/v19/services/campaign_service/client.rb
@@ -511,6 +511,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -595,6 +596,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/addresses/rest/client.rb
@@ -741,6 +741,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -813,6 +814,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/global_operations/rest/client.rb
@@ -404,6 +404,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -476,6 +477,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/networks/rest/client.rb
@@ -464,6 +464,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -536,6 +537,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_instance_group_managers/rest/client.rb
@@ -363,6 +363,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -435,6 +436,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest/client.rb
+++ b/shared/output/cloud/compute_small/lib/google/cloud/compute/v1/region_operations/rest/client.rb
@@ -596,6 +596,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -668,6 +669,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/shared/output/cloud/compute_small_wrapper/lib/google/cloud/compute.rb
+++ b/shared/output/cloud/compute_small_wrapper/lib/google/cloud/compute.rb
@@ -380,6 +380,7 @@ module Google
       #     * `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
       #     * `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
       #     * `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+      #     * `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
       #     * `:retry_codes` (*type:* `Array<String>`) -
       #       The error codes that should trigger a retry.
       #

--- a/shared/output/cloud/grafeas_v1/grafeas-v1.gemspec
+++ b/shared/output/cloud/grafeas_v1/grafeas-v1.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/shared/output/cloud/grafeas_v1/lib/grafeas/v1/grafeas/client.rb
+++ b/shared/output/cloud/grafeas_v1/lib/grafeas/v1/grafeas/client.rb
@@ -1545,6 +1545,7 @@ module Grafeas
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -1628,6 +1629,7 @@ module Grafeas
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
+++ b/shared/output/cloud/language_v1/google-cloud-language-v1.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/client.rb
@@ -1340,6 +1340,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -1423,6 +1424,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/rest/client.rb
+++ b/shared/output/cloud/language_v1/lib/google/cloud/language/v1/language_service/rest/client.rb
@@ -844,6 +844,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -916,6 +917,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
+++ b/shared/output/cloud/language_v1beta1/google-cloud-language-v1beta1.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta1/lib/google/cloud/language/v1beta1/language_service/client.rb
@@ -602,6 +602,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -685,6 +686,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
+++ b/shared/output/cloud/language_v1beta2/google-cloud-language-v1beta2.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
+++ b/shared/output/cloud/language_v1beta2/lib/google/cloud/language/v1beta2/language_service/client.rb
@@ -841,6 +841,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -924,6 +925,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/cloud/language_wrapper/lib/google/cloud/language.rb
+++ b/shared/output/cloud/language_wrapper/lib/google/cloud/language.rb
@@ -139,6 +139,7 @@ module Google
       #     * `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
       #     * `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
       #     * `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+      #     * `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
       #     * `:retry_codes` (*type:* `Array<String>`) -
       #       The error codes that should trigger a retry.
       #

--- a/shared/output/cloud/location/google-cloud-location.gemspec
+++ b/shared/output/cloud/location/google-cloud-location.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/shared/output/cloud/location/lib/google/cloud/location/locations/client.rb
+++ b/shared/output/cloud/location/lib/google/cloud/location/locations/client.rb
@@ -460,6 +460,7 @@ module Google
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -543,6 +544,7 @@ module Google
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/cloud/location/lib/google/cloud/location/locations/rest/client.rb
+++ b/shared/output/cloud/location/lib/google/cloud/location/locations/rest/client.rb
@@ -417,6 +417,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -496,6 +497,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/cloud/noservice_cloud/google-cloud-noservice.gemspec
+++ b/shared/output/cloud/noservice_cloud/google-cloud-noservice.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
+++ b/shared/output/cloud/secretmanager_v1beta1/google-cloud-secret_manager-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", "~> 1.11"
 end

--- a/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
+++ b/shared/output/cloud/secretmanager_v1beta1/lib/google/cloud/secret_manager/v1beta1/secret_manager_service/client.rb
@@ -1685,6 +1685,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -1768,6 +1769,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/cloud/secretmanager_wrapper/lib/google/cloud/secret_manager.rb
+++ b/shared/output/cloud/secretmanager_wrapper/lib/google/cloud/secret_manager.rb
@@ -135,6 +135,7 @@ module Google
       #     * `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
       #     * `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
       #     * `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+      #     * `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
       #     * `:retry_codes` (*type:* `Array<String>`) -
       #       The error codes that should trigger a retry.
       #

--- a/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
+++ b/shared/output/cloud/speech_v1/google-cloud-speech-v1.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/adaptation/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/adaptation/client.rb
@@ -1282,6 +1282,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -1365,6 +1366,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -549,6 +549,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -632,6 +633,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/shared/output/cloud/speech_v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -703,6 +703,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -786,6 +787,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
+++ b/shared/output/cloud/vision_v1/google-cloud-vision-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "google-cloud-location", "~> 1.0"
 end

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -739,6 +739,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -822,6 +823,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -703,6 +703,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -786,6 +787,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/rest/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/rest/client.rb
@@ -711,6 +711,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -790,6 +791,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/rest/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/image_annotator/rest/operations.rb
@@ -541,6 +541,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -613,6 +614,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -2244,6 +2244,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -2327,6 +2328,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -703,6 +703,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -786,6 +787,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/client.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/client.rb
@@ -2079,6 +2079,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -2158,6 +2159,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/operations.rb
+++ b/shared/output/cloud/vision_v1/lib/google/cloud/vision/v1/product_search/rest/operations.rb
@@ -541,6 +541,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -613,6 +614,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/shared/output/gapic/templates/garbage/google-garbage.gemspec
+++ b/shared/output/gapic/templates/garbage/google-garbage.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "grpc-google-iam-v1", "~> 1.11"
 end

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/deprecated_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/deprecated_service/client.rb
@@ -341,6 +341,7 @@ module So
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -425,6 +426,7 @@ module So
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/client.rb
@@ -1794,6 +1794,7 @@ module So
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -1878,6 +1879,7 @@ module So
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/garbage_service/operations.rb
@@ -701,6 +701,7 @@ module So
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -785,6 +786,7 @@ module So
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/iam_policy/client.rb
@@ -582,6 +582,7 @@ module So
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -666,6 +667,7 @@ module So
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/really_renamed_service/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/really_renamed_service/client.rb
@@ -341,6 +341,7 @@ module So
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -425,6 +426,7 @@ module So
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/client.rb
+++ b/shared/output/gapic/templates/garbage/lib/so/much/trash/resource_names/client.rb
@@ -643,6 +643,7 @@ module So
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -727,6 +728,7 @@ module So
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/noservice/google-garbage-noservice.gemspec
+++ b/shared/output/gapic/templates/noservice/google-garbage-noservice.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
 end

--- a/shared/output/gapic/templates/showcase/google-showcase.gemspec
+++ b/shared/output/gapic/templates/showcase/google-showcase.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "google-cloud-location", "~> 1.0"
   gem.add_dependency "google-iam-v1", "~> 1.3"
 end

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/compliance/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/compliance/client.rb
@@ -1228,6 +1228,7 @@ module Google
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -1312,6 +1313,7 @@ module Google
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/compliance/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/compliance/rest/client.rb
@@ -1181,6 +1181,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -1261,6 +1262,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/client.rb
@@ -1326,6 +1326,7 @@ module Google
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -1410,6 +1411,7 @@ module Google
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/operations.rb
@@ -693,6 +693,7 @@ module Google
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -777,6 +778,7 @@ module Google
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/client.rb
@@ -1132,6 +1132,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -1212,6 +1213,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/echo/rest/operations.rb
@@ -549,6 +549,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -622,6 +623,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/client.rb
@@ -723,6 +723,7 @@ module Google
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -807,6 +808,7 @@ module Google
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/identity/rest/client.rb
@@ -684,6 +684,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -764,6 +765,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/client.rb
@@ -1529,6 +1529,7 @@ module Google
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -1613,6 +1614,7 @@ module Google
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/operations.rb
@@ -693,6 +693,7 @@ module Google
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -777,6 +778,7 @@ module Google
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/rest/client.rb
@@ -1303,6 +1303,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -1383,6 +1384,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/rest/operations.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/messaging/rest/operations.rb
@@ -549,6 +549,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -622,6 +623,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/sequence_service/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/sequence_service/client.rb
@@ -796,6 +796,7 @@ module Google
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -880,6 +881,7 @@ module Google
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/sequence_service/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/sequence_service/rest/client.rb
@@ -750,6 +750,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -830,6 +831,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/client.rb
@@ -1000,6 +1000,7 @@ module Google
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -1084,6 +1085,7 @@ module Google
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/rest/client.rb
+++ b/shared/output/gapic/templates/showcase/lib/google/showcase/v1beta1/testing/rest/client.rb
@@ -946,6 +946,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -1026,6 +1027,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_no_retry/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_no_retry/client.rb
@@ -354,6 +354,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -438,6 +439,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_no_retry/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_no_retry/rest/client.rb
@@ -325,6 +325,7 @@ module Testing
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -405,6 +406,7 @@ module Testing
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_with_retries/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_with_retries/client.rb
@@ -431,6 +431,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -515,6 +516,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_with_retries/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/grpc_service_config/service_with_retries/rest/client.rb
@@ -403,6 +403,7 @@ module Testing
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -483,6 +484,7 @@ module Testing
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc/client.rb
@@ -354,6 +354,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -438,6 +439,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc/rest/client.rb
@@ -325,6 +325,7 @@ module Testing
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -405,6 +406,7 @@ module Testing
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc_and_non_rest_ops/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc_and_non_rest_ops/client.rb
@@ -446,6 +446,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -530,6 +531,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc_and_non_rest_ops/operations.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc_and_non_rest_ops/operations.rb
@@ -692,6 +692,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -776,6 +777,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc_and_non_rest_ops/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/mixins/service_with_loc_and_non_rest_ops/rest/client.rb
@@ -325,6 +325,7 @@ module Testing
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -405,6 +406,7 @@ module Testing
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/client.rb
@@ -733,6 +733,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -817,6 +818,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/operations.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/operations.rb
@@ -692,6 +692,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -776,6 +777,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/client.rb
@@ -715,6 +715,7 @@ module Testing
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -795,6 +796,7 @@ module Testing
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/operations.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/all_subclients_consumer/rest/operations.rb
@@ -548,6 +548,7 @@ module Testing
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -621,6 +622,7 @@ module Testing
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/another_lro_provider/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/another_lro_provider/client.rb
@@ -362,6 +362,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -446,6 +447,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/another_lro_provider/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/another_lro_provider/rest/client.rb
@@ -333,6 +333,7 @@ module Testing
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -413,6 +414,7 @@ module Testing
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/client.rb
@@ -385,6 +385,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -469,6 +470,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_consumer/rest/client.rb
@@ -356,6 +356,7 @@ module Testing
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -436,6 +437,7 @@ module Testing
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_provider/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_provider/client.rb
@@ -362,6 +362,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -446,6 +447,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_provider/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/nonstandard_lro_grpc/plain_lro_provider/rest/client.rb
@@ -333,6 +333,7 @@ module Testing
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -413,6 +414,7 @@ module Testing
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/testing/lib/testing/resources/service_resources/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/resources/service_resources/client.rb
@@ -579,6 +579,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -663,6 +664,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_explicit_headers/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_explicit_headers/client.rb
@@ -781,6 +781,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -865,6 +866,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_explicit_headers/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_explicit_headers/rest/client.rb
@@ -687,6 +687,7 @@ module Testing
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -767,6 +768,7 @@ module Testing
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_implicit_headers/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_implicit_headers/client.rb
@@ -563,6 +563,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -647,6 +648,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_implicit_headers/rest/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_implicit_headers/rest/client.rb
@@ -515,6 +515,7 @@ module Testing
           #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #       trigger a retry.
           #   @return [::Hash]
@@ -595,6 +596,7 @@ module Testing
             #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #         trigger a retry.
             #

--- a/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_no_headers/client.rb
+++ b/shared/output/gapic/templates/testing/lib/testing/routing_headers/service_no_headers/client.rb
@@ -372,6 +372,7 @@ module Testing
         #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
         #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
         #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+        #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
         #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
         #       trigger a retry.
         #   @return [::Hash]
@@ -456,6 +457,7 @@ module Testing
           #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
           #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
           #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+          #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
           #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
           #         trigger a retry.
           #

--- a/shared/output/gapic/templates/testing/testing.gemspec
+++ b/shared/output/gapic/templates/testing/testing.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "google-cloud-common", "~> 1.0"
   gem.add_dependency "google-cloud-location", "~> 1.0"
 end

--- a/shared/test/showcase/echo/wait_test.rb
+++ b/shared/test/showcase/echo/wait_test.rb
@@ -56,6 +56,45 @@ class WaitTest < ShowcaseTest
     assert operation.error?
     assert_equal "nope", operation.error.message
   end
+
+  def test_wait_retry_default_jitter
+    return unless @client
+    operation = @client.wait ttl: { nanos: 500000 }, error: Google::Rpc::Status.new(message: "nope")
+
+    # The default jitter is 1.0. The policy is configured with initial_delay: 0.2
+    # The sleep duration should be delay + rand(0.0..1.0), so between 0.2 and 1.2
+    sleep_calls = []
+    Kernel.stub :sleep, ->(delay) { sleep_calls << delay } do
+      operation.wait_until_done! retry_policy: @retry_policy
+    end
+    
+    refute_empty sleep_calls
+    sleep_calls.each do |delay|
+      assert delay >= 0.2, "Delay #{delay} should be at least initial_delay 0.2"
+      assert delay <= 1.2, "Delay #{delay} should be at most delay (0.2) + default jitter (1.0)"
+    end
+  end
+
+  def test_wait_retry_configured_jitter
+    return unless @client
+    operation = @client.wait ttl: { nanos: 500000 }, error: Google::Rpc::Status.new(message: "nope")
+
+    # Configure a custom jitter of 0.5
+    custom_policy = ::Gapic::Operation::RetryPolicy.new initial_delay: 0.2, multiplier: 2, max_delay: 1, timeout: 2, jitter: 0.5
+    
+    # The first sleep should be between 0.2 and 0.7 (0.2 + 0.5)
+    # The max delay is 1, so subsequent sleeps could be up to 1.0, but the initial max is 0.7
+    sleep_calls = []
+    Kernel.stub :sleep, ->(delay) { sleep_calls << delay } do
+      operation.wait_until_done! retry_policy: custom_policy
+    end
+    
+    refute_empty sleep_calls
+    # Check the first sleep call specifically for the 0.2 + 0.5 bound
+    first_delay = sleep_calls.first
+    assert first_delay >= 0.2, "First delay #{first_delay} should be at least initial_delay 0.2"
+    assert first_delay <= 0.7, "First delay #{first_delay} should be at most delay (0.2) + custom jitter (0.5)"
+  end
 end
 
 class WaitGRPCTest < WaitTest


### PR DESCRIPTION
Changes:
*   **Templates**: Updated the ERB templates for gRPC, REST, and Cloud wrapper gems to document the `:jitter` field in the `retry_policy` configuration block. It is documented as a `Numeric` with a default of `1.0`.
*   **Showcase Tests**: Added tests (`test_wait_retry_default_jitter` and `test_wait_retry_configured_jitter`) to verify the jitter logic is functioning correctly when utilizing `wait`.
*   **gapic-common Dependency**: Bumped the `gapic-common` dependency version to `~> 1.3` in `gapic-generator/lib/gapic/presenters/gem_presenter.rb` to utilize the new jitter features.
*   **Golden Files**: Regenerated all golden files to include the updated `retry_policy` documentation and the new `gapic-common` version dependency.
